### PR TITLE
F-052 parallax horizon and roadside sprites

### DIFF
--- a/docs/FOLLOWUPS.md
+++ b/docs/FOLLOWUPS.md
@@ -10,6 +10,24 @@ or `obsolete` so the trail is preserved.
 
 ---
 
+## F-054: Fix hill-bottom car stutter and repeated road collision bounce
+**Created:** 2026-04-27
+**Priority:** blocks-release
+**Status:** open
+**Notes:** Manual race observation: when the player reaches the bottom
+of a hill and starts climbing the next grade, the player car appears to
+stutter, bounce, or repeatedly collide with the road. This likely sits
+at the seam between authored grade projection, camera road-height
+sampling, and physics / damage collision feedback. Reproduce on the
+default `/race` elevation track, then add a deterministic regression
+test that drives through the dip-to-climb transition and asserts the
+player car does not receive repeated ground-collision impulses or
+visible vertical jitter. Inspect `src/road/segmentProjector.ts`,
+`src/game/physics.ts`, `src/game/raceSession.ts`, and the camera setup
+in `src/app/race/page.tsx`.
+
+---
+
 ## F-053: Add a machine-checkable GDD coverage ledger
 **Created:** 2026-04-26
 **Priority:** blocks-release

--- a/docs/FOLLOWUPS.md
+++ b/docs/FOLLOWUPS.md
@@ -33,13 +33,25 @@ refs, plus the latest progress-log entry's coverage-ledger section.
 ## F-052: Add parallax horizon and roadside sprites to the race renderer
 **Created:** 2026-04-26
 **Priority:** polish
-**Status:** open
+**Status:** done (2026-04-27)
 **Notes:** §16 and §21 call for layered horizon art, parallax
 backgrounds, and roadside sprites drawn from compiled track segment
 content. The current race view renders flat sky, grass, and road strips
 only. Wire the race renderer to consume region background layers and
 roadside sprite ids from compiled track data, then verify that the
 assets move at distinct depths in a browser smoke.
+
+Closed by `feat/f-052-parallax-roadside`. The live race route now
+builds three procedural temperate parallax layers (sky, mountains,
+hills) and passes them to `drawRoad` with the live camera so each layer
+uses its own scroll depth. `drawRoad` now reads `roadsideLeftId` and
+`roadsideRightId` from compiled strips and paints original procedural
+billboards for sign, tree, fence, rock, and light-pole ids. The bundled
+`test/elevation` smoke track now authors non-default roadside ids so
+the default `/race` path proves both elevation and track-driven scenery.
+Unit tests cover parallax fallback fills and roadside id drawing; the
+race Playwright smoke samples canvas pixels for the horizon layer and
+roadside sign colour.
 
 ---
 

--- a/docs/GDD_COVERAGE.json
+++ b/docs/GDD_COVERAGE.json
@@ -41,7 +41,18 @@
         "docs/gdd/21-technical-design-for-web-implementation.md"
       ],
       "requirement": "The race renderer consumes region parallax layers and compiled roadside sprite ids at distinct depths.",
-      "coverage": ["open-followup"],
+      "coverage": ["implemented-code", "automated-test"],
+      "implementationRefs": [
+        "src/app/race/page.tsx",
+        "src/render/parallax.ts",
+        "src/render/pseudoRoadCanvas.ts",
+        "src/data/tracks/test-elevation.json"
+      ],
+      "testRefs": [
+        "src/render/__tests__/parallax.test.ts",
+        "src/render/__tests__/pseudoRoadCanvas.test.ts",
+        "e2e/race-demo.spec.ts"
+      ],
       "followupRefs": ["F-052"]
     },
     {

--- a/docs/PROGRESS_LOG.md
+++ b/docs/PROGRESS_LOG.md
@@ -43,6 +43,9 @@ renderer.
 - `npm run verify` clean: lint, typecheck, unit tests, and
   content-lint all passed; 2,158 unit tests passed.
 - `npm run test:e2e` green, 55 passed.
+- Copilot PR review thread on roadside vertical culling addressed with
+  a focused `pseudoRoadCanvas` regression test; the focused test file
+  and `npm run typecheck` are green after the fix.
 
 ### Decisions and assumptions
 - Binary region art is not present in the repo yet, so this slice uses

--- a/docs/PROGRESS_LOG.md
+++ b/docs/PROGRESS_LOG.md
@@ -34,6 +34,8 @@ renderer.
 - `docs/FOLLOWUPS.md`: marked F-052 done.
 - `docs/GDD_COVERAGE.json`: changed GDD-16-PARALLAX-ROADSIDE from
   open followup to implemented code plus automated tests.
+- `docs/WORKING_AGREEMENT.md`: added PR review-thread inspection to
+  the merge process so Copilot feedback is checked during future loops.
 
 ### Verified
 - `npx vitest run src/render/__tests__/pseudoRoadCanvas.test.ts src/render/__tests__/parallax.test.ts src/data/__tests__/tracks-content.test.ts`

--- a/docs/PROGRESS_LOG.md
+++ b/docs/PROGRESS_LOG.md
@@ -6,6 +6,69 @@ Correct them by adding a new entry that references the old one.
 
 ---
 
+## 2026-04-27: Slice: F-052 parallax horizon and roadside sprites
+
+**GDD sections touched:**
+[§9](gdd/09-track-design.md) roadside scenery,
+[§16](gdd/16-rendering-and-visual-design.md) parallax backgrounds and
+roadside objects,
+[§21](gdd/21-technical-design-for-web-implementation.md) Canvas2D
+renderer.
+**Branch / PR:** `feat/f-052-parallax-roadside`, PR pending.
+**Status:** Implemented.
+
+### Done
+- `src/app/race/page.tsx`: builds three procedural temperate parallax
+  layers and passes them to `drawRoad` with the live camera.
+- `src/render/parallax.ts`: accepts canvas-backed layers and
+  per-layer fallback fills while preserving the existing missing-art
+  placeholder path.
+- `src/render/pseudoRoadCanvas.ts`: consumes compiled
+  `roadsideLeftId` and `roadsideRightId` values and paints procedural
+  sign, tree, fence, rock, and light-pole billboards at projected
+  roadside depth.
+- `src/data/tracks/test-elevation.json`: authors non-default roadside
+  ids so the default `/race` smoke path proves track-driven scenery.
+- `e2e/race-demo.spec.ts`: samples live canvas pixels for the horizon
+  layer and roadside sign colour.
+- `docs/FOLLOWUPS.md`: marked F-052 done.
+- `docs/GDD_COVERAGE.json`: changed GDD-16-PARALLAX-ROADSIDE from
+  open followup to implemented code plus automated tests.
+
+### Verified
+- `npx vitest run src/render/__tests__/pseudoRoadCanvas.test.ts src/render/__tests__/parallax.test.ts src/data/__tests__/tracks-content.test.ts`
+  green, 41 passed.
+- `npm run typecheck` clean.
+- `npm run test:e2e -- e2e/race-demo.spec.ts` green, 3 passed.
+- `npm run verify` clean: lint, typecheck, unit tests, and
+  content-lint all passed; 2,158 unit tests passed.
+- `npm run test:e2e` green, 55 passed.
+
+### Decisions and assumptions
+- Binary region art is not present in the repo yet, so this slice uses
+  original procedural Canvas2D layer art and billboard shapes. The draw
+  path is the same parallax and compiled-roadside contract later atlas
+  assets will use.
+- Roadside drawing skips the `default` id and maps existing legacy
+  fixture ids (`palms_sparse`, `marina_signs`, `guardrail`,
+  `water_wall`) to matching procedural categories so older content still
+  renders useful scenery.
+
+### Coverage ledger
+- GDD-16-PARALLAX-ROADSIDE: covered by live race wiring, procedural
+  parallax layers, compiled roadside id drawing, unit tests, and the
+  race Playwright canvas-pixel smoke.
+- Uncovered adjacent requirements: GDD-16-CAR-SPRITE-ATLAS remains open
+  under F-051.
+
+### Followups created
+None.
+
+### GDD edits
+None. This slice implements existing §9, §16, and §21 requirements.
+
+---
+
 ## 2026-04-27: Slice: F-014 key remapping UI and persistence
 
 **GDD sections touched:**

--- a/docs/PROGRESS_LOG.md
+++ b/docs/PROGRESS_LOG.md
@@ -34,8 +34,9 @@ renderer.
 - `docs/FOLLOWUPS.md`: marked F-052 done.
 - `docs/GDD_COVERAGE.json`: changed GDD-16-PARALLAX-ROADSIDE from
   open followup to implemented code plus automated tests.
-- `docs/WORKING_AGREEMENT.md`: added PR review-thread inspection to
-  the merge process so Copilot feedback is checked during future loops.
+- `docs/WORKING_AGREEMENT.md`: added PR review-thread inspection and
+  response requirements to the merge process so Copilot and inline
+  feedback are handled during future loops.
 
 ### Verified
 - `npx vitest run src/render/__tests__/pseudoRoadCanvas.test.ts src/render/__tests__/parallax.test.ts src/data/__tests__/tracks-content.test.ts`

--- a/docs/PROGRESS_LOG.md
+++ b/docs/PROGRESS_LOG.md
@@ -67,7 +67,8 @@ renderer.
   under F-051.
 
 ### Followups created
-None.
+- F-054: hill-bottom car stutter / repeated road-collision bounce
+  observed on the live elevation track.
 
 ### GDD edits
 None. This slice implements existing §9, §16, and §21 requirements.

--- a/docs/PROGRESS_LOG.md
+++ b/docs/PROGRESS_LOG.md
@@ -48,6 +48,8 @@ renderer.
 - Copilot PR review thread on roadside vertical culling addressed with
   a focused `pseudoRoadCanvas` regression test; the focused test file
   and `npm run typecheck` are green after the fix.
+- Follow-up Copilot PR review thread on e2e pixel scanning addressed by
+  short-circuiting the helper after a small threshold.
 
 ### Decisions and assumptions
 - Binary region art is not present in the repo yet, so this slice uses

--- a/docs/WORKING_AGREEMENT.md
+++ b/docs/WORKING_AGREEMENT.md
@@ -54,6 +54,9 @@ build*; this agreement wins for *how to operate*.
   - Any followups created and the ids they got in `FOLLOWUPS.md`.
 - Do not open a PR until CI would plausibly pass locally (type-check, lint,
   tests).
+- Before merging, inspect unresolved PR review comments and review threads,
+  including automated Copilot feedback. Address actionable comments with a
+  follow-up commit or state why they are not actionable.
 - Wait for CI to go green before merging. If CI fails, fix the cause; do not
   retry the same red push hoping for a flake.
 - Squash-merge into `main` unless the slice deliberately benefits from

--- a/docs/WORKING_AGREEMENT.md
+++ b/docs/WORKING_AGREEMENT.md
@@ -54,9 +54,11 @@ build*; this agreement wins for *how to operate*.
   - Any followups created and the ids they got in `FOLLOWUPS.md`.
 - Do not open a PR until CI would plausibly pass locally (type-check, lint,
   tests).
-- Before merging, inspect unresolved PR review comments and review threads,
-  including automated Copilot feedback. Address actionable comments with a
-  follow-up commit or state why they are not actionable.
+- Before merging, inspect unresolved PR review comments, including inline
+  and threaded review comments plus automated Copilot feedback. Address
+  actionable comments with a follow-up commit. Respond to each actionable
+  thread with what changed or why no code change is appropriate, then
+  re-check for new comments before merge.
 - Wait for CI to go green before merging. If CI fails, fix the cause; do not
   retry the same red push hoping for a flake.
 - Squash-merge into `main` unless the slice deliberately benefits from

--- a/e2e/race-demo.spec.ts
+++ b/e2e/race-demo.spec.ts
@@ -21,15 +21,16 @@ async function centerRoadTopY(canvas: Locator): Promise<number> {
   });
 }
 
-async function countCanvasColourNear(
+async function hasCanvasColourNear(
   canvas: Locator,
   target: { r: number; g: number; b: number },
   tolerance: number,
-): Promise<number> {
-  return canvas.evaluate((node, { colour, maxDelta }) => {
+  threshold: number,
+): Promise<boolean> {
+  return canvas.evaluate((node, { colour, maxDelta, threshold }) => {
     const canvasEl = node as HTMLCanvasElement;
     const ctx = canvasEl.getContext("2d");
-    if (!ctx) return 0;
+    if (!ctx) return false;
     const { data } = ctx.getImageData(0, 0, canvasEl.width, canvasEl.height);
     let count = 0;
     for (let i = 0; i < data.length; i += 4) {
@@ -39,10 +40,11 @@ async function countCanvasColourNear(
         Math.abs((data[i + 2] ?? 0) - colour.b) <= maxDelta
       ) {
         count += 1;
+        if (count >= threshold) return true;
       }
     }
-    return count;
-  }, { colour: target, maxDelta: tolerance });
+    return false;
+  }, { colour: target, maxDelta: tolerance, threshold });
 }
 
 /**
@@ -123,17 +125,17 @@ test.describe("phase 1 race demo", () => {
       timeout: 10_000,
     });
 
-    const mountainPixels = await countCanvasColourNear(canvas, {
+    const hasMountainPixels = await hasCanvasColourNear(canvas, {
       r: 37,
       g: 58,
       b: 85,
-    }, 3);
-    const signPixels = await countCanvasColourNear(canvas, {
+    }, 3, 8);
+    const hasSignPixels = await hasCanvasColourNear(canvas, {
       r: 231,
       g: 210,
       b: 77,
-    }, 3);
-    expect(mountainPixels).toBeGreaterThan(0);
-    expect(signPixels).toBeGreaterThan(0);
+    }, 3, 8);
+    expect(hasMountainPixels).toBe(true);
+    expect(hasSignPixels).toBe(true);
   });
 });

--- a/e2e/race-demo.spec.ts
+++ b/e2e/race-demo.spec.ts
@@ -21,6 +21,30 @@ async function centerRoadTopY(canvas: Locator): Promise<number> {
   });
 }
 
+async function countCanvasColourNear(
+  canvas: Locator,
+  target: { r: number; g: number; b: number },
+  tolerance: number,
+): Promise<number> {
+  return canvas.evaluate((node, { colour, maxDelta }) => {
+    const canvasEl = node as HTMLCanvasElement;
+    const ctx = canvasEl.getContext("2d");
+    if (!ctx) return 0;
+    const { data } = ctx.getImageData(0, 0, canvasEl.width, canvasEl.height);
+    let count = 0;
+    for (let i = 0; i < data.length; i += 4) {
+      if (
+        Math.abs((data[i] ?? 0) - colour.r) <= maxDelta &&
+        Math.abs((data[i + 1] ?? 0) - colour.g) <= maxDelta &&
+        Math.abs((data[i + 2] ?? 0) - colour.b) <= maxDelta
+      ) {
+        count += 1;
+      }
+    }
+    return count;
+  }, { colour: target, maxDelta: tolerance });
+}
+
 /**
  * Phase 1 vertical-slice smoke. Visits `/race`, waits for the loading gate
  * to settle, asserts the countdown renders, drives forward for a few
@@ -87,5 +111,29 @@ test.describe("phase 1 race demo", () => {
     const after = await centerRoadTopY(canvas);
     expect(after).toBeGreaterThanOrEqual(0);
     expect(before - after).toBeGreaterThanOrEqual(12);
+  });
+
+  test("default race track renders parallax and roadside billboard colours", async ({
+    page,
+  }) => {
+    await page.goto("/race");
+    const canvas = page.getByTestId("race-canvas-element");
+    await expect(canvas).toBeVisible();
+    await expect(page.getByTestId("race-phase")).toHaveText("racing", {
+      timeout: 10_000,
+    });
+
+    const mountainPixels = await countCanvasColourNear(canvas, {
+      r: 37,
+      g: 58,
+      b: 85,
+    }, 3);
+    const signPixels = await countCanvasColourNear(canvas, {
+      r: 231,
+      g: 210,
+      b: 77,
+    }, 3);
+    expect(mountainPixels).toBeGreaterThan(0);
+    expect(signPixels).toBeGreaterThan(0);
   });
 });

--- a/src/app/race/page.tsx
+++ b/src/app/race/page.tsx
@@ -83,6 +83,7 @@ import {
 } from "@/road";
 import { drawRoad } from "@/render/pseudoRoadCanvas";
 import { drawMinimap, type MinimapCar } from "@/render/hudMinimap";
+import type { ParallaxLayer } from "@/render/parallax";
 import { drawSplitsWidget } from "@/render/hudSplits";
 import { drawHud } from "@/render/uiRenderer";
 import { defaultSave, loadSave, saveSave } from "@/persistence/save";
@@ -108,6 +109,77 @@ const MINIMAP_BOX = Object.freeze({
   w: MINIMAP_SIZE,
   h: MINIMAP_SIZE,
 });
+
+function createLayerCanvas(
+  width: number,
+  height: number,
+  paint: (ctx: CanvasRenderingContext2D, width: number, height: number) => void,
+): HTMLCanvasElement {
+  const canvas = document.createElement("canvas");
+  canvas.width = width;
+  canvas.height = height;
+  const ctx = canvas.getContext("2d");
+  if (ctx) paint(ctx, width, height);
+  return canvas;
+}
+
+function createTemperateParallaxLayers(viewport: Viewport): readonly ParallaxLayer[] {
+  const sky = createLayerCanvas(512, 256, (ctx, width, height) => {
+    const gradient = ctx.createLinearGradient(0, 0, 0, height);
+    gradient.addColorStop(0, "#0e1730");
+    gradient.addColorStop(1, "#4d6f94");
+    ctx.fillStyle = gradient;
+    ctx.fillRect(0, 0, width, height);
+  });
+  const mountains = createLayerCanvas(512, 96, (ctx, width, height) => {
+    ctx.fillStyle = "#253a55";
+    ctx.beginPath();
+    ctx.moveTo(0, height);
+    ctx.lineTo(64, height * 0.08);
+    ctx.lineTo(130, height * 0.82);
+    ctx.lineTo(210, height * 0.06);
+    ctx.lineTo(300, height * 0.74);
+    ctx.lineTo(386, height * 0.1);
+    ctx.lineTo(width, height * 0.78);
+    ctx.lineTo(width, height);
+    ctx.closePath();
+    ctx.fill();
+  });
+  const hills = createLayerCanvas(512, 96, (ctx, width, height) => {
+    ctx.fillStyle = "#265c2d";
+    ctx.beginPath();
+    ctx.moveTo(0, height);
+    ctx.quadraticCurveTo(width * 0.18, height * 0.3, width * 0.36, height * 0.7);
+    ctx.quadraticCurveTo(width * 0.58, height * 1.05, width * 0.78, height * 0.45);
+    ctx.quadraticCurveTo(width * 0.9, height * 0.18, width, height * 0.5);
+    ctx.lineTo(width, height);
+    ctx.closePath();
+    ctx.fill();
+    ctx.fillStyle = "#43565d";
+    for (let x = 28; x < width; x += 74) {
+      const blockHeight = 12 + ((x / 2) % 18);
+      ctx.fillRect(x, height - blockHeight - 3, 18, blockHeight);
+    }
+  });
+
+  return [
+    { id: "sky", image: sky, scrollX: 0, bandHeight: viewport.height, yAnchor: 0 },
+    {
+      id: "mountains",
+      image: mountains,
+      scrollX: 0.22,
+      bandHeight: viewport.height * 0.1,
+      yAnchor: 0.01,
+    },
+    {
+      id: "hills",
+      image: hills,
+      scrollX: 0.55,
+      bandHeight: viewport.height * 0.09,
+      yAnchor: 0.04,
+    },
+  ];
+}
 
 /**
  * Sparrow GT base stats. Mirrors `src/data/cars/sparrow-gt.json`. Inlined
@@ -449,6 +521,7 @@ function RaceCanvas({ track, lapsOverride, mode }: RaceCanvasProps): ReactElemen
       depth: CAMERA_DEPTH,
     };
     const viewport: Viewport = { width: VIEWPORT_WIDTH, height: VIEWPORT_HEIGHT };
+    const parallaxLayers = createTemperateParallaxLayers(viewport);
 
     // Refit the unit-square minimap polyline into the §20 layout box once
     // per track so the per-frame draw loop only pays for `projectCar`. The
@@ -606,6 +679,7 @@ function RaceCanvas({ track, lapsOverride, mode }: RaceCanvasProps): ReactElemen
           ghostOverlayTickRef.current = null;
         }
         drawRoad(ctx, strips, viewport, {
+          parallax: { layers: parallaxLayers, camera },
           ghostCar: ghostOverlayRef.current,
           playerCar: {},
         });

--- a/src/data/tracks/test-elevation.json
+++ b/src/data/tracks/test-elevation.json
@@ -10,14 +10,14 @@
   "weatherOptions": ["clear"],
   "difficulty": 1,
   "segments": [
-    { "len": 72, "curve": 0, "grade": 0, "roadsideLeft": "default", "roadsideRight": "default", "hazards": [] },
-    { "len": 156, "curve": 0, "grade": 0.09, "roadsideLeft": "default", "roadsideRight": "default", "hazards": [] },
-    { "len": 132, "curve": 0.18, "grade": -0.08, "roadsideLeft": "default", "roadsideRight": "default", "hazards": [] },
-    { "len": 120, "curve": 0, "grade": 0.04, "roadsideLeft": "default", "roadsideRight": "default", "hazards": [] },
-    { "len": 120, "curve": -0.22, "grade": 0, "roadsideLeft": "default", "roadsideRight": "default", "hazards": [] },
-    { "len": 180, "curve": 0, "grade": -0.03, "roadsideLeft": "default", "roadsideRight": "default", "hazards": [] },
-    { "len": 180, "curve": 0.14, "grade": 0, "roadsideLeft": "default", "roadsideRight": "default", "hazards": [] },
-    { "len": 240, "curve": 0, "grade": 0, "roadsideLeft": "default", "roadsideRight": "default", "hazards": [] }
+    { "len": 72, "curve": 0, "grade": 0, "roadsideLeft": "sign_marker", "roadsideRight": "tree_pine", "hazards": [] },
+    { "len": 156, "curve": 0, "grade": 0.09, "roadsideLeft": "tree_pine", "roadsideRight": "light_pole", "hazards": [] },
+    { "len": 132, "curve": 0.18, "grade": -0.08, "roadsideLeft": "fence_post", "roadsideRight": "rock_boulder", "hazards": [] },
+    { "len": 120, "curve": 0, "grade": 0.04, "roadsideLeft": "tree_pine", "roadsideRight": "sign_marker", "hazards": [] },
+    { "len": 120, "curve": -0.22, "grade": 0, "roadsideLeft": "rock_boulder", "roadsideRight": "fence_post", "hazards": [] },
+    { "len": 180, "curve": 0, "grade": -0.03, "roadsideLeft": "light_pole", "roadsideRight": "tree_pine", "hazards": [] },
+    { "len": 180, "curve": 0.14, "grade": 0, "roadsideLeft": "sign_marker", "roadsideRight": "rock_boulder", "hazards": [] },
+    { "len": 240, "curve": 0, "grade": 0, "roadsideLeft": "tree_pine", "roadsideRight": "fence_post", "hazards": [] }
   ],
   "checkpoints": [
     { "segmentIndex": 0, "label": "start" },

--- a/src/render/__tests__/parallax.test.ts
+++ b/src/render/__tests__/parallax.test.ts
@@ -187,6 +187,29 @@ describe("drawParallax", () => {
     ]);
   });
 
+  it("uses a layer fallback fill when the image is null", () => {
+    const { ctx, calls } = makeSpy();
+    const layer: ParallaxLayer = {
+      id: "hills",
+      image: null,
+      scrollX: 0.6,
+      bandHeight: 80,
+      yAnchor: 1,
+      fallbackFill: "#123456",
+    };
+    drawParallax(ctx, [layer], { x: 0, z: 0 }, VIEWPORT);
+    expect(calls).toEqual([
+      {
+        type: "fillRect",
+        fillStyle: "#123456",
+        x: 0,
+        y: VIEWPORT.height - 80,
+        w: VIEWPORT.width,
+        h: 80,
+      },
+    ]);
+  });
+
   it("anchors yAnchor=1 layers flush with the viewport bottom", () => {
     const { ctx, calls } = makeSpy();
     const layer: ParallaxLayer = {

--- a/src/render/__tests__/pseudoRoadCanvas.test.ts
+++ b/src/render/__tests__/pseudoRoadCanvas.test.ts
@@ -362,6 +362,67 @@ describe("drawRoad foreground projection", () => {
   });
 });
 
+describe("drawRoad roadside sprites", () => {
+  it("paints compiled roadside ids as depth-scaled billboards", () => {
+    const spy = makeCanvasSpy();
+    const strips: readonly Strip[] = [
+      strip({
+        screenY: 440,
+        screenW: 260,
+        segment: {
+          ...strip({}).segment,
+          index: 0,
+          roadsideLeftId: "tree_pine",
+          roadsideRightId: "light_pole",
+        },
+      }),
+      strip({
+        screenY: 300,
+        screenW: 110,
+        segment: {
+          ...strip({}).segment,
+          index: 1,
+          roadsideLeftId: "tree_pine",
+          roadsideRightId: "light_pole",
+        },
+      }),
+    ];
+
+    drawRoad(spy.ctx, strips, VIEWPORT, {});
+
+    const fills = spy.calls.filter((c): c is FillCall => c.type === "fill");
+    expect(fills.some((call) => call.fillStyle === "#245c2f")).toBe(true);
+    expect(fills.some((call) => call.fillStyle === "#2f7a3a")).toBe(true);
+
+    const fillRects = spy.calls.filter(
+      (c): c is FillRectCall => c.type === "fillRect",
+    );
+    expect(fillRects.some((call) => call.fillStyle === "#1b3a20")).toBe(true);
+  });
+
+  it("skips the default roadside id", () => {
+    const spy = makeCanvasSpy();
+    const strips: readonly Strip[] = [
+      strip({
+        screenY: 440,
+        screenW: 260,
+        segment: { ...strip({}).segment, index: 0 },
+      }),
+      strip({
+        screenY: 300,
+        screenW: 110,
+        segment: { ...strip({}).segment, index: 1 },
+      }),
+    ];
+
+    drawRoad(spy.ctx, strips, VIEWPORT, {});
+
+    const fills = spy.calls.filter((c): c is FillCall => c.type === "fill");
+    expect(fills.some((call) => call.fillStyle === "#245c2f")).toBe(false);
+    expect(fills.some((call) => call.fillStyle === "#2f7a3a")).toBe(false);
+  });
+});
+
 describe("drawRoad player car overlay", () => {
   it("paints the live player car at the §16 standard camera footprint", () => {
     const spy = makeCanvasSpy();

--- a/src/render/__tests__/pseudoRoadCanvas.test.ts
+++ b/src/render/__tests__/pseudoRoadCanvas.test.ts
@@ -421,6 +421,38 @@ describe("drawRoad roadside sprites", () => {
     expect(fills.some((call) => call.fillStyle === "#245c2f")).toBe(false);
     expect(fills.some((call) => call.fillStyle === "#2f7a3a")).toBe(false);
   });
+
+  it("culls roadside sprites whose base is above the viewport", () => {
+    const spy = makeCanvasSpy();
+    const strips: readonly Strip[] = [
+      strip({
+        screenY: -1,
+        screenW: 260,
+        segment: {
+          ...strip({}).segment,
+          index: 0,
+          roadsideLeftId: "tree_pine",
+          roadsideRightId: "default",
+        },
+      }),
+      strip({
+        screenY: -80,
+        screenW: 110,
+        segment: {
+          ...strip({}).segment,
+          index: 1,
+          roadsideLeftId: "tree_pine",
+          roadsideRightId: "default",
+        },
+      }),
+    ];
+
+    drawRoad(spy.ctx, strips, VIEWPORT, {});
+
+    const fills = spy.calls.filter((c): c is FillCall => c.type === "fill");
+    expect(fills.some((call) => call.fillStyle === "#245c2f")).toBe(false);
+    expect(fills.some((call) => call.fillStyle === "#2f7a3a")).toBe(false);
+  });
 });
 
 describe("drawRoad player car overlay", () => {

--- a/src/render/parallax.ts
+++ b/src/render/parallax.ts
@@ -43,13 +43,19 @@ import type { Camera, Viewport } from "@/road/types";
  */
 export interface ParallaxLayer {
   id: "sky" | "mountains" | "hills";
-  image: HTMLImageElement | null;
+  image: (CanvasImageSource & { width: number }) | null;
   /** Horizontal scroll factor; 0 = static, 1 = locks to `camera.x`. */
   scrollX: number;
   /** Vertical band height in CSS pixels. */
   bandHeight: number;
   /** Vertical anchor in viewport: 0 = top, 1 = bottom. */
   yAnchor: number;
+  /**
+   * Optional fallback fill for procedural or not-yet-loaded layers.
+   * Kept per-layer so live race views can avoid the dev-only magenta
+   * missing-art fill while tests can still exercise that fallback.
+   */
+  fallbackFill?: string;
 }
 
 /**
@@ -120,7 +126,7 @@ export function drawParallax(
       // not loaded. Renderers are expected to swap in the loaded image
       // once `loadImage` resolves; see `spriteAtlas.loadAtlas` for the
       // analogous pattern in the sprite path.
-      ctx.fillStyle = PLACEHOLDER_FILL;
+      ctx.fillStyle = layer.fallbackFill ?? PLACEHOLDER_FILL;
       ctx.fillRect(0, y, viewport.width, height);
       continue;
     }

--- a/src/render/pseudoRoadCanvas.ts
+++ b/src/render/pseudoRoadCanvas.ts
@@ -338,7 +338,7 @@ function drawRoadsideSprite(
   const baseX = strip.screenX + sideSign * strip.screenW * 1.32;
   const baseY = strip.screenY;
 
-  if (baseY + height < 0 || baseY - height > viewport.height) return;
+  if (baseY < 0 || baseY - height > viewport.height) return;
   if (baseX + width < 0 || baseX - width > viewport.width) return;
 
   switch (style.kind) {

--- a/src/render/pseudoRoadCanvas.ts
+++ b/src/render/pseudoRoadCanvas.ts
@@ -9,8 +9,9 @@
  * the drawer paints the parallax bands instead of the flat sky gradient,
  * preserving the painter's algorithm (background first, road over).
  *
- * No textures in Phase 1, no sprites in this module. Those land in
- * follow-up slices (`spriteAtlas.ts`).
+ * Texture-backed sprite atlases land in `spriteAtlas.ts`; this drawer
+ * owns the procedural roadside billboard fallback so compiled roadside
+ * ids are visible before binary art ships.
  *
  * The drawer is the only module that knows about a Canvas2D context. The
  * projector is pure so unit tests can run without jsdom canvas mocking.
@@ -21,6 +22,7 @@ import {
   GRASS_STRIPE_LEN,
   LANE_STRIPE_LEN,
   RUMBLE_STRIPE_LEN,
+  SPRITE_BASE_SCALE,
 } from "@/road/constants";
 import type { Camera, Strip, Viewport } from "@/road/types";
 
@@ -66,6 +68,8 @@ export const PLAYER_CAR_DEFAULT_TAIL_LIGHT = "#ff3d38";
  */
 export const PLAYER_CAR_HEIGHT_FRACTION = 0.18;
 export const PLAYER_CAR_WIDTH_TO_HEIGHT = 1.15;
+export const ROADSIDE_DRAW_PERIOD = 10;
+export const ROADSIDE_MAX_HEIGHT_FRACTION = 0.22;
 
 export interface RoadColors {
   skyTop: string;
@@ -151,6 +155,27 @@ export interface DrawRoadOptions {
   } | null;
 }
 
+type RoadsideSpriteKind = "sign" | "tree" | "fence" | "rock" | "pole";
+
+interface RoadsideSpriteStyle {
+  kind: RoadsideSpriteKind;
+  widthToHeight: number;
+  heightRoadFactor: number;
+  minHeight: number;
+}
+
+const ROADSIDE_SPRITE_STYLES: Record<string, RoadsideSpriteStyle> = {
+  sign_marker: { kind: "sign", widthToHeight: 0.45, heightRoadFactor: 0.85, minHeight: 8 },
+  tree_pine: { kind: "tree", widthToHeight: 0.58, heightRoadFactor: 1.35, minHeight: 12 },
+  fence_post: { kind: "fence", widthToHeight: 0.32, heightRoadFactor: 0.5, minHeight: 5 },
+  rock_boulder: { kind: "rock", widthToHeight: 1.2, heightRoadFactor: 0.42, minHeight: 5 },
+  light_pole: { kind: "pole", widthToHeight: 0.16, heightRoadFactor: 1.9, minHeight: 14 },
+  palms_sparse: { kind: "tree", widthToHeight: 0.58, heightRoadFactor: 1.35, minHeight: 12 },
+  marina_signs: { kind: "sign", widthToHeight: 0.45, heightRoadFactor: 0.85, minHeight: 8 },
+  guardrail: { kind: "fence", widthToHeight: 0.32, heightRoadFactor: 0.5, minHeight: 5 },
+  water_wall: { kind: "rock", widthToHeight: 1.2, heightRoadFactor: 0.42, minHeight: 5 },
+};
+
 const FALLBACK_COLORS: RoadColors = {
   skyTop: DEFAULT_COLORS.skyTop,
   skyBottom: DEFAULT_COLORS.skyBottom,
@@ -234,9 +259,11 @@ export function drawRoad(
       ctx.save();
       ctx.translate(shakeOffset.dx, shakeOffset.dy);
       drawStrips(ctx, strips, viewport, colors);
+      drawRoadsideSprites(ctx, strips, viewport);
       ctx.restore();
     } else {
       drawStrips(ctx, strips, viewport, colors);
+      drawRoadsideSprites(ctx, strips, viewport);
     }
   }
 
@@ -261,6 +288,163 @@ export function drawRoad(
   if (options.playerCar) {
     drawPlayerCar(ctx, options.playerCar, viewport);
   }
+}
+
+function roadsideStyleFor(id: string): RoadsideSpriteStyle | null {
+  if (id === "default") return null;
+  return ROADSIDE_SPRITE_STYLES[id] ?? null;
+}
+
+function shouldDrawRoadsideSprite(strip: Strip, side: "left" | "right"): boolean {
+  const offset = side === "left" ? 0 : Math.floor(ROADSIDE_DRAW_PERIOD / 2);
+  return (strip.segment.index + offset) % ROADSIDE_DRAW_PERIOD === 0;
+}
+
+function drawRoadsideSprites(
+  ctx: CanvasRenderingContext2D,
+  strips: readonly Strip[],
+  viewport: Viewport,
+): void {
+  for (let i = strips.length - 1; i >= 0; i--) {
+    const strip = strips[i];
+    if (!strip?.visible) continue;
+    drawRoadsideSprite(ctx, strip, viewport, "left");
+    drawRoadsideSprite(ctx, strip, viewport, "right");
+  }
+}
+
+function drawRoadsideSprite(
+  ctx: CanvasRenderingContext2D,
+  strip: Strip,
+  viewport: Viewport,
+  side: "left" | "right",
+): void {
+  if (!shouldDrawRoadsideSprite(strip, side)) return;
+  const id =
+    side === "left" ? strip.segment.roadsideLeftId : strip.segment.roadsideRightId;
+  const style = roadsideStyleFor(id);
+  if (!style) return;
+  if (viewport.width <= 0 || viewport.height <= 0) return;
+  if (!Number.isFinite(strip.screenW) || strip.screenW <= 0) return;
+  if (!Number.isFinite(strip.screenX) || !Number.isFinite(strip.screenY)) return;
+
+  const maxHeight = viewport.height * ROADSIDE_MAX_HEIGHT_FRACTION;
+  const height = Math.max(
+    style.minHeight,
+    Math.min(maxHeight, strip.screenW * style.heightRoadFactor * SPRITE_BASE_SCALE),
+  );
+  const width = height * style.widthToHeight;
+  const sideSign = side === "left" ? -1 : 1;
+  const baseX = strip.screenX + sideSign * strip.screenW * 1.32;
+  const baseY = strip.screenY;
+
+  if (baseY + height < 0 || baseY - height > viewport.height) return;
+  if (baseX + width < 0 || baseX - width > viewport.width) return;
+
+  switch (style.kind) {
+    case "tree":
+      drawTreeSprite(ctx, baseX, baseY, width, height);
+      break;
+    case "sign":
+      drawSignSprite(ctx, baseX, baseY, width, height);
+      break;
+    case "fence":
+      drawFenceSprite(ctx, baseX, baseY, width, height);
+      break;
+    case "rock":
+      drawRockSprite(ctx, baseX, baseY, width, height);
+      break;
+    case "pole":
+      drawPoleSprite(ctx, baseX, baseY, width, height);
+      break;
+  }
+}
+
+function drawTreeSprite(
+  ctx: CanvasRenderingContext2D,
+  baseX: number,
+  baseY: number,
+  width: number,
+  height: number,
+): void {
+  ctx.fillStyle = "#1b3a20";
+  ctx.fillRect(baseX - width * 0.08, baseY - height * 0.42, width * 0.16, height * 0.42);
+  ctx.fillStyle = "#245c2f";
+  ctx.beginPath();
+  ctx.moveTo(baseX, baseY - height);
+  ctx.lineTo(baseX + width * 0.55, baseY - height * 0.32);
+  ctx.lineTo(baseX - width * 0.55, baseY - height * 0.32);
+  ctx.closePath();
+  ctx.fill();
+  ctx.fillStyle = "#2f7a3a";
+  ctx.beginPath();
+  ctx.moveTo(baseX, baseY - height * 0.8);
+  ctx.lineTo(baseX + width * 0.45, baseY - height * 0.18);
+  ctx.lineTo(baseX - width * 0.45, baseY - height * 0.18);
+  ctx.closePath();
+  ctx.fill();
+}
+
+function drawSignSprite(
+  ctx: CanvasRenderingContext2D,
+  baseX: number,
+  baseY: number,
+  width: number,
+  height: number,
+): void {
+  ctx.fillStyle = "#d9d7c7";
+  ctx.fillRect(baseX - width * 0.08, baseY - height * 0.58, width * 0.16, height * 0.58);
+  ctx.fillStyle = "#e7d24d";
+  ctx.fillRect(baseX - width * 0.5, baseY - height, width, height * 0.38);
+  ctx.fillStyle = "#23304d";
+  ctx.fillRect(baseX - width * 0.36, baseY - height * 0.88, width * 0.72, height * 0.08);
+}
+
+function drawFenceSprite(
+  ctx: CanvasRenderingContext2D,
+  baseX: number,
+  baseY: number,
+  width: number,
+  height: number,
+): void {
+  ctx.fillStyle = "#d7d4c5";
+  ctx.fillRect(baseX - width * 0.5, baseY - height * 0.7, width, height * 0.12);
+  ctx.fillRect(baseX - width * 0.5, baseY - height * 0.38, width, height * 0.12);
+  ctx.fillStyle = "#8d8a80";
+  ctx.fillRect(baseX - width * 0.08, baseY - height, width * 0.16, height);
+}
+
+function drawRockSprite(
+  ctx: CanvasRenderingContext2D,
+  baseX: number,
+  baseY: number,
+  width: number,
+  height: number,
+): void {
+  ctx.fillStyle = "#767c82";
+  ctx.beginPath();
+  ctx.moveTo(baseX - width * 0.5, baseY);
+  ctx.lineTo(baseX - width * 0.36, baseY - height * 0.7);
+  ctx.lineTo(baseX + width * 0.08, baseY - height);
+  ctx.lineTo(baseX + width * 0.5, baseY - height * 0.42);
+  ctx.lineTo(baseX + width * 0.44, baseY);
+  ctx.closePath();
+  ctx.fill();
+  ctx.fillStyle = "#9aa0a5";
+  ctx.fillRect(baseX - width * 0.18, baseY - height * 0.7, width * 0.28, height * 0.12);
+}
+
+function drawPoleSprite(
+  ctx: CanvasRenderingContext2D,
+  baseX: number,
+  baseY: number,
+  width: number,
+  height: number,
+): void {
+  ctx.fillStyle = "#c9ccd2";
+  ctx.fillRect(baseX - width * 0.22, baseY - height, width * 0.44, height);
+  ctx.fillStyle = "#f1e36a";
+  ctx.fillRect(baseX - width * 1.4, baseY - height, width * 2.8, height * 0.09);
 }
 
 /**


### PR DESCRIPTION
## GDD sections
- docs/gdd/09-track-design.md: roadside scenery and horizon set pieces
- docs/gdd/16-rendering-and-visual-design.md: parallax backgrounds and roadside objects
- docs/gdd/21-technical-design-for-web-implementation.md: Canvas2D renderer

## Requirement inventory
- Implements GDD-16-PARALLAX-ROADSIDE.
- The live race route now creates three procedural region layers: sky, mountains, and hills.
- `drawRoad` now receives those layers with the live camera so each layer scrolls at its own depth.
- `drawRoad` now consumes compiled `roadsideLeftId` and `roadsideRightId` values and paints procedural billboards for sign, tree, fence, rock, and light-pole ids.
- The bundled `test/elevation` track now authors non-default roadside ids so `/race` proves elevation and track-driven scenery together.
- Leaves GDD-16-CAR-SPRITE-ATLAS to F-051: live and ghost cars still need atlas-backed directional frames.

## Progress log
- docs/PROGRESS_LOG.md: `2026-04-27: Slice: F-052 parallax horizon and roadside sprites`

## Followups
- Marks F-052 done.
- No new followups created.

## Test plan
- [x] `npx vitest run src/render/__tests__/pseudoRoadCanvas.test.ts src/render/__tests__/parallax.test.ts src/data/__tests__/tracks-content.test.ts`
- [x] `npm run typecheck`
- [x] `npm run test:e2e -- e2e/race-demo.spec.ts`
- [x] `npm run verify`
- [x] `npm run test:e2e`
- [x] `grep -rn $'\u2014\|\u2013' src/app/race/page.tsx src/render/parallax.ts src/render/pseudoRoadCanvas.ts src/render/__tests__/parallax.test.ts src/render/__tests__/pseudoRoadCanvas.test.ts src/data/tracks/test-elevation.json e2e/race-demo.spec.ts docs/FOLLOWUPS.md docs/GDD_COVERAGE.json docs/PROGRESS_LOG.md`
- [x] `git diff --check`
