### PR TITLE
feat(time-trial): wire ghost consumer

### DIFF
--- a/docs/FOLLOWUPS.md
+++ b/docs/FOLLOWUPS.md
@@ -834,7 +834,7 @@ F-021 / F-022 producer-then-consumer split around the ghost slice).
 ## F-022: Render the ghost car in `pseudoRoadCanvas.ts`
 **Created:** 2026-04-26
 **Priority:** nice-to-have
-**Status:** in-progress (drawer side landed in `feat/f-022-ghost-car-render`)
+**Status:** done (2026-04-26, `feat/f-022-time-trial-ghost-consumer`)
 **Notes:** The ghost slice produces a `Player` whose `readNext(tick)`
 returns the input the recorded driver pressed on each tick. The
 consumer drives a second physics step from those inputs (same
@@ -935,6 +935,18 @@ into the renderer for the live player car (currently the live car is
 also a placeholder; both upgrades land together). Until then the
 `fill` override on the prop lets the consumer pin a per-car tint without
 touching the renderer.
+
+**Resolution:** Closed by `feat/f-022-time-trial-ghost-consumer`.
+The race shell now supports `?mode=timeTrial`, and `/time-trial`
+redirects into that mode. Time Trial sessions create a
+`createGhostDriver` from `save.ghosts[track.id]`, advance the driver
+once per simulation tick, and pass the resulting `ghostCar` overlay to
+`drawRoad`. The same mode wires `createTimeTrialRecorder` to the
+post-step race-session tick stream and persists a faster PB through
+`applyTimeTrialResult` + `saveSave` when the recorder finalises.
+Time Trial finishes skip economy credit commits so the ghost write is
+not overwritten by a stale race-reward save. The title screen now
+links to `/time-trial`.
 
 ## F-021: SaveGameSchema integration for ghost replays + v3 migration
 **Created:** 2026-04-26

--- a/docs/PROGRESS_LOG.md
+++ b/docs/PROGRESS_LOG.md
@@ -6,6 +6,61 @@ Correct them by adding a new entry that references the old one.
 
 ---
 
+## 2026-04-26: Slice: F-022 Time Trial ghost consumer
+
+**GDD sections touched:**
+[§6](gdd/06-game-modes.md) "Time trial",
+[§20](gdd/20-hud-and-ui-ux.md) race HUD and title navigation,
+[§22](gdd/22-data-schemas.md) "Ghost replay".
+**Branch / PR:** `feat/f-022-time-trial-ghost-consumer`, PR pending.
+**Status:** Implemented.
+
+### Done
+- `src/app/race/page.tsx`: added `?mode=timeTrial` support, saved
+  ghost playback via `createGhostDriver`, recorder persistence via
+  `createTimeTrialRecorder` and `applyTimeTrialResult`, and a
+  `data-mode` hook for browser verification.
+- `src/app/race/page.tsx`: review fix reloads the latest save before
+  committing a new time-trial ghost, preserving unrelated save changes
+  and letting same-page restarts consume the new personal best.
+- `src/app/time-trial/page.tsx`: added a route that enters the race
+  shell in Time Trial mode.
+- `src/app/page.tsx`: added a Time Trial menu entry.
+- `src/game/index.ts`: exported the Time Trial helper module from the
+  game barrel.
+- `src/app/__tests__/page.test.tsx` and `e2e/title-screen.spec.ts`:
+  covered the new title menu entry and Time Trial navigation.
+- `docs/FOLLOWUPS.md`: marked F-022 done.
+
+### Verified
+- `grep -rn $'\u2014\|\u2013' src/app/race/page.tsx src/app/time-trial/page.tsx src/app/page.tsx src/app/__tests__/page.test.tsx e2e/title-screen.spec.ts src/game/index.ts docs/FOLLOWUPS.md docs/PROGRESS_LOG.md`
+  returned no hits.
+- `npx vitest run src/app/__tests__/page.test.tsx src/game/__tests__/timeTrial.test.ts src/game/__tests__/ghostDriver.test.ts`
+  green, 38 passed.
+- `npm run lint` clean.
+- `npm run typecheck` clean.
+- `npm test` green, 2117 passed.
+- `npm run content-lint` clean.
+- `npm run build` clean.
+- `npm run test:e2e -- e2e/title-screen.spec.ts` green, 5 passed.
+- `git diff --check` clean.
+
+### Decisions and assumptions
+- Time Trial mode skips economy credit persistence on finish so the
+  ghost PB write cannot be overwritten by the normal race reward save.
+- The `/time-trial` route redirects to `/race?mode=timeTrial` to keep
+  the race shell single-owner until the broader mode-selection UI
+  lands.
+
+### Followups created
+None.
+
+### GDD edits
+None. The implementation matches the existing §6 and §22 ghost replay
+contracts.
+
+---
+
 ## 2026-04-26: Slice: Licence files finalisation
 
 **GDD sections touched:**
@@ -49,7 +104,7 @@ None. The implementation matches the existing §26 licence table.
 **GDD sections touched:**
 [§12](gdd/12-upgrade-and-economy-system.md) "Catch-up mechanisms",
 [§8](gdd/08-world-and-progression-design.md) "Tour progression".
-**Branch / PR:** `feat/f-037-easy-mode-tour-bonus`, PR pending.
+**Branch / PR:** `feat/f-037-easy-mode-tour-bonus`, PR #7.
 **Status:** Implemented.
 
 ### Done

--- a/e2e/title-screen.spec.ts
+++ b/e2e/title-screen.spec.ts
@@ -15,6 +15,11 @@ test.describe("title screen", () => {
     await expect(startRace).toHaveText("Start Race");
     await expect(startRace).toHaveAttribute("href", "/race");
 
+    const timeTrial = page.getByTestId("menu-time-trial");
+    await expect(timeTrial).toBeVisible();
+    await expect(timeTrial).toHaveText("Time Trial");
+    await expect(timeTrial).toHaveAttribute("href", "/time-trial");
+
     const garage = page.getByTestId("menu-garage");
     await expect(garage).toBeVisible();
     await expect(garage).toHaveText("Garage");
@@ -38,6 +43,16 @@ test.describe("title screen", () => {
     await page.goto("/");
     await page.getByTestId("menu-garage").click();
     await expect(page).toHaveURL(/\/garage\/cars$/);
+  });
+
+  test("Time Trial link navigates to time-trial race mode", async ({ page }) => {
+    await page.goto("/");
+    await page.getByTestId("menu-time-trial").click();
+    await expect(page).toHaveURL(/\/race\?mode=timeTrial$/);
+    await expect(page.getByTestId("race-canvas")).toHaveAttribute(
+      "data-mode",
+      "timeTrial",
+    );
   });
 
   test("Options link navigates to /options", async ({ page }) => {

--- a/src/app/__tests__/page.test.tsx
+++ b/src/app/__tests__/page.test.tsx
@@ -5,7 +5,7 @@ import { renderToStaticMarkup } from "react-dom/server";
 import TitlePage from "../page";
 
 /**
- * Title-screen menu wiring (GDD §5, §20). Asserts the three menu items
+ * Title-screen menu wiring (GDD §5, §20). Asserts the main menu items
  * render with the expected hrefs (or pending state for Options) and
  * keep the data-testid hooks the e2e smoke spec depends on.
  *
@@ -32,6 +32,12 @@ describe("TitlePage", () => {
     expect(match?.[0]).toContain('href="/race"');
   });
 
+  it("renders Time Trial as an anchor pointing at /time-trial", () => {
+    const match = html.match(/<a[^>]*data-testid="menu-time-trial"[^>]*>/);
+    expect(match, "menu-time-trial anchor not found").not.toBeNull();
+    expect(match?.[0]).toContain('href="/time-trial"');
+  });
+
   it("renders Garage as an anchor pointing at /garage/cars", () => {
     const match = html.match(/<a[^>]*data-testid="menu-garage"[^>]*>/);
     expect(match, "menu-garage anchor not found").not.toBeNull();
@@ -44,12 +50,14 @@ describe("TitlePage", () => {
     expect(match?.[0]).toContain('href="/options"');
   });
 
-  it("places Start Race before Garage before Options in tab order", () => {
+  it("places Start Race before Time Trial before Garage before Options in tab order", () => {
     const startIdx = html.indexOf('data-testid="menu-start-race"');
+    const timeTrialIdx = html.indexOf('data-testid="menu-time-trial"');
     const garageIdx = html.indexOf('data-testid="menu-garage"');
     const optionsIdx = html.indexOf('data-testid="menu-options"');
     expect(startIdx).toBeGreaterThan(-1);
-    expect(garageIdx).toBeGreaterThan(startIdx);
+    expect(timeTrialIdx).toBeGreaterThan(startIdx);
+    expect(garageIdx).toBeGreaterThan(timeTrialIdx);
     expect(optionsIdx).toBeGreaterThan(garageIdx);
   });
 

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -6,14 +6,15 @@ import styles from "./page.module.css";
 /**
  * Title screen.
  *
- * Renders the three top-level main menu items per GDD §5 and §20:
- * Start Race -> `/race`, Garage -> `/garage/cars`, Options ->
- * `/options`. The Options entry was a disabled placeholder
+ * Renders the top-level main menu items per GDD §5 and §20:
+ * Start Race -> `/race`, Time Trial -> `/time-trial`, Garage ->
+ * `/garage/cars`, Options -> `/options`. The Options entry was a disabled placeholder
  * (`menu-options-pending`) until the `/options` scaffold landed in
  * `VibeGear2-implement-options-screen-a9379c4a`. Its replacement keeps
  * the original `menu-options` test id that the e2e suite asserts on.
  *
- * Keyboard order is Start Race -> Garage -> Options (DOM order).
+ * Keyboard order is Start Race -> Time Trial -> Garage -> Options
+ * (DOM order).
  *
  * The footer carries two pieces of metadata. The pre-existing
  * `build-status` line tracks the design phase (kept verbatim so the
@@ -32,6 +33,7 @@ interface MenuItem {
 
 const MENU: ReadonlyArray<MenuItem> = [
   { label: "Start Race", href: "/race", testId: "menu-start-race" },
+  { label: "Time Trial", href: "/time-trial", testId: "menu-time-trial" },
   { label: "Garage", href: "/garage/cars", testId: "menu-garage" },
   { label: "Options", href: "/options", testId: "menu-options" },
 ];

--- a/src/app/race/page.tsx
+++ b/src/app/race/page.tsx
@@ -40,14 +40,17 @@ import { PauseOverlay } from "@/components/pause/PauseOverlay";
 import { usePauseActions } from "@/components/pause/usePauseActions";
 import { usePauseToggle } from "@/components/pause/usePauseToggle";
 import { saveRaceResult } from "@/components/results/raceResultStorage";
-import { TRACK_IDS, loadTrack } from "@/data";
-import type { Track } from "@/data/schemas";
+import { TRACK_IDS, TRACK_RAW, loadTrack } from "@/data";
+import { TrackSchema, type Track } from "@/data/schemas";
 import {
+  applyTimeTrialResult,
   buildFinalCarInputsFromSession,
   buildFinalRaceState,
   buildRaceResult,
+  createGhostDriver,
   createInputManager,
   createRaceSession,
+  createTimeTrialRecorder,
   deriveHudState,
   deriveSplitsState,
   applyRaceResultRecords,
@@ -59,6 +62,9 @@ import {
   type RaceSessionConfig,
   type RaceSessionState,
   type RankedCar,
+  type GhostDriver,
+  type GhostOverlay,
+  type TimeTrialRecorder,
 } from "@/game";
 import { FIXED_STEP_SECONDS } from "@/game/loop";
 import type { AIDriver, CarBaseStats } from "@/data/schemas";
@@ -135,12 +141,20 @@ const DEMO_DRIVER: AIDriver = Object.freeze({
 
 interface ResolvedTrack {
   id: string;
+  version: number;
   compiled: CompiledTrack;
 }
 
 function resolveTrack(requestedId: string | null): ResolvedTrack {
   const id = requestedId && TRACK_IDS.includes(requestedId) ? requestedId : DEFAULT_TRACK_ID;
-  return { id, compiled: loadTrack(id) };
+  const parsed = TrackSchema.parse(TRACK_RAW[id]);
+  return { id, version: parsed.version, compiled: loadTrack(id) };
+}
+
+type RaceMode = "race" | "timeTrial";
+
+function resolveRaceMode(raw: string | null): RaceMode {
+  return raw === "timeTrial" ? "timeTrial" : "race";
 }
 
 /**
@@ -265,21 +279,28 @@ function RaceShell(): ReactElement {
   const search = useSearchParams();
   const requestedId = search?.get("track") ?? null;
   const lapsRaw = search?.get("laps") ?? null;
+  const modeRaw = search?.get("mode") ?? null;
   const track = useMemo(() => resolveTrack(requestedId), [requestedId]);
   const lapsOverride = useMemo(() => resolveLapsOverride(lapsRaw), [lapsRaw]);
-  return <RaceCanvas track={track} lapsOverride={lapsOverride} />;
+  const mode = useMemo(() => resolveRaceMode(modeRaw), [modeRaw]);
+  return <RaceCanvas track={track} lapsOverride={lapsOverride} mode={mode} />;
 }
 
 interface RaceCanvasProps {
   track: ResolvedTrack;
   lapsOverride: number | null;
+  mode: RaceMode;
 }
 
-function RaceCanvas({ track, lapsOverride }: RaceCanvasProps): ReactElement {
+function RaceCanvas({ track, lapsOverride, mode }: RaceCanvasProps): ReactElement {
   const router = useRouter();
   const canvasRef = useRef<HTMLCanvasElement | null>(null);
   const handleRef = useRef<LoopHandle | null>(null);
   const sessionRef = useRef<RaceSessionState | null>(null);
+  const ghostDriverRef = useRef<GhostDriver | null>(null);
+  const ghostOverlayRef = useRef<GhostOverlay>(null);
+  const ghostOverlayTickRef = useRef<number | null>(null);
+  const timeTrialRecorderRef = useRef<TimeTrialRecorder | null>(null);
   // Imperative pause-menu effects, populated inside the loop effect
   // below so the hook layer can stay decoupled from the loop / session
   // / config refs. The hook reads these getters once per click; mid-
@@ -348,12 +369,16 @@ function RaceCanvas({ track, lapsOverride }: RaceCanvasProps): ReactElement {
     // as `false` already, and an undefined `difficultyPreset` resolves
     // to Balanced via `resolvePresetScalars`.
     const persisted = loadSave();
+    const sessionSave =
+      persisted.kind === "loaded" ? persisted.save : defaultSave();
     const persistedSettings =
       persisted.kind === "loaded"
         ? persisted.save.settings
         : defaultSave().settings;
     const persistedAssists = persistedSettings.assists;
     const persistedDifficulty = persistedSettings.difficultyPreset;
+    const timeTrialEnabled = mode === "timeTrial";
+    const raceSeed = 1;
 
     const config: RaceSessionConfig = {
       track: track.compiled,
@@ -363,11 +388,45 @@ function RaceCanvas({ track, lapsOverride }: RaceCanvasProps): ReactElement {
         difficultyPreset: persistedDifficulty,
       },
       ai: [{ driver: DEMO_DRIVER, stats: STARTER_STATS }],
-      seed: 1,
+      seed: raceSeed,
       ...(lapsOverride !== null ? { totalLaps: lapsOverride } : {}),
     };
 
+    const resetTimeTrialRuntime = (): void => {
+      ghostOverlayRef.current = null;
+      ghostOverlayTickRef.current = null;
+      if (!timeTrialEnabled) {
+        ghostDriverRef.current = null;
+        timeTrialRecorderRef.current = null;
+        return;
+      }
+      const currentGhost = sessionSave.ghosts?.[track.id] ?? null;
+      ghostDriverRef.current = createGhostDriver({
+        replay: currentGhost,
+        stats: STARTER_STATS,
+      });
+      timeTrialRecorderRef.current = createTimeTrialRecorder({
+        trackId: track.id,
+        trackVersion: track.version,
+        carId: sessionSave.garage.activeCarId,
+        seed: raceSeed,
+        onFinalize: (replay) => {
+          const current = sessionSave.ghosts?.[track.id] ?? null;
+          const best = applyTimeTrialResult(current, replay);
+          if (best === null || best === current) return;
+          saveSave({
+            ...sessionSave,
+            ghosts: {
+              ...(sessionSave.ghosts ?? {}),
+              [track.id]: best,
+            },
+          });
+        },
+      });
+    };
+
     sessionRef.current = createRaceSession(config);
+    resetTimeTrialRuntime();
     // Re-arm the natural-finish guard on every fresh mount. The
     // restart callback below also flips it back so a second race
     // after a restart still routes once when it finishes.
@@ -406,6 +465,7 @@ function RaceCanvas({ track, lapsOverride }: RaceCanvasProps): ReactElement {
       const handle = handleRef.current;
       if (!handle) return;
       sessionRef.current = createRaceSession(config);
+      resetTimeTrialRuntime();
       // Re-arm the natural-finish guard so the restarted race can
       // route on its own finish. Must precede `handle.resume()` so the
       // first render tick after resume sees the fresh `false` latch.
@@ -463,14 +523,16 @@ function RaceCanvas({ track, lapsOverride }: RaceCanvasProps): ReactElement {
       // F-034: credit the wallet (DNF cars receive the §12 participation
       // cash) and mirror the delta onto `RaceResult.creditsAwarded` so
       // the §20 results screen renders the actual wallet change.
-      const committed = commitRaceCredits({
-        result,
-        save,
-        // §15 default per `SaveGameSettingsSchema`: a v1 save without
-        // a `difficultyPreset` field reads as `'normal'`.
-        difficulty: persistedDifficulty ?? "normal",
-        baseTrackReward: baseRewardForTrackDifficulty(track.compiled.difficulty),
-      });
+      const committed = timeTrialEnabled
+        ? { ...result, creditsAwarded: 0 }
+        : commitRaceCredits({
+            result,
+            save,
+            // §15 default per `SaveGameSettingsSchema`: a v1 save without
+            // a `difficultyPreset` field reads as `'normal'`.
+            difficulty: persistedDifficulty ?? "normal",
+            baseTrackReward: baseRewardForTrackDifficulty(track.compiled.difficulty),
+          });
       saveRaceResult(committed);
       // Flip the natural-finish guard so the render callback's finish
       // wiring cannot also fire on the next frame (the loop tear-down
@@ -500,6 +562,11 @@ function RaceCanvas({ track, lapsOverride }: RaceCanvasProps): ReactElement {
         const input = inputManager.sample();
         const next = stepRaceSession(session, input, config, dt);
         sessionRef.current = next;
+        timeTrialRecorderRef.current?.observe({
+          phase: next.race.phase,
+          tick: next.tick,
+          input,
+        });
       },
       render: () => {
         const session = sessionRef.current;
@@ -508,7 +575,25 @@ function RaceCanvas({ track, lapsOverride }: RaceCanvasProps): ReactElement {
         camera.x = session.player.car.x;
 
         const strips = project(track.compiled.segments, camera, viewport);
-        drawRoad(ctx, strips, viewport);
+        if (
+          timeTrialEnabled &&
+          session.race.phase === "racing" &&
+          ghostDriverRef.current !== null &&
+          ghostOverlayTickRef.current !== session.tick
+        ) {
+          ghostOverlayRef.current = ghostDriverRef.current.tick({
+            tick: session.tick,
+            dt: FIXED_STEP_SECONDS,
+            camera,
+            viewport,
+            segments: track.compiled.segments,
+          });
+          ghostOverlayTickRef.current = session.tick;
+        } else if (!timeTrialEnabled || session.race.phase === "countdown") {
+          ghostOverlayRef.current = null;
+          ghostOverlayTickRef.current = null;
+        }
+        drawRoad(ctx, strips, viewport, { ghostCar: ghostOverlayRef.current });
 
         const cars: RankedCar[] = [
           {
@@ -625,16 +710,18 @@ function RaceCanvas({ track, lapsOverride }: RaceCanvasProps): ReactElement {
             // results screen will render. The `commitRaceCredits`
             // helper persists the merged save and mirrors the
             // wallet delta onto `RaceResult.creditsAwarded`.
-            const committed = commitRaceCredits({
-              result,
-              save,
-              // §15 default per `SaveGameSettingsSchema`: a v1 save
-              // without a `difficultyPreset` reads as `'normal'`.
-              difficulty: persistedDifficulty ?? "normal",
-              baseTrackReward: baseRewardForTrackDifficulty(
-                track.compiled.difficulty,
-              ),
-            });
+            const committed = timeTrialEnabled
+              ? { ...result, creditsAwarded: 0 }
+              : commitRaceCredits({
+                  result,
+                  save,
+                  // §15 default per `SaveGameSettingsSchema`: a v1 save
+                  // without a `difficultyPreset` reads as `'normal'`.
+                  difficulty: persistedDifficulty ?? "normal",
+                  baseTrackReward: baseRewardForTrackDifficulty(
+                    track.compiled.difficulty,
+                  ),
+                });
             saveRaceResult(committed);
             // Tear down the loop / input before the route hop so the
             // rAF handle and the keydown listener cannot outlive the
@@ -661,10 +748,15 @@ function RaceCanvas({ track, lapsOverride }: RaceCanvasProps): ReactElement {
       sessionRef.current = null;
       inputManager.dispose();
     };
-  }, [track, router, lapsOverride, initialTotalLaps]);
+  }, [track, router, lapsOverride, initialTotalLaps, mode]);
 
   return (
-    <main data-testid="race-canvas" data-track={track.id} style={shellStyle}>
+    <main
+      data-testid="race-canvas"
+      data-track={track.id}
+      data-mode={mode}
+      style={shellStyle}
+    >
       <canvas
         ref={canvasRef}
         width={VIEWPORT_WIDTH}

--- a/src/app/race/page.tsx
+++ b/src/app/race/page.tsx
@@ -379,6 +379,7 @@ function RaceCanvas({ track, lapsOverride, mode }: RaceCanvasProps): ReactElemen
     const persistedDifficulty = persistedSettings.difficultyPreset;
     const timeTrialEnabled = mode === "timeTrial";
     const raceSeed = 1;
+    let timeTrialSaveSnapshot = sessionSave;
 
     const config: RaceSessionConfig = {
       track: track.compiled,
@@ -400,7 +401,7 @@ function RaceCanvas({ track, lapsOverride, mode }: RaceCanvasProps): ReactElemen
         timeTrialRecorderRef.current = null;
         return;
       }
-      const currentGhost = sessionSave.ghosts?.[track.id] ?? null;
+      const currentGhost = timeTrialSaveSnapshot.ghosts?.[track.id] ?? null;
       ghostDriverRef.current = createGhostDriver({
         replay: currentGhost,
         stats: STARTER_STATS,
@@ -408,19 +409,26 @@ function RaceCanvas({ track, lapsOverride, mode }: RaceCanvasProps): ReactElemen
       timeTrialRecorderRef.current = createTimeTrialRecorder({
         trackId: track.id,
         trackVersion: track.version,
-        carId: sessionSave.garage.activeCarId,
+        carId: timeTrialSaveSnapshot.garage.activeCarId,
         seed: raceSeed,
         onFinalize: (replay) => {
-          const current = sessionSave.ghosts?.[track.id] ?? null;
+          const latest = loadSave();
+          const latestSave =
+            latest.kind === "loaded" ? latest.save : timeTrialSaveSnapshot;
+          const current = latestSave.ghosts?.[track.id] ?? null;
           const best = applyTimeTrialResult(current, replay);
           if (best === null || best === current) return;
-          saveSave({
-            ...sessionSave,
+          const nextSave: SaveGame = {
+            ...latestSave,
             ghosts: {
-              ...(sessionSave.ghosts ?? {}),
+              ...(latestSave.ghosts ?? {}),
               [track.id]: best,
             },
-          });
+          };
+          const write = saveSave(nextSave);
+          if (write.kind === "ok") {
+            timeTrialSaveSnapshot = nextSave;
+          }
         },
       });
     };

--- a/src/app/time-trial/page.tsx
+++ b/src/app/time-trial/page.tsx
@@ -1,0 +1,5 @@
+import { redirect } from "next/navigation";
+
+export default function TimeTrialPage(): never {
+  redirect("/race?mode=timeTrial");
+}

--- a/src/game/index.ts
+++ b/src/game/index.ts
@@ -18,6 +18,7 @@ export * from "./sectorTimer";
 export * from "./rng";
 export * from "./ghost";
 export * from "./ghostDriver";
+export * from "./timeTrial";
 export * from "./assists";
 export * from "./difficultyPresets";
 // `raceBonuses` is the owner of the §5 bonus pipeline; `raceResult` is


### PR DESCRIPTION
## Summary
- Add Time Trial navigation and route entry into the race shell.
- Wire saved ghost playback and recorder persistence for time-trial runs.
- Fix ghost finalization to reload the latest save before writing a new personal best.

## GDD
- docs/gdd/06-game-modes.md
- docs/gdd/20-hud-and-ui-ux.md
- docs/gdd/22-data-schemas.md

## Progress Log
- docs/PROGRESS_LOG.md F-022 Time Trial ghost consumer entry

## Test Plan
- npx vitest run src/app/__tests__/page.test.tsx src/game/__tests__/timeTrial.test.ts src/game/__tests__/ghostDriver.test.ts
- npm run typecheck
- git diff --check
- grep scan for U+2014/U+2013 in touched files