### PR TITLE
chore(licensing): finalise licence files

### DIFF
--- a/DATA-LICENSE
+++ b/DATA-LICENSE
@@ -1,0 +1,148 @@
+VibeGear2 data license declaration
+
+Scope. This file governs original structured game data shipped from this
+repository, including `src/data/**`, track JSON, championship JSON, balancing
+tables encoded as data, and future community mod data under `public/mods/**`.
+It does not govern source code, which is licensed separately under the MIT
+License declared in `LICENSE`, or original art and audio assets, which are
+licensed separately in `ASSETS-LICENSE`.
+
+Default license. Original track, championship, balancing, and community mod
+data in this repository are released under the Creative Commons
+Attribution-ShareAlike 4.0 International License (CC BY-SA 4.0), unless an
+individual data manifest declares a different compatible license.
+
+ShareAlike scope. When you adapt CC BY-SA 4.0 game data from this repository,
+the adapted material must be distributed under the same license. This is
+intentional: track layouts, championship structures, and community data should
+stay remixable for the project and its contributors.
+
+Attribution. When you reuse CC BY-SA 4.0 data from this repository, include
+the data id or file path, the project name (`VibeGear2`), and a link back to
+this repository. If the data file or manifest names a specific contributor,
+include that contributor in the attribution.
+
+Originality. Per GDD section 26, every shipped data file must be original work
+or correctly licensed work. Do not contribute real-world circuit copies,
+licensed car data, copied Top Gear 2 track layouts, or data generated from
+unlicensed sources.
+
+Full license texts.
+
+  CC BY-SA 4.0: https://creativecommons.org/licenses/by-sa/4.0/legalcode
+  CC BY 4.0:    https://creativecommons.org/licenses/by/4.0/legalcode
+  CC0 1.0:      https://creativecommons.org/publicdomain/zero/1.0/legalcode
+
+Creative Commons Attribution-ShareAlike 4.0 International (CC BY-SA 4.0)
+
+By exercising the Licensed Rights (defined below), You accept and agree to be
+bound by the terms and conditions of this Creative Commons Attribution-
+ShareAlike 4.0 International Public License ("Public License"). To the extent
+this Public License may be interpreted as a contract, You are granted the
+Licensed Rights in consideration of Your acceptance of these terms and
+conditions, and the Licensor grants You such rights in consideration of
+benefits the Licensor receives from making the Licensed Material available
+under these terms and conditions.
+
+Section 1. Definitions.
+
+  a. Adapted Material means material subject to Copyright and Similar Rights
+     that is derived from or based upon the Licensed Material and in which the
+     Licensed Material is translated, altered, arranged, transformed, or
+     otherwise modified in a manner requiring permission under the Copyright
+     and Similar Rights held by the Licensor. For purposes of this Public
+     License, where the Licensed Material is a musical work, performance, or
+     sound recording, Adapted Material is always produced where the Licensed
+     Material is synched in timed relation with a moving image.
+  b. Adapter's License means the license You apply to Your Copyright and
+     Similar Rights in Your contributions to Adapted Material in accordance
+     with the terms and conditions of this Public License.
+  c. BY-SA Compatible License means a license listed at
+     creativecommons.org/compatiblelicenses, approved by Creative Commons as
+     essentially the equivalent of this Public License.
+  d. Copyright and Similar Rights means copyright and/or similar rights
+     closely related to copyright including, without limitation, performance,
+     broadcast, sound recording, and Sui Generis Database Rights, without
+     regard to how the rights are labeled or categorized.
+  e. Licensed Material means the artistic or literary work, database, or
+     other material to which the Licensor applied this Public License.
+  f. Licensed Rights means the rights granted to You subject to the terms and
+     conditions of this Public License.
+  g. Licensor means the individual(s) or entity(ies) granting rights under
+     this Public License.
+  h. Share means to provide material to the public by any means or process
+     that requires permission under the Licensed Rights, including
+     reproduction, public display, public performance, distribution,
+     dissemination, communication, or importation, and to make material
+     available to the public including in ways that members of the public may
+     access the material from a place and at a time individually chosen by
+     them.
+  i. You means the individual or entity exercising the Licensed Rights under
+     this Public License. Your has a corresponding meaning.
+
+Section 2. Scope.
+
+  a. License grant. Subject to the terms and conditions of this Public
+     License, the Licensor hereby grants You a worldwide, royalty-free,
+     non-sublicensable, non-exclusive, irrevocable license to exercise the
+     Licensed Rights in the Licensed Material to:
+       1. reproduce and Share the Licensed Material, in whole or in part; and
+       2. produce, reproduce, and Share Adapted Material.
+  b. The Licensor waives and/or agrees not to assert any right or authority
+     to forbid You from making technical modifications necessary to exercise
+     the Licensed Rights, including technical modifications necessary to
+     circumvent Effective Technological Measures.
+
+Section 3. License Conditions.
+
+  Your exercise of the Licensed Rights is expressly made subject to the
+  following conditions.
+
+  a. Attribution. If You Share the Licensed Material, including in modified
+     form, You must retain identification of the creator(s), a copyright
+     notice, a notice that refers to this Public License, a notice that refers
+     to the disclaimer of warranties, and a URI or hyperlink to the Licensed
+     Material to the extent reasonably practicable.
+  b. ShareAlike. In addition to the conditions in Section 3(a), if You Share
+     Adapted Material You produce, the Adapter's License You apply must be a
+     Creative Commons license with the same License Elements, this version or
+     later, or a BY-SA Compatible License.
+
+Section 4. Sui Generis Database Rights.
+
+  Where the Licensed Rights include Sui Generis Database Rights that apply to
+  Your use of the Licensed Material, You may extract, reuse, reproduce, and
+  Share all or a substantial portion of the contents of the database, and if
+  You include all or a substantial portion of the database contents in a
+  database in which You have Sui Generis Database Rights, then the database in
+  which You have Sui Generis Database Rights is Adapted Material.
+
+Section 5. Disclaimer of Warranties and Limitation of Liability.
+
+  Unless otherwise separately undertaken by the Licensor, to the extent
+  possible, the Licensor offers the Licensed Material as-is and as-available,
+  and makes no representations or warranties of any kind concerning the
+  Licensed Material, whether express, implied, statutory, or other. This
+  includes, without limitation, warranties of title, merchantability, fitness
+  for a particular purpose, non-infringement, absence of latent or other
+  defects, accuracy, or the presence or absence of errors, whether or not
+  known or discoverable.
+
+  To the extent possible, in no event will the Licensor be liable to You on
+  any legal theory or otherwise for any direct, special, indirect, incidental,
+  consequential, punitive, exemplary, or other losses, costs, expenses, or
+  damages arising out of this Public License or use of the Licensed Material,
+  even if the Licensor has been advised of the possibility of such losses,
+  costs, expenses, or damages.
+
+Section 6. Term and Termination.
+
+  This Public License applies for the term of the Copyright and Similar Rights
+  licensed here. However, if You fail to comply with this Public License, then
+  Your rights under this Public License terminate automatically. Where Your
+  right to use the Licensed Material has terminated, it reinstates
+  automatically as of the date the violation is cured, provided it is cured
+  within 30 days of Your discovery of the violation.
+
+For the canonical legal text and additional sections, see
+https://creativecommons.org/licenses/by-sa/4.0/legalcode.

--- a/README.md
+++ b/README.md
@@ -30,6 +30,20 @@ npm run build        # production build
 - `src/render/` Canvas2D renderer, sprite atlas, HUD overlay.
 - `docs/` GDD, implementation plan, working agreement, and per-loop logs.
 
+## Licensing
+
+VibeGear2 uses separate licenses for code, original assets, and structured
+game data:
+
+- Source code is licensed under MIT. See [`LICENSE`](LICENSE).
+- Original art, sprites, sound effects, music, and asset manifests default to
+  CC BY 4.0. See [`ASSETS-LICENSE`](ASSETS-LICENSE).
+- Track, championship, balancing, and community mod data default to
+  CC BY-SA 4.0. See [`DATA-LICENSE`](DATA-LICENSE).
+
+The asymmetry is intentional: code stays permissive, original media preserves
+attribution, and community track or data remixes stay share-alike.
+
 ## Deploy
 
 `main` deploys to Vercel Hobby (region `iad1`) via GitHub Actions. Every push

--- a/docs/LEGAL_SAFETY.md
+++ b/docs/LEGAL_SAFETY.md
@@ -20,9 +20,8 @@ This document complements the licence files:
 - [`LICENSE`](../LICENSE) (MIT) for source code.
 - [`ASSETS-LICENSE`](../ASSETS-LICENSE) (CC BY 4.0 default) for original art,
   sprites, sound effects, and music.
-- `DATA-LICENSE` (CC BY-SA 4.0 default) for track and community data when
-  that file lands in the licence-files slice; until then, track JSON contributed
-  to this repository is licensed CC BY-SA 4.0 by convention per GDD section 26.
+- [`DATA-LICENSE`](../DATA-LICENSE) (CC BY-SA 4.0 default) for track,
+  championship, balancing, and community mod data.
 
 ## 2. The IP perimeter (binding)
 

--- a/docs/OPEN_QUESTIONS.md
+++ b/docs/OPEN_QUESTIONS.md
@@ -418,17 +418,18 @@ CC-BY-4.0 for original assets (credit required, remix allowed). Add `LICENSE`
 and `ASSETS-LICENSE` files at repo root.
 
 **Resolution.** Adopted the recommended defaults. Code is licensed under
-MIT (`LICENSE` at repo root, sibling chore slice). Original art, sound
-effects, and music ship under CC-BY-4.0 by default. Track and community
-data ship under CC-BY-SA-4.0 per GDD section 26 ("Suggested licenses"
-table). Public-domain (`CC0-1.0` or `public-domain`) is permitted on a
-per-entry basis for contributed assets that arrive with that grant.
-Implemented by `feat/assets-license`: `ASSETS-LICENSE` at repo root with
-the CC BY 4.0 text and the per-entry licence taxonomy,
-`AssetEntry.license` required on every manifest entry,
-`assertManifestLicenses` runtime guard for the future mod loader,
-default licences encoded in `DEFAULT_ASSET_LICENSES` in
-`src/asset/manifest.ts`, and unit tests that pin the contract.
+MIT (`LICENSE` at repo root, `package.json` license field). Original art,
+sound effects, and music ship under CC-BY-4.0 by default via
+`ASSETS-LICENSE`. Track, championship, balancing, and community mod data
+ship under CC-BY-SA-4.0 via `DATA-LICENSE` per GDD section 26
+("Suggested licenses" table). Public-domain (`CC0-1.0` or
+`public-domain`) is permitted on a per-entry basis for contributed assets
+that arrive with that grant. Implemented by `feat/assets-license` and
+`feat/licence-files-finalisation-loop`: `AssetEntry.license` is required
+on every manifest entry, `assertManifestLicenses` guards future mod
+loading, default licences are encoded in `DEFAULT_ASSET_LICENSES` in
+`src/asset/manifest.ts`, README links the three root license files, and
+unit tests pin the manifest contract.
 
 **Blocking?** No for early implementation, yes before any public release.
 Resolved.

--- a/docs/PROGRESS_LOG.md
+++ b/docs/PROGRESS_LOG.md
@@ -6,6 +6,44 @@ Correct them by adding a new entry that references the old one.
 
 ---
 
+## 2026-04-26: Slice: Licence files finalisation
+
+**GDD sections touched:**
+[§26](gdd/26-open-source-project-guidance.md) "Suggested licenses",
+[§27](gdd/27-risks-and-mitigations.md) legal/IP safety risks.
+**Branch / PR:** `feat/licence-files-finalisation-loop`, PR pending.
+**Status:** Implemented.
+
+### Done
+- `DATA-LICENSE`: added the CC BY-SA 4.0 data licence declaration for
+  track, championship, balancing, and community mod data.
+- `package.json`: added `"license": "MIT"`.
+- `README.md`: added a Licensing section linking `LICENSE`,
+  `ASSETS-LICENSE`, and `DATA-LICENSE`.
+- `docs/OPEN_QUESTIONS.md`: updated Q-002 resolution to cite the
+  completed root licence files and package metadata.
+- `docs/LEGAL_SAFETY.md`: replaced the temporary DATA-LICENSE note
+  with a direct link to the landed file.
+
+### Verified
+- `grep -rn $'\u2014\|\u2013' LICENSE ASSETS-LICENSE DATA-LICENSE README.md docs/OPEN_QUESTIONS.md docs/LEGAL_SAFETY.md docs/PROGRESS_LOG.md package.json`
+  returned no hits.
+- `npm run verify` clean: lint, typecheck, unit tests, and
+  content-lint all passed.
+- `git diff --check` clean.
+
+### Decisions and assumptions
+- Preserved the existing Q-002 licence split: MIT for code, CC BY 4.0
+  for original media assets, and CC BY-SA 4.0 for structured game data.
+
+### Followups created
+None.
+
+### GDD edits
+None. The implementation matches the existing §26 licence table.
+
+---
+
 ## 2026-04-26: Slice: Main CI mobile browser fix
 
 **GDD sections touched:**

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "vibegear2",
   "version": "0.0.0",
   "private": true,
+  "license": "MIT",
   "description": "Open source spiritual successor to Top Gear 2",
   "scripts": {
     "dev": "next dev",


### PR DESCRIPTION
## Summary
- Add DATA-LICENSE for original structured game data.
- Declare package MIT licensing and document code, data, art, and generated asset licensing.
- Mark Q-002 answered and log the slice.

## GDD
- docs/gdd/26-legal-and-safety.md

## Progress Log
- docs/PROGRESS_LOG.md licence files finalisation loop entry

## Test Plan
- npm run verify
- git diff --check
- grep -rn U+2014/U+2013 scan