### PR TITLE
F-050 live elevation proof

### DIFF
--- a/docs/FOLLOWUPS.md
+++ b/docs/FOLLOWUPS.md
@@ -55,7 +55,7 @@ a missing-asset fallback.
 ## F-050: Prove authored elevation in the live race view
 **Created:** 2026-04-26
 **Priority:** blocks-release
-**Status:** open
+**Status:** done (2026-04-26)
 **Notes:** §9 defines mild crests, aggressive crests, dips, and
 plateaus, while §16 and §21 say segment `grade` drives hills through
 the pseudo-3D projection pipeline. The bundled `/race` content used in
@@ -65,6 +65,14 @@ small representative track with non-zero grade, validate it through the
 track schema and compiler, and add a browser smoke that confirms the
 projected road and horizon shift as the car advances through the
 grade-bearing segments.
+
+Closed by `fix/f-050-live-elevation-proof`. `/race` now defaults to
+`test/elevation`, a bundled smoke track with authored flat launch,
+crest, dip, plateau, and recovery segments. Track content tests assert
+the JSON validates and compiles with non-zero grade. The race demo
+Playwright smoke samples the center canvas column before and after
+accelerating and asserts the top of the projected road rises as the
+player reaches the grade-bearing segment.
 
 ---
 

--- a/docs/PROGRESS_LOG.md
+++ b/docs/PROGRESS_LOG.md
@@ -6,6 +6,57 @@ Correct them by adding a new entry that references the old one.
 
 ---
 
+## 2026-04-26: Slice: F-050 live elevation proof
+
+**GDD sections touched:**
+[§9](gdd/09-track-design.md) elevation and hills,
+[§16](gdd/16-rendering-and-visual-design.md) segment-based projection,
+[§22](gdd/22-data-schemas.md) Track JSON schema.
+**Branch / PR:** `fix/f-050-live-elevation-proof`, PR pending.
+**Status:** Implemented.
+
+### Done
+- `src/data/tracks/test-elevation.json`: added a bundled smoke track
+  with an authored flat launch, crest, dip, plateau, and recovery run.
+- `src/data/tracks/index.ts`: registered `test/elevation` in the track
+  catalogue.
+- `src/app/race/page.tsx`: changed the default `/race` track to
+  `test/elevation` so the main live race path exercises authored grade.
+- `src/data/__tests__/tracks-content.test.ts`: added catalogue coverage
+  and non-zero grade assertions for the elevation track.
+- `e2e/race-demo.spec.ts`: added a canvas-pixel smoke that verifies the
+  projected road top moves upward while driving into the grade-bearing
+  segment.
+- `docs/FOLLOWUPS.md`: marked F-050 done.
+
+### Verified
+- `npx vitest run src/data/__tests__/tracks-content.test.ts` green,
+  9 passed.
+- `npm run lint` clean.
+- `npm run test:e2e -- e2e/race-demo.spec.ts` green, 2 passed.
+- `npm run verify` clean: lint, typecheck, unit tests, and
+  content-lint all passed; 2,134 unit tests passed.
+- `grep -rn $'\u2014\|\u2013' src/data/tracks/test-elevation.json src/data/tracks/index.ts src/app/race/page.tsx src/data/__tests__/tracks-content.test.ts e2e/race-demo.spec.ts docs/FOLLOWUPS.md docs/PROGRESS_LOG.md`
+  returned no hits.
+- `git diff --check` clean.
+
+### Decisions and assumptions
+- Kept the existing `test/curve` and `test/straight` fixtures available
+  for focused flat-road tests. Only the default smoke path changes to
+  `test/elevation` so future agents cannot miss grade-backed rendering
+  in `/race`.
+- The e2e samples canvas pixels rather than a hidden debug metric so the
+  proof stays tied to what the player actually sees.
+
+### Followups created
+None.
+
+### GDD edits
+None. The implementation matches the existing §9, §16, and §22
+requirements.
+
+---
+
 ## 2026-04-26: Slice: Vercel local link ignores
 
 **GDD sections touched:**

--- a/e2e/race-demo.spec.ts
+++ b/e2e/race-demo.spec.ts
@@ -1,4 +1,25 @@
-import { expect, test } from "@playwright/test";
+import { expect, test, type Locator } from "@playwright/test";
+
+async function centerRoadTopY(canvas: Locator): Promise<number> {
+  return canvas.evaluate((node) => {
+    const canvasEl = node as HTMLCanvasElement;
+    const ctx = canvasEl.getContext("2d");
+    if (!ctx) return -1;
+
+    const x = Math.floor(canvasEl.width / 2);
+    const { data } = ctx.getImageData(x, 0, 1, canvasEl.height);
+    for (let y = 0; y < canvasEl.height; y += 1) {
+      const offset = y * 4;
+      const r = data[offset] ?? 0;
+      const g = data[offset + 1] ?? 0;
+      const b = data[offset + 2] ?? 0;
+      const greyRoad = Math.abs(r - g) <= 8 && Math.abs(g - b) <= 8 && r >= 70 && r <= 230;
+      const lanePaint = r >= 220 && g >= 220 && b >= 220;
+      if (greyRoad || lanePaint) return y;
+    }
+    return -1;
+  });
+}
 
 /**
  * Phase 1 vertical-slice smoke. Visits `/race`, waits for the loading gate
@@ -38,5 +59,33 @@ test.describe("phase 1 race demo", () => {
     // Lap label should still be 1 / N for the curve track.
     const lapText = await page.getByTestId("hud-lap").innerText();
     expect(lapText).toMatch(/^1 \/ \d+$/);
+  });
+
+  test("default race track projects authored elevation as the player advances", async ({
+    page,
+  }) => {
+    await page.goto("/race");
+    await expect(page.getByTestId("race-canvas")).toHaveAttribute(
+      "data-track",
+      "test/elevation",
+    );
+
+    const canvas = page.getByTestId("race-canvas-element");
+    await expect(canvas).toBeVisible();
+    await expect(page.getByTestId("race-phase")).toHaveText("racing", {
+      timeout: 10_000,
+    });
+
+    const before = await centerRoadTopY(canvas);
+    expect(before).toBeGreaterThan(0);
+
+    await canvas.focus();
+    await page.keyboard.down("ArrowUp");
+    await page.waitForTimeout(4_000);
+    await page.keyboard.up("ArrowUp");
+
+    const after = await centerRoadTopY(canvas);
+    expect(after).toBeGreaterThanOrEqual(0);
+    expect(before - after).toBeGreaterThanOrEqual(12);
   });
 });

--- a/src/app/race/page.tsx
+++ b/src/app/race/page.tsx
@@ -91,7 +91,7 @@ import type { RaceResult } from "@/game/raceResult";
 
 const VIEWPORT_WIDTH = 800;
 const VIEWPORT_HEIGHT = 480;
-const DEFAULT_TRACK_ID = "test/curve";
+const DEFAULT_TRACK_ID = "test/elevation";
 const PLAYER_ID = "player";
 
 /**

--- a/src/data/__tests__/tracks-content.test.ts
+++ b/src/data/__tests__/tracks-content.test.ts
@@ -16,7 +16,7 @@ import { describe, expect, it } from "vitest";
 import { TRACK_IDS, TRACK_RAW, loadTrack } from "@/data";
 import { TrackSchema } from "@/data/schemas";
 
-const EXPECTED_IDS = ["test/curve", "test/straight"];
+const EXPECTED_IDS = ["test/curve", "test/elevation", "test/straight"];
 
 describe("track catalogue", () => {
   it("registers every expected MVP track id", () => {
@@ -47,3 +47,15 @@ describe.each(EXPECTED_IDS.map((id) => [id] as const))(
     });
   },
 );
+
+describe("test/elevation track", () => {
+  it("contains non-zero authored grade so the live smoke path exercises hills", () => {
+    const parsed = TrackSchema.parse(TRACK_RAW["test/elevation"]);
+    expect(parsed.segments.some((segment) => segment.grade !== 0)).toBe(true);
+  });
+
+  it("compiles grade-bearing segments into the renderer segment buffer", () => {
+    const compiled = loadTrack("test/elevation");
+    expect(compiled.segments.some((segment) => segment.grade !== 0)).toBe(true);
+  });
+});

--- a/src/data/tracks/index.ts
+++ b/src/data/tracks/index.ts
@@ -12,11 +12,13 @@
  */
 
 import testCurve from "./test-curve.json";
+import testElevation from "./test-elevation.json";
 import testStraight from "./test-straight.json";
 
 export const TRACK_RAW: Readonly<Record<string, unknown>> = Object.freeze({
   "test/straight": testStraight,
   "test/curve": testCurve,
+  "test/elevation": testElevation,
 });
 
 /** Sorted list of available track slugs for menu builders. */

--- a/src/data/tracks/test-elevation.json
+++ b/src/data/tracks/test-elevation.json
@@ -1,0 +1,28 @@
+{
+  "id": "test/elevation",
+  "name": "Test Elevation",
+  "tourId": "test",
+  "author": "core",
+  "version": 1,
+  "lengthMeters": 1200,
+  "laps": 1,
+  "laneCount": 3,
+  "weatherOptions": ["clear"],
+  "difficulty": 1,
+  "segments": [
+    { "len": 72, "curve": 0, "grade": 0, "roadsideLeft": "default", "roadsideRight": "default", "hazards": [] },
+    { "len": 156, "curve": 0, "grade": 0.09, "roadsideLeft": "default", "roadsideRight": "default", "hazards": [] },
+    { "len": 132, "curve": 0.18, "grade": -0.08, "roadsideLeft": "default", "roadsideRight": "default", "hazards": [] },
+    { "len": 120, "curve": 0, "grade": 0.04, "roadsideLeft": "default", "roadsideRight": "default", "hazards": [] },
+    { "len": 120, "curve": -0.22, "grade": 0, "roadsideLeft": "default", "roadsideRight": "default", "hazards": [] },
+    { "len": 180, "curve": 0, "grade": -0.03, "roadsideLeft": "default", "roadsideRight": "default", "hazards": [] },
+    { "len": 180, "curve": 0.14, "grade": 0, "roadsideLeft": "default", "roadsideRight": "default", "hazards": [] },
+    { "len": 240, "curve": 0, "grade": 0, "roadsideLeft": "default", "roadsideRight": "default", "hazards": [] }
+  ],
+  "checkpoints": [
+    { "segmentIndex": 0, "label": "start" },
+    { "segmentIndex": 2, "label": "crest" },
+    { "segmentIndex": 5, "label": "plateau-exit" }
+  ],
+  "spawn": { "gridSlots": 12 }
+}


### PR DESCRIPTION
## Summary
- Add `test/elevation`, a bundled smoke track with authored crest, dip, plateau, and recovery segments.
- Make `/race` default to `test/elevation` so the live race path exercises grade-backed projection.
- Add content and Playwright coverage that proves non-zero grade reaches the compiled segments and changes the visible canvas projection while driving.

## GDD
- §9 Track design: elevation and hills.
- §16 Rendering and visual design: segment y drives hills through pseudo-3D projection.
- §22 Data schemas: Track JSON schema.

## Requirement inventory
- Handled: bundled live smoke content now includes non-zero authored `grade`.
- Handled: `/race` defaults to grade-bearing content instead of a flat-only track.
- Handled: browser smoke samples the actual canvas and asserts the projected road rises as the player reaches the grade-bearing segment.
- Left to followups: parallax horizon and roadside sprite layers remain F-052; atlas car sprites remain F-051.

## Progress log
- `docs/PROGRESS_LOG.md`: 2026-04-26, Slice: F-050 live elevation proof.

## Followups
- Marks F-050 done.
- Creates no new followups.

## Test plan
- [x] `npx vitest run src/data/__tests__/tracks-content.test.ts`
- [x] `npm run lint`
- [x] `npm run test:e2e -- e2e/race-demo.spec.ts`
- [x] `npm run verify`
- [x] `grep -rn $'\u2014\|\u2013' src/data/tracks/test-elevation.json src/data/tracks/index.ts src/app/race/page.tsx src/data/__tests__/tracks-content.test.ts e2e/race-demo.spec.ts docs/FOLLOWUPS.md docs/PROGRESS_LOG.md`\n- [x] `git diff --check`