### PR TITLE
Race start player car overlay

### DIFF
--- a/docs/FOLLOWUPS.md
+++ b/docs/FOLLOWUPS.md
@@ -10,6 +10,21 @@ or `obsolete` so the trail is preserved.
 
 ---
 
+## F-053: Add a machine-checkable GDD coverage ledger
+**Created:** 2026-04-26
+**Priority:** blocks-release
+**Status:** open
+**Notes:** The current loop relies on each agent reading the relevant
+GDD sections and remembering to file followups for adjacent required
+behaviour. Add a coverage ledger that maps each concrete GDD requirement
+to one of: implemented code, automated test, open followup, or open
+question. Add a CI or content-lint check that fails when a progress log
+entry claims GDD coverage without listing the remaining uncovered
+requirements. This should catch gaps like road elevation proof before a
+visual slice reaches review.
+
+---
+
 ## F-052: Add parallax horizon and roadside sprites to the race renderer
 **Created:** 2026-04-26
 **Priority:** polish

--- a/docs/FOLLOWUPS.md
+++ b/docs/FOLLOWUPS.md
@@ -10,6 +10,49 @@ or `obsolete` so the trail is preserved.
 
 ---
 
+## F-052: Add parallax horizon and roadside sprites to the race renderer
+**Created:** 2026-04-26
+**Priority:** polish
+**Status:** open
+**Notes:** §16 and §21 call for layered horizon art, parallax
+backgrounds, and roadside sprites drawn from compiled track segment
+content. The current race view renders flat sky, grass, and road strips
+only. Wire the race renderer to consume region background layers and
+roadside sprite ids from compiled track data, then verify that the
+assets move at distinct depths in a browser smoke.
+
+---
+
+## F-051: Replace live and ghost car placeholders with atlas sprites
+**Created:** 2026-04-26
+**Priority:** polish
+**Status:** open
+**Notes:** The live player car and Time Trial ghost still use original
+Canvas2D placeholder shapes. §16 expects 12 to 16 directional car
+frames, damage variants, brake lights, nitro effects, and weather
+variants. Replace the live `playerCar` overlay and the F-022 ghost
+rectangle with frames from the same loaded sprite atlas, selected from
+steering and road curve state. Keep the current Canvas2D shape only as
+a missing-asset fallback.
+
+---
+
+## F-050: Prove authored elevation in the live race view
+**Created:** 2026-04-26
+**Priority:** blocks-release
+**Status:** open
+**Notes:** §9 defines mild crests, aggressive crests, dips, and
+plateaus, while §16 and §21 say segment `grade` drives hills through
+the pseudo-3D projection pipeline. The bundled `/race` content used in
+the smoke path currently has zero grade everywhere, so the live view
+does not prove Top Gear-style elevation changes yet. Add or route to a
+small representative track with non-zero grade, validate it through the
+track schema and compiler, and add a browser smoke that confirms the
+projected road and horizon shift as the car advances through the
+grade-bearing segments.
+
+---
+
 ## F-049: Implement options reset persistence wiring
 **Created:** 2026-04-26
 **Priority:** nice-to-have

--- a/docs/IMPLEMENTATION_PLAN.md
+++ b/docs/IMPLEMENTATION_PLAN.md
@@ -112,6 +112,9 @@ typically 1–3 days of agent work, never more than what fits in a single PR.
 │                                                         │
 ├─ clarify ───────────────────────────────────────────────┤
 │  read the relevant GDD section(s) end to end            │
+│  list the concrete GDD requirements touched by the      │
+│  slice, including adjacent required behaviour that will  │
+│  not be implemented in this PR                          │
 │  if anything is ambiguous, write the question into      │
 │  OPEN_QUESTIONS.md and either:                          │
 │    - block the slice and pick another, or               │
@@ -137,6 +140,8 @@ typically 1–3 days of agent work, never more than what fits in a single PR.
 │  mark resolved OPEN_QUESTIONS.md items answered or      │
 │  obsolete (do not delete; history is preserved)         │
 │  add any new followups to FOLLOWUPS.md                  │
+│  confirm every unmet GDD requirement noticed during     │
+│  the slice has a followup or open question              │
 │  if implementation forced a GDD change, edit the GDD    │
 │  in the same PR and call it out in the log              │
 │                                                         │
@@ -219,8 +224,12 @@ A slice is done when **all** of the following hold:
       the user-visible path.
 - [ ] If the slice changes UI/feel, the agent has either driven it in a browser
       or explicitly flagged that it needs human verification in the log.
+- [ ] The progress log names the concrete GDD requirements the slice touched
+      and any adjacent requirements deliberately left for later.
 - [ ] PROGRESS_LOG.md has a new entry.
 - [ ] OPEN_QUESTIONS.md and FOLLOWUPS.md reflect the new state.
+- [ ] Every unmet GDD requirement discovered while working has either a
+      `FOLLOWUPS.md` id or an `OPEN_QUESTIONS.md` id.
 - [ ] CI is green on the PR.
 - [ ] Auto-deploy succeeds on merge to `main` and the deployed build still
       boots to the title screen.

--- a/docs/PROGRESS_LOG.md
+++ b/docs/PROGRESS_LOG.md
@@ -21,6 +21,8 @@ Correct them by adding a new entry that references the old one.
 - `src/render/pseudoRoadCanvas.ts`: refined the placeholder into a
   rear chase-view silhouette with tires, rear deck, and tail lights so
   it reads less like a flat UI icon.
+- `src/render/pseudoRoadCanvas.ts`: replaced protruding tire blocks and
+  the over-wide rear deck with contained path shapes.
 - `src/app/race/page.tsx`: passes the player-car overlay option to the
   road renderer every race frame so a fresh race has a visible car
   anchor at the bottom of the view.
@@ -41,6 +43,9 @@ Correct them by adding a new entry that references the old one.
 - Browser layout check at 2048x1240 confirmed a 1280x768 canvas,
   a clipped 1x1 debug metrics box, 3,954 yellow car pixels, and
   217 red tail-light pixels during countdown.
+- Browser artifact check at 2048x1240 confirmed 3,841 yellow car
+  pixels, 193 red tail-light pixels, and only 38 dark pixels outside
+  the right side of the car footprint.
 - `npm run test:e2e -- e2e/race-demo.spec.ts` green, 1 passed.
 - `npm run verify` clean: lint, typecheck, unit tests, and
   content-lint all passed; 2,128 unit tests passed.

--- a/docs/PROGRESS_LOG.md
+++ b/docs/PROGRESS_LOG.md
@@ -18,12 +18,18 @@ Correct them by adding a new entry that references the old one.
 - `src/render/pseudoRoadCanvas.ts`: added a live player-car overlay
   placeholder that paints after the road and dust layers, using the
   §16 standard camera footprint of 18 percent viewport height.
+- `src/render/pseudoRoadCanvas.ts`: refined the placeholder into a
+  rear chase-view silhouette with tires, rear deck, and tail lights so
+  it reads less like a flat UI icon.
 - `src/app/race/page.tsx`: passes the player-car overlay option to the
   road renderer every race frame so a fresh race has a visible car
   anchor at the bottom of the view.
+- `src/app/race/page.tsx`: lets the canvas scale up to a 1280 px
+  wide race viewport and clips the debug metrics out of sighted
+  layout while keeping the existing Playwright test IDs available.
 - `src/render/__tests__/pseudoRoadCanvas.test.ts`: covered the player
-  car overlay footprint, default colours, custom colours, headlights,
-  and omitted / null behavior.
+  car overlay footprint, default colours, custom colours, tires,
+  tail lights, and omitted / null behavior.
 
 ### Verified
 - `npx vitest run src/render/__tests__/pseudoRoadCanvas.test.ts`
@@ -32,6 +38,9 @@ Correct them by adding a new entry that references the old one.
 - `npm run typecheck` clean.
 - Browser pixel check against `http://localhost:3000/race` found
   3,160 live-car pixels in the lower canvas during countdown.
+- Browser layout check at 2048x1240 confirmed a 1280x768 canvas,
+  a clipped 1x1 debug metrics box, 3,954 yellow car pixels, and
+  217 red tail-light pixels during countdown.
 - `npm run test:e2e -- e2e/race-demo.spec.ts` green, 1 passed.
 - `npm run verify` clean: lint, typecheck, unit tests, and
   content-lint all passed; 2,128 unit tests passed.

--- a/docs/PROGRESS_LOG.md
+++ b/docs/PROGRESS_LOG.md
@@ -6,6 +6,51 @@ Correct them by adding a new entry that references the old one.
 
 ---
 
+## 2026-04-26: Slice: Race start player car overlay
+
+**GDD sections touched:**
+[§16](gdd/16-rendering-and-visual-design.md) "Sprite scaling",
+[§20](gdd/20-hud-and-ui-ux.md) race HUD.
+**Branch / PR:** `fix/race-start-view`, PR pending.
+**Status:** Implemented.
+
+### Done
+- `src/render/pseudoRoadCanvas.ts`: added a live player-car overlay
+  placeholder that paints after the road and dust layers, using the
+  §16 standard camera footprint of 18 percent viewport height.
+- `src/app/race/page.tsx`: passes the player-car overlay option to the
+  road renderer every race frame so a fresh race has a visible car
+  anchor at the bottom of the view.
+- `src/render/__tests__/pseudoRoadCanvas.test.ts`: covered the player
+  car overlay footprint, default colours, custom colours, headlights,
+  and omitted / null behavior.
+
+### Verified
+- `npx vitest run src/render/__tests__/pseudoRoadCanvas.test.ts`
+  green, 14 passed.
+- `npm run lint` clean.
+- `npm run typecheck` clean.
+- Browser pixel check against `http://localhost:3000/race` found
+  3,160 live-car pixels in the lower canvas during countdown.
+- `npm run test:e2e -- e2e/race-demo.spec.ts` green, 1 passed.
+- `npm run verify` clean: lint, typecheck, unit tests, and
+  content-lint all passed; 2,128 unit tests passed.
+- `grep -rn $'\u2014\|\u2013' src/render/pseudoRoadCanvas.ts src/render/__tests__/pseudoRoadCanvas.test.ts src/app/race/page.tsx`
+  returned no hits.
+- `git diff --check` clean.
+
+### Decisions and assumptions
+- Used an original Canvas2D placeholder silhouette until the §17 car
+  sprite atlas is wired into the live race renderer.
+
+### Followups created
+None.
+
+### GDD edits
+None. The implementation matches the existing §16 player-car footprint.
+
+---
+
 ## 2026-04-26: Slice: F-022 Time Trial ghost consumer
 
 **GDD sections touched:**

--- a/docs/PROGRESS_LOG.md
+++ b/docs/PROGRESS_LOG.md
@@ -39,6 +39,9 @@ Correct them by adding a new entry that references the old one.
 - `src/render/__tests__/pseudoRoadCanvas.test.ts`: covered the player
   car overlay footprint, default colours, custom colours, tires,
   tail lights, and omitted / null behavior.
+- `docs/IMPLEMENTATION_PLAN.md` and `docs/WORKING_AGREEMENT.md`: added
+  an explicit requirement-inventory step so future agents must record
+  adjacent GDD requirements that a slice exposes but does not implement.
 
 ### Verified
 - `npx vitest run src/render/__tests__/pseudoRoadCanvas.test.ts`
@@ -73,6 +76,7 @@ Correct them by adding a new entry that references the old one.
 - F-050: Prove authored elevation in the live race view.
 - F-051: Replace live and ghost car placeholders with atlas sprites.
 - F-052: Add parallax horizon and roadside sprites to the race renderer.
+- F-053: Add a machine-checkable GDD coverage ledger.
 
 ### GDD edits
 None. The implementation matches the existing §16 player-car footprint.

--- a/docs/PROGRESS_LOG.md
+++ b/docs/PROGRESS_LOG.md
@@ -26,6 +26,10 @@ Correct them by adding a new entry that references the old one.
 - `src/render/pseudoRoadCanvas.ts`: extends the closest visible road
   strip down to the bottom of the viewport so the lower quarter no
   longer shows the sky gradient under the car.
+- `src/road/segmentProjector.ts`: moved foreground coverage into the
+  projection contract by attaching a screen-bottom endpoint to the
+  closest visible strip. The renderer now draws that endpoint as a
+  normal strip pair instead of inventing foreground geometry.
 - `src/app/race/page.tsx`: passes the player-car overlay option to the
   road renderer every race frame so a fresh race has a visible car
   anchor at the bottom of the view.
@@ -52,9 +56,11 @@ Correct them by adding a new entry that references the old one.
 - Browser foreground check at 2048x1240 confirmed the bottom quarter
   is 0.55 percent blue and 79.78 percent road, with the player car
   still visible.
+- `npx vitest run src/road/__tests__/segmentProjector.test.ts src/render/__tests__/pseudoRoadCanvas.test.ts`
+  green, 48 passed.
 - `npm run test:e2e -- e2e/race-demo.spec.ts` green, 1 passed.
 - `npm run verify` clean: lint, typecheck, unit tests, and
-  content-lint all passed; 2,128 unit tests passed.
+  content-lint all passed; 2,130 unit tests passed.
 - `grep -rn $'\u2014\|\u2013' src/render/pseudoRoadCanvas.ts src/render/__tests__/pseudoRoadCanvas.test.ts src/app/race/page.tsx`
   returned no hits.
 - `git diff --check` clean.

--- a/docs/PROGRESS_LOG.md
+++ b/docs/PROGRESS_LOG.md
@@ -23,6 +23,9 @@ Correct them by adding a new entry that references the old one.
   it reads less like a flat UI icon.
 - `src/render/pseudoRoadCanvas.ts`: replaced protruding tire blocks and
   the over-wide rear deck with contained path shapes.
+- `src/render/pseudoRoadCanvas.ts`: extends the closest visible road
+  strip down to the bottom of the viewport so the lower quarter no
+  longer shows the sky gradient under the car.
 - `src/app/race/page.tsx`: passes the player-car overlay option to the
   road renderer every race frame so a fresh race has a visible car
   anchor at the bottom of the view.
@@ -46,6 +49,9 @@ Correct them by adding a new entry that references the old one.
 - Browser artifact check at 2048x1240 confirmed 3,841 yellow car
   pixels, 193 red tail-light pixels, and only 38 dark pixels outside
   the right side of the car footprint.
+- Browser foreground check at 2048x1240 confirmed the bottom quarter
+  is 0.55 percent blue and 79.78 percent road, with the player car
+  still visible.
 - `npm run test:e2e -- e2e/race-demo.spec.ts` green, 1 passed.
 - `npm run verify` clean: lint, typecheck, unit tests, and
   content-lint all passed; 2,128 unit tests passed.

--- a/docs/PROGRESS_LOG.md
+++ b/docs/PROGRESS_LOG.md
@@ -11,7 +11,7 @@ Correct them by adding a new entry that references the old one.
 **GDD sections touched:**
 [§16](gdd/16-rendering-and-visual-design.md) "Sprite scaling",
 [§20](gdd/20-hud-and-ui-ux.md) race HUD.
-**Branch / PR:** `fix/race-start-view`, PR pending.
+**Branch / PR:** `fix/race-start-view`, PR #9.
 **Status:** Implemented.
 
 ### Done
@@ -70,7 +70,9 @@ Correct them by adding a new entry that references the old one.
   sprite atlas is wired into the live race renderer.
 
 ### Followups created
-None.
+- F-050: Prove authored elevation in the live race view.
+- F-051: Replace live and ghost car placeholders with atlas sprites.
+- F-052: Add parallax horizon and roadside sprites to the race renderer.
 
 ### GDD edits
 None. The implementation matches the existing §16 player-car footprint.

--- a/docs/WORKING_AGREEMENT.md
+++ b/docs/WORKING_AGREEMENT.md
@@ -47,6 +47,8 @@ build*; this agreement wins for *how to operate*.
 - Each slice gets one PR. PR title mirrors the slice title.
 - PR body includes:
   - Link to the GDD section(s) implemented.
+  - Requirement inventory: the concrete GDD behaviours this PR handles, plus
+    any nearby required behaviours it leaves to a followup or open question.
   - Link to the matching `PROGRESS_LOG.md` entry.
   - Test plan checklist.
   - Any followups created and the ids they got in `FOLLOWUPS.md`.
@@ -73,6 +75,10 @@ build*; this agreement wins for *how to operate*.
 For every slice, before marking it done:
 
 - Run the project's lint, type-check, unit, and integration suites.
+- Compare the implemented behaviour against the relevant GDD section and
+  adjacent cross-references. If the slice exposes another required behaviour
+  that is not implemented yet, file it in `FOLLOWUPS.md` before the PR is
+  marked ready.
 - For features with a user-visible surface, run the dev server and exercise
   the feature in a real browser. If the agent's environment cannot drive a
   browser, say so explicitly in the log and request manual verification — do

--- a/src/app/race/page.tsx
+++ b/src/app/race/page.tsx
@@ -601,7 +601,10 @@ function RaceCanvas({ track, lapsOverride, mode }: RaceCanvasProps): ReactElemen
           ghostOverlayRef.current = null;
           ghostOverlayTickRef.current = null;
         }
-        drawRoad(ctx, strips, viewport, { ghostCar: ghostOverlayRef.current });
+        drawRoad(ctx, strips, viewport, {
+          ghostCar: ghostOverlayRef.current,
+          playerCar: {},
+        });
 
         const cars: RankedCar[] = [
           {

--- a/src/app/race/page.tsx
+++ b/src/app/race/page.tsx
@@ -776,8 +776,9 @@ function RaceCanvas({ track, lapsOverride, mode }: RaceCanvasProps): ReactElemen
         tabIndex={0}
         style={{
           display: "block",
-          width: VIEWPORT_WIDTH,
-          height: VIEWPORT_HEIGHT,
+          width: "min(100%, 1280px, calc((100vh - 3rem) * 1.6667))",
+          height: "auto",
+          aspectRatio: `${VIEWPORT_WIDTH} / ${VIEWPORT_HEIGHT}`,
           maxWidth: "100%",
           background: "#000",
           imageRendering: "pixelated",
@@ -824,15 +825,18 @@ const shellStyle: CSSProperties = {
   display: "flex",
   flexDirection: "column",
   alignItems: "center",
-  gap: "1rem",
 };
 
 const metricsStyle: CSSProperties = {
-  display: "grid",
-  gridTemplateColumns: "max-content 1fr",
-  gap: "0.25rem 2rem",
-  maxWidth: "32rem",
-  width: "100%",
+  position: "absolute",
+  width: 1,
+  height: 1,
+  padding: 0,
+  margin: -1,
+  overflow: "hidden",
+  clip: "rect(0, 0, 0, 0)",
+  whiteSpace: "nowrap",
+  border: 0,
 };
 
 const resultStyle: CSSProperties = {

--- a/src/render/__tests__/pseudoRoadCanvas.test.ts
+++ b/src/render/__tests__/pseudoRoadCanvas.test.ts
@@ -24,6 +24,11 @@ import type { Strip, Viewport } from "@/road/types";
 import {
   GHOST_CAR_DEFAULT_ALPHA,
   GHOST_CAR_DEFAULT_FILL,
+  PLAYER_CAR_DEFAULT_FILL,
+  PLAYER_CAR_DEFAULT_SHADOW,
+  PLAYER_CAR_DEFAULT_WINDSHIELD,
+  PLAYER_CAR_HEIGHT_FRACTION,
+  PLAYER_CAR_WIDTH_TO_HEIGHT,
   drawRoad,
   type DrawRoadOptions,
 } from "../pseudoRoadCanvas";
@@ -281,5 +286,70 @@ describe("drawRoad ghost car overlay", () => {
         c.type === "fillRect" && c.w === 40 && c.h === 20,
     );
     expect(ghostRect).toBeUndefined();
+  });
+});
+
+describe("drawRoad player car overlay", () => {
+  it("paints the live player car at the §16 standard camera footprint", () => {
+    const spy = makeCanvasSpy();
+    drawRoad(spy.ctx, EMPTY_STRIPS, VIEWPORT, { playerCar: {} });
+
+    const fills = spy.calls.filter((c): c is FillCall => c.type === "fill");
+    expect(fills).toHaveLength(3);
+    expect(fills[0]!.fillStyle).toBe(PLAYER_CAR_DEFAULT_SHADOW);
+    expect(fills[1]!.fillStyle).toBe(PLAYER_CAR_DEFAULT_FILL);
+    expect(fills[2]!.fillStyle).toBe(PLAYER_CAR_DEFAULT_WINDSHIELD);
+
+    const height = VIEWPORT.height * PLAYER_CAR_HEIGHT_FRACTION;
+    expect(height / VIEWPORT.height).toBeGreaterThanOrEqual(0.16);
+    expect(height / VIEWPORT.height).toBeLessThanOrEqual(0.22);
+    expect(height * PLAYER_CAR_WIDTH_TO_HEIGHT).toBeCloseTo(99.36, 2);
+  });
+
+  it("paints two headlight rects after the body silhouette", () => {
+    const spy = makeCanvasSpy();
+    drawRoad(spy.ctx, EMPTY_STRIPS, VIEWPORT, { playerCar: {} });
+
+    const fillRects = spy.calls.filter(
+      (c): c is FillRectCall => c.type === "fillRect",
+    );
+    expect(fillRects).toHaveLength(3);
+    const headlightW = VIEWPORT.height *
+      PLAYER_CAR_HEIGHT_FRACTION *
+      PLAYER_CAR_WIDTH_TO_HEIGHT *
+      0.16;
+    const headlightH = VIEWPORT.height * PLAYER_CAR_HEIGHT_FRACTION * 0.08;
+    expect(fillRects[1]!.w).toBeCloseTo(headlightW, 6);
+    expect(fillRects[1]!.h).toBeCloseTo(headlightH, 6);
+    expect(fillRects[2]!.w).toBeCloseTo(headlightW, 6);
+    expect(fillRects[2]!.h).toBeCloseTo(headlightH, 6);
+  });
+
+  it("restores fillStyle after painting the player car", () => {
+    const spy = makeCanvasSpy();
+    spy.ctx.fillStyle = "#123456";
+    drawRoad(spy.ctx, EMPTY_STRIPS, VIEWPORT, {
+      playerCar: {
+        fill: "#aa3300",
+        shadow: "#001122",
+        windshield: "#223344",
+      },
+    });
+
+    const fills = spy.calls.filter((c): c is FillCall => c.type === "fill");
+    expect(fills[0]!.fillStyle).toBe("#001122");
+    expect(fills[1]!.fillStyle).toBe("#aa3300");
+    expect(fills[2]!.fillStyle).toBe("#223344");
+    expect(spy.finalAlpha()).toBeCloseTo(1, 6);
+  });
+
+  it("does not paint the live player car when omitted or null", () => {
+    const omitted = makeCanvasSpy();
+    drawRoad(omitted.ctx, EMPTY_STRIPS, VIEWPORT, {});
+    expect(omitted.calls.filter((c) => c.type === "fill")).toHaveLength(0);
+
+    const nulled = makeCanvasSpy();
+    drawRoad(nulled.ctx, EMPTY_STRIPS, VIEWPORT, { playerCar: null });
+    expect(nulled.calls.filter((c) => c.type === "fill")).toHaveLength(0);
   });
 });

--- a/src/render/__tests__/pseudoRoadCanvas.test.ts
+++ b/src/render/__tests__/pseudoRoadCanvas.test.ts
@@ -314,8 +314,8 @@ describe("drawRoad ghost car overlay", () => {
   });
 });
 
-describe("drawRoad foreground road continuation", () => {
-  it("fills the near-plane gap from the closest visible strip to the bottom", () => {
+describe("drawRoad foreground projection", () => {
+  it("draws the projector-supplied foreground endpoint as a normal strip pair", () => {
     const spy = makeCanvasSpy();
     const colors = {
       skyTop: "#000001",
@@ -330,7 +330,16 @@ describe("drawRoad foreground road continuation", () => {
     };
     const strips: readonly Strip[] = [
       strip({ visible: false, screenY: VIEWPORT.height, screenW: 0 }),
-      strip({ screenY: 300, screenW: 80, segment: { ...strip({}).segment, index: 0 } }),
+      strip({
+        screenY: 300,
+        screenW: 80,
+        foreground: {
+          screenX: VIEWPORT.width / 2,
+          screenY: VIEWPORT.height,
+          screenW: 240,
+        },
+        segment: { ...strip({}).segment, index: 0 },
+      }),
       strip({ screenY: 240, screenW: 40, segment: { ...strip({}).segment, index: 1 } }),
     ];
 

--- a/src/render/__tests__/pseudoRoadCanvas.test.ts
+++ b/src/render/__tests__/pseudoRoadCanvas.test.ts
@@ -297,10 +297,12 @@ describe("drawRoad player car overlay", () => {
     drawRoad(spy.ctx, EMPTY_STRIPS, VIEWPORT, { playerCar: {} });
 
     const fills = spy.calls.filter((c): c is FillCall => c.type === "fill");
-    expect(fills).toHaveLength(3);
-    expect(fills[0]!.fillStyle).toBe(PLAYER_CAR_DEFAULT_SHADOW);
-    expect(fills[1]!.fillStyle).toBe(PLAYER_CAR_DEFAULT_FILL);
-    expect(fills[2]!.fillStyle).toBe(PLAYER_CAR_DEFAULT_WINDSHIELD);
+    expect(fills).toHaveLength(5);
+    expect(fills[0]!.fillStyle).toBe(PLAYER_CAR_DEFAULT_TIRE);
+    expect(fills[1]!.fillStyle).toBe(PLAYER_CAR_DEFAULT_TIRE);
+    expect(fills[2]!.fillStyle).toBe(PLAYER_CAR_DEFAULT_SHADOW);
+    expect(fills[3]!.fillStyle).toBe(PLAYER_CAR_DEFAULT_FILL);
+    expect(fills[4]!.fillStyle).toBe(PLAYER_CAR_DEFAULT_WINDSHIELD);
 
     const height = VIEWPORT.height * PLAYER_CAR_HEIGHT_FRACTION;
     expect(height / VIEWPORT.height).toBeGreaterThanOrEqual(0.16);
@@ -308,40 +310,40 @@ describe("drawRoad player car overlay", () => {
     expect(height * PLAYER_CAR_WIDTH_TO_HEIGHT).toBeCloseTo(99.36, 2);
   });
 
-  it("paints tires, rear deck, and two tail-light rects", () => {
+  it("paints contained tires, rear deck, and two tail-light rects", () => {
     const spy = makeCanvasSpy();
     drawRoad(spy.ctx, EMPTY_STRIPS, VIEWPORT, { playerCar: {} });
+
+    const fills = spy.calls.filter((c): c is FillCall => c.type === "fill");
+    expect(fills).toHaveLength(5);
+    expect(fills[0]!.fillStyle).toBe(PLAYER_CAR_DEFAULT_TIRE);
+    expect(fills[1]!.fillStyle).toBe(PLAYER_CAR_DEFAULT_TIRE);
+    expect(fills[2]!.fillStyle).toBe(PLAYER_CAR_DEFAULT_SHADOW);
+    expect(fills[3]!.fillStyle).toBe(PLAYER_CAR_DEFAULT_FILL);
+    expect(fills[4]!.fillStyle).toBe(PLAYER_CAR_DEFAULT_WINDSHIELD);
 
     const fillRects = spy.calls.filter(
       (c): c is FillRectCall => c.type === "fillRect",
     );
-    expect(fillRects).toHaveLength(6);
+    expect(fillRects).toHaveLength(4);
 
-    const tireW = VIEWPORT.height *
-      PLAYER_CAR_HEIGHT_FRACTION *
-      PLAYER_CAR_WIDTH_TO_HEIGHT *
-      0.18;
-    const tireH = VIEWPORT.height * PLAYER_CAR_HEIGHT_FRACTION * 0.5;
-    expect(fillRects[1]!.fillStyle).toBe(PLAYER_CAR_DEFAULT_TIRE);
-    expect(fillRects[1]!.w).toBeCloseTo(tireW, 6);
-    expect(fillRects[1]!.h).toBeCloseTo(tireH, 6);
-    expect(fillRects[2]!.fillStyle).toBe(PLAYER_CAR_DEFAULT_TIRE);
-    expect(fillRects[2]!.w).toBeCloseTo(tireW, 6);
-    expect(fillRects[2]!.h).toBeCloseTo(tireH, 6);
-
-    expect(fillRects[3]!.fillStyle).toBe("#d7a91e");
+    expect(fillRects[1]!.fillStyle).toBe("#d7a91e");
+    expect(fillRects[1]!.w).toBeCloseTo(
+      VIEWPORT.height * PLAYER_CAR_HEIGHT_FRACTION * PLAYER_CAR_WIDTH_TO_HEIGHT * 0.64,
+      6,
+    );
 
     const tailLightW = VIEWPORT.height *
       PLAYER_CAR_HEIGHT_FRACTION *
       PLAYER_CAR_WIDTH_TO_HEIGHT *
-      0.18;
+      0.16;
     const tailLightH = VIEWPORT.height * PLAYER_CAR_HEIGHT_FRACTION * 0.08;
-    expect(fillRects[4]!.fillStyle).toBe(PLAYER_CAR_DEFAULT_TAIL_LIGHT);
-    expect(fillRects[4]!.w).toBeCloseTo(tailLightW, 6);
-    expect(fillRects[4]!.h).toBeCloseTo(tailLightH, 6);
-    expect(fillRects[5]!.fillStyle).toBe(PLAYER_CAR_DEFAULT_TAIL_LIGHT);
-    expect(fillRects[5]!.w).toBeCloseTo(tailLightW, 6);
-    expect(fillRects[5]!.h).toBeCloseTo(tailLightH, 6);
+    expect(fillRects[2]!.fillStyle).toBe(PLAYER_CAR_DEFAULT_TAIL_LIGHT);
+    expect(fillRects[2]!.w).toBeCloseTo(tailLightW, 6);
+    expect(fillRects[2]!.h).toBeCloseTo(tailLightH, 6);
+    expect(fillRects[3]!.fillStyle).toBe(PLAYER_CAR_DEFAULT_TAIL_LIGHT);
+    expect(fillRects[3]!.w).toBeCloseTo(tailLightW, 6);
+    expect(fillRects[3]!.h).toBeCloseTo(tailLightH, 6);
   });
 
   it("restores fillStyle after painting the player car", () => {
@@ -358,9 +360,11 @@ describe("drawRoad player car overlay", () => {
     });
 
     const fills = spy.calls.filter((c): c is FillCall => c.type === "fill");
-    expect(fills[0]!.fillStyle).toBe("#001122");
-    expect(fills[1]!.fillStyle).toBe("#aa3300");
-    expect(fills[2]!.fillStyle).toBe("#223344");
+    expect(fills[0]!.fillStyle).toBe("#050505");
+    expect(fills[1]!.fillStyle).toBe("#050505");
+    expect(fills[2]!.fillStyle).toBe("#001122");
+    expect(fills[3]!.fillStyle).toBe("#aa3300");
+    expect(fills[4]!.fillStyle).toBe("#223344");
     expect(spy.finalAlpha()).toBeCloseTo(1, 6);
   });
 

--- a/src/render/__tests__/pseudoRoadCanvas.test.ts
+++ b/src/render/__tests__/pseudoRoadCanvas.test.ts
@@ -121,6 +121,29 @@ function makeCanvasSpy(): CanvasSpy {
  */
 const EMPTY_STRIPS: readonly Strip[] = [];
 
+function strip(overrides: Partial<Strip>): Strip {
+  return {
+    segment: {
+      index: 0,
+      worldZ: 0,
+      curve: 0,
+      grade: 0,
+      authoredIndex: 0,
+      roadsideLeftId: "default",
+      roadsideRightId: "default",
+      hazardIds: [],
+    },
+    visible: true,
+    screenX: VIEWPORT.width / 2,
+    screenY: VIEWPORT.height / 2,
+    screenW: 80,
+    scale: 1,
+    worldX: 0,
+    worldY: 0,
+    ...overrides,
+  };
+}
+
 describe("drawRoad ghost car overlay", () => {
   it("paints a translucent rect at the projected ground point with the default alpha", () => {
     const spy = makeCanvasSpy();
@@ -288,6 +311,45 @@ describe("drawRoad ghost car overlay", () => {
         c.type === "fillRect" && c.w === 40 && c.h === 20,
     );
     expect(ghostRect).toBeUndefined();
+  });
+});
+
+describe("drawRoad foreground road continuation", () => {
+  it("fills the near-plane gap from the closest visible strip to the bottom", () => {
+    const spy = makeCanvasSpy();
+    const colors = {
+      skyTop: "#000001",
+      skyBottom: "#000002",
+      grassLight: "#112233",
+      grassDark: "#223344",
+      rumbleLight: "#334455",
+      rumbleDark: "#445566",
+      roadLight: "#556677",
+      roadDark: "#667788",
+      lane: "#778899",
+    };
+    const strips: readonly Strip[] = [
+      strip({ visible: false, screenY: VIEWPORT.height, screenW: 0 }),
+      strip({ screenY: 300, screenW: 80, segment: { ...strip({}).segment, index: 0 } }),
+      strip({ screenY: 240, screenW: 40, segment: { ...strip({}).segment, index: 1 } }),
+    ];
+
+    drawRoad(spy.ctx, strips, VIEWPORT, { colors });
+
+    const foregroundGrass = spy.calls.find(
+      (c): c is FillRectCall =>
+        c.type === "fillRect" &&
+        c.fillStyle === colors.grassLight &&
+        c.x === 0 &&
+        c.y === 300 &&
+        c.w === VIEWPORT.width &&
+        c.h === VIEWPORT.height - 300,
+    );
+    expect(foregroundGrass).toBeDefined();
+
+    const fills = spy.calls.filter((c): c is FillCall => c.type === "fill");
+    expect(fills.some((call) => call.fillStyle === colors.roadLight)).toBe(true);
+    expect(fills.some((call) => call.fillStyle === colors.lane)).toBe(true);
   });
 });
 

--- a/src/render/__tests__/pseudoRoadCanvas.test.ts
+++ b/src/render/__tests__/pseudoRoadCanvas.test.ts
@@ -26,6 +26,8 @@ import {
   GHOST_CAR_DEFAULT_FILL,
   PLAYER_CAR_DEFAULT_FILL,
   PLAYER_CAR_DEFAULT_SHADOW,
+  PLAYER_CAR_DEFAULT_TAIL_LIGHT,
+  PLAYER_CAR_DEFAULT_TIRE,
   PLAYER_CAR_DEFAULT_WINDSHIELD,
   PLAYER_CAR_HEIGHT_FRACTION,
   PLAYER_CAR_WIDTH_TO_HEIGHT,
@@ -306,23 +308,40 @@ describe("drawRoad player car overlay", () => {
     expect(height * PLAYER_CAR_WIDTH_TO_HEIGHT).toBeCloseTo(99.36, 2);
   });
 
-  it("paints two headlight rects after the body silhouette", () => {
+  it("paints tires, rear deck, and two tail-light rects", () => {
     const spy = makeCanvasSpy();
     drawRoad(spy.ctx, EMPTY_STRIPS, VIEWPORT, { playerCar: {} });
 
     const fillRects = spy.calls.filter(
       (c): c is FillRectCall => c.type === "fillRect",
     );
-    expect(fillRects).toHaveLength(3);
-    const headlightW = VIEWPORT.height *
+    expect(fillRects).toHaveLength(6);
+
+    const tireW = VIEWPORT.height *
       PLAYER_CAR_HEIGHT_FRACTION *
       PLAYER_CAR_WIDTH_TO_HEIGHT *
-      0.16;
-    const headlightH = VIEWPORT.height * PLAYER_CAR_HEIGHT_FRACTION * 0.08;
-    expect(fillRects[1]!.w).toBeCloseTo(headlightW, 6);
-    expect(fillRects[1]!.h).toBeCloseTo(headlightH, 6);
-    expect(fillRects[2]!.w).toBeCloseTo(headlightW, 6);
-    expect(fillRects[2]!.h).toBeCloseTo(headlightH, 6);
+      0.18;
+    const tireH = VIEWPORT.height * PLAYER_CAR_HEIGHT_FRACTION * 0.5;
+    expect(fillRects[1]!.fillStyle).toBe(PLAYER_CAR_DEFAULT_TIRE);
+    expect(fillRects[1]!.w).toBeCloseTo(tireW, 6);
+    expect(fillRects[1]!.h).toBeCloseTo(tireH, 6);
+    expect(fillRects[2]!.fillStyle).toBe(PLAYER_CAR_DEFAULT_TIRE);
+    expect(fillRects[2]!.w).toBeCloseTo(tireW, 6);
+    expect(fillRects[2]!.h).toBeCloseTo(tireH, 6);
+
+    expect(fillRects[3]!.fillStyle).toBe("#d7a91e");
+
+    const tailLightW = VIEWPORT.height *
+      PLAYER_CAR_HEIGHT_FRACTION *
+      PLAYER_CAR_WIDTH_TO_HEIGHT *
+      0.18;
+    const tailLightH = VIEWPORT.height * PLAYER_CAR_HEIGHT_FRACTION * 0.08;
+    expect(fillRects[4]!.fillStyle).toBe(PLAYER_CAR_DEFAULT_TAIL_LIGHT);
+    expect(fillRects[4]!.w).toBeCloseTo(tailLightW, 6);
+    expect(fillRects[4]!.h).toBeCloseTo(tailLightH, 6);
+    expect(fillRects[5]!.fillStyle).toBe(PLAYER_CAR_DEFAULT_TAIL_LIGHT);
+    expect(fillRects[5]!.w).toBeCloseTo(tailLightW, 6);
+    expect(fillRects[5]!.h).toBeCloseTo(tailLightH, 6);
   });
 
   it("restores fillStyle after painting the player car", () => {
@@ -332,6 +351,8 @@ describe("drawRoad player car overlay", () => {
       playerCar: {
         fill: "#aa3300",
         shadow: "#001122",
+        tire: "#050505",
+        tailLight: "#ff0000",
         windshield: "#223344",
       },
     });

--- a/src/render/pseudoRoadCanvas.ts
+++ b/src/render/pseudoRoadCanvas.ts
@@ -343,8 +343,20 @@ function drawPlayerCar(
   const prevFill = ctx.fillStyle;
   try {
     ctx.fillStyle = car.tire ?? PLAYER_CAR_DEFAULT_TIRE;
-    ctx.fillRect(centerX - halfW * 0.72, topY + height * 0.38, width * 0.18, height * 0.5);
-    ctx.fillRect(centerX + halfW * 0.54, topY + height * 0.38, width * 0.18, height * 0.5);
+    ctx.beginPath();
+    ctx.moveTo(centerX - halfW * 0.68, bottomY - height * 0.12);
+    ctx.lineTo(centerX - halfW * 0.54, bottomY - height * 0.12);
+    ctx.lineTo(centerX - halfW * 0.48, topY + height * 0.42);
+    ctx.lineTo(centerX - halfW * 0.58, topY + height * 0.42);
+    ctx.closePath();
+    ctx.fill();
+    ctx.beginPath();
+    ctx.moveTo(centerX + halfW * 0.54, bottomY - height * 0.12);
+    ctx.lineTo(centerX + halfW * 0.68, bottomY - height * 0.12);
+    ctx.lineTo(centerX + halfW * 0.58, topY + height * 0.42);
+    ctx.lineTo(centerX + halfW * 0.48, topY + height * 0.42);
+    ctx.closePath();
+    ctx.fill();
 
     ctx.fillStyle = car.shadow ?? PLAYER_CAR_DEFAULT_SHADOW;
     ctx.beginPath();
@@ -376,11 +388,11 @@ function drawPlayerCar(
     ctx.fill();
 
     ctx.fillStyle = "#d7a91e";
-    ctx.fillRect(centerX - halfW * 0.42, topY + height * 0.54, width * 0.84, height * 0.09);
+    ctx.fillRect(centerX - halfW * 0.32, topY + height * 0.56, width * 0.64, height * 0.07);
 
     ctx.fillStyle = car.tailLight ?? PLAYER_CAR_DEFAULT_TAIL_LIGHT;
-    ctx.fillRect(centerX - halfW * 0.54, bottomY - height * 0.24, width * 0.18, height * 0.08);
-    ctx.fillRect(centerX + halfW * 0.36, bottomY - height * 0.24, width * 0.18, height * 0.08);
+    ctx.fillRect(centerX - halfW * 0.52, bottomY - height * 0.24, width * 0.16, height * 0.08);
+    ctx.fillRect(centerX + halfW * 0.36, bottomY - height * 0.24, width * 0.16, height * 0.08);
   } finally {
     ctx.fillStyle = prevFill;
   }

--- a/src/render/pseudoRoadCanvas.ts
+++ b/src/render/pseudoRoadCanvas.ts
@@ -482,4 +482,84 @@ function drawStrips(
       );
     }
   }
+  drawForegroundContinuation(ctx, strips, viewport, colors);
+}
+
+/**
+ * Fill the near-plane gap between the closest projected strip and the
+ * bottom of the viewport. The projector correctly hides strips behind
+ * the camera near plane; without this continuation the sky gradient
+ * remains visible in the foreground, which makes the lower quarter of
+ * the race screen look like empty blue space instead of road.
+ */
+function drawForegroundContinuation(
+  ctx: CanvasRenderingContext2D,
+  strips: readonly Strip[],
+  viewport: Viewport,
+  colors: RoadColors,
+): void {
+  const near = strips.find((strip) => strip.visible);
+  if (!near) return;
+  if (near.screenY >= viewport.height) return;
+
+  const grassColor = pickAlternating(
+    near.segment.index,
+    GRASS_STRIPE_LEN,
+    colors.grassLight,
+    colors.grassDark,
+  );
+  ctx.fillStyle = grassColor;
+  ctx.fillRect(0, near.screenY, viewport.width, viewport.height - near.screenY);
+
+  const bottomX = near.screenX;
+  const bottomY = viewport.height;
+  const roadBottomHalfW = Math.max(near.screenW * 2.8, viewport.width * 0.54);
+  const rumbleBottomHalfW = roadBottomHalfW * 1.15;
+
+  const rumbleColor = pickAlternating(
+    near.segment.index,
+    RUMBLE_STRIPE_LEN,
+    colors.rumbleLight,
+    colors.rumbleDark,
+  );
+  drawTrapezoid(
+    ctx,
+    rumbleColor,
+    bottomX,
+    bottomY,
+    rumbleBottomHalfW,
+    near.screenX,
+    near.screenY,
+    near.screenW * 1.15,
+  );
+
+  const roadColor = pickAlternating(
+    near.segment.index,
+    RUMBLE_STRIPE_LEN,
+    colors.roadLight,
+    colors.roadDark,
+  );
+  drawTrapezoid(
+    ctx,
+    roadColor,
+    bottomX,
+    bottomY,
+    roadBottomHalfW,
+    near.screenX,
+    near.screenY,
+    near.screenW,
+  );
+
+  if (Math.floor(near.segment.index / LANE_STRIPE_LEN) % 2 === 0) {
+    drawTrapezoid(
+      ctx,
+      colors.lane,
+      bottomX,
+      bottomY,
+      Math.max(2, roadBottomHalfW * 0.025),
+      near.screenX,
+      near.screenY,
+      Math.max(1, near.screenW * 0.03),
+    );
+  }
 }

--- a/src/render/pseudoRoadCanvas.ts
+++ b/src/render/pseudoRoadCanvas.ts
@@ -412,112 +412,57 @@ function drawStrips(
     const near = strips[n - 1];
     if (!far || !near) continue;
     if (!far.visible || !near.visible) continue;
-
-    const segIndex = far.segment.index;
-
-    // Grass band: full-width fill behind the road on this strip slice.
-    const grassColor = pickAlternating(
-      segIndex,
-      GRASS_STRIPE_LEN,
-      colors.grassLight,
-      colors.grassDark,
-    );
-    ctx.fillStyle = grassColor;
-    const yTop = far.screenY;
-    const yBottom = near.screenY;
-    if (yBottom > yTop) {
-      ctx.fillRect(0, yTop, viewport.width, yBottom - yTop);
-    }
-
-    // Rumble strips: trapezoid 15% wider than the road.
-    const rumbleColor = pickAlternating(
-      segIndex,
-      RUMBLE_STRIPE_LEN,
-      colors.rumbleLight,
-      colors.rumbleDark,
-    );
-    drawTrapezoid(
-      ctx,
-      rumbleColor,
-      near.screenX,
-      near.screenY,
-      near.screenW * 1.15,
-      far.screenX,
-      far.screenY,
-      far.screenW * 1.15,
-    );
-
-    // Road surface.
-    const roadColor = pickAlternating(
-      segIndex,
-      RUMBLE_STRIPE_LEN,
-      colors.roadLight,
-      colors.roadDark,
-    );
-    drawTrapezoid(
-      ctx,
-      roadColor,
-      near.screenX,
-      near.screenY,
-      near.screenW,
-      far.screenX,
-      far.screenY,
-      far.screenW,
-    );
-
-    // Lane markings: a narrow center stripe on alternating segments. Phase 1
-    // ships a single lane line down the middle; multi-lane comes in §9.
-    if (Math.floor(segIndex / LANE_STRIPE_LEN) % 2 === 0) {
-      const laneHalfNear = Math.max(1, near.screenW * 0.03);
-      const laneHalfFar = Math.max(0.5, far.screenW * 0.03);
-      drawTrapezoid(
-        ctx,
-        colors.lane,
-        near.screenX,
-        near.screenY,
-        laneHalfNear,
-        far.screenX,
-        far.screenY,
-        laneHalfFar,
-      );
-    }
+    drawStripPair(ctx, near, far, viewport, colors);
   }
-  drawForegroundContinuation(ctx, strips, viewport, colors);
+
+  const foregroundFar = strips.find((strip) => strip.visible && strip.foreground);
+  if (foregroundFar?.foreground) {
+    drawStripPair(
+      ctx,
+      {
+        segment: foregroundFar.segment,
+        screenX: foregroundFar.foreground.screenX,
+        screenY: foregroundFar.foreground.screenY,
+        screenW: foregroundFar.foreground.screenW,
+      },
+      foregroundFar,
+      viewport,
+      colors,
+    );
+  }
 }
 
-/**
- * Fill the near-plane gap between the closest projected strip and the
- * bottom of the viewport. The projector correctly hides strips behind
- * the camera near plane; without this continuation the sky gradient
- * remains visible in the foreground, which makes the lower quarter of
- * the race screen look like empty blue space instead of road.
- */
-function drawForegroundContinuation(
+interface StripEdge {
+  segment: Strip["segment"];
+  screenX: number;
+  screenY: number;
+  screenW: number;
+}
+
+function drawStripPair(
   ctx: CanvasRenderingContext2D,
-  strips: readonly Strip[],
+  near: StripEdge,
+  far: StripEdge,
   viewport: Viewport,
   colors: RoadColors,
 ): void {
-  const near = strips.find((strip) => strip.visible);
-  if (!near) return;
-  if (near.screenY >= viewport.height) return;
+  const segIndex = far.segment.index;
 
   const grassColor = pickAlternating(
-    near.segment.index,
+    segIndex,
     GRASS_STRIPE_LEN,
     colors.grassLight,
     colors.grassDark,
   );
   ctx.fillStyle = grassColor;
-  ctx.fillRect(0, near.screenY, viewport.width, viewport.height - near.screenY);
-
-  const bottomX = near.screenX;
-  const bottomY = viewport.height;
-  const roadBottomHalfW = Math.max(near.screenW * 2.8, viewport.width * 0.54);
-  const rumbleBottomHalfW = roadBottomHalfW * 1.15;
+  const yTop = far.screenY;
+  const yBottom = near.screenY;
+  if (yBottom > yTop) {
+    ctx.fillRect(0, yTop, viewport.width, yBottom - yTop);
+  }
 
   const rumbleColor = pickAlternating(
-    near.segment.index,
+    segIndex,
     RUMBLE_STRIPE_LEN,
     colors.rumbleLight,
     colors.rumbleDark,
@@ -525,16 +470,16 @@ function drawForegroundContinuation(
   drawTrapezoid(
     ctx,
     rumbleColor,
-    bottomX,
-    bottomY,
-    rumbleBottomHalfW,
     near.screenX,
     near.screenY,
     near.screenW * 1.15,
+    far.screenX,
+    far.screenY,
+    far.screenW * 1.15,
   );
 
   const roadColor = pickAlternating(
-    near.segment.index,
+    segIndex,
     RUMBLE_STRIPE_LEN,
     colors.roadLight,
     colors.roadDark,
@@ -542,24 +487,26 @@ function drawForegroundContinuation(
   drawTrapezoid(
     ctx,
     roadColor,
-    bottomX,
-    bottomY,
-    roadBottomHalfW,
     near.screenX,
     near.screenY,
     near.screenW,
+    far.screenX,
+    far.screenY,
+    far.screenW,
   );
 
-  if (Math.floor(near.segment.index / LANE_STRIPE_LEN) % 2 === 0) {
+  if (Math.floor(segIndex / LANE_STRIPE_LEN) % 2 === 0) {
+    const laneHalfNear = Math.max(1, near.screenW * 0.03);
+    const laneHalfFar = Math.max(0.5, far.screenW * 0.03);
     drawTrapezoid(
       ctx,
       colors.lane,
-      bottomX,
-      bottomY,
-      Math.max(2, roadBottomHalfW * 0.025),
       near.screenX,
       near.screenY,
-      Math.max(1, near.screenW * 0.03),
+      laneHalfNear,
+      far.screenX,
+      far.screenY,
+      laneHalfFar,
     );
   }
 }

--- a/src/render/pseudoRoadCanvas.ts
+++ b/src/render/pseudoRoadCanvas.ts
@@ -56,6 +56,8 @@ export const GHOST_CAR_DEFAULT_FILL = "#5fb6ff";
 export const PLAYER_CAR_DEFAULT_FILL = "#f2c94c";
 export const PLAYER_CAR_DEFAULT_SHADOW = "rgba(0, 0, 0, 0.55)";
 export const PLAYER_CAR_DEFAULT_WINDSHIELD = "#18243d";
+export const PLAYER_CAR_DEFAULT_TIRE = "#10151f";
+export const PLAYER_CAR_DEFAULT_TAIL_LIGHT = "#ff3d38";
 
 /**
  * Standard player-car footprint. §16 pins the player car at 16 to 22
@@ -143,6 +145,8 @@ export interface DrawRoadOptions {
   playerCar?: {
     fill?: string;
     shadow?: string;
+    tire?: string;
+    tailLight?: string;
     windshield?: string;
   } | null;
 }
@@ -338,36 +342,45 @@ function drawPlayerCar(
 
   const prevFill = ctx.fillStyle;
   try {
+    ctx.fillStyle = car.tire ?? PLAYER_CAR_DEFAULT_TIRE;
+    ctx.fillRect(centerX - halfW * 0.72, topY + height * 0.38, width * 0.18, height * 0.5);
+    ctx.fillRect(centerX + halfW * 0.54, topY + height * 0.38, width * 0.18, height * 0.5);
+
     ctx.fillStyle = car.shadow ?? PLAYER_CAR_DEFAULT_SHADOW;
     ctx.beginPath();
-    ctx.moveTo(centerX - halfW * 0.78, bottomY);
-    ctx.lineTo(centerX + halfW * 0.78, bottomY);
-    ctx.lineTo(centerX + halfW * 0.48, topY + height * 0.1);
-    ctx.lineTo(centerX - halfW * 0.48, topY + height * 0.1);
+    ctx.moveTo(centerX - halfW * 0.82, bottomY);
+    ctx.lineTo(centerX + halfW * 0.82, bottomY);
+    ctx.lineTo(centerX + halfW * 0.56, topY + height * 0.12);
+    ctx.lineTo(centerX - halfW * 0.56, topY + height * 0.12);
     ctx.closePath();
     ctx.fill();
 
     ctx.fillStyle = car.fill ?? PLAYER_CAR_DEFAULT_FILL;
     ctx.beginPath();
-    ctx.moveTo(centerX - halfW * 0.62, bottomY - height * 0.04);
-    ctx.lineTo(centerX + halfW * 0.62, bottomY - height * 0.04);
-    ctx.lineTo(centerX + halfW * 0.36, topY);
-    ctx.lineTo(centerX - halfW * 0.36, topY);
+    ctx.moveTo(centerX - halfW * 0.68, bottomY - height * 0.06);
+    ctx.lineTo(centerX + halfW * 0.68, bottomY - height * 0.06);
+    ctx.lineTo(centerX + halfW * 0.46, topY + height * 0.04);
+    ctx.lineTo(centerX + halfW * 0.24, topY);
+    ctx.lineTo(centerX - halfW * 0.24, topY);
+    ctx.lineTo(centerX - halfW * 0.46, topY + height * 0.04);
     ctx.closePath();
     ctx.fill();
 
     ctx.fillStyle = car.windshield ?? PLAYER_CAR_DEFAULT_WINDSHIELD;
     ctx.beginPath();
-    ctx.moveTo(centerX - halfW * 0.28, topY + height * 0.18);
-    ctx.lineTo(centerX + halfW * 0.28, topY + height * 0.18);
-    ctx.lineTo(centerX + halfW * 0.18, topY + height * 0.5);
-    ctx.lineTo(centerX - halfW * 0.18, topY + height * 0.5);
+    ctx.moveTo(centerX - halfW * 0.28, topY + height * 0.2);
+    ctx.lineTo(centerX + halfW * 0.28, topY + height * 0.2);
+    ctx.lineTo(centerX + halfW * 0.18, topY + height * 0.48);
+    ctx.lineTo(centerX - halfW * 0.18, topY + height * 0.48);
     ctx.closePath();
     ctx.fill();
 
-    ctx.fillStyle = "#f7f7f7";
-    ctx.fillRect(centerX - halfW * 0.5, bottomY - height * 0.24, width * 0.16, height * 0.08);
-    ctx.fillRect(centerX + halfW * 0.34, bottomY - height * 0.24, width * 0.16, height * 0.08);
+    ctx.fillStyle = "#d7a91e";
+    ctx.fillRect(centerX - halfW * 0.42, topY + height * 0.54, width * 0.84, height * 0.09);
+
+    ctx.fillStyle = car.tailLight ?? PLAYER_CAR_DEFAULT_TAIL_LIGHT;
+    ctx.fillRect(centerX - halfW * 0.54, bottomY - height * 0.24, width * 0.18, height * 0.08);
+    ctx.fillRect(centerX + halfW * 0.36, bottomY - height * 0.24, width * 0.18, height * 0.08);
   } finally {
     ctx.fillStyle = prevFill;
   }

--- a/src/render/pseudoRoadCanvas.ts
+++ b/src/render/pseudoRoadCanvas.ts
@@ -48,6 +48,23 @@ export const GHOST_CAR_DEFAULT_ALPHA = 0.5;
  */
 export const GHOST_CAR_DEFAULT_FILL = "#5fb6ff";
 
+/**
+ * Default live player-car overlay colours. These are placeholder fills
+ * until the §16 / §17 atlas slice wires real directional sprites through
+ * the renderer.
+ */
+export const PLAYER_CAR_DEFAULT_FILL = "#f2c94c";
+export const PLAYER_CAR_DEFAULT_SHADOW = "rgba(0, 0, 0, 0.55)";
+export const PLAYER_CAR_DEFAULT_WINDSHIELD = "#18243d";
+
+/**
+ * Standard player-car footprint. §16 pins the player car at 16 to 22
+ * percent of screen height in the standard camera mode; 0.18 leaves
+ * headroom for the HUD and minimap while reading clearly at 800x480.
+ */
+export const PLAYER_CAR_HEIGHT_FRACTION = 0.18;
+export const PLAYER_CAR_WIDTH_TO_HEIGHT = 1.15;
+
 export interface RoadColors {
   skyTop: string;
   skyBottom: string;
@@ -115,6 +132,18 @@ export interface DrawRoadOptions {
     screenW: number;
     alpha?: number;
     fill?: string;
+  } | null;
+  /**
+   * Optional live player car overlay. Pseudo-3D road strips represent the
+   * world moving under a chase camera, so the player car is drawn as a
+   * fixed bottom-screen overlay after the road and dust layers. The
+   * placeholder is intentionally simple until atlas sprites land, but it
+   * preserves the §16 standard camera footprint.
+   */
+  playerCar?: {
+    fill?: string;
+    shadow?: string;
+    windshield?: string;
   } | null;
 }
 
@@ -219,10 +248,14 @@ export function drawRoad(
     drawGhostCar(ctx, options.ghostCar, viewport);
   }
 
-  // Dust paints last so particles sit over the road / grass strips.
+  // Dust paints over the road / grass strips and under the live car.
   // The pool is owned by the caller; the drawer is read-only on it.
   if (options.dust) {
     drawDust(ctx, options.dust, viewport);
+  }
+
+  if (options.playerCar) {
+    drawPlayerCar(ctx, options.playerCar, viewport);
   }
 }
 
@@ -276,6 +309,66 @@ function drawGhostCar(
     ctx.fillRect(ghost.screenX - halfW, ghost.screenY - heightPx, ghost.screenW, heightPx);
   } finally {
     ctx.globalAlpha = prevAlpha;
+    ctx.fillStyle = prevFill;
+  }
+}
+
+/**
+ * Paint the live player car as a centered chase-camera overlay.
+ *
+ * The shape is a temporary original silhouette, not a substitute for the
+ * §17 directional sprite atlas. It gives the runtime view the correct
+ * readable player-car anchor at race start and keeps the visual footprint
+ * inside the §16 16 to 22 percent height band.
+ */
+function drawPlayerCar(
+  ctx: CanvasRenderingContext2D,
+  car: NonNullable<DrawRoadOptions["playerCar"]>,
+  viewport: Viewport,
+): void {
+  if (viewport.width <= 0 || viewport.height <= 0) return;
+
+  const height = viewport.height * PLAYER_CAR_HEIGHT_FRACTION;
+  if (!Number.isFinite(height) || height <= 0) return;
+  const width = height * PLAYER_CAR_WIDTH_TO_HEIGHT;
+  const centerX = viewport.width / 2;
+  const bottomY = viewport.height - Math.max(14, viewport.height * 0.035);
+  const topY = bottomY - height;
+  const halfW = width / 2;
+
+  const prevFill = ctx.fillStyle;
+  try {
+    ctx.fillStyle = car.shadow ?? PLAYER_CAR_DEFAULT_SHADOW;
+    ctx.beginPath();
+    ctx.moveTo(centerX - halfW * 0.78, bottomY);
+    ctx.lineTo(centerX + halfW * 0.78, bottomY);
+    ctx.lineTo(centerX + halfW * 0.48, topY + height * 0.1);
+    ctx.lineTo(centerX - halfW * 0.48, topY + height * 0.1);
+    ctx.closePath();
+    ctx.fill();
+
+    ctx.fillStyle = car.fill ?? PLAYER_CAR_DEFAULT_FILL;
+    ctx.beginPath();
+    ctx.moveTo(centerX - halfW * 0.62, bottomY - height * 0.04);
+    ctx.lineTo(centerX + halfW * 0.62, bottomY - height * 0.04);
+    ctx.lineTo(centerX + halfW * 0.36, topY);
+    ctx.lineTo(centerX - halfW * 0.36, topY);
+    ctx.closePath();
+    ctx.fill();
+
+    ctx.fillStyle = car.windshield ?? PLAYER_CAR_DEFAULT_WINDSHIELD;
+    ctx.beginPath();
+    ctx.moveTo(centerX - halfW * 0.28, topY + height * 0.18);
+    ctx.lineTo(centerX + halfW * 0.28, topY + height * 0.18);
+    ctx.lineTo(centerX + halfW * 0.18, topY + height * 0.5);
+    ctx.lineTo(centerX - halfW * 0.18, topY + height * 0.5);
+    ctx.closePath();
+    ctx.fill();
+
+    ctx.fillStyle = "#f7f7f7";
+    ctx.fillRect(centerX - halfW * 0.5, bottomY - height * 0.24, width * 0.16, height * 0.08);
+    ctx.fillRect(centerX + halfW * 0.34, bottomY - height * 0.24, width * 0.16, height * 0.08);
+  } finally {
     ctx.fillStyle = prevFill;
   }
 }

--- a/src/road/__tests__/segmentProjector.test.ts
+++ b/src/road/__tests__/segmentProjector.test.ts
@@ -180,6 +180,26 @@ describe("project (pseudo-3D segment projector)", () => {
     expect(second.visible).toBe(true);
     expect(second.scale).toBeCloseTo(CAMERA_DEPTH / SEGMENT_LENGTH, 6);
   });
+
+  it("attaches a projected foreground endpoint to the closest visible strip", () => {
+    const segs = flatTrack(16);
+    const strips = project(segs, makeCamera(), VIEWPORT, { drawDistance: 8 });
+    const visible = strips.filter((s) => s.visible);
+    expect(visible.length).toBeGreaterThan(1);
+
+    const near = visible[0]!;
+    const far = visible[1]!;
+    expect(near.foreground).toBeDefined();
+    expect(near.foreground!.screenY).toBe(VIEWPORT.height);
+    expect(near.foreground!.screenX).toBeCloseTo(near.screenX, 6);
+    expect(near.foreground!.screenW).toBeGreaterThan(near.screenW);
+
+    const expected =
+      near.screenW +
+      ((near.screenW - far.screenW) * (VIEWPORT.height - near.screenY)) /
+        (near.screenY - far.screenY);
+    expect(near.foreground!.screenW).toBeCloseTo(expected, 6);
+  });
 });
 
 describe("upcomingCurvature", () => {

--- a/src/road/segmentProjector.ts
+++ b/src/road/segmentProjector.ts
@@ -134,7 +134,38 @@ export function project(
     maxY = strip.screenY;
   }
 
+  attachForegroundProjection(strips, viewport);
+
   return strips;
+}
+
+/**
+ * Attach a screen-bottom endpoint to the closest visible strip. This keeps
+ * the renderer's foreground road inside the same projection contract as
+ * the rest of the strip list instead of patching the lower viewport with
+ * hard-coded road geometry.
+ */
+function attachForegroundProjection(strips: Strip[], viewport: Viewport): void {
+  const nearIndex = strips.findIndex((strip) => strip.visible);
+  if (nearIndex < 0) return;
+
+  const near = strips[nearIndex]!;
+  if (near.screenY >= viewport.height) return;
+
+  const far = strips.slice(nearIndex + 1).find((strip) => strip.visible);
+  const projectedHalfW =
+    far && near.screenY > far.screenY
+      ? near.screenW +
+        ((near.screenW - far.screenW) * (viewport.height - near.screenY)) /
+          (near.screenY - far.screenY)
+      : near.screenW;
+  const screenW = Math.max(near.screenW, projectedHalfW);
+
+  near.foreground = {
+    screenX: near.screenX,
+    screenY: viewport.height,
+    screenW,
+  };
 }
 
 /**

--- a/src/road/types.ts
+++ b/src/road/types.ts
@@ -136,6 +136,16 @@ export interface Strip {
   screenX: number;
   screenY: number;
   screenW: number;
+  /**
+   * Optional foreground endpoint for the closest visible strip. When
+   * present, the renderer uses this as the near edge of the first strip
+   * pair instead of inventing foreground geometry outside projection.
+   */
+  foreground?: {
+    screenX: number;
+    screenY: number;
+    screenW: number;
+  };
   scale: number;
   /** Camera-space world x after curve accumulation, before projection. */
   worldX: number;


### PR DESCRIPTION
## Summary

Adds a live player-car overlay to the pseudo-3D race renderer so a fresh race has a visible bottom-screen car anchor instead of an empty road and HUD view.

Root cause: the race renderer drew the road, ghost overlay, dust, minimap, splits, and HUD, but never drew the live player car. The camera view therefore looked like an empty chase camera even though the session was running.

The final foreground fix keeps coverage in the projection contract: the nearest visible road strip now receives a screen-bottom endpoint, and the renderer draws that as a normal strip pair instead of inventing separate foreground geometry.

## GDD

- §16 Rendering and visual design: Sprite scaling
- §20 HUD and UI/UX: race HUD

## Requirement inventory

Handled in this PR:

- §16 player car uses a chase-view bottom-screen footprint near the standard 16 to 22 percent height range.
- §20 race HUD remains visible while the car and foreground road render.
- §21 pseudo-3D projection owns the visible road foreground, including the nearest strip endpoint.

Left to tracked followups:

- F-050: authored `grade` content must visibly change road elevation in the live race view.
- F-051: live and ghost car placeholders must be replaced with atlas sprites.
- F-052: parallax horizon layers and roadside sprites must be rendered from track data.
- F-053: a GDD coverage ledger should make this inventory machine-checkable.

## Progress log

- docs/PROGRESS_LOG.md: 2026-04-26, Slice: Race start player car overlay

## Test plan

- [x] `npx vitest run src/render/__tests__/pseudoRoadCanvas.test.ts`
- [x] `npm run lint`
- [x] `npm run typecheck`
- [x] Browser pixel check against `http://localhost:3000/race`
- [x] Browser lower-quarter pixel check against `http://localhost:3000/race`
- [x] `npx vitest run src/road/__tests__/segmentProjector.test.ts src/render/__tests__/pseudoRoadCanvas.test.ts`
- [x] `npm run test:e2e -- e2e/race-demo.spec.ts`
- [x] `npm run verify`
- [x] `npm run content-lint`
- [x] `grep -rn $'\u2014\|\u2013' src/render/pseudoRoadCanvas.ts src/render/__tests__/pseudoRoadCanvas.test.ts src/app/race/page.tsx docs/IMPLEMENTATION_PLAN.md docs/WORKING_AGREEMENT.md docs/FOLLOWUPS.md docs/PROGRESS_LOG.md`
- [x] `git diff --check`

## Followups

- F-050: Prove authored elevation in the live race view.
- F-051: Replace live and ghost car placeholders with atlas sprites.
- F-052: Add parallax horizon and roadside sprites to the race renderer.
- F-053: Add a machine-checkable GDD coverage ledger.
