### PR TITLE
F-053 GDD coverage ledger

### DIFF
--- a/docs/FOLLOWUPS.md
+++ b/docs/FOLLOWUPS.md
@@ -13,7 +13,7 @@ or `obsolete` so the trail is preserved.
 ## F-053: Add a machine-checkable GDD coverage ledger
 **Created:** 2026-04-26
 **Priority:** blocks-release
-**Status:** open
+**Status:** done (2026-04-26)
 **Notes:** The current loop relies on each agent reading the relevant
 GDD sections and remembering to file followups for adjacent required
 behaviour. Add a coverage ledger that maps each concrete GDD requirement
@@ -22,6 +22,11 @@ question. Add a CI or content-lint check that fails when a progress log
 entry claims GDD coverage without listing the remaining uncovered
 requirements. This should catch gaps like road elevation proof before a
 visual slice reaches review.
+
+Closed by `feat/f-053-gdd-coverage-ledger`. `docs/GDD_COVERAGE.json`
+now records requirement-level coverage ids, and `content-lint` validates
+ledger shape, code refs, test refs, open followup refs, open question
+refs, plus the latest progress-log entry's coverage-ledger section.
 
 ---
 

--- a/docs/GDD_COVERAGE.json
+++ b/docs/GDD_COVERAGE.json
@@ -1,0 +1,65 @@
+{
+  "version": 1,
+  "requirements": [
+    {
+      "id": "GDD-09-ELEVATION-LIVE",
+      "gddSections": [
+        "docs/gdd/09-track-design.md",
+        "docs/gdd/16-rendering-and-visual-design.md",
+        "docs/gdd/22-data-schemas.md"
+      ],
+      "requirement": "The live race view projects authored track grade so crests, dips, and plateaus are visible while driving.",
+      "coverage": ["implemented-code", "automated-test"],
+      "implementationRefs": [
+        "src/data/tracks/test-elevation.json",
+        "src/data/tracks/index.ts",
+        "src/app/race/page.tsx",
+        "src/road/segmentProjector.ts",
+        "src/road/trackCompiler.ts"
+      ],
+      "testRefs": [
+        "src/data/__tests__/tracks-content.test.ts",
+        "e2e/race-demo.spec.ts"
+      ],
+      "followupRefs": ["F-050"]
+    },
+    {
+      "id": "GDD-16-CAR-SPRITE-ATLAS",
+      "gddSections": [
+        "docs/gdd/16-rendering-and-visual-design.md",
+        "docs/gdd/17-art-direction.md"
+      ],
+      "requirement": "Live and ghost cars use original directional sprite atlas frames with damage, brake, nitro, and weather variants.",
+      "coverage": ["open-followup"],
+      "followupRefs": ["F-051"]
+    },
+    {
+      "id": "GDD-16-PARALLAX-ROADSIDE",
+      "gddSections": [
+        "docs/gdd/09-track-design.md",
+        "docs/gdd/16-rendering-and-visual-design.md",
+        "docs/gdd/21-technical-design-for-web-implementation.md"
+      ],
+      "requirement": "The race renderer consumes region parallax layers and compiled roadside sprite ids at distinct depths.",
+      "coverage": ["open-followup"],
+      "followupRefs": ["F-052"]
+    },
+    {
+      "id": "GDD-25-LOOP-COVERAGE-LEDGER",
+      "gddSections": [
+        "docs/IMPLEMENTATION_PLAN.md",
+        "docs/WORKING_AGREEMENT.md"
+      ],
+      "requirement": "Each GDD-touching slice ties its progress log entry to a machine-checkable coverage ledger and lists uncovered adjacent requirements.",
+      "coverage": ["implemented-code", "automated-test"],
+      "implementationRefs": [
+        "docs/GDD_COVERAGE.json",
+        "scripts/content-lint.ts",
+        "docs/IMPLEMENTATION_PLAN.md",
+        "docs/WORKING_AGREEMENT.md"
+      ],
+      "testRefs": ["scripts/__tests__/content-lint.test.ts"],
+      "followupRefs": ["F-053"]
+    }
+  ]
+}

--- a/docs/PROGRESS_LOG.md
+++ b/docs/PROGRESS_LOG.md
@@ -6,6 +6,68 @@ Correct them by adding a new entry that references the old one.
 
 ---
 
+## 2026-04-26: Slice: F-053 GDD coverage ledger
+
+**GDD sections touched:**
+[§25](gdd/25-development-roadmap.md) implementation governance,
+[§27](gdd/27-risks-and-mitigations.md) automated regression
+mitigation.
+**Branch / PR:** `feat/f-053-gdd-coverage-ledger`, PR pending.
+**Status:** Implemented.
+
+### Done
+- `docs/GDD_COVERAGE.json`: added the initial machine-checkable
+  requirement ledger for live elevation proof, car sprite atlas work,
+  parallax / roadside rendering work, and the ledger process itself.
+- `scripts/content-lint.ts`: added GDD coverage ledger validation for
+  requirement ids, GDD section refs, code refs, test refs, open followup
+  refs, and open question refs.
+- `scripts/content-lint.ts`: added latest progress-log enforcement so a
+  GDD-touching entry must include a `Coverage ledger` section, cite at
+  least one `GDD-` id, and list uncovered adjacent requirements.
+- `scripts/__tests__/content-lint.test.ts`: added focused coverage for
+  valid and invalid ledger entries plus progress-log enforcement.
+- `docs/FOLLOWUPS.md`: marked F-053 done.
+
+### Verified
+- `npx vitest run scripts/__tests__/content-lint.test.ts` green,
+  54 passed.
+- `npm run content-lint` clean.
+- `npm run lint` clean.
+- `npm run verify` clean: lint, typecheck, unit tests, and
+  content-lint all passed; 2,143 unit tests passed.
+- `grep -rn $'\u2014\|\u2013' docs/GDD_COVERAGE.json scripts/content-lint.ts scripts/__tests__/content-lint.test.ts docs/FOLLOWUPS.md docs/PROGRESS_LOG.md`
+  returned no hits.
+- `git diff --check` clean.
+
+### Decisions and assumptions
+- The lint only enforces the newest progress-log entry so historical
+  entries do not need a noisy retrofit. Every future slice that prepends
+  a GDD-touching log entry must include the ledger section.
+- Seeded the ledger with the road-rendering requirements that produced
+  F-050, F-051, and F-052, plus the new process requirement. The ledger
+  should grow one requirement at a time as slices touch more GDD surface.
+
+### Coverage ledger
+- GDD-09-ELEVATION-LIVE: covered by code and browser/content tests.
+- GDD-16-CAR-SPRITE-ATLAS: uncovered adjacent requirement tracked by
+  F-051.
+- GDD-16-PARALLAX-ROADSIDE: uncovered adjacent requirement tracked by
+  F-052.
+- GDD-25-LOOP-COVERAGE-LEDGER: covered by `content-lint` code and unit
+  tests.
+- Uncovered adjacent requirements: GDD-16-CAR-SPRITE-ATLAS,
+  GDD-16-PARALLAX-ROADSIDE.
+
+### Followups created
+None.
+
+### GDD edits
+None. This slice adds process enforcement around the existing GDD and
+backlog.
+
+---
+
 ## 2026-04-26: Slice: F-050 live elevation proof
 
 **GDD sections touched:**

--- a/scripts/__tests__/content-lint.test.ts
+++ b/scripts/__tests__/content-lint.test.ts
@@ -30,6 +30,8 @@ import {
   findDenylistHit,
   formatHit,
   isBinaryAssetPath,
+  lintGddCoverageLedger,
+  lintLatestProgressLogCoverage,
   lintBinaryManifest,
   lintCarNames,
   lintTopGearText,
@@ -391,6 +393,156 @@ describe("lintTopGearText", () => {
 
 // runContentLint ------------------------------------------------------------
 
+// GDD coverage ledger -------------------------------------------------------
+
+function writeBaseDocs(): void {
+  writeFile(
+    "docs/FOLLOWUPS.md",
+    [
+      "# Followups",
+      "",
+      "## F-001: Followup",
+      "**Status:** open",
+      "",
+      "## F-002: Closed followup",
+      "**Status:** done",
+      "",
+    ].join("\n"),
+  );
+  writeFile(
+    "docs/OPEN_QUESTIONS.md",
+    [
+      "# Open Questions",
+      "",
+      "## Q-001: Question",
+      "**Status:** open",
+      "",
+    ].join("\n"),
+  );
+  writeFile("docs/gdd/09-track-design.md", "# 9. Track design\n");
+  writeFile("src/game/sample.ts", "export const sample = true;\n");
+  writeFile("src/game/__tests__/sample.test.ts", "test('sample', () => {});\n");
+}
+
+function writeCoverageLedger(overrides: Record<string, unknown> = {}): void {
+  writeFile(
+    "docs/GDD_COVERAGE.json",
+    JSON.stringify(
+      {
+        version: 1,
+        requirements: [
+          {
+            id: "GDD-09-SAMPLE",
+            gddSections: ["docs/gdd/09-track-design.md"],
+            requirement: "Sample requirement.",
+            coverage: ["implemented-code", "automated-test"],
+            implementationRefs: ["src/game/sample.ts"],
+            testRefs: ["src/game/__tests__/sample.test.ts"],
+            ...overrides,
+          },
+        ],
+      },
+      null,
+      2,
+    ),
+  );
+}
+
+describe("lintGddCoverageLedger", () => {
+  it("returns no hits when docs/ does not exist", () => {
+    expect(lintGddCoverageLedger({ repoRoot })).toEqual([]);
+  });
+
+  it("flags a docs tree without a coverage ledger", () => {
+    writeFile("docs/FOLLOWUPS.md", "# Followups\n");
+    const hits = lintGddCoverageLedger({ repoRoot });
+    expect(hits).toHaveLength(1);
+    expect(hits[0]?.rule).toBe("gdd-coverage-ledger");
+    expect(hits[0]?.detail).toContain("missing");
+  });
+
+  it("passes a valid implemented and tested requirement", () => {
+    writeBaseDocs();
+    writeCoverageLedger();
+    expect(lintGddCoverageLedger({ repoRoot })).toEqual([]);
+  });
+
+  it("requires implemented-code entries to name existing implementation refs", () => {
+    writeBaseDocs();
+    writeCoverageLedger({ implementationRefs: ["src/game/missing.ts"] });
+    const hits = lintGddCoverageLedger({ repoRoot });
+    expect(hits).toHaveLength(1);
+    expect(hits[0]?.detail).toContain("implementationRefs ref does not exist");
+  });
+
+  it("requires open-followup refs to point at an open followup", () => {
+    writeBaseDocs();
+    writeCoverageLedger({
+      coverage: ["open-followup"],
+      followupRefs: ["F-002"],
+    });
+    const hits = lintGddCoverageLedger({ repoRoot });
+    expect(hits).toHaveLength(1);
+    expect(hits[0]?.detail).toContain("status is not open");
+  });
+
+  it("accepts open-question refs that point at open questions", () => {
+    writeBaseDocs();
+    writeCoverageLedger({
+      coverage: ["open-question"],
+      questionRefs: ["Q-001"],
+    });
+    expect(lintGddCoverageLedger({ repoRoot })).toEqual([]);
+  });
+});
+
+describe("lintLatestProgressLogCoverage", () => {
+  it("returns no hits when PROGRESS_LOG.md does not exist", () => {
+    expect(lintLatestProgressLogCoverage({ repoRoot })).toEqual([]);
+  });
+
+  it("flags a latest GDD-touching entry without coverage ledger fields", () => {
+    writeFile(
+      "docs/PROGRESS_LOG.md",
+      [
+        "# Progress Log",
+        "",
+        "## 2026-04-26: Slice: Missing coverage",
+        "",
+        "**GDD sections touched:** §9.",
+        "**Status:** Implemented.",
+        "",
+      ].join("\n"),
+    );
+    const hits = lintLatestProgressLogCoverage({ repoRoot });
+    expect(hits.map((hit) => hit.rule)).toEqual([
+      "progress-log-coverage",
+      "progress-log-coverage",
+      "progress-log-coverage",
+    ]);
+  });
+
+  it("passes a latest GDD-touching entry with ledger ids and uncovered list", () => {
+    writeFile(
+      "docs/PROGRESS_LOG.md",
+      [
+        "# Progress Log",
+        "",
+        "## 2026-04-26: Slice: Covered",
+        "",
+        "**GDD sections touched:** §9.",
+        "**Status:** Implemented.",
+        "",
+        "### Coverage ledger",
+        "- GDD-09-SAMPLE.",
+        "- Uncovered adjacent requirements: None.",
+        "",
+      ].join("\n"),
+    );
+    expect(lintLatestProgressLogCoverage({ repoRoot })).toEqual([]);
+  });
+});
+
 describe("runContentLint", () => {
   it("returns hits from every pass in stable order", () => {
     writeFile("public/assets/cars/orphan.png", "x");
@@ -463,4 +615,3 @@ describe("repository data is clean", () => {
     expect(TRACK_BODY_FRAGMENT.length).toBeGreaterThan(0);
   });
 });
-

--- a/scripts/content-lint.ts
+++ b/scripts/content-lint.ts
@@ -128,7 +128,9 @@ export interface LintHit {
     | "binary-without-manifest"
     | "track-real-circuit-name"
     | "car-manufacturer-name"
-    | "topgear-text";
+    | "topgear-text"
+    | "gdd-coverage-ledger"
+    | "progress-log-coverage";
   detail: string;
 }
 
@@ -385,6 +387,339 @@ function safeRead(abs: string): string | null {
   }
 }
 
+// GDD coverage ledger -------------------------------------------------------
+
+const GDD_COVERAGE_PATH = "docs/GDD_COVERAGE.json";
+
+const COVERAGE_KINDS = [
+  "implemented-code",
+  "automated-test",
+  "open-followup",
+  "open-question",
+] as const;
+
+type CoverageKind = (typeof COVERAGE_KINDS)[number];
+
+const COVERAGE_KIND_SET = new Set<string>(COVERAGE_KINDS);
+
+interface CoverageLedgerEntry {
+  id: string;
+  gddSections: string[];
+  requirement: string;
+  coverage: CoverageKind[];
+  implementationRefs?: string[];
+  testRefs?: string[];
+  followupRefs?: string[];
+  questionRefs?: string[];
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+function stringArray(value: unknown): string[] | null {
+  if (!Array.isArray(value)) return null;
+  if (!value.every((item) => typeof item === "string" && item.trim().length > 0)) {
+    return null;
+  }
+  return value;
+}
+
+function parseStatusEntries(markdown: string, prefix: "F" | "Q"): Map<string, string> {
+  const statuses = new Map<string, string>();
+  const re = new RegExp(
+    `^## (${prefix}-\\d+):[\\s\\S]*?^\\*\\*Status:\\*\\* ([^\\n]+)`,
+    "gmu",
+  );
+  for (const match of markdown.matchAll(re)) {
+    const id = match[1];
+    const status = match[2];
+    if (id && status) {
+      statuses.set(id, status.trim().toLowerCase());
+    }
+  }
+  return statuses;
+}
+
+function refPathExists(repoRoot: string, ref: string): boolean {
+  const pathOnly = ref.split("#")[0] ?? ref;
+  const abs = resolve(repoRoot, pathOnly);
+  return existsSync(abs);
+}
+
+function parseCoverageEntry(raw: unknown): CoverageLedgerEntry | string {
+  if (!isRecord(raw)) return "entry must be an object";
+  const id = typeof raw.id === "string" ? raw.id : "";
+  if (!/^GDD-\d{2}-[A-Z0-9-]+$/u.test(id)) {
+    return "entry id must match GDD-NN-SLUG";
+  }
+
+  const gddSections = stringArray(raw.gddSections);
+  if (!gddSections || gddSections.length === 0) {
+    return `${id}: gddSections must be a non-empty string array`;
+  }
+
+  const requirement =
+    typeof raw.requirement === "string" ? raw.requirement.trim() : "";
+  if (requirement.length === 0) {
+    return `${id}: requirement must be a non-empty string`;
+  }
+
+  const coverageRaw = stringArray(raw.coverage);
+  if (!coverageRaw || coverageRaw.length === 0) {
+    return `${id}: coverage must be a non-empty string array`;
+  }
+  const coverage: CoverageKind[] = [];
+  for (const item of coverageRaw) {
+    if (!COVERAGE_KIND_SET.has(item)) {
+      return `${id}: unknown coverage kind "${item}"`;
+    }
+    coverage.push(item as CoverageKind);
+  }
+
+  const parsed: CoverageLedgerEntry = {
+    id,
+    gddSections,
+    requirement,
+    coverage,
+  };
+  for (const key of [
+    "implementationRefs",
+    "testRefs",
+    "followupRefs",
+    "questionRefs",
+  ] as const) {
+    const value = raw[key];
+    if (value !== undefined) {
+      const parsedValue = stringArray(value);
+      if (!parsedValue) return `${id}: ${key} must be a string array`;
+      parsed[key] = parsedValue;
+    }
+  }
+  return parsed;
+}
+
+/**
+ * Validate the machine-checkable GDD coverage ledger. The ledger maps
+ * concrete requirements to code, tests, open followups, or open questions.
+ */
+export function lintGddCoverageLedger(input: LintInput): LintHit[] {
+  const docsDir = resolve(input.repoRoot, "docs");
+  if (!existsSync(docsDir)) return [];
+
+  const ledgerAbs = resolve(input.repoRoot, GDD_COVERAGE_PATH);
+  if (!existsSync(ledgerAbs)) {
+    return [
+      {
+        path: GDD_COVERAGE_PATH,
+        rule: "gdd-coverage-ledger",
+        detail: "missing GDD coverage ledger",
+      },
+    ];
+  }
+
+  const text = safeRead(ledgerAbs);
+  if (!text) {
+    return [
+      {
+        path: GDD_COVERAGE_PATH,
+        rule: "gdd-coverage-ledger",
+        detail: "ledger cannot be read",
+      },
+    ];
+  }
+
+  let raw: unknown;
+  try {
+    raw = JSON.parse(text);
+  } catch (error) {
+    return [
+      {
+        path: GDD_COVERAGE_PATH,
+        rule: "gdd-coverage-ledger",
+        detail: `ledger JSON parse failed: ${(error as Error).message}`,
+      },
+    ];
+  }
+
+  if (!isRecord(raw) || raw.version !== 1 || !Array.isArray(raw.requirements)) {
+    return [
+      {
+        path: GDD_COVERAGE_PATH,
+        rule: "gdd-coverage-ledger",
+        detail: "ledger must contain version 1 and a requirements array",
+      },
+    ];
+  }
+
+  const followupStatuses = parseStatusEntries(
+    safeRead(resolve(input.repoRoot, "docs/FOLLOWUPS.md")) ?? "",
+    "F",
+  );
+  const questionStatuses = parseStatusEntries(
+    safeRead(resolve(input.repoRoot, "docs/OPEN_QUESTIONS.md")) ?? "",
+    "Q",
+  );
+
+  const hits: LintHit[] = [];
+  const seen = new Set<string>();
+  for (const rawEntry of raw.requirements) {
+    const parsed = parseCoverageEntry(rawEntry);
+    if (typeof parsed === "string") {
+      hits.push({
+        path: GDD_COVERAGE_PATH,
+        rule: "gdd-coverage-ledger",
+        detail: parsed,
+      });
+      continue;
+    }
+
+    if (seen.has(parsed.id)) {
+      hits.push({
+        path: GDD_COVERAGE_PATH,
+        rule: "gdd-coverage-ledger",
+        detail: `${parsed.id}: duplicate requirement id`,
+      });
+    }
+    seen.add(parsed.id);
+
+    for (const ref of parsed.gddSections) {
+      if (!refPathExists(input.repoRoot, ref)) {
+        hits.push({
+          path: GDD_COVERAGE_PATH,
+          rule: "gdd-coverage-ledger",
+          detail: `${parsed.id}: missing GDD section ref ${ref}`,
+        });
+      }
+    }
+
+    if (parsed.coverage.includes("implemented-code")) {
+      validatePathRefs(input, hits, parsed.id, "implementationRefs", parsed.implementationRefs);
+    }
+    if (parsed.coverage.includes("automated-test")) {
+      validatePathRefs(input, hits, parsed.id, "testRefs", parsed.testRefs);
+    }
+    if (parsed.coverage.includes("open-followup")) {
+      validateStatusRefs(hits, parsed.id, "followupRefs", parsed.followupRefs, followupStatuses, [
+        "open",
+        "in-progress",
+      ]);
+    }
+    if (parsed.coverage.includes("open-question")) {
+      validateStatusRefs(hits, parsed.id, "questionRefs", parsed.questionRefs, questionStatuses, [
+        "open",
+      ]);
+    }
+  }
+  return hits;
+}
+
+function validatePathRefs(
+  input: LintInput,
+  hits: LintHit[],
+  id: string,
+  key: "implementationRefs" | "testRefs",
+  refs: string[] | undefined,
+): void {
+  if (!refs || refs.length === 0) {
+    hits.push({
+      path: GDD_COVERAGE_PATH,
+      rule: "gdd-coverage-ledger",
+      detail: `${id}: ${key} is required`,
+    });
+    return;
+  }
+  for (const ref of refs) {
+    if (!refPathExists(input.repoRoot, ref)) {
+      hits.push({
+        path: GDD_COVERAGE_PATH,
+        rule: "gdd-coverage-ledger",
+        detail: `${id}: ${key} ref does not exist: ${ref}`,
+      });
+    }
+  }
+}
+
+function validateStatusRefs(
+  hits: LintHit[],
+  id: string,
+  key: "followupRefs" | "questionRefs",
+  refs: string[] | undefined,
+  statuses: Map<string, string>,
+  allowedPrefixes: readonly string[],
+): void {
+  if (!refs || refs.length === 0) {
+    hits.push({
+      path: GDD_COVERAGE_PATH,
+      rule: "gdd-coverage-ledger",
+      detail: `${id}: ${key} is required`,
+    });
+    return;
+  }
+  for (const ref of refs) {
+    const status = statuses.get(ref);
+    if (!status) {
+      hits.push({
+        path: GDD_COVERAGE_PATH,
+        rule: "gdd-coverage-ledger",
+        detail: `${id}: ${key} ref not found: ${ref}`,
+      });
+      continue;
+    }
+    if (!allowedPrefixes.some((prefix) => status.startsWith(prefix))) {
+      hits.push({
+        path: GDD_COVERAGE_PATH,
+        rule: "gdd-coverage-ledger",
+        detail: `${id}: ${ref} status is not open (${status})`,
+      });
+    }
+  }
+}
+
+/**
+ * Require the newest progress-log entry to name coverage ledger ids when
+ * it claims GDD coverage. This keeps the append-only log tied to the
+ * machine-checkable ledger without rewriting historical entries.
+ */
+export function lintLatestProgressLogCoverage(input: LintInput): LintHit[] {
+  const progressAbs = resolve(input.repoRoot, "docs/PROGRESS_LOG.md");
+  if (!existsSync(progressAbs)) return [];
+  const text = safeRead(progressAbs);
+  if (!text) return [];
+
+  const match = /^## \d{4}-\d{2}-\d{2}: Slice: .+$/mu.exec(text);
+  if (!match || match.index === undefined) return [];
+  const start = match.index;
+  const next = text.indexOf("\n## ", start + 1);
+  const block = next >= 0 ? text.slice(start, next) : text.slice(start);
+  if (!block.includes("**GDD sections touched:**")) return [];
+
+  const hits: LintHit[] = [];
+  const path = relative(input.repoRoot, progressAbs);
+  if (!block.includes("### Coverage ledger")) {
+    hits.push({
+      path,
+      rule: "progress-log-coverage",
+      detail: "latest GDD-touching entry must include a Coverage ledger section",
+    });
+  }
+  if (!/GDD-\d{2}-[A-Z0-9-]+/u.test(block)) {
+    hits.push({
+      path,
+      rule: "progress-log-coverage",
+      detail: "latest GDD-touching entry must cite at least one coverage ledger id",
+    });
+  }
+  if (!/Uncovered adjacent requirements:/u.test(block)) {
+    hits.push({
+      path,
+      rule: "progress-log-coverage",
+      detail: "latest GDD-touching entry must list uncovered adjacent requirements",
+    });
+  }
+  return hits;
+}
+
 /**
  * Run every pass and return the concatenated hit list. Order is stable:
  * binary-without-manifest first, then track / car / topgear. Tests rely
@@ -396,6 +731,8 @@ export function runContentLint(input: LintInput): LintHit[] {
     ...lintTrackNames(input),
     ...lintCarNames(input),
     ...lintTopGearText(input),
+    ...lintGddCoverageLedger(input),
+    ...lintLatestProgressLogCoverage(input),
   ];
 }
 


### PR DESCRIPTION
## Summary
- Add `docs/GDD_COVERAGE.json` as the machine-checkable requirement ledger.
- Extend `content-lint` to validate coverage ids, GDD refs, code refs, test refs, open followup refs, and open question refs.
- Require the newest GDD-touching progress-log entry to cite coverage ledger ids and list uncovered adjacent requirements.

## GDD
- §25 Development roadmap: implementation governance.
- §27 Risks and mitigations: automated regression mitigation.

## Requirement inventory
- Handled: coverage ledger maps requirements to implemented code, automated tests, open followups, or open questions.
- Handled: CI path catches malformed ledger refs through `npm run content-lint`.
- Handled: latest GDD-touching progress-log entry must name coverage ids and uncovered adjacent requirements.
- Left to followups: the ledger is seeded with the renderer requirements around F-050 through F-052 and should grow as future slices touch more GDD surface.

## Coverage ledger
- GDD-09-ELEVATION-LIVE.
- GDD-16-CAR-SPRITE-ATLAS.
- GDD-16-PARALLAX-ROADSIDE.
- GDD-25-LOOP-COVERAGE-LEDGER.
- Uncovered adjacent requirements: GDD-16-CAR-SPRITE-ATLAS, GDD-16-PARALLAX-ROADSIDE.

## Progress log
- `docs/PROGRESS_LOG.md`: 2026-04-26, Slice: F-053 GDD coverage ledger.

## Followups
- Marks F-053 done.
- Creates no new followups.

## Test plan
- [x] `npx vitest run scripts/__tests__/content-lint.test.ts`
- [x] `npm run content-lint`
- [x] `npm run lint`
- [x] `npm run verify`
- [x] `grep -rn $'\u2014\|\u2013' docs/GDD_COVERAGE.json scripts/content-lint.ts scripts/__tests__/content-lint.test.ts docs/FOLLOWUPS.md docs/PROGRESS_LOG.md`\n- [x] `git diff --check`