### PR TITLE
feat(options): add key remapping

### DIFF
--- a/docs/FOLLOWUPS.md
+++ b/docs/FOLLOWUPS.md
@@ -97,9 +97,11 @@ path is wired and tested.
 Closed by `feat/f-049-options-reset`. The footer button now resets shipped
 options fields only: `settings.assists` and `settings.difficultyPreset`.
 Profile data and placeholder-owned settings such as display units, audio,
-accessibility presentation prefs, transmission mode, and key bindings are
-preserved. Unit tests cover the pure reset helper and Playwright covers the
-full localStorage round-trip.
+accessibility presentation prefs, and transmission mode are preserved. At
+the time F-049 landed, key bindings were still preserved because Controls
+was a placeholder; F-014 later made key bindings a shipped pane and added
+them to reset defaults. Unit tests cover the pure reset helper and Playwright
+covers the full localStorage round-trip.
 
 ---
 
@@ -1238,12 +1240,18 @@ the accumulated damage crosses the `total = 0.75` boundary.
 ## F-014: Key remapping UI and persistence
 **Created:** 2026-04-26
 **Priority:** nice-to-have
-**Status:** open
+**Status:** done (2026-04-27)
 **Notes:** `createInputManager` already accepts a `bindings` override and
 the §22 SaveSchema reserves a slot for control profiles, but there is no
 UI to edit or persist them. Build a settings screen that shows each action,
 prompts for a key, validates against conflicts, and writes back to the
 save file. §19 lists this as a first-class feature on desktop.
+
+Closed by `feat/f-014-key-remapping`. The `/options` Controls tab now
+renders a real remapping pane, captures one primary key per action, rejects
+conflicts against other actions, persists to `settings.keyBindings`, and
+offers a reset for bindings. `/race` now reads persisted key bindings when
+creating the input manager, so a custom binding applies at race start.
 
 ## F-013: Touch and mobile input
 **Created:** 2026-04-26

--- a/docs/GDD_COVERAGE.json
+++ b/docs/GDD_COVERAGE.json
@@ -119,6 +119,29 @@
         "e2e/options-screen.spec.ts"
       ],
       "followupRefs": ["F-049"]
+    },
+    {
+      "id": "GDD-19-KEY-REMAPPING",
+      "gddSections": [
+        "docs/gdd/19-controls-and-input.md",
+        "docs/gdd/20-hud-and-ui-ux.md",
+        "docs/gdd/22-data-schemas.md"
+      ],
+      "requirement": "Desktop keyboard actions can be remapped in options, conflicts are rejected, bindings persist to the save, and races consume the persisted bindings at session start.",
+      "coverage": ["implemented-code", "automated-test"],
+      "implementationRefs": [
+        "src/components/options/ControlsPane.tsx",
+        "src/components/options/controlsPaneState.ts",
+        "src/app/options/page.tsx",
+        "src/app/race/page.tsx",
+        "src/persistence/save.ts"
+      ],
+      "testRefs": [
+        "src/components/options/__tests__/controlsPaneState.test.ts",
+        "src/components/options/__tests__/ControlsPane.test.tsx",
+        "e2e/options-screen.spec.ts"
+      ],
+      "followupRefs": ["F-014"]
     }
   ]
 }

--- a/docs/PROGRESS_LOG.md
+++ b/docs/PROGRESS_LOG.md
@@ -6,6 +6,63 @@ Correct them by adding a new entry that references the old one.
 
 ---
 
+## 2026-04-27: Slice: F-014 key remapping UI and persistence
+
+**GDD sections touched:**
+[§19](gdd/19-controls-and-input.md) keyboard remapping,
+[§20](gdd/20-hud-and-ui-ux.md) settings screen,
+[§22](gdd/22-data-schemas.md) `SaveGameSettings.keyBindings`.
+**Branch / PR:** `feat/f-014-key-remapping`, PR pending.
+**Status:** Implemented.
+
+### Done
+- `src/components/options/controlsPaneState.ts`: added the pure controls
+  remapping model, display labels, conflict detection, default reset, and
+  event-token normalisation.
+- `src/components/options/ControlsPane.tsx`: replaced the Controls
+  placeholder with a real remapping pane that captures one primary key per
+  action and persists changes through `saveSave`.
+- `src/app/race/page.tsx`: reads persisted key bindings at race start and
+  passes them to `createInputManager`.
+- `src/components/options/optionsResetState.ts`: now resets key bindings
+  because Controls is a shipped pane.
+- `e2e/options-screen.spec.ts`: covers persistence, conflict rejection, and
+  custom binding consumption in a live race.
+- `docs/FOLLOWUPS.md`: marked F-014 done.
+- `docs/GDD_COVERAGE.json`: added GDD-19-KEY-REMAPPING.
+
+### Verified
+- `npx vitest run src/components/options/__tests__/controlsPaneState.test.ts src/components/options/__tests__/ControlsPane.test.tsx src/components/options/__tests__/optionsResetState.test.ts src/app/options/__tests__/page.test.tsx`
+  green, 21 passed.
+- `npm run typecheck` clean.
+- `npm run test:e2e -- e2e/options-screen.spec.ts` green, 8 passed.
+- `npm run verify` clean: lint, typecheck, unit tests, and content-lint
+  all passed; 2,155 unit tests passed.
+- `grep -rn $'\u2014\|\u2013' src/components/options/ControlsPane.tsx src/components/options/controlsPaneState.ts src/components/options/__tests__/ControlsPane.test.tsx src/components/options/__tests__/controlsPaneState.test.ts src/components/options/optionsResetState.ts src/components/options/__tests__/optionsResetState.test.ts src/app/options/page.tsx src/app/race/page.tsx e2e/options-screen.spec.ts docs/FOLLOWUPS.md docs/GDD_COVERAGE.json docs/PROGRESS_LOG.md`
+  returned no hits.
+- `git diff --check` clean.
+
+### Decisions and assumptions
+- The pane captures one primary key per action. The save schema still
+  supports up to four tokens per action, and defaults keep their multi-key
+  bindings until the player remaps an action.
+- Conflict validation rejects any key already bound to another action.
+
+### Coverage ledger
+- GDD-19-KEY-REMAPPING: covered by the Controls pane, pure helper tests,
+  and Playwright persistence plus race-consumption tests.
+- Uncovered adjacent requirements: Gamepad remapping remains out of scope
+  for this desktop keyboard slice; the GDD only requires full desktop
+  remapping here.
+
+### Followups created
+None.
+
+### GDD edits
+None. This slice implements existing §19, §20, and §22 requirements.
+
+---
+
 ## 2026-04-27: Slice: F-049 options reset persistence
 
 **GDD sections touched:**

--- a/e2e/options-screen.spec.ts
+++ b/e2e/options-screen.spec.ts
@@ -95,10 +95,6 @@ test.describe("options screen", () => {
         largeUiText: true,
         screenShakeScale: 0.25,
       };
-      save.settings.keyBindings = {
-        throttle: ["KeyI"],
-        brake: ["KeyK"],
-      };
       window.localStorage.setItem(key, JSON.stringify(save));
     }, "vibegear2:save:v3");
 
@@ -122,6 +118,65 @@ test.describe("options screen", () => {
       music: 0.3,
       sfx: 0.4,
     });
+  });
+
+  test("Controls remapping persists custom keyboard bindings and rejects conflicts", async ({
+    page,
+  }) => {
+    await page.goto("/options");
+    await page.getByTestId("options-tab-controls").click();
+
+    await expect(page.getByTestId("controls-pane")).toBeVisible();
+    await expect(page.getByTestId("controls-binding-nitro")).toHaveText("Space");
+
+    await page.getByTestId("controls-remap-nitro").click();
+    await expect(page.getByTestId("controls-row-nitro")).toHaveAttribute(
+      "data-listening",
+      "true",
+    );
+    await page.keyboard.press("KeyN");
+
+    await expect(page.getByTestId("controls-binding-nitro")).toHaveText("N");
+    await expect(page.getByTestId("controls-status")).toContainText("saved");
+
+    const persisted = await page.evaluate((key) => {
+      const raw = window.localStorage.getItem(key);
+      return raw ? JSON.parse(raw) : null;
+    }, "vibegear2:save:v3");
+    expect(persisted?.settings?.keyBindings?.nitro).toEqual(["KeyN"]);
+
+    await page.getByTestId("controls-remap-brake").click();
+    await page.keyboard.press("KeyN");
+    await expect(page.getByTestId("controls-status")).toContainText(
+      "already bound to Nitro",
+    );
+    await expect(page.getByTestId("controls-binding-brake")).toHaveText("Down");
+  });
+
+  test("custom accelerate binding is used when a race starts", async ({
+    page,
+  }) => {
+    await page.goto("/options");
+    await page.getByTestId("options-tab-controls").click();
+    await page.getByTestId("controls-remap-accelerate").click();
+    await page.keyboard.press("KeyI");
+
+    await page.goto("/race?track=test/straight");
+    const canvas = page.getByTestId("race-canvas-element");
+    await expect(canvas).toBeVisible();
+    await expect(page.getByTestId("race-phase")).toHaveText("racing", {
+      timeout: 10_000,
+    });
+
+    await canvas.focus();
+    await page.keyboard.down("KeyI");
+    await page.waitForTimeout(1_500);
+    await page.keyboard.up("KeyI");
+
+    const speedText = await page.getByTestId("hud-speed").innerText();
+    const speed = Number(speedText);
+    expect(Number.isFinite(speed)).toBe(true);
+    expect(speed).toBeGreaterThan(0);
   });
 
   test("Back to title link returns to /", async ({ page }) => {

--- a/src/app/options/page.tsx
+++ b/src/app/options/page.tsx
@@ -27,6 +27,7 @@ import { useCallback, useEffect, useRef, useState } from "react";
 import type { CSSProperties, KeyboardEvent, ReactElement } from "react";
 
 import { AccessibilityPane } from "@/components/options/AccessibilityPane";
+import { ControlsPane } from "@/components/options/ControlsPane";
 import { DifficultyPane } from "@/components/options/DifficultyPane";
 import { ProfileSection } from "@/components/options/ProfileSection";
 import { resetShippedOptionsToDefaults } from "@/components/options/optionsResetState";
@@ -76,9 +77,7 @@ const TABS: ReadonlyArray<TabSpec> = [
   {
     key: "controls",
     label: "Controls",
-    headline: "Control remap coming soon",
-    body: "Keyboard and gamepad rebinding lands with the dedicated key remap UI per GDD section 19.",
-    dotId: "VibeGear2-implement-key-remap-a0908466",
+    pane: () => <ControlsPane />,
   },
   {
     key: "accessibility",

--- a/src/app/race/page.tsx
+++ b/src/app/race/page.tsx
@@ -37,6 +37,7 @@ import { useRouter, useSearchParams } from "next/navigation";
 
 import { ErrorBoundary } from "@/components/error/ErrorBoundary";
 import { PauseOverlay } from "@/components/pause/PauseOverlay";
+import { readKeyBindings } from "@/components/options/controlsPaneState";
 import { usePauseActions } from "@/components/pause/usePauseActions";
 import { usePauseToggle } from "@/components/pause/usePauseToggle";
 import { saveRaceResult } from "@/components/results/raceResultStorage";
@@ -377,6 +378,7 @@ function RaceCanvas({ track, lapsOverride, mode }: RaceCanvasProps): ReactElemen
         : defaultSave().settings;
     const persistedAssists = persistedSettings.assists;
     const persistedDifficulty = persistedSettings.difficultyPreset;
+    const persistedKeyBindings = readKeyBindings(sessionSave);
     const timeTrialEnabled = mode === "timeTrial";
     const raceSeed = 1;
     let timeTrialSaveSnapshot = sessionSave;
@@ -458,7 +460,9 @@ function RaceCanvas({ track, lapsOverride, mode }: RaceCanvasProps): ReactElemen
     const totalSegments = track.compiled.totalCompiledSegments;
     const totalLength = track.compiled.totalLengthMeters;
 
-    const inputManager = createInputManager({});
+    const inputManager = createInputManager({
+      bindings: persistedKeyBindings,
+    });
 
     // Wire the §20 pause-menu imperative actions. Each callback closes
     // over the local `config`, the persisted save, the input manager,

--- a/src/components/options/ControlsPane.tsx
+++ b/src/components/options/ControlsPane.tsx
@@ -1,0 +1,266 @@
+"use client";
+
+/**
+ * Controls remapping pane for /options.
+ */
+
+import type { CSSProperties, ReactElement } from "react";
+import { useCallback, useEffect, useState } from "react";
+
+import type { SaveGame } from "@/data/schemas";
+import type { Action } from "@/game/input";
+import { defaultSave, loadSave, saveSave } from "@/persistence";
+
+import {
+  CONTROL_ACTIONS,
+  applyPrimaryKeyBinding,
+  labelForAction,
+  primaryBindingLabel,
+  readKeyBindings,
+  resetKeyBindings,
+  tokenFromKeyboardEvent,
+} from "./controlsPaneState";
+
+interface PaneStatus {
+  readonly kind: "idle" | "info" | "error";
+  readonly message: string;
+}
+
+export function ControlsPane(): ReactElement {
+  const [save, setSave] = useState<SaveGame | null>(null);
+  const [listeningAction, setListeningAction] = useState<Action | null>(null);
+  const [status, setStatus] = useState<PaneStatus>({ kind: "idle", message: "" });
+
+  useEffect(() => {
+    const outcome = loadSave();
+    if (outcome.kind === "loaded") {
+      setSave(outcome.save);
+    } else {
+      setSave(defaultSave());
+      if (outcome.reason !== "missing" && outcome.reason !== "no-storage") {
+        setStatus({
+          kind: "info",
+          message: `Loaded default save (reason: ${outcome.reason}).`,
+        });
+      }
+    }
+  }, []);
+
+  useEffect(() => {
+    if (!listeningAction || !save) return;
+
+    const onKeyDown = (event: KeyboardEvent): void => {
+      event.preventDefault();
+      event.stopPropagation();
+      const token = tokenFromKeyboardEvent(event);
+      const result = applyPrimaryKeyBinding(save, listeningAction, token);
+      const label = labelForAction(listeningAction);
+      setListeningAction(null);
+
+      if (result.kind === "noop") {
+        setStatus({ kind: "info", message: `${label} already uses that key.` });
+        return;
+      }
+      if (result.kind === "error") {
+        setStatus({
+          kind: "error",
+          message: `${token} is already bound to ${labelForAction(result.conflictingAction)}.`,
+        });
+        return;
+      }
+
+      setSave(result.save);
+      const write = saveSave(result.save);
+      if (write.kind === "ok") {
+        setStatus({ kind: "info", message: `${label} binding saved.` });
+      } else {
+        setStatus({
+          kind: "error",
+          message: `Save failed (${write.reason}); change kept in memory only.`,
+        });
+      }
+    };
+
+    window.addEventListener("keydown", onKeyDown, { capture: true });
+    return () => window.removeEventListener("keydown", onKeyDown, { capture: true });
+  }, [listeningAction, save]);
+
+  const onReset = useCallback(() => {
+    if (!save) return;
+    const next = resetKeyBindings(save);
+    setSave(next);
+    setListeningAction(null);
+    const write = saveSave(next);
+    if (write.kind === "ok") {
+      setStatus({ kind: "info", message: "Key bindings reset to defaults." });
+    } else {
+      setStatus({
+        kind: "error",
+        message: `Save failed (${write.reason}); defaults kept in memory only.`,
+      });
+    }
+  }, [save]);
+
+  if (!save) {
+    return (
+      <div data-testid="controls-pane-loading" style={loadingStyle}>
+        Loading control bindings.
+      </div>
+    );
+  }
+
+  const bindings = readKeyBindings(save);
+
+  return (
+    <div data-testid="controls-pane" style={paneStyle}>
+      <header style={headerStyle}>
+        <h2 style={headlineStyle}>Control remapping</h2>
+        <p style={subtitleStyle}>
+          Desktop keyboard bindings persist to your save and apply when a race starts.
+        </p>
+      </header>
+
+      <ul style={listStyle} data-testid="controls-bindings">
+        {CONTROL_ACTIONS.map(({ action, label }) => {
+          const listening = listeningAction === action;
+          return (
+            <li
+              key={action}
+              style={itemStyle(listening)}
+              data-testid={`controls-row-${action}`}
+              data-listening={listening ? "true" : "false"}
+            >
+              <span style={labelStyle}>{label}</span>
+              <kbd
+                style={keyStyle}
+                data-testid={`controls-binding-${action}`}
+              >
+                {primaryBindingLabel(bindings, action)}
+              </kbd>
+              <button
+                type="button"
+                style={buttonStyle}
+                onClick={() => {
+                  setListeningAction(action);
+                  setStatus({
+                    kind: "info",
+                    message: `Press a key for ${label}.`,
+                  });
+                }}
+                data-testid={`controls-remap-${action}`}
+              >
+                {listening ? "Listening" : "Change"}
+              </button>
+            </li>
+          );
+        })}
+      </ul>
+
+      <button
+        type="button"
+        style={resetButtonStyle}
+        onClick={onReset}
+        data-testid="controls-reset-keybindings"
+      >
+        Reset key bindings
+      </button>
+
+      {status.kind !== "idle" ? (
+        <p
+          data-testid="controls-status"
+          data-status={status.kind}
+          style={statusStyle(status.kind)}
+        >
+          {status.message}
+        </p>
+      ) : null}
+    </div>
+  );
+}
+
+const paneStyle: CSSProperties = {
+  display: "flex",
+  flexDirection: "column",
+  gap: "1rem",
+};
+
+const loadingStyle: CSSProperties = {
+  color: "var(--muted, #aaa)",
+};
+
+const headerStyle: CSSProperties = {
+  display: "flex",
+  flexDirection: "column",
+  gap: "0.25rem",
+};
+
+const headlineStyle: CSSProperties = {
+  margin: 0,
+  color: "var(--fg, #ddd)",
+  fontSize: "1.05rem",
+};
+
+const subtitleStyle: CSSProperties = {
+  margin: 0,
+  color: "var(--muted, #aaa)",
+};
+
+const listStyle: CSSProperties = {
+  display: "flex",
+  flexDirection: "column",
+  gap: "0.5rem",
+  listStyle: "none",
+  margin: 0,
+  padding: 0,
+};
+
+function itemStyle(listening: boolean): CSSProperties {
+  return {
+    display: "grid",
+    gridTemplateColumns: "minmax(8rem, 1fr) minmax(6rem, auto) auto",
+    gap: "0.75rem",
+    alignItems: "center",
+    border: `1px solid ${listening ? "var(--accent, #8cf)" : "var(--muted, #444)"}`,
+    borderRadius: "6px",
+    padding: "0.5rem 0.75rem",
+    background: listening ? "rgba(140, 200, 255, 0.06)" : "transparent",
+  };
+}
+
+const labelStyle: CSSProperties = {
+  color: "var(--fg, #ddd)",
+  fontWeight: 600,
+};
+
+const keyStyle: CSSProperties = {
+  justifySelf: "start",
+  minWidth: "4.5rem",
+  border: "1px solid var(--muted, #555)",
+  borderRadius: "4px",
+  padding: "0.25rem 0.45rem",
+  color: "var(--accent, #8cf)",
+  background: "rgba(255, 255, 255, 0.04)",
+  fontFamily: "var(--font-mono, monospace)",
+};
+
+const buttonStyle: CSSProperties = {
+  border: "1px solid var(--muted, #555)",
+  borderRadius: "6px",
+  padding: "0.35rem 0.65rem",
+  background: "transparent",
+  color: "var(--fg, #ddd)",
+  cursor: "pointer",
+};
+
+const resetButtonStyle: CSSProperties = {
+  ...buttonStyle,
+  alignSelf: "flex-start",
+};
+
+function statusStyle(kind: PaneStatus["kind"]): CSSProperties {
+  return {
+    margin: 0,
+    color: kind === "error" ? "#f88" : "var(--accent, #8cf)",
+    fontSize: "0.9rem",
+  };
+}

--- a/src/components/options/__tests__/ControlsPane.test.tsx
+++ b/src/components/options/__tests__/ControlsPane.test.tsx
@@ -1,0 +1,14 @@
+import { describe, expect, it } from "vitest";
+import { createElement } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+
+import { ControlsPane } from "../ControlsPane";
+
+describe("ControlsPane SSR shell", () => {
+  it("renders the loading state before client hydration", () => {
+    const html = renderToStaticMarkup(createElement(ControlsPane));
+
+    expect(html).toContain('data-testid="controls-pane-loading"');
+    expect(html).toContain("Loading control bindings.");
+  });
+});

--- a/src/components/options/__tests__/controlsPaneState.test.ts
+++ b/src/components/options/__tests__/controlsPaneState.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from "vitest";
+
+import { defaultSave } from "@/persistence";
+
+import {
+  applyPrimaryKeyBinding,
+  defaultKeyBindings,
+  formatKeyToken,
+  primaryBindingLabel,
+  readKeyBindings,
+  resetKeyBindings,
+  tokenFromKeyboardEvent,
+} from "../controlsPaneState";
+
+describe("controlsPaneState", () => {
+  it("reads default key bindings from a fresh save", () => {
+    const bindings = readKeyBindings(defaultSave());
+
+    expect(bindings.accelerate).toEqual(["ArrowUp", "KeyW"]);
+    expect(bindings.nitro).toEqual(["Space"]);
+  });
+
+  it("applies a primary key binding without mutating the input save", () => {
+    const save = defaultSave();
+    const before = JSON.stringify(save);
+
+    const result = applyPrimaryKeyBinding(save, "nitro", "KeyN");
+
+    expect(result.kind).toBe("applied");
+    if (result.kind === "applied") {
+      expect(result.save.settings.keyBindings?.nitro).toEqual(["KeyN"]);
+      expect(primaryBindingLabel(readKeyBindings(result.save), "nitro")).toBe("N");
+    }
+    expect(JSON.stringify(save)).toBe(before);
+  });
+
+  it("rejects a token already bound to another action", () => {
+    const result = applyPrimaryKeyBinding(defaultSave(), "nitro", "KeyW");
+
+    expect(result).toEqual({
+      kind: "error",
+      reason: "conflict",
+      conflictingAction: "accelerate",
+    });
+  });
+
+  it("returns noop when assigning the same single binding", () => {
+    const changed = applyPrimaryKeyBinding(defaultSave(), "nitro", "KeyN");
+    expect(changed.kind).toBe("applied");
+    if (changed.kind !== "applied") return;
+
+    expect(applyPrimaryKeyBinding(changed.save, "nitro", "KeyN")).toEqual({
+      kind: "noop",
+      reason: "same-binding",
+    });
+  });
+
+  it("resets key bindings to defaults", () => {
+    const changed = applyPrimaryKeyBinding(defaultSave(), "handbrake", "KeyH");
+    expect(changed.kind).toBe("applied");
+    if (changed.kind !== "applied") return;
+
+    expect(resetKeyBindings(changed.save).settings.keyBindings).toEqual(
+      defaultKeyBindings(),
+    );
+  });
+
+  it("formats common keyboard event tokens for display", () => {
+    expect(formatKeyToken("KeyA")).toBe("A");
+    expect(formatKeyToken("Digit7")).toBe("7");
+    expect(formatKeyToken("ArrowLeft")).toBe("Left");
+    expect(formatKeyToken("Escape")).toBe("Esc");
+    expect(formatKeyToken("ShiftRight")).toBe("Right Shift");
+    expect(formatKeyToken("Space")).toBe("Space");
+  });
+
+  it("prefers KeyboardEvent.code over key for layout-independent bindings", () => {
+    expect(tokenFromKeyboardEvent({ code: "KeyZ", key: "z" })).toBe("KeyZ");
+    expect(tokenFromKeyboardEvent({ code: "", key: "?" })).toBe("?");
+  });
+});

--- a/src/components/options/__tests__/optionsResetState.test.ts
+++ b/src/components/options/__tests__/optionsResetState.test.ts
@@ -74,7 +74,7 @@ describe("resetShippedOptionsToDefaults", () => {
         customised.settings.accessibility,
       );
       expect(result.save.settings.keyBindings).toEqual(
-        customised.settings.keyBindings,
+        defaultSave().settings.keyBindings,
       );
     }
   });

--- a/src/components/options/controlsPaneState.ts
+++ b/src/components/options/controlsPaneState.ts
@@ -1,0 +1,126 @@
+/**
+ * Pure state helpers for the Controls pane (GDD section 19 remapping).
+ */
+
+import type { SaveGame } from "@/data/schemas";
+import {
+  DEFAULT_KEY_BINDINGS,
+  type Action,
+} from "@/game/input";
+
+export interface ControlActionSpec {
+  readonly action: Action;
+  readonly label: string;
+}
+
+export const CONTROL_ACTIONS: ReadonlyArray<ControlActionSpec> = [
+  { action: "accelerate", label: "Accelerate" },
+  { action: "brake", label: "Brake / reverse" },
+  { action: "left", label: "Steer left" },
+  { action: "right", label: "Steer right" },
+  { action: "nitro", label: "Nitro" },
+  { action: "handbrake", label: "Handbrake" },
+  { action: "pause", label: "Pause" },
+  { action: "shiftUp", label: "Shift up" },
+  { action: "shiftDown", label: "Shift down" },
+];
+
+export type KeyBindingsByAction = Record<Action, string[]>;
+
+export type ApplyKeyBindingResult =
+  | { kind: "applied"; save: SaveGame }
+  | { kind: "noop"; reason: "same-binding" }
+  | { kind: "error"; reason: "conflict"; conflictingAction: Action };
+
+export function defaultKeyBindings(): KeyBindingsByAction {
+  const out = {} as KeyBindingsByAction;
+  for (const { action } of CONTROL_ACTIONS) {
+    out[action] = [...DEFAULT_KEY_BINDINGS[action]];
+  }
+  return out;
+}
+
+export function readKeyBindings(save: SaveGame): KeyBindingsByAction {
+  const out = defaultKeyBindings();
+  const persisted = save.settings.keyBindings;
+  if (!persisted) return out;
+  for (const { action } of CONTROL_ACTIONS) {
+    const raw = persisted[action];
+    if (Array.isArray(raw) && raw.length > 0) {
+      out[action] = raw.slice(0, 4);
+    }
+  }
+  return out;
+}
+
+export function primaryBindingLabel(bindings: KeyBindingsByAction, action: Action): string {
+  return formatKeyToken(bindings[action]?.[0] ?? DEFAULT_KEY_BINDINGS[action][0] ?? "");
+}
+
+export function formatKeyToken(token: string): string {
+  if (token === " ") return "Space";
+  if (token === "Space") return "Space";
+  if (token.startsWith("Key") && token.length === 4) return token.slice(3);
+  if (token.startsWith("Digit") && token.length === 6) return token.slice(5);
+  if (token.startsWith("Arrow")) return token.replace("Arrow", "");
+  if (token === "Escape") return "Esc";
+  if (token === "ShiftLeft") return "Left Shift";
+  if (token === "ShiftRight") return "Right Shift";
+  return token;
+}
+
+export function tokenFromKeyboardEvent(event: Pick<KeyboardEvent, "code" | "key">): string {
+  return event.code || event.key;
+}
+
+export function applyPrimaryKeyBinding(
+  save: SaveGame,
+  action: Action,
+  token: string,
+): ApplyKeyBindingResult {
+  const trimmed = token.trim();
+  if (trimmed.length === 0) {
+    return { kind: "noop", reason: "same-binding" };
+  }
+
+  const current = readKeyBindings(save);
+  if (current[action]?.length === 1 && current[action]?.[0] === trimmed) {
+    return { kind: "noop", reason: "same-binding" };
+  }
+
+  for (const { action: other } of CONTROL_ACTIONS) {
+    if (other === action) continue;
+    if (current[other]?.includes(trimmed)) {
+      return { kind: "error", reason: "conflict", conflictingAction: other };
+    }
+  }
+
+  const nextBindings: KeyBindingsByAction = {
+    ...current,
+    [action]: [trimmed],
+  };
+  return {
+    kind: "applied",
+    save: {
+      ...save,
+      settings: {
+        ...save.settings,
+        keyBindings: nextBindings,
+      },
+    },
+  };
+}
+
+export function resetKeyBindings(save: SaveGame): SaveGame {
+  return {
+    ...save,
+    settings: {
+      ...save.settings,
+      keyBindings: defaultKeyBindings(),
+    },
+  };
+}
+
+export function labelForAction(action: Action): string {
+  return CONTROL_ACTIONS.find((item) => item.action === action)?.label ?? action;
+}

--- a/src/components/options/optionsResetState.ts
+++ b/src/components/options/optionsResetState.ts
@@ -20,13 +20,16 @@ export function resetShippedOptionsToDefaults(
       ...save.settings,
       assists: { ...defaults.settings.assists },
       difficultyPreset: defaults.settings.difficultyPreset,
+      keyBindings: defaults.settings.keyBindings,
     },
   };
 
   if (
     JSON.stringify(next.settings.assists) ===
       JSON.stringify(save.settings.assists) &&
-    next.settings.difficultyPreset === save.settings.difficultyPreset
+    next.settings.difficultyPreset === save.settings.difficultyPreset &&
+    JSON.stringify(next.settings.keyBindings) ===
+      JSON.stringify(save.settings.keyBindings)
   ) {
     return { kind: "noop", reason: "already-default" };
   }


### PR DESCRIPTION
## Summary
- Replace the Controls placeholder with a keyboard remapping pane.
- Persist one primary key per action, reject conflicts, and reset key bindings to defaults.
- Thread saved key bindings into the race input manager at session start.
- Update F-014 docs and the GDD coverage ledger.

## GDD sections
- docs/gdd/19-controls-and-input.md
- docs/gdd/20-hud-and-ui-ux.md
- docs/gdd/22-data-schemas.md

## Progress log
- docs/PROGRESS_LOG.md: F-014 key remapping UI and persistence

## Test plan
- npx vitest run src/components/options/__tests__/controlsPaneState.test.ts src/components/options/__tests__/ControlsPane.test.tsx src/components/options/__tests__/optionsResetState.test.ts src/app/options/__tests__/page.test.tsx
- npm run typecheck
- npm run test:e2e -- e2e/options-screen.spec.ts
- npm run verify
- grep -rn $'\\u2014\\|\\u2013' src/components/options/ControlsPane.tsx src/components/options/controlsPaneState.ts src/components/options/__tests__/ControlsPane.test.tsx src/components/options/__tests__/controlsPaneState.test.ts src/components/options/optionsResetState.ts src/components/options/__tests__/optionsResetState.test.ts src/app/options/page.tsx src/app/race/page.tsx e2e/options-screen.spec.ts docs/FOLLOWUPS.md docs/GDD_COVERAGE.json docs/PROGRESS_LOG.md\n- git diff --check