### PR TITLE
docs(plan): add implementation plan, working agreement, and tracking files

### DIFF
--- a/docs/FOLLOWUPS.md
+++ b/docs/FOLLOWUPS.md
@@ -1,0 +1,37 @@
+# Followups
+
+Known followup work that did not fit in the slice that surfaced it. Each
+entry has an id (`F-NNN`), a one-line description, the loop that created it,
+and a priority.
+
+Priorities: `blocks-release`, `nice-to-have`, `polish`. Statuses: `open`,
+`in-progress`, `done`, `obsolete`. Do not delete entries — mark them `done`
+or `obsolete` so the trail is preserved.
+
+---
+
+## F-003 — Auto-deploy pipeline from `main`
+**Created:** 2026-04-26
+**Priority:** blocks-release
+**Status:** open
+**Notes:** Blocked by Q-003 (deploy target). Once chosen, add CI workflow
+that builds, runs the test suite, and deploys on every merge to `main`.
+
+## F-002 — Project skeleton (Next.js + TypeScript + CI)
+**Created:** 2026-04-26
+**Priority:** blocks-release
+**Status:** open
+**Notes:** First implementation slice once Q-001 is answered. Must include
+lint, type-check, unit tests, e2e harness, and a smoke test that the dev
+server boots.
+
+## F-001 — Author GDD sections 18–28
+**Created:** 2026-04-26
+**Priority:** blocks-release
+**Status:** open
+**Notes:** `GDD.md` lists 28 sections; only 01–17 currently exist as files.
+Draft the remaining sections (18 Sound and Music, 19 Controls and Input,
+20 HUD and UI/UX, 21 Technical Design, 22 Data Schemas, 23 Balancing Tables,
+24 Content Plan, 25 Development Roadmap, 26 Open Source Project Guidance,
+27 Risks and Mitigations, 28 Appendices) from cross-references and flag
+unresolved spots for dev review. Each section should land in its own slice.

--- a/docs/IMPLEMENTATION_PLAN.md
+++ b/docs/IMPLEMENTATION_PLAN.md
@@ -46,57 +46,57 @@ revisit earlier ones — but each phase has a primary focus.
 
 ### Phase 0 — Foundations and GDD completion
 - Verify all 28 GDD section files exist. Author missing files
-  (`18-sound-and-music-design.md` through `28-appendices-and-research-references.md`)
+  ([`docs/gdd/18-sound-and-music-design.md`](gdd/18-sound-and-music-design.md) through [`docs/gdd/28-appendices-and-research-references.md`](gdd/28-appendices-and-research-references.md))
   by drafting from the parent index and any cross-references, then flagging
   unresolved sections for dev review.
 - Stand up the project skeleton described in
-  `21-technical-design-for-web-implementation.md`: Next.js + TypeScript app,
+  [`docs/gdd/21-technical-design-for-web-implementation.md`](gdd/21-technical-design-for-web-implementation.md): Next.js + TypeScript app,
   lint, type-check, unit-test, end-to-end harness, CI, and a deploy target.
 - Wire `PROGRESS_LOG.md`, `OPEN_QUESTIONS.md`, and `FOLLOWUPS.md` so every
   later loop has a place to write.
-- Define the JSON schemas in `22-data-schemas.md` as TypeScript types and
+- Define the JSON schemas in [`docs/gdd/22-data-schemas.md`](gdd/22-data-schemas.md) as TypeScript types and
   runtime validators.
 
 ### Phase 1 — Vertical slice (drivable road)
 - Pseudo-3D road renderer (Canvas2D) with one straight + one curve track.
-- Player car with arcade physics from `10-driving-model-and-physics.md`
+- Player car with arcade physics from [`docs/gdd/10-driving-model-and-physics.md`](gdd/10-driving-model-and-physics.md)
   (acceleration, top speed, steering, basic collision feedback).
 - Single AI car using the simplest opponent profile from
-  `15-cpu-opponents-and-ai.md`.
+  [`docs/gdd/15-cpu-opponents-and-ai.md`](gdd/15-cpu-opponents-and-ai.md).
 - HUD with speed, lap, and position only.
 - Goal: a 30-second drive feels like the design pillars in
-  `01-title-and-high-concept.md`.
+  [`docs/gdd/01-title-and-high-concept.md`](gdd/01-title-and-high-concept.md).
 
 ### Phase 2 — Race rules and economy
-- Full race rules from `07-race-rules-and-structure.md` (countdown, laps,
+- Full race rules from [`docs/gdd/07-race-rules-and-structure.md`](gdd/07-race-rules-and-structure.md) (countdown, laps,
   placement, DNF rules).
-- Damage model from `13-damage-repairs-and-risk.md`.
+- Damage model from [`docs/gdd/13-damage-repairs-and-risk.md`](gdd/13-damage-repairs-and-risk.md).
 - Credits, repairs, and the upgrade categories from
-  `12-upgrade-and-economy-system.md`.
-- Garage flow from `05-core-gameplay-loop.md`.
-- Save / load from `21-technical-design-for-web-implementation.md` (local
+  [`docs/gdd/12-upgrade-and-economy-system.md`](gdd/12-upgrade-and-economy-system.md).
+- Garage flow from [`docs/gdd/05-core-gameplay-loop.md`](gdd/05-core-gameplay-loop.md).
+- Save / load from [`docs/gdd/21-technical-design-for-web-implementation.md`](gdd/21-technical-design-for-web-implementation.md) (local
   storage MVP).
 
 ### Phase 3 — World, tours, and content
-- Region and tour structure from `08-world-and-progression-design.md`.
-- Track authoring pipeline using the schema in `22-data-schemas.md`.
-- The track set required by `24-content-plan.md` for MVP.
-- Car set and stats from `11-cars-and-stats.md`.
-- Balancing pass against `23-balancing-tables.md`.
+- Region and tour structure from [`docs/gdd/08-world-and-progression-design.md`](gdd/08-world-and-progression-design.md).
+- Track authoring pipeline using the schema in [`docs/gdd/22-data-schemas.md`](gdd/22-data-schemas.md).
+- The track set required by [`docs/gdd/24-content-plan.md`](gdd/24-content-plan.md) for MVP.
+- Car set and stats from [`docs/gdd/11-cars-and-stats.md`](gdd/11-cars-and-stats.md).
+- Balancing pass against [`docs/gdd/23-balancing-tables.md`](gdd/23-balancing-tables.md).
 
 ### Phase 4 — Atmosphere and feel
-- Weather and environmental systems (`14-weather-and-environmental-systems.md`).
-- Sound and music (`18-sound-and-music-design.md`).
-- Visual polish from `16-rendering-and-visual-design.md` and `17-art-direction.md`.
-- HUD/UX polish from `20-hud-and-ui-ux.md`.
+- Weather and environmental systems ([`docs/gdd/14-weather-and-environmental-systems.md`](gdd/14-weather-and-environmental-systems.md)).
+- Sound and music ([`docs/gdd/18-sound-and-music-design.md`](gdd/18-sound-and-music-design.md)).
+- Visual polish from [`docs/gdd/16-rendering-and-visual-design.md`](gdd/16-rendering-and-visual-design.md) and [`docs/gdd/17-art-direction.md`](gdd/17-art-direction.md).
+- HUD/UX polish from [`docs/gdd/20-hud-and-ui-ux.md`](gdd/20-hud-and-ui-ux.md).
 
 ### Phase 5 — Modes, modding, and stretch
-- Time trial, daily challenge, and any additional modes in `06-game-modes.md`.
-- Track editor and mod loading per `26-open-source-project-guidance.md`.
+- Time trial, daily challenge, and any additional modes in [`docs/gdd/06-game-modes.md`](gdd/06-game-modes.md).
+- Track editor and mod loading per [`docs/gdd/26-open-source-project-guidance.md`](gdd/26-open-source-project-guidance.md).
 - Optional ghost racing / leaderboard hooks.
 
 ### Phase 6 — Hardening and release
-- Risks/mitigations sweep from `27-risks-and-mitigations.md`.
+- Risks/mitigations sweep from [`docs/gdd/27-risks-and-mitigations.md`](gdd/27-risks-and-mitigations.md).
 - Cross-browser, performance, and accessibility verification.
 - Versioned release, changelog, and tagged deploy.
 
@@ -134,7 +134,8 @@ typically 1–3 days of agent work, never more than what fits in a single PR.
 │                                                         │
 ├─ document ──────────────────────────────────────────────┤
 │  append a PROGRESS_LOG.md entry (template in §6)        │
-│  move resolved items out of OPEN_QUESTIONS.md           │
+│  mark resolved OPEN_QUESTIONS.md items answered or      │
+│  obsolete (do not delete; history is preserved)         │
 │  add any new followups to FOLLOWUPS.md                  │
 │  if implementation forced a GDD change, edit the GDD    │
 │  in the same PR and call it out in the log              │
@@ -148,7 +149,7 @@ typically 1–3 days of agent work, never more than what fits in a single PR.
 
 The loop terminates only when:
 1. Every GDD section is marked `Implemented` in `PROGRESS_LOG.md`, **and**
-2. `FOLLOWUPS.md` contains no `must-fix-before-release` items, **and**
+2. `FOLLOWUPS.md` contains no `blocks-release` items, **and**
 3. A tagged release has deployed cleanly and a smoke test of the deployed game
    passes.
 

--- a/docs/IMPLEMENTATION_PLAN.md
+++ b/docs/IMPLEMENTATION_PLAN.md
@@ -1,0 +1,238 @@
+# VibeGear2 Implementation Plan
+
+A long-running, agent-executable plan for turning `GDD.md` and the section files
+under `docs/gdd/` into a working, deployed game. The plan is structured as a
+**repeating loop** that continues, slice by slice, for as many iterations and
+months as needed until the GDD is fully realised, verified, and shipped.
+
+This document describes **what** we are building and **how the work is sliced**.
+The companion file `WORKING_AGREEMENT.md` describes **how the agents must
+behave** while executing it.
+
+---
+
+## 1. Goals
+
+1. Implement every feature, system, schema, and content asset described in the
+   GDD until the game matches the design.
+2. Keep the codebase shippable on `main` at all times: every loop ends with a
+   green build, automated tests passing, and a successful auto-deploy.
+3. Keep the GDD as the single source of truth. When the implementation diverges
+   from the GDD, either change the GDD (with a logged decision) or change the
+   code — never let them drift silently.
+4. Maintain a transparent, auditable trail (`PROGRESS_LOG.md`,
+   `OPEN_QUESTIONS.md`, `FOLLOWUPS.md`) so a new agent or human can pick up the
+   work mid-flight without context loss.
+5. Operate autonomously where possible and pause for human clarification only
+   when the GDD is silent, ambiguous, or self-contradictory on a decision the
+   agent cannot reasonably make on its own.
+
+## 2. Scope of "the GDD"
+
+The implementation target is everything reachable from `GDD.md`:
+
+- The 28 numbered sections listed in `GDD.md` (sections 18–28 must be authored
+  before they can be implemented — see Phase 0).
+- Any cross-referenced schema, table, or appendix.
+- The `docs/` tree as it grows.
+
+The `GDD.docx` binary is treated as a historical export. The Markdown tree is
+canonical.
+
+## 3. Phases
+
+The loop runs through phases. Phases are not strict gates — later phases can
+revisit earlier ones — but each phase has a primary focus.
+
+### Phase 0 — Foundations and GDD completion
+- Verify all 28 GDD section files exist. Author missing files
+  (`18-sound-and-music-design.md` through `28-appendices-and-research-references.md`)
+  by drafting from the parent index and any cross-references, then flagging
+  unresolved sections for dev review.
+- Stand up the project skeleton described in
+  `21-technical-design-for-web-implementation.md`: Next.js + TypeScript app,
+  lint, type-check, unit-test, end-to-end harness, CI, and a deploy target.
+- Wire `PROGRESS_LOG.md`, `OPEN_QUESTIONS.md`, and `FOLLOWUPS.md` so every
+  later loop has a place to write.
+- Define the JSON schemas in `22-data-schemas.md` as TypeScript types and
+  runtime validators.
+
+### Phase 1 — Vertical slice (drivable road)
+- Pseudo-3D road renderer (Canvas2D) with one straight + one curve track.
+- Player car with arcade physics from `10-driving-model-and-physics.md`
+  (acceleration, top speed, steering, basic collision feedback).
+- Single AI car using the simplest opponent profile from
+  `15-cpu-opponents-and-ai.md`.
+- HUD with speed, lap, and position only.
+- Goal: a 30-second drive feels like the design pillars in
+  `01-title-and-high-concept.md`.
+
+### Phase 2 — Race rules and economy
+- Full race rules from `07-race-rules-and-structure.md` (countdown, laps,
+  placement, DNF rules).
+- Damage model from `13-damage-repairs-and-risk.md`.
+- Credits, repairs, and the upgrade categories from
+  `12-upgrade-and-economy-system.md`.
+- Garage flow from `05-core-gameplay-loop.md`.
+- Save / load from `21-technical-design-for-web-implementation.md` (local
+  storage MVP).
+
+### Phase 3 — World, tours, and content
+- Region and tour structure from `08-world-and-progression-design.md`.
+- Track authoring pipeline using the schema in `22-data-schemas.md`.
+- The track set required by `24-content-plan.md` for MVP.
+- Car set and stats from `11-cars-and-stats.md`.
+- Balancing pass against `23-balancing-tables.md`.
+
+### Phase 4 — Atmosphere and feel
+- Weather and environmental systems (`14-weather-and-environmental-systems.md`).
+- Sound and music (`18-sound-and-music-design.md`).
+- Visual polish from `16-rendering-and-visual-design.md` and `17-art-direction.md`.
+- HUD/UX polish from `20-hud-and-ui-ux.md`.
+
+### Phase 5 — Modes, modding, and stretch
+- Time trial, daily challenge, and any additional modes in `06-game-modes.md`.
+- Track editor and mod loading per `26-open-source-project-guidance.md`.
+- Optional ghost racing / leaderboard hooks.
+
+### Phase 6 — Hardening and release
+- Risks/mitigations sweep from `27-risks-and-mitigations.md`.
+- Cross-browser, performance, and accessibility verification.
+- Versioned release, changelog, and tagged deploy.
+
+## 4. The Loop
+
+Every iteration follows the same shape. A loop is a small, ship-shaped slice —
+typically 1–3 days of agent work, never more than what fits in a single PR.
+
+```text
+┌─ select slice ──────────────────────────────────────────┐
+│  pick the next item from the active phase               │
+│  scope it to one PR-sized change                        │
+│                                                         │
+├─ clarify ───────────────────────────────────────────────┤
+│  read the relevant GDD section(s) end to end            │
+│  if anything is ambiguous, write the question into      │
+│  OPEN_QUESTIONS.md and either:                          │
+│    - block the slice and pick another, or               │
+│    - proceed with a clearly-labelled assumption         │
+│                                                         │
+├─ implement ─────────────────────────────────────────────┤
+│  smallest change that satisfies the slice               │
+│  write or update tests alongside the code               │
+│                                                         │
+├─ verify ────────────────────────────────────────────────┤
+│  type-check, lint, unit, integration, e2e all green     │
+│  for UI/feel changes, run the dev server and exercise   │
+│  the feature in a browser; if the agent cannot drive a  │
+│  browser, say so and request human verification         │
+│                                                         │
+├─ clean and refactor ────────────────────────────────────┤
+│  remove dead code introduced by the slice               │
+│  extract only abstractions justified by ≥3 callers      │
+│  invoke /simplify (or equivalent reviewer) before push  │
+│                                                         │
+├─ document ──────────────────────────────────────────────┤
+│  append a PROGRESS_LOG.md entry (template in §6)        │
+│  move resolved items out of OPEN_QUESTIONS.md           │
+│  add any new followups to FOLLOWUPS.md                  │
+│  if implementation forced a GDD change, edit the GDD    │
+│  in the same PR and call it out in the log              │
+│                                                         │
+├─ push and deploy ───────────────────────────────────────┤
+│  commit, push the working branch, open/refresh PR       │
+│  wait for CI green; auto-deploy from main on merge      │
+│                                                         │
+└─ repeat ────────────────────────────────────────────────┘
+```
+
+The loop terminates only when:
+1. Every GDD section is marked `Implemented` in `PROGRESS_LOG.md`, **and**
+2. `FOLLOWUPS.md` contains no `must-fix-before-release` items, **and**
+3. A tagged release has deployed cleanly and a smoke test of the deployed game
+   passes.
+
+Until all three are true, the loop continues.
+
+## 5. Slice selection rules
+
+When picking the next slice the agent should prefer, in order:
+
+1. Anything blocking the current phase's primary focus.
+2. Anything that unblocks the most other slices (e.g. shared schemas, shared
+   rendering primitives).
+3. Items in `FOLLOWUPS.md` flagged `blocks-release`.
+4. Items that close `OPEN_QUESTIONS.md` entries the dev has answered.
+5. The next unimplemented item in GDD section order.
+
+Never pick a slice the agent does not fully understand from the GDD. File a
+question instead.
+
+## 6. PROGRESS_LOG.md entry template
+
+Every loop appends a single entry, newest at the top:
+
+```markdown
+## YYYY-MM-DD — Slice: <short title>
+
+**GDD sections touched:** §X.Y, §X.Z
+**Branch / PR:** <branch>, #<pr>
+**Status:** Implemented | Partial | Reverted
+
+### Done
+- bullet, bullet
+
+### Verified
+- how it was tested (unit/e2e/manual)
+
+### Decisions and assumptions
+- any judgement calls made when the GDD was silent
+
+### Followups created
+- link to FOLLOWUPS.md ids
+
+### GDD edits
+- list any GDD files modified in this PR and why
+```
+
+## 7. OPEN_QUESTIONS.md and FOLLOWUPS.md
+
+- `OPEN_QUESTIONS.md` holds anything blocked on dev input. Each entry has an id
+  (`Q-NNN`), the GDD reference, the question, the agent's recommended default,
+  and a status (`open`, `answered`, `obsolete`).
+- `FOLLOWUPS.md` holds known followup work that did not fit in the slice that
+  surfaced it. Each entry has an id (`F-NNN`), a one-line description, the
+  triggering loop, and a priority (`blocks-release`, `nice-to-have`, `polish`).
+
+Both files are append-mostly. Do not delete entries — mark them `answered`,
+`done`, or `obsolete` so the history is preserved.
+
+## 8. Definition of Done (per slice)
+
+A slice is done when **all** of the following hold:
+
+- [ ] Code compiles and type-checks cleanly.
+- [ ] Lint passes with no new warnings.
+- [ ] Unit tests for new logic exist and pass.
+- [ ] If the slice changes runtime behaviour, an integration or e2e test covers
+      the user-visible path.
+- [ ] If the slice changes UI/feel, the agent has either driven it in a browser
+      or explicitly flagged that it needs human verification in the log.
+- [ ] PROGRESS_LOG.md has a new entry.
+- [ ] OPEN_QUESTIONS.md and FOLLOWUPS.md reflect the new state.
+- [ ] CI is green on the PR.
+- [ ] Auto-deploy succeeds on merge to `main` and the deployed build still
+      boots to the title screen.
+
+## 9. Definition of Done (per phase)
+
+A phase is done when every GDD section primarily owned by that phase is marked
+`Implemented` in `PROGRESS_LOG.md`, the phase's gameplay goals are demonstrably
+met (link to a recorded session or a deployed build), and no `blocks-release`
+items remain that point at that phase.
+
+## 10. Living document
+
+This plan is itself subject to the loop. If the GDD changes, or a phase proves
+mis-scoped, edit this file in the same PR that motivates the change and note
+the edit in `PROGRESS_LOG.md`.

--- a/docs/OPEN_QUESTIONS.md
+++ b/docs/OPEN_QUESTIONS.md
@@ -1,0 +1,64 @@
+# Open Questions
+
+Questions the agent has paused on, awaiting dev input. Newest at the top.
+Each entry has an id (`Q-NNN`), a GDD reference, the question, options
+considered, the agent's recommended default, and a status.
+
+Statuses: `open`, `answered`, `obsolete`. Do not delete answered entries —
+they are part of the design history.
+
+---
+
+## Q-003 — Auto-deploy target
+
+**GDD reference:** §21 (not yet authored), §26
+**Status:** open
+**Asked in loop:** 2026-04-26
+
+**Question.** Where should `main` auto-deploy to? Options: Vercel (matches
+Next.js defaults), Cloudflare Pages, Netlify, GitHub Pages with a static
+export, or self-hosted.
+
+**Recommended default.** Vercel preview + production, free tier, configured
+via a `vercel.json` and a GitHub Action triggered on push to `main`. Easy to
+swap later because the app stays static-exportable.
+
+**Blocking?** Yes for `F-003`. Other slices can proceed without it.
+
+---
+
+## Q-002 — Licence choice
+
+**GDD reference:** §1 ("Code under a permissive open-source license. Assets
+under original permissive asset licenses."), §26
+**Status:** open
+**Asked in loop:** 2026-04-26
+
+**Question.** Which permissive licence for code (MIT vs Apache-2.0 vs BSD-2)
+and which for assets (CC0 vs CC-BY-4.0 vs CC-BY-SA-4.0)?
+
+**Recommended default.** MIT for code (broadest compatibility, simplest),
+CC-BY-4.0 for original assets (credit required, remix allowed). Add `LICENSE`
+and `ASSETS-LICENSE` files at repo root.
+
+**Blocking?** No for early implementation, yes before any public release.
+
+---
+
+## Q-001 — Section 21 stack confirmation
+
+**GDD reference:** §21 (file not yet authored)
+**Status:** open
+**Asked in loop:** 2026-04-26
+
+**Question.** `01-title-and-high-concept.md` says: "Reuse VibeRacer patterns:
+Next.js, React, TypeScript, custom math, Web Audio, local storage, schema
+validation, and automated tests." Should §21 simply codify that exact stack,
+or is anything intended to differ (e.g. SvelteKit, Vite, no React)?
+
+**Recommended default.** Codify exactly the stated stack: Next.js (App
+Router), React 18, TypeScript strict, Vitest for unit, Playwright for e2e,
+Zod for schema validation, Web Audio for sound, Canvas2D for the road
+renderer.
+
+**Blocking?** Yes for Phase 0 project skeleton (`F-002`).

--- a/docs/OPEN_QUESTIONS.md
+++ b/docs/OPEN_QUESTIONS.md
@@ -51,7 +51,7 @@ and `ASSETS-LICENSE` files at repo root.
 **Status:** open
 **Asked in loop:** 2026-04-26
 
-**Question.** `01-title-and-high-concept.md` says: "Reuse VibeRacer patterns:
+**Question.** [`docs/gdd/01-title-and-high-concept.md`](gdd/01-title-and-high-concept.md) says: "Reuse VibeRacer patterns:
 Next.js, React, TypeScript, custom math, Web Audio, local storage, schema
 validation, and automated tests." Should §21 simply codify that exact stack,
 or is anything intended to differ (e.g. SvelteKit, Vite, no React)?

--- a/docs/PROGRESS_LOG.md
+++ b/docs/PROGRESS_LOG.md
@@ -1,0 +1,44 @@
+# Progress Log
+
+Append a new entry at the **top** of this file at the end of every loop. Use
+the template from `IMPLEMENTATION_PLAN.md` §6. Never delete past entries —
+correct them by adding a new entry that references the old one.
+
+---
+
+## 2026-04-26 — Slice: Bootstrap implementation plan and working agreement
+
+**GDD sections touched:** none (meta)
+**Branch / PR:** `claude/gdd-implementation-plan-Z0cpN`, PR pending
+**Status:** Implemented
+
+### Done
+- Added `docs/IMPLEMENTATION_PLAN.md` describing phases, the per-loop
+  workflow, slice selection rules, definitions of done, and stopping
+  conditions.
+- Added `docs/WORKING_AGREEMENT.md` describing branching, commits, PRs,
+  auto-deploy expectations, verification rules, clarification protocol, and
+  risky-action gates.
+- Seeded `docs/PROGRESS_LOG.md`, `docs/OPEN_QUESTIONS.md`, and
+  `docs/FOLLOWUPS.md` so subsequent loops have a place to write.
+
+### Verified
+- Manual review of the four documents for internal consistency and against
+  `GDD.md` section list.
+
+### Decisions and assumptions
+- Treated `GDD.docx` as a historical artefact; Markdown is canonical.
+- Assumed Next.js + TypeScript + Canvas2D stack as implied by
+  `01-title-and-high-concept.md` and `21-technical-design-for-web-implementation.md`
+  (the latter is not yet authored — flagged as Q-001).
+- Chose squash-merge as the default merge strategy, reversible by dev request.
+
+### Followups created
+- F-001 Author the eleven missing GDD sections (18–28) before Phase 0 can
+  close.
+- F-002 Stand up the Next.js + TypeScript project skeleton with CI and a
+  deploy target.
+- F-003 Wire an auto-deploy pipeline from `main`.
+
+### GDD edits
+- None.

--- a/docs/WORKING_AGREEMENT.md
+++ b/docs/WORKING_AGREEMENT.md
@@ -18,10 +18,9 @@ build*; this agreement wins for *how to operate*.
 
 ## 2. Branching and pushing
 
-- Long-running implementation work happens on
-  `claude/gdd-implementation-plan-Z0cpN` and short-lived child branches off
-  `main` named `feat/<slice>`, `fix/<slice>`, `chore/<slice>`, or
-  `docs/<slice>`.
+- Implementation work happens on short-lived branches off `main` named
+  `feat/<slice>`, `fix/<slice>`, `chore/<slice>`, or `docs/<slice>`. One
+  branch per slice; delete after merge.
 - Never push directly to `main`. Always go through a PR.
 - Every push uses `git push -u origin <branch-name>`. On network failure, retry
   up to 4 times with exponential backoff (2s, 4s, 8s, 16s).
@@ -81,7 +80,7 @@ For every slice, before marking it done:
 - For physics, AI, or numeric systems, write a deterministic test that pins
   the behaviour. Floating-point comparisons use tolerances, not equality.
 - For data-driven content (tracks, cars, tours), validate against the schema
-  defined in `22-data-schemas.md` as part of CI.
+  defined in [`docs/gdd/22-data-schemas.md`](gdd/22-data-schemas.md) as part of CI.
 
 ## 7. Refactoring
 
@@ -108,8 +107,8 @@ The agent **must** stop and ask when:
 The agent **may** proceed with a labelled assumption when:
 
 - The GDD is silent but the choice is local, reversible, and low-stakes.
-- A reasonable default exists in `01-title-and-high-concept.md`'s pillars or
-  the cited research in `03-top-gear-2-research-summary.md`.
+- A reasonable default exists in [`docs/gdd/01-title-and-high-concept.md`](gdd/01-title-and-high-concept.md)'s pillars or
+  the cited research in [`docs/gdd/03-top-gear-2-research-summary.md`](gdd/03-top-gear-2-research-summary.md).
 
 How to ask:
 

--- a/docs/WORKING_AGREEMENT.md
+++ b/docs/WORKING_AGREEMENT.md
@@ -1,0 +1,179 @@
+# Agent Working Agreement
+
+This is the contract every agent (human or AI) follows while executing
+`IMPLEMENTATION_PLAN.md`. The plan says **what** to build; this file says
+**how to behave** while building it.
+
+If something here ever conflicts with the plan, the plan wins for *what to
+build*; this agreement wins for *how to operate*.
+
+---
+
+## 1. Source of truth
+
+- The Markdown GDD under `docs/gdd/` (and `GDD.md` index) is canonical.
+- `GDD.docx` is a historical artefact; do not edit it.
+- If code and GDD disagree, fix the disagreement explicitly: either change the
+  code or change the GDD, in the same PR, and note it in `PROGRESS_LOG.md`.
+
+## 2. Branching and pushing
+
+- Long-running implementation work happens on
+  `claude/gdd-implementation-plan-Z0cpN` and short-lived child branches off
+  `main` named `feat/<slice>`, `fix/<slice>`, `chore/<slice>`, or
+  `docs/<slice>`.
+- Never push directly to `main`. Always go through a PR.
+- Every push uses `git push -u origin <branch-name>`. On network failure, retry
+  up to 4 times with exponential backoff (2s, 4s, 8s, 16s).
+- Force-push only the agent's own short-lived feature branches, never `main`
+  or any branch with someone else's commits on it.
+
+## 3. Commits
+
+- One coherent change per commit. Prefer many small commits over one large one.
+- Commit message style:
+
+  ```
+  <type>(<area>): <imperative summary>
+
+  <why this change exists, not what it does>
+  ```
+
+  where `<type>` ∈ `feat`, `fix`, `chore`, `docs`, `refactor`, `test`, `perf`.
+- Never `--amend` a pushed commit. Create a new commit instead.
+- Never use `--no-verify` to bypass hooks. If a hook fails, fix the cause.
+
+## 4. PRs and review
+
+- Each slice gets one PR. PR title mirrors the slice title.
+- PR body includes:
+  - Link to the GDD section(s) implemented.
+  - Link to the matching `PROGRESS_LOG.md` entry.
+  - Test plan checklist.
+  - Any followups created and the ids they got in `FOLLOWUPS.md`.
+- Do not open a PR until CI would plausibly pass locally (type-check, lint,
+  tests).
+- Wait for CI to go green before merging. If CI fails, fix the cause; do not
+  retry the same red push hoping for a flake.
+- Squash-merge into `main` unless the slice deliberately benefits from
+  preserving history.
+
+## 5. Auto-deploy
+
+- `main` is the deploy branch. Every merge to `main` triggers an auto-deploy.
+- After merge, the agent must:
+  1. Watch the deploy job.
+  2. Hit the deployed URL and verify it loads to at least the title screen.
+  3. If the deploy or smoke test fails, the immediate next slice is a hotfix —
+     no new feature work until the deployed build is healthy again.
+- Treat a broken deploy on `main` as a P0. Roll forward with a fix; do not
+  revert unless rolling forward would take longer than reverting.
+
+## 6. Verification
+
+For every slice, before marking it done:
+
+- Run the project's lint, type-check, unit, and integration suites.
+- For features with a user-visible surface, run the dev server and exercise
+  the feature in a real browser. If the agent's environment cannot drive a
+  browser, say so explicitly in the log and request manual verification — do
+  not claim the UI works.
+- For physics, AI, or numeric systems, write a deterministic test that pins
+  the behaviour. Floating-point comparisons use tolerances, not equality.
+- For data-driven content (tracks, cars, tours), validate against the schema
+  defined in `22-data-schemas.md` as part of CI.
+
+## 7. Refactoring
+
+- Refactor *as part of* the slice that touches the code, not as a separate
+  invisible cleanup pass.
+- Allowed within a slice: rename, inline, extract, dedupe, reorder.
+- Not allowed within a slice: speculative abstractions, framework swaps, broad
+  reformatting unrelated to the change.
+- If a larger refactor is needed, open a `FOLLOWUPS.md` entry and a separate
+  PR.
+- Run `/simplify` (or the equivalent reviewer pass) on every slice before
+  pushing.
+
+## 8. Asking the dev for clarification
+
+The agent **must** stop and ask when:
+
+- The GDD is silent on a decision the agent cannot reverse cheaply (e.g. a
+  schema field name that will end up in saved data).
+- Two GDD sections contradict each other.
+- A balancing number would be guessed and downstream content depends on it.
+- A third-party dependency, paid service, or licence choice is required.
+
+The agent **may** proceed with a labelled assumption when:
+
+- The GDD is silent but the choice is local, reversible, and low-stakes.
+- A reasonable default exists in `01-title-and-high-concept.md`'s pillars or
+  the cited research in `03-top-gear-2-research-summary.md`.
+
+How to ask:
+
+1. Append a `Q-NNN` entry to `OPEN_QUESTIONS.md` with the GDD reference, the
+   question, options considered, and the agent's recommended default.
+2. If the slice can proceed under the recommended default, proceed and label
+   the assumption clearly in `PROGRESS_LOG.md`.
+3. If the slice cannot proceed, mark it blocked, pick a different slice, and
+   surface the question in the next PR description so the dev sees it.
+
+When the dev answers, mark the entry `answered`, link to the answering commit
+or comment, and (if needed) open a slice to apply the answer.
+
+## 9. Logging and continuity
+
+- Every loop appends to `PROGRESS_LOG.md` using the template in
+  `IMPLEMENTATION_PLAN.md` §6. Newest entries on top.
+- Never delete log entries. Correct mistakes by adding a new entry that
+  references the old one.
+- A new agent starting cold should be able to read, in order: `README.md`,
+  `IMPLEMENTATION_PLAN.md`, `WORKING_AGREEMENT.md`, the most recent dozen
+  `PROGRESS_LOG.md` entries, and `OPEN_QUESTIONS.md`, and have enough context
+  to pick the next slice. If that ever stops being true, fix the docs in the
+  next slice.
+
+## 10. Scope discipline
+
+- One slice = one PR-sized change. If the slice grows past that, split it.
+- Do not add features the GDD does not require.
+- Do not add error handling for cases the type system or callers already
+  prevent.
+- Do not add comments that restate the code. Comments are for the non-obvious
+  *why*.
+- Do not introduce backwards-compatibility shims for code that has no users
+  yet.
+
+## 11. Risky and irreversible actions
+
+Always confirm with the dev (via `OPEN_QUESTIONS.md` or PR comment) before:
+
+- Deleting branches or rewriting shared history.
+- Dropping or renaming persisted save fields.
+- Changing the licence, package name, or deploy target.
+- Adding paid third-party services or telemetry.
+- Publishing public assets (music, art) under a licence not already approved.
+
+For local, reversible work (file edits, local tests, branch creation on the
+agent's own branches) the agent does not need to ask.
+
+## 12. Stopping conditions
+
+The loop stops, and the agent reports completion, only when all three of:
+
+1. Every GDD section is `Implemented` in `PROGRESS_LOG.md`.
+2. `FOLLOWUPS.md` contains zero `blocks-release` items.
+3. A tagged release has deployed cleanly and the agent has smoke-tested the
+   deployed build.
+
+Short of that, the agent keeps looping — across days, weeks, or months — and
+treats every loop as the next move in a long game, not the last.
+
+## 13. Tone for log and PR text
+
+- Short, concrete, present tense.
+- Lead with what changed and why.
+- No marketing language. No emojis unless the dev asks.
+- Reference files as `path/to/file.ts:line` so the dev can click through.


### PR DESCRIPTION
Establishes the long-running, agent-executable workflow for turning the GDD
into a deployed game. The plan defines phases, the per-loop shape (select →
clarify → implement → verify → clean → document → push → deploy → repeat),
slice selection rules, and stopping conditions. The working agreement defines
branching, commits, PRs, verification gates, the clarification protocol, and
risky-action confirmations. Seeds PROGRESS_LOG, OPEN_QUESTIONS, and FOLLOWUPS
so subsequent loops have a place to write.