### PR TITLE
feat(options): wire reset defaults

### DIFF
--- a/docs/FOLLOWUPS.md
+++ b/docs/FOLLOWUPS.md
@@ -84,7 +84,7 @@ player reaches the grade-bearing segment.
 ## F-049: Implement options reset persistence wiring
 **Created:** 2026-04-26
 **Priority:** nice-to-have
-**Status:** open
+**Status:** done (2026-04-27)
 **Notes:** The `/options` footer renders a disabled "Reset to defaults"
 button. SaveGameSettings v2 has shipped, so the remaining blocker is not
 schema allocation; it is reset semantics across panes that now ship at
@@ -93,6 +93,13 @@ default source and persistence path. The action should reset only fields
 owned by shipped panes, leave placeholder-pane fields untouched, write
 through `saveSave`, and keep the existing disabled state until that full
 path is wired and tested.
+
+Closed by `feat/f-049-options-reset`. The footer button now resets shipped
+options fields only: `settings.assists` and `settings.difficultyPreset`.
+Profile data and placeholder-owned settings such as display units, audio,
+accessibility presentation prefs, transmission mode, and key bindings are
+preserved. Unit tests cover the pure reset helper and Playwright covers the
+full localStorage round-trip.
 
 ---
 

--- a/docs/GDD_COVERAGE.json
+++ b/docs/GDD_COVERAGE.json
@@ -98,6 +98,27 @@
         "README.md"
       ],
       "followupRefs": ["F-003"]
+    },
+    {
+      "id": "GDD-20-OPTIONS-RESET",
+      "gddSections": [
+        "docs/gdd/19-controls-and-input.md",
+        "docs/gdd/20-hud-and-ui-ux.md",
+        "docs/gdd/22-data-schemas.md"
+      ],
+      "requirement": "The options screen can reset shipped settings panes to defaults without overwriting settings owned by placeholder panes or profile data.",
+      "coverage": ["implemented-code", "automated-test"],
+      "implementationRefs": [
+        "src/app/options/page.tsx",
+        "src/components/options/optionsResetState.ts",
+        "src/persistence/save.ts"
+      ],
+      "testRefs": [
+        "src/components/options/__tests__/optionsResetState.test.ts",
+        "src/app/options/__tests__/page.test.tsx",
+        "e2e/options-screen.spec.ts"
+      ],
+      "followupRefs": ["F-049"]
     }
   ]
 }

--- a/docs/PROGRESS_LOG.md
+++ b/docs/PROGRESS_LOG.md
@@ -6,6 +6,61 @@ Correct them by adding a new entry that references the old one.
 
 ---
 
+## 2026-04-27: Slice: F-049 options reset persistence
+
+**GDD sections touched:**
+[§19](gdd/19-controls-and-input.md) controls and accessibility settings,
+[§20](gdd/20-hud-and-ui-ux.md) settings screen,
+[§22](gdd/22-data-schemas.md) `SaveGameSettings`.
+**Branch / PR:** `feat/f-049-options-reset`, PR pending.
+**Status:** Implemented.
+
+### Done
+- `src/components/options/optionsResetState.ts`: added a pure helper that
+  resets only shipped options fields to defaults: accessibility assists and
+  difficulty preset.
+- `src/app/options/page.tsx`: enabled the footer reset button, persisted
+  the reset through `saveSave`, reported status, and remounted the active
+  pane after a successful reset so the visible controls refresh.
+- `src/app/options/__tests__/page.test.tsx`,
+  `src/components/options/__tests__/optionsResetState.test.ts`, and
+  `e2e/options-screen.spec.ts`: added unit and browser coverage for the
+  reset contract.
+- `docs/FOLLOWUPS.md`: marked F-049 done.
+- `docs/GDD_COVERAGE.json`: added GDD-20-OPTIONS-RESET.
+
+### Verified
+- `npx vitest run src/components/options/__tests__/optionsResetState.test.ts src/app/options/__tests__/page.test.tsx`
+  green, 13 passed.
+- `npm run typecheck` clean.
+- `npm run test:e2e -- e2e/options-screen.spec.ts` green, 6 passed.
+- `npm run verify` clean: lint, typecheck, unit tests, and content-lint
+  all passed; 2,147 unit tests passed.
+- `grep -rn $'\u2014\|\u2013' src/app/options/page.tsx src/app/options/page.module.css src/app/options/__tests__/page.test.tsx src/components/options/optionsResetState.ts src/components/options/__tests__/optionsResetState.test.ts e2e/options-screen.spec.ts docs/FOLLOWUPS.md docs/GDD_COVERAGE.json docs/PROGRESS_LOG.md`
+  returned no hits.
+- `git diff --check` clean.
+
+### Decisions and assumptions
+- The reset action intentionally owns only fields for panes that actually
+  ship today: `settings.assists` and `settings.difficultyPreset`. Display,
+  audio, controls, performance, profile import/export, and profile progress
+  data are preserved until those panes define their own reset semantics.
+
+### Coverage ledger
+- GDD-20-OPTIONS-RESET: covered by the new reset helper, page wiring, unit
+  tests, and the Playwright localStorage round-trip.
+- Uncovered adjacent requirements: F-014 still tracks full key remapping UI
+  and persistence; F-049 does not reset key bindings because the Controls
+  pane is still a placeholder.
+
+### Followups created
+None.
+
+### GDD edits
+None. This slice implements the existing options and save-schema intent.
+
+---
+
 ## 2026-04-26: Slice: F-002/F-003 foundation followup closure
 
 **GDD sections touched:**

--- a/e2e/options-screen.spec.ts
+++ b/e2e/options-screen.spec.ts
@@ -69,16 +69,59 @@ test.describe("options screen", () => {
     );
   });
 
-  test("Reset to defaults is disabled and cites the reset wiring followup", async ({ page }) => {
+  test("Reset to defaults restores shipped settings and preserves placeholder-owned settings", async ({ page }) => {
     await page.goto("/options");
 
     const reset = page.getByTestId("options-reset-defaults");
     await expect(reset).toBeVisible();
-    await expect(reset).toBeDisabled();
-    await expect(reset).toHaveAttribute(
-      "title",
-      /F-049/,
+    await expect(reset).toBeEnabled();
+
+    await page.getByTestId("options-tab-accessibility").click();
+    await page.getByTestId("accessibility-toggle-autoAccelerate").check();
+    await page.getByTestId("options-tab-difficulty").click();
+    await page.getByTestId("difficulty-preset-hard-input").check();
+
+    await page.evaluate((key) => {
+      const raw = window.localStorage.getItem(key);
+      if (!raw) throw new Error("save missing after option edits");
+      const save = JSON.parse(raw);
+      save.profileName = "Reset Proof";
+      save.settings.displaySpeedUnit = "mph";
+      save.settings.transmissionMode = "manual";
+      save.settings.audio = { master: 0.2, music: 0.3, sfx: 0.4 };
+      save.settings.accessibility = {
+        colorBlindMode: "protanopia",
+        reducedMotion: true,
+        largeUiText: true,
+        screenShakeScale: 0.25,
+      };
+      save.settings.keyBindings = {
+        throttle: ["KeyI"],
+        brake: ["KeyK"],
+      };
+      window.localStorage.setItem(key, JSON.stringify(save));
+    }, "vibegear2:save:v3");
+
+    await reset.click();
+    await expect(page.getByTestId("options-reset-status")).toContainText(
+      "reset to defaults",
     );
+
+    const persisted = await page.evaluate((key) => {
+      const raw = window.localStorage.getItem(key);
+      return raw ? JSON.parse(raw) : null;
+    }, "vibegear2:save:v3");
+
+    expect(persisted?.settings?.assists?.autoAccelerate).toBe(false);
+    expect(persisted?.settings?.difficultyPreset).toBe("normal");
+    expect(persisted?.profileName).toBe("Reset Proof");
+    expect(persisted?.settings?.displaySpeedUnit).toBe("mph");
+    expect(persisted?.settings?.transmissionMode).toBe("manual");
+    expect(persisted?.settings?.audio).toEqual({
+      master: 0.2,
+      music: 0.3,
+      sfx: 0.4,
+    });
   });
 
   test("Back to title link returns to /", async ({ page }) => {

--- a/src/app/options/__tests__/page.test.tsx
+++ b/src/app/options/__tests__/page.test.tsx
@@ -63,15 +63,13 @@ describe("OptionsPage", () => {
     expect(html).toContain("VibeGear2-implement-visual-polish-7d31d112");
   });
 
-  it("disables the Reset to defaults button until reset persistence lands", () => {
+  it("enables the Reset to defaults button now that reset persistence has landed", () => {
     const reset = html.match(
       /<button[^>]*data-testid="options-reset-defaults"[^>]*>/,
     );
     expect(reset, "reset button not found").not.toBeNull();
-    expect(reset?.[0]).toContain("disabled");
-    expect(reset?.[0]).toContain('aria-disabled="true"');
-    expect(reset?.[0]).toContain("F-049");
-    expect(reset?.[0]).toContain("options reset persistence wiring");
+    expect(reset?.[0]).not.toContain("disabled");
+    expect(reset?.[0]).toContain("Reset shipped options panes to defaults");
   });
 
   it("renders a back-to-title link", () => {

--- a/src/app/options/page.module.css
+++ b/src/app/options/page.module.css
@@ -125,6 +125,16 @@
   cursor: not-allowed;
 }
 
+.resetStatus {
+  margin: 0;
+  color: var(--accent, #8cf);
+  font-size: 0.9rem;
+}
+
+.resetStatus[data-status="error"] {
+  color: #f88;
+}
+
 .backLink {
   color: var(--accent, #8cf);
   text-decoration: none;

--- a/src/app/options/page.tsx
+++ b/src/app/options/page.tsx
@@ -9,9 +9,8 @@
  * content, so the next agent can grep its dot id and find the exact
  * insertion point.
  *
- * - The Reset to defaults button is intentionally disabled: full reset
- *   semantics need F-049 persistence wiring so each shipped pane can
- *   reset without clobbering fields still owned by placeholder panes.
+ * - The Reset to defaults button resets only fields owned by shipped
+ *   panes. Placeholder-pane fields stay untouched until those panes land.
  * - Pressing Esc returns to the title screen via `history.back()` when
  *   there is browser history, otherwise it falls through to a hard
  *   navigation to "/". This matches the §20 pause-menu Exit-to-title
@@ -30,6 +29,8 @@ import type { CSSProperties, KeyboardEvent, ReactElement } from "react";
 import { AccessibilityPane } from "@/components/options/AccessibilityPane";
 import { DifficultyPane } from "@/components/options/DifficultyPane";
 import { ProfileSection } from "@/components/options/ProfileSection";
+import { resetShippedOptionsToDefaults } from "@/components/options/optionsResetState";
+import { defaultSave, loadSave, saveSave } from "@/persistence";
 
 import styles from "./page.module.css";
 import { TAB_ORDER, isTabNavKey, nextTabIndex, type TabKey } from "./tabNav";
@@ -103,10 +104,18 @@ const TABS: ReadonlyArray<TabSpec> = [
   },
 ];
 
-const RESET_PENDING_FOLLOWUP = "F-049";
+interface ResetStatus {
+  readonly kind: "idle" | "info" | "error";
+  readonly message: string;
+}
 
 export default function OptionsPage(): ReactElement {
   const [activeIndex, setActiveIndex] = useState<number>(0);
+  const [resetStatus, setResetStatus] = useState<ResetStatus>({
+    kind: "idle",
+    message: "",
+  });
+  const [resetNonce, setResetNonce] = useState<number>(0);
   const tabRefs = useRef<Array<HTMLButtonElement | null>>([]);
   const focusOnUpdateRef = useRef<boolean>(false);
 
@@ -154,6 +163,33 @@ export default function OptionsPage(): ReactElement {
 
   const onTabClick = useCallback((index: number) => {
     setActiveIndex(index);
+  }, []);
+
+  const onResetDefaults = useCallback(() => {
+    const loaded = loadSave();
+    const current = loaded.kind === "loaded" ? loaded.save : defaultSave();
+    const result = resetShippedOptionsToDefaults(current, defaultSave());
+    if (result.kind === "noop") {
+      setResetStatus({
+        kind: "info",
+        message: "Shipped options are already at defaults.",
+      });
+      return;
+    }
+
+    const write = saveSave(result.save);
+    if (write.kind === "ok") {
+      setResetNonce((n) => n + 1);
+      setResetStatus({
+        kind: "info",
+        message: "Shipped options reset to defaults.",
+      });
+    } else {
+      setResetStatus({
+        kind: "error",
+        message: `Save failed (${write.reason}); defaults kept in memory only.`,
+      });
+    }
   }, []);
 
   const activeTab = TABS[activeIndex] ?? TABS[0];
@@ -215,6 +251,7 @@ export default function OptionsPage(): ReactElement {
         </ul>
 
         <section
+          key={`${activeTab.key}-${resetNonce}`}
           className={styles.panel}
           role="tabpanel"
           id={`options-panel-${activeTab.key}`}
@@ -249,13 +286,21 @@ export default function OptionsPage(): ReactElement {
             type="button"
             className={styles.resetButton}
             data-testid="options-reset-defaults"
-            disabled
-            aria-disabled="true"
-            title={`Disabled until ${RESET_PENDING_FOLLOWUP} ships options reset persistence wiring.`}
+            onClick={onResetDefaults}
+            title="Reset shipped options panes to defaults."
           >
             Reset to defaults
           </button>
         </footer>
+        {resetStatus.kind !== "idle" ? (
+          <p
+            className={styles.resetStatus}
+            data-testid="options-reset-status"
+            data-status={resetStatus.kind}
+          >
+            {resetStatus.message}
+          </p>
+        ) : null}
       </section>
     </main>
   );

--- a/src/components/options/__tests__/optionsResetState.test.ts
+++ b/src/components/options/__tests__/optionsResetState.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, it } from "vitest";
+
+import { defaultSave } from "@/persistence";
+
+import { resetShippedOptionsToDefaults } from "../optionsResetState";
+
+describe("resetShippedOptionsToDefaults", () => {
+  it("resets assists and difficulty to defaults", () => {
+    const save = defaultSave();
+    const customised = {
+      ...save,
+      settings: {
+        ...save.settings,
+        assists: {
+          ...save.settings.assists,
+          autoAccelerate: true,
+          brakeAssist: true,
+        },
+        difficultyPreset: "hard" as const,
+      },
+    };
+
+    const result = resetShippedOptionsToDefaults(customised, defaultSave());
+
+    expect(result.kind).toBe("applied");
+    if (result.kind === "applied") {
+      expect(result.save.settings.assists).toEqual(defaultSave().settings.assists);
+      expect(result.save.settings.difficultyPreset).toBe("normal");
+    }
+  });
+
+  it("preserves placeholder-owned settings and profile data", () => {
+    const save = defaultSave();
+    const customised = {
+      ...save,
+      profileName: "Reset Proof",
+      settings: {
+        ...save.settings,
+        displaySpeedUnit: "mph" as const,
+        transmissionMode: "manual" as const,
+        audio: { master: 0.2, music: 0.3, sfx: 0.4 },
+        accessibility: {
+          colorBlindMode: "protanopia" as const,
+          reducedMotion: true,
+          largeUiText: true,
+          screenShakeScale: 0.25,
+        },
+        keyBindings: {
+          throttle: ["KeyI"],
+          brake: ["KeyK"],
+        },
+        assists: {
+          ...save.settings.assists,
+          nitroToggleMode: true,
+        },
+        difficultyPreset: "easy" as const,
+      },
+      garage: {
+        ...save.garage,
+        credits: 1234,
+      },
+    };
+
+    const result = resetShippedOptionsToDefaults(customised, defaultSave());
+
+    expect(result.kind).toBe("applied");
+    if (result.kind === "applied") {
+      expect(result.save.profileName).toBe("Reset Proof");
+      expect(result.save.garage.credits).toBe(1234);
+      expect(result.save.settings.displaySpeedUnit).toBe("mph");
+      expect(result.save.settings.transmissionMode).toBe("manual");
+      expect(result.save.settings.audio).toEqual(customised.settings.audio);
+      expect(result.save.settings.accessibility).toEqual(
+        customised.settings.accessibility,
+      );
+      expect(result.save.settings.keyBindings).toEqual(
+        customised.settings.keyBindings,
+      );
+    }
+  });
+
+  it("returns noop when shipped options already match defaults", () => {
+    const save = defaultSave();
+
+    expect(resetShippedOptionsToDefaults(save, defaultSave())).toEqual({
+      kind: "noop",
+      reason: "already-default",
+    });
+  });
+
+  it("does not mutate the input save", () => {
+    const save = defaultSave();
+    const customised = {
+      ...save,
+      settings: {
+        ...save.settings,
+        assists: {
+          ...save.settings.assists,
+          steeringSmoothing: true,
+        },
+        difficultyPreset: "hard" as const,
+      },
+    };
+    const before = JSON.stringify(customised);
+
+    resetShippedOptionsToDefaults(customised, defaultSave());
+
+    expect(JSON.stringify(customised)).toBe(before);
+  });
+});

--- a/src/components/options/optionsResetState.ts
+++ b/src/components/options/optionsResetState.ts
@@ -1,0 +1,35 @@
+/**
+ * Pure reset helper for the /options footer. It resets only settings owned
+ * by shipped panes so placeholder tabs do not silently clobber fields they
+ * have not exposed yet.
+ */
+
+import type { SaveGame } from "@/data/schemas";
+
+export type OptionsResetResult =
+  | { kind: "applied"; save: SaveGame }
+  | { kind: "noop"; reason: "already-default" };
+
+export function resetShippedOptionsToDefaults(
+  save: SaveGame,
+  defaults: SaveGame,
+): OptionsResetResult {
+  const next: SaveGame = {
+    ...save,
+    settings: {
+      ...save.settings,
+      assists: { ...defaults.settings.assists },
+      difficultyPreset: defaults.settings.difficultyPreset,
+    },
+  };
+
+  if (
+    JSON.stringify(next.settings.assists) ===
+      JSON.stringify(save.settings.assists) &&
+    next.settings.difficultyPreset === save.settings.difficultyPreset
+  ) {
+    return { kind: "noop", reason: "already-default" };
+  }
+
+  return { kind: "applied", save: next };
+}


### PR DESCRIPTION
## Summary
- Enable the /options Reset to defaults button for shipped settings panes.
- Reset assists and difficulty to defaults while preserving profile data and placeholder-owned settings.
- Add unit, page, e2e, coverage ledger, followup, and progress log updates for F-049.

## GDD sections
- docs/gdd/19-controls-and-input.md
- docs/gdd/20-hud-and-ui-ux.md
- docs/gdd/22-data-schemas.md

## Progress log
- docs/PROGRESS_LOG.md: F-049 options reset persistence

## Test plan
- npx vitest run src/components/options/__tests__/optionsResetState.test.ts src/app/options/__tests__/page.test.tsx
- npm run typecheck
- npm run test:e2e -- e2e/options-screen.spec.ts
- npm run verify
- grep -rn $'\\u2014\\|\\u2013' src/app/options/page.tsx src/app/options/page.module.css src/app/options/__tests__/page.test.tsx src/components/options/optionsResetState.ts src/components/options/__tests__/optionsResetState.test.ts e2e/options-screen.spec.ts docs/FOLLOWUPS.md docs/GDD_COVERAGE.json docs/PROGRESS_LOG.md\n- git diff --check