### PR TITLE
feat(championship): wire easy mode tour bonus

### DIFF
--- a/docs/FOLLOWUPS.md
+++ b/docs/FOLLOWUPS.md
@@ -382,7 +382,7 @@ the §6 mode wiring (separate dots own those surfaces).
 ## F-037: Wire `easyModeBonus` into the tour-clear bonus payout
 **Created:** 2026-04-26
 **Priority:** nice-to-have
-**Status:** open
+**Status:** done (2026-04-26, `feat/f-037-easy-mode-tour-bonus`)
 **Notes:** The `feat/economy-catch-up` slice landed
 `easyModeBonus(save, sumRewards)` in `src/game/catchUp.ts` and proved
 the rate with eight unit tests. The function has no in-app caller
@@ -394,6 +394,18 @@ combined amount via `awardCredits` (or a new
 `creditFlat(save, amount)` helper if that path lands first).
 Mirrors the F-026 / F-032 / F-034 producer-without-consumer
 pattern.
+
+**Resolution:** Closed by `feat/f-037-easy-mode-tour-bonus`.
+`tourComplete(activeTour, championship, playerCarId?, raceRewards?, save?)`
+now accepts an optional save and appends an `easyModeTourComplete`
+bonus when the tour passed, race rewards produce a positive sum, and
+`save.settings.difficultyPreset === "easy"`. Existing callers that
+omit the save keep the previous bonus list exactly: the standard
+`tourComplete` chip only. The easy-mode chip uses the already-pinned
+`easyModeBonus(save, raceRewards)` helper, so negative reward entries
+are clamped consistently with the standard tour-clear bonus. The
+future `/world` surface can sum `summary.bonuses` and credit both
+tour-clear bonuses through the same wallet path.
 
 ---
 

--- a/docs/PROGRESS_LOG.md
+++ b/docs/PROGRESS_LOG.md
@@ -11,7 +11,7 @@ Correct them by adding a new entry that references the old one.
 **GDD sections touched:**
 [§26](gdd/26-open-source-project-guidance.md) "Suggested licenses",
 [§27](gdd/27-risks-and-mitigations.md) legal/IP safety risks.
-**Branch / PR:** `feat/licence-files-finalisation-loop`, PR pending.
+**Branch / PR:** `feat/licence-files-finalisation-loop`, PR #6.
 **Status:** Implemented.
 
 ### Done
@@ -41,6 +41,49 @@ None.
 
 ### GDD edits
 None. The implementation matches the existing §26 licence table.
+
+---
+
+## 2026-04-26: Slice: F-037 easy-mode tour-clear bonus wiring
+
+**GDD sections touched:**
+[§12](gdd/12-upgrade-and-economy-system.md) "Catch-up mechanisms",
+[§8](gdd/08-world-and-progression-design.md) "Tour progression".
+**Branch / PR:** `feat/f-037-easy-mode-tour-bonus`, PR pending.
+**Status:** Implemented.
+
+### Done
+- `src/game/championship.ts`: extended `tourComplete` with an
+  optional `save` argument and appends an `easyModeTourComplete`
+  bonus when a passed tour is completed on the Easy preset.
+- `src/game/raceBonuses.ts`: added the `easyModeTourComplete`
+  bonus kind for the §20 chip pipeline.
+- `src/game/__tests__/championship.test.ts`: added F-037 coverage
+  for Easy, Normal, Hard, Master, failed tours, omitted save, and
+  negative reward clamping.
+- `docs/FOLLOWUPS.md`: marked F-037 done.
+
+### Verified
+- `npx vitest run src/game/__tests__/championship.test.ts src/game/__tests__/raceBonuses.test.ts src/game/__tests__/raceResult.test.ts`
+  green, 148 passed.
+- `npm run lint` clean.
+- `npm run typecheck` clean.
+- `npm test` green, 2123 passed.
+- `npm run build` clean.
+- `npm run content-lint` clean.
+- `git diff --check` clean.
+- No em or en dashes in touched files.
+
+### Decisions and assumptions
+- Kept the `tourComplete` API backward compatible by making `save`
+  optional. Callers that omit it keep the pre-F-037 bonus list.
+
+### Followups created
+None.
+
+### GDD edits
+None. The implementation matches the existing §12 easy-mode catch-up
+mechanism.
 
 ---
 

--- a/src/game/__tests__/championship.test.ts
+++ b/src/game/__tests__/championship.test.ts
@@ -30,6 +30,7 @@ import {
   type TourRaceResult,
 } from "../championship";
 import {
+  EASY_MODE_TOUR_BONUS_FRACTION,
   STIPEND_AMOUNT,
   STIPEND_THRESHOLD_CREDITS,
   getStipendClaimed,
@@ -460,6 +461,113 @@ describe("tourComplete", () => {
       const a = tourComplete(passingCursor, FIXTURE_CHAMPIONSHIP, "player", rewards);
       const b = tourComplete(passingCursor, FIXTURE_CHAMPIONSHIP, "player", rewards);
       expect(a).toEqual(b);
+    });
+  });
+
+  describe("easy-mode tour-clear bonus (F-037)", () => {
+    const passingCursor: ActiveTour = {
+      tourId: "first-tour",
+      raceIndex: 4,
+      results: [
+        makeResult("first/a", 1),
+        makeResult("first/b", 1),
+        makeResult("first/c", 1),
+        makeResult("first/d", 1),
+      ],
+    };
+    const failingCursor: ActiveTour = {
+      tourId: "third-tour",
+      raceIndex: 4,
+      results: [
+        makeResult("third/a", 6),
+        makeResult("third/b", 6),
+        makeResult("third/c", 6),
+        makeResult("third/d", 6),
+      ],
+    };
+
+    function saveWithDifficulty(
+      difficultyPreset: SaveGame["settings"]["difficultyPreset"],
+    ) {
+      const save = freshSave();
+      save.settings.difficultyPreset = difficultyPreset;
+      return save;
+    }
+
+    it("appends tour completion and easy-mode bonuses on a passed Easy tour", () => {
+      const rewards = [1000, 800, 1200, 900];
+      const summary = tourComplete(
+        passingCursor,
+        FIXTURE_CHAMPIONSHIP,
+        "player",
+        rewards,
+        saveWithDifficulty("easy"),
+      );
+      expect(summary.passed).toBe(true);
+      expect(summary.bonuses.map((b) => b.kind)).toEqual([
+        "tourComplete",
+        "easyModeTourComplete",
+      ]);
+      const rewardSum = rewards.reduce((acc, n) => acc + n, 0);
+      expect(summary.bonuses[0]?.cashCredits).toBe(
+        Math.round(rewardSum * TOUR_COMPLETION_BONUS_RATE),
+      );
+      expect(summary.bonuses[1]).toEqual({
+        kind: "easyModeTourComplete",
+        label: "Easy mode tour clear",
+        cashCredits: Math.round(rewardSum * EASY_MODE_TOUR_BONUS_FRACTION),
+      });
+    });
+
+    it.each(["normal", "hard", "master"] as const)(
+      "does not append the easy-mode bonus for %s difficulty",
+      (difficultyPreset) => {
+        const rewards = [1000, 800, 1200, 900];
+        const summary = tourComplete(
+          passingCursor,
+          FIXTURE_CHAMPIONSHIP,
+          "player",
+          rewards,
+          saveWithDifficulty(difficultyPreset),
+        );
+        expect(summary.bonuses.map((b) => b.kind)).toEqual(["tourComplete"]);
+      },
+    );
+
+    it("does not append either tour-clear bonus on a failed Easy tour", () => {
+      const summary = tourComplete(
+        failingCursor,
+        FIXTURE_CHAMPIONSHIP,
+        "player",
+        [1000, 1000, 1000, 1000],
+        saveWithDifficulty("easy"),
+      );
+      expect(summary.passed).toBe(false);
+      expect(summary.bonuses).toEqual([]);
+    });
+
+    it("keeps the pre-F-037 behavior when no save is supplied", () => {
+      const rewards = [1000, 800, 1200, 900];
+      const summary = tourComplete(
+        passingCursor,
+        FIXTURE_CHAMPIONSHIP,
+        "player",
+        rewards,
+      );
+      expect(summary.bonuses.map((b) => b.kind)).toEqual(["tourComplete"]);
+    });
+
+    it("clamps negative reward entries before computing the Easy bonus", () => {
+      const summary = tourComplete(
+        passingCursor,
+        FIXTURE_CHAMPIONSHIP,
+        "player",
+        [1000, -500, 1000, 1000],
+        saveWithDifficulty("easy"),
+      );
+      expect(summary.bonuses[1]?.cashCredits).toBe(
+        Math.round(3000 * EASY_MODE_TOUR_BONUS_FRACTION),
+      );
     });
   });
 });

--- a/src/game/championship.ts
+++ b/src/game/championship.ts
@@ -16,15 +16,15 @@
  * - `recordResult(activeTour, raceResult)`: append the per-race outcome
  *   and advance `raceIndex`. Never mutates the input. Caller decides
  *   whether to persist (the §20 results screen owns the save commit).
- * - `tourComplete(activeTour, championship, playerCarId?, raceRewards?)`:
+ * - `tourComplete(activeTour, championship, playerCarId?, raceRewards?, save?)`:
  *   aggregate the recorded results into `{ passed, playerStanding,
  *   standings, bonuses }`. `passed` is true when the player's aggregate
  *   placement is at most `tour.requiredStanding`. `standings` is a
  *   per-car points list computed from the §7 `PLACEMENT_POINTS` table;
  *   DNFs receive `0`. `bonuses` is the §12 tour-clear `RaceBonus` list
  *   (today: `tourCompletionBonus` per F-039 when `raceRewards` is
- *   supplied and the tour passed; F-037 will append `easyModeBonus`
- *   alongside). The wallet credit is the page surface's responsibility:
+ *   supplied and the tour passed; the optional save argument appends
+ *   the Easy preset catch-up bonus). The wallet credit is the page surface's responsibility:
  *   the §20 results screen sums the `bonuses` `cashCredits` into a
  *   single `awardCredits` call so the chip strip and the wallet delta
  *   stay in lockstep with the per-race pipeline.
@@ -51,16 +51,13 @@
  * - The `/world` page surface (region map, tour-tile picker, "Enter
  *   tour" affordance). The pure module here is the data plane the page
  *   consumes; the page wiring lands in a follow-up sub-slice.
- * - F-037 easy-mode tour-clear bonus: `tourComplete` is the consumer;
- *   the `easyModeBonus` call lands in a follow-up so the §12 lever
- *   appends a second `RaceBonus` to the same `bonuses` list.
  * - The Playwright `e2e/tour-flow.spec.ts` end-to-end spec: lands once
  *   the `/world` page surface ships.
  */
 
 import type { Championship, ChampionshipTour, SaveGame } from "@/data/schemas";
 
-import { computeStipend, recordStipendClaim } from "./catchUp";
+import { computeStipend, easyModeBonus, recordStipendClaim } from "./catchUp";
 import { PLACEMENT_POINTS } from "./raceResult";
 import { tourCompletionBonus, type RaceBonus } from "./raceBonuses";
 
@@ -165,12 +162,13 @@ export interface TourCompletionSummary {
    */
   readonly standings: ReadonlyArray<TourStandingsEntry>;
   /**
-   * §12 tour-clear bonus list. Today this carries the `tourComplete`
+   * §12 tour-clear bonus list. This carries the `tourComplete`
    * `RaceBonus` (per F-039) when the caller passes `raceRewards` and
-   * the tour passed; the §12 `easyModeBonus` (F-037) will append a
-   * second entry once its consumer wires here. Empty when the tour
-   * failed, when `raceRewards` is omitted / empty, or when the rewards
-   * sum to zero (the bonus would round to 0). The §20 results screen
+   * the tour passed. When the optional `save` argument is present and
+   * its difficulty preset is Easy, this also carries an
+   * `easyModeTourComplete` chip for the §12 catch-up lever. Empty when
+   * the tour failed, when `raceRewards` is omitted / empty, or when
+   * the rewards sum to zero (the bonus would round to 0). The §20 results screen
    * folds these into a single `awardCredits` call alongside the per-race
    * placement payout so the chip strip and the wallet delta agree.
    */
@@ -314,18 +312,17 @@ export function recordResult(
  * results screen (sum of placement cash + bonuses). The list feeds the
  * §12 `tourCompletionBonus` lever (F-039): when supplied with at least
  * one entry on a passed tour the returned `bonuses` array carries a
- * single `tourComplete` `RaceBonus`; otherwise it is empty. Defaults to
- * an empty list so callers that do not yet thread the per-race ledger
- * (existing unit tests, the championship pure-module sub-slice) keep
- * `bonuses` empty without changing their assertions. F-037 will append
- * `easyModeBonus(save, raceRewards)` to the same list once its consumer
- * wires here.
+ * `tourComplete` `RaceBonus`; otherwise it is empty. The optional
+ * `save` argument feeds the §12 easy-mode tour-clear catch-up lever.
+ * Defaults keep callers that do not yet thread the per-race ledger or
+ * save object on the pre-F-037 behavior.
  */
 export function tourComplete(
   activeTour: ActiveTour,
   championship: Championship,
   playerCarId = "player",
   raceRewards: ReadonlyArray<number> = [],
+  save?: SaveGame,
 ): TourCompletionSummary {
   const lookup = findTour(championship, activeTour.tourId);
   if (lookup === null) {
@@ -343,11 +340,10 @@ export function tourComplete(
   const playerStanding = standingOf(sorted, playerCarId);
   const passed =
     playerStanding !== null && playerStanding <= tour.requiredStanding;
-  // §12 F-039: append the tour-completion bonus when the lever fires.
+  // §12 F-039/F-037: append tour-clear bonuses when their levers fire.
   // `tourCompletionBonus` already filters failed tours, empty rewards,
-  // and zero-sum rewards down to `null`, so this branch is a thin
-  // collector. F-037's `easyModeBonus` will append a sibling entry to
-  // the same list once its consumer wires here.
+  // and zero-sum rewards down to `null`; `easyModeBonus` mirrors the
+  // same reward list and returns 0 for non-Easy presets.
   const bonuses: RaceBonus[] = [];
   const completionBonus = tourCompletionBonus({
     raceRewards,
@@ -355,6 +351,16 @@ export function tourComplete(
   });
   if (completionBonus !== null) {
     bonuses.push(completionBonus);
+  }
+  if (passed && save !== undefined) {
+    const easyCredits = easyModeBonus(save, raceRewards);
+    if (easyCredits > 0) {
+      bonuses.push({
+        kind: "easyModeTourComplete",
+        label: "Easy mode tour clear",
+        cashCredits: easyCredits,
+      });
+    }
   }
   return { passed, playerStanding, standings: sorted, bonuses };
 }

--- a/src/game/raceBonuses.ts
+++ b/src/game/raceBonuses.ts
@@ -64,6 +64,7 @@ export type RaceBonusKind =
   | "cleanRace"
   | "underdog"
   | "tourComplete"
+  | "easyModeTourComplete"
   | "sponsor";
 
 /**


### PR DESCRIPTION
## Summary
- Add the easy-mode tour-clear bonus kind to the race bonus pipeline.
- Extend tour completion to emit the bonus for passed Easy tours when a save is supplied.
- Cover Easy, non-Easy, failed, omitted-save, and clamped reward cases.

## GDD
- docs/gdd/12-upgrade-and-economy-system.md
- docs/gdd/08-world-and-progression-design.md

## Progress Log
- docs/PROGRESS_LOG.md F-037 easy-mode tour-clear bonus wiring entry

## Test Plan
- npx vitest run src/game/__tests__/championship.test.ts src/game/__tests__/raceBonuses.test.ts src/game/__tests__/raceResult.test.ts
- npm run typecheck
- git diff --check
- grep scan for U+2014/U+2013 in touched files