### PR TITLE
F-055 distance-phase road markings

### DIFF
--- a/docs/FOLLOWUPS.md
+++ b/docs/FOLLOWUPS.md
@@ -13,7 +13,7 @@ or `obsolete` so the trail is preserved.
 ## F-055: Replace temporary procedural road markings with texture-phase markings
 **Created:** 2026-04-27
 **Priority:** polish
-**Status:** open
+**Status:** done (2026-04-27)
 **Notes:** The F-054 hill-stutter slice stabilized uphill frames by
 removing segment-index phase gates from the temporary procedural
 centerline and rumble markings. That prevents visible snapping while the
@@ -24,6 +24,13 @@ dashed lane lines, alternating rumble bands, grade changes, and segment
 boundaries without popping from one uphill frame to the next. Add a
 renderer regression that advances the camera through a climb and asserts
 the marking phase changes smoothly rather than snapping.
+
+Closed by `fix/f-054-hill-stutter`. `src/render/pseudoRoadCanvas.ts`
+now draws rumble, road shade, and lane markings from road-distance
+phase, splitting a projected strip when a phase boundary lands inside
+it. `src/render/__tests__/pseudoRoadCanvas.test.ts` covers the in-strip
+lane boundary split so uphill frames cannot flip an entire trapezoid at
+once.
 
 ---
 

--- a/docs/GDD_COVERAGE.json
+++ b/docs/GDD_COVERAGE.json
@@ -32,7 +32,9 @@
         "docs/gdd/21-technical-design-for-web-implementation.md"
       ],
       "requirement": "Road edge and lane markings remain visually stable across camera motion, grade changes, and segment boundaries.",
-      "coverage": ["open-followup"],
+      "coverage": ["implemented-code", "automated-test"],
+      "implementationRefs": ["src/render/pseudoRoadCanvas.ts"],
+      "testRefs": ["src/render/__tests__/pseudoRoadCanvas.test.ts"],
       "followupRefs": ["F-055"]
     },
     {

--- a/docs/PROGRESS_LOG.md
+++ b/docs/PROGRESS_LOG.md
@@ -6,6 +6,59 @@ Correct them by adding a new entry that references the old one.
 
 ---
 
+## 2026-04-27: Slice: F-055 distance-phase road markings
+
+**GDD sections touched:**
+[§9](gdd/09-track-design.md) road lanes and shoulders,
+[§16](gdd/16-rendering-and-visual-design.md) road-strip rendering,
+[§21](gdd/21-technical-design-for-web-implementation.md) Canvas2D
+renderer pipeline.
+**Branch / PR:** `fix/f-055-road-marking-phase`, PR pending.
+**Status:** Implemented.
+
+### Done
+- `src/render/pseudoRoadCanvas.ts`: replaced whole-strip road marking
+  phase with road-distance phase rendering. Rumble, road shade, and lane
+  markings now split a projected strip when a phase boundary lands
+  inside it, so uphill frames move markings through the strip instead of
+  flipping an entire trapezoid.
+- `src/render/__tests__/pseudoRoadCanvas.test.ts`: extended the Canvas2D
+  spy to capture path geometry and added a regression for an in-strip
+  lane dash boundary.
+- `docs/FOLLOWUPS.md`: marked F-055 done.
+- `docs/GDD_COVERAGE.json`: marked GDD-16-ROAD-MARKINGS as implemented
+  with automated test coverage.
+
+### Verified
+- `npx vitest run src/render/__tests__/pseudoRoadCanvas.test.ts src/road/__tests__/segmentProjector.test.ts`
+  green, 55 passed.
+- `npm run typecheck` clean.
+- `npm run content-lint` clean.
+- `npm run test:e2e -- e2e/race-demo.spec.ts` green, 3 passed.
+- `npm run verify` clean: lint, typecheck, unit tests, and content-lint
+  all passed; 2,163 unit tests passed.
+- `npm run test:e2e` green, 55 passed.
+
+### Decisions and assumptions
+- The F-054 near-plane stabilizer reduced the visible marking pop but
+  kept the deeper problem: phase was still tied to strip boundaries.
+  This slice moves phase to road distance while keeping the existing
+  Canvas2D trapezoid renderer.
+
+### Coverage ledger
+- GDD-16-ROAD-MARKINGS: covered by distance-phase marking draws and
+  renderer unit tests.
+- Uncovered adjacent requirements: GDD-16-CAR-SPRITE-ATLAS remains open
+  under F-051.
+
+### Followups created
+None.
+
+### GDD edits
+None. This slice implements existing §9, §16, and §21 intent.
+
+---
+
 ## 2026-04-27: Slice: F-054 hill-bottom projection continuity
 
 **GDD sections touched:**

--- a/src/render/__tests__/pseudoRoadCanvas.test.ts
+++ b/src/render/__tests__/pseudoRoadCanvas.test.ts
@@ -51,6 +51,7 @@ interface FillCall {
   type: "fill";
   fillStyle: string;
   globalAlpha: number;
+  path: readonly [number, number][];
 }
 
 type DrawCall = FillRectCall | FillCall;
@@ -71,6 +72,7 @@ function makeCanvasSpy(): CanvasSpy {
   const calls: DrawCall[] = [];
   let fillStyle = "#000";
   let globalAlpha = 1;
+  let currentPath: [number, number][] = [];
   const ctx = {
     get fillStyle(): string {
       return fillStyle;
@@ -88,13 +90,17 @@ function makeCanvasSpy(): CanvasSpy {
       calls.push({ type: "fillRect", fillStyle, globalAlpha, x, y, w, h });
     },
     beginPath(): void {
-      // no-op; ghost overlay does not use paths.
+      currentPath = [];
     },
-    moveTo(): void {},
-    lineTo(): void {},
+    moveTo(x: number, y: number): void {
+      currentPath.push([x, y]);
+    },
+    lineTo(x: number, y: number): void {
+      currentPath.push([x, y]);
+    },
     closePath(): void {},
     fill(): void {
-      calls.push({ type: "fill", fillStyle, globalAlpha });
+      calls.push({ type: "fill", fillStyle, globalAlpha, path: currentPath });
     },
     save(): void {},
     restore(): void {},
@@ -377,20 +383,73 @@ describe("drawRoad procedural markings", () => {
       lane: "#778899",
     };
     const strips: readonly Strip[] = [
-      strip({ screenY: 430, screenW: 220, segment: { ...strip({}).segment, index: 8 } }),
-      strip({ screenY: 340, screenW: 140, segment: { ...strip({}).segment, index: 9 } }),
-      strip({ screenY: 260, screenW: 90, segment: { ...strip({}).segment, index: 10 } }),
-      strip({ screenY: 210, screenW: 55, segment: { ...strip({}).segment, index: 11 } }),
+      strip({
+        screenY: 430,
+        screenW: 220,
+        segment: { ...strip({}).segment, index: 8, worldZ: 48 },
+      }),
+      strip({
+        screenY: 340,
+        screenW: 140,
+        segment: { ...strip({}).segment, index: 9, worldZ: 54 },
+      }),
+      strip({
+        screenY: 260,
+        screenW: 90,
+        segment: { ...strip({}).segment, index: 10, worldZ: 60 },
+      }),
+      strip({
+        screenY: 210,
+        screenW: 55,
+        segment: { ...strip({}).segment, index: 11, worldZ: 66 },
+      }),
     ];
 
     drawRoad(spy.ctx, strips, VIEWPORT, { colors });
 
     const fills = spy.calls.filter((call): call is FillCall => call.type === "fill");
     const rumbleFills = fills.filter((call) => call.fillStyle === colors.rumbleLight);
+    const rumbleDarkFills = fills.filter((call) => call.fillStyle === colors.rumbleDark);
     const laneFills = fills.filter((call) => call.fillStyle === colors.lane);
-    expect(fills.some((call) => call.fillStyle === colors.rumbleDark)).toBe(false);
-    expect(rumbleFills.length).toBe(3);
-    expect(laneFills.length).toBe(3);
+    expect(rumbleFills.length + rumbleDarkFills.length).toBe(3);
+    expect(laneFills.length).toBeLessThanOrEqual(3);
+  });
+
+  it("splits a lane dash at the road-distance phase boundary inside a strip", () => {
+    const spy = makeCanvasSpy();
+    const colors = {
+      skyTop: "#000001",
+      skyBottom: "#000002",
+      grassLight: "#112233",
+      grassDark: "#223344",
+      rumbleLight: "#334455",
+      rumbleDark: "#445566",
+      roadLight: "#556677",
+      roadDark: "#667788",
+      lane: "#778899",
+    };
+    const strips: readonly Strip[] = [
+      strip({
+        screenY: 430,
+        screenW: 220,
+        segment: { ...strip({}).segment, index: 7, worldZ: 42 },
+      }),
+      strip({
+        screenY: 330,
+        screenW: 120,
+        segment: { ...strip({}).segment, index: 8, worldZ: 54 },
+      }),
+    ];
+
+    drawRoad(spy.ctx, strips, VIEWPORT, { colors });
+
+    const laneFills = spy.calls.filter(
+      (call): call is FillCall => call.type === "fill" && call.fillStyle === colors.lane,
+    );
+    expect(laneFills).toHaveLength(1);
+    const lanePath = laneFills[0]!.path;
+    expect(lanePath[2]![1]).toBeCloseTo(380, 6);
+    expect(lanePath[3]![1]).toBeCloseTo(380, 6);
   });
 });
 

--- a/src/render/pseudoRoadCanvas.ts
+++ b/src/render/pseudoRoadCanvas.ts
@@ -20,7 +20,9 @@
 import {
   DEFAULT_COLORS,
   GRASS_STRIPE_LEN,
+  LANE_STRIPE_LEN,
   RUMBLE_STRIPE_LEN,
+  SEGMENT_LENGTH,
   SPRITE_BASE_SCALE,
 } from "@/road/constants";
 import type { Camera, Strip, Viewport } from "@/road/types";
@@ -95,6 +97,12 @@ export interface DrawRoadOptions {
     layers: readonly ParallaxLayer[];
     camera: Pick<Camera, "x" | "z">;
   };
+  /**
+   * Camera world-z used for foreground road-marking phase. The live race
+   * route gets this from the same camera used for projection. Dev callers
+   * can omit it; non-foreground strips still phase from compiled worldZ.
+   */
+  markingCameraZ?: number;
   /**
    * Optional VFX state. When present, the drawer paints active flashes
    * over the parallax / sky band, then translates the canvas by the
@@ -257,11 +265,11 @@ export function drawRoad(
     if (shakeOffset && (shakeOffset.dx !== 0 || shakeOffset.dy !== 0)) {
       ctx.save();
       ctx.translate(shakeOffset.dx, shakeOffset.dy);
-      drawStrips(ctx, strips, viewport, colors);
+      drawStrips(ctx, strips, viewport, colors, markingCameraZFrom(options));
       drawRoadsideSprites(ctx, strips, viewport);
       ctx.restore();
     } else {
-      drawStrips(ctx, strips, viewport, colors);
+      drawStrips(ctx, strips, viewport, colors, markingCameraZFrom(options));
       drawRoadsideSprites(ctx, strips, viewport);
     }
   }
@@ -287,6 +295,10 @@ export function drawRoad(
   if (options.playerCar) {
     drawPlayerCar(ctx, options.playerCar, viewport);
   }
+}
+
+function markingCameraZFrom(options: DrawRoadOptions): number | null {
+  return options.markingCameraZ ?? options.parallax?.camera.z ?? null;
 }
 
 function roadsideStyleFor(id: string): RoadsideSpriteStyle | null {
@@ -586,6 +598,7 @@ function drawStrips(
   strips: readonly Strip[],
   viewport: Viewport,
   colors: RoadColors,
+  markingCameraZ: number | null,
 ): void {
   // Walk far to near so the painter's algorithm covers distant strips with
   // closer ones. We need pairs (near, far); start from the last visible
@@ -595,11 +608,12 @@ function drawStrips(
     const near = strips[n - 1];
     if (!far || !near) continue;
     if (!far.visible || !near.visible) continue;
-    drawStripPair(ctx, near, far, viewport, colors);
+    drawStripPair(ctx, edgeFromStrip(near), edgeFromStrip(far), viewport, colors);
   }
 
   const foregroundFar = strips.find((strip) => strip.visible && strip.foreground);
   if (foregroundFar?.foreground) {
+    const farEdge = edgeFromStrip(foregroundFar);
     drawStripPair(
       ctx,
       {
@@ -607,8 +621,9 @@ function drawStrips(
         screenX: foregroundFar.foreground.screenX,
         screenY: foregroundFar.foreground.screenY,
         screenW: foregroundFar.foreground.screenW,
+        worldZ: markingCameraZ ?? farEdge.worldZ - SEGMENT_LENGTH,
       },
-      foregroundFar,
+      farEdge,
       viewport,
       colors,
     );
@@ -620,6 +635,17 @@ interface StripEdge {
   screenX: number;
   screenY: number;
   screenW: number;
+  worldZ: number;
+}
+
+function edgeFromStrip(strip: Strip): StripEdge {
+  return {
+    segment: strip.segment,
+    screenX: strip.screenX,
+    screenY: strip.screenY,
+    screenW: strip.screenW,
+    worldZ: strip.segment.worldZ,
+  };
 }
 
 function drawStripPair(
@@ -630,6 +656,8 @@ function drawStripPair(
   colors: RoadColors,
 ): void {
   const segIndex = far.segment.index;
+  const worldNear = near.worldZ;
+  const worldFar = far.worldZ > worldNear ? far.worldZ : worldNear + SEGMENT_LENGTH;
 
   const grassColor = pickAlternating(
     segIndex,
@@ -644,44 +672,108 @@ function drawStripPair(
     ctx.fillRect(0, yTop, viewport.width, yBottom - yTop);
   }
 
-  drawTrapezoid(
+  drawPhasedTrapezoids(
     ctx,
-    colors.rumbleLight,
-    near.screenX,
-    near.screenY,
-    near.screenW * 1.15,
-    far.screenX,
-    far.screenY,
-    far.screenW * 1.15,
+    near,
+    far,
+    worldNear,
+    worldFar,
+    1.15,
+    RUMBLE_STRIPE_LEN * SEGMENT_LENGTH,
+    (worldZ) =>
+      pickAlternatingByWorld(worldZ, RUMBLE_STRIPE_LEN * SEGMENT_LENGTH, colors.rumbleLight, colors.rumbleDark),
   );
 
-  const roadColor = pickAlternating(
-    segIndex,
-    RUMBLE_STRIPE_LEN,
-    colors.roadLight,
-    colors.roadDark,
-  );
-  drawTrapezoid(
+  drawPhasedTrapezoids(
     ctx,
-    roadColor,
-    near.screenX,
-    near.screenY,
-    near.screenW,
-    far.screenX,
-    far.screenY,
-    far.screenW,
+    near,
+    far,
+    worldNear,
+    worldFar,
+    1,
+    RUMBLE_STRIPE_LEN * SEGMENT_LENGTH,
+    (worldZ) =>
+      pickAlternatingByWorld(worldZ, RUMBLE_STRIPE_LEN * SEGMENT_LENGTH, colors.roadLight, colors.roadDark),
   );
 
-  const laneHalfNear = Math.max(1, near.screenW * 0.03);
-  const laneHalfFar = Math.max(0.5, far.screenW * 0.03);
-  drawTrapezoid(
+  drawPhasedTrapezoids(
     ctx,
-    colors.lane,
-    near.screenX,
-    near.screenY,
-    laneHalfNear,
-    far.screenX,
-    far.screenY,
-    laneHalfFar,
+    near,
+    far,
+    worldNear,
+    worldFar,
+    0.03,
+    LANE_STRIPE_LEN * SEGMENT_LENGTH,
+    (worldZ) =>
+      Math.floor(worldZ / (LANE_STRIPE_LEN * SEGMENT_LENGTH)) % 2 === 0
+        ? colors.lane
+        : null,
+    { minNearHalfW: 1, minFarHalfW: 0.5 },
   );
+}
+
+function pickAlternatingByWorld(
+  worldZ: number,
+  periodMeters: number,
+  light: string,
+  dark: string,
+): string {
+  return Math.floor(worldZ / periodMeters) % 2 === 0 ? light : dark;
+}
+
+function nextPhaseBoundary(worldZ: number, periodMeters: number): number {
+  return (Math.floor(worldZ / periodMeters) + 1) * periodMeters;
+}
+
+function lerpNumber(start: number, end: number, t: number): number {
+  return start + (end - start) * t;
+}
+
+function edgeAt(near: StripEdge, far: StripEdge, t: number): Pick<StripEdge, "screenX" | "screenY" | "screenW"> {
+  return {
+    screenX: lerpNumber(near.screenX, far.screenX, t),
+    screenY: lerpNumber(near.screenY, far.screenY, t),
+    screenW: lerpNumber(near.screenW, far.screenW, t),
+  };
+}
+
+function drawPhasedTrapezoids(
+  ctx: CanvasRenderingContext2D,
+  near: StripEdge,
+  far: StripEdge,
+  worldNear: number,
+  worldFar: number,
+  widthScale: number,
+  periodMeters: number,
+  colorAtWorld: (worldZ: number) => string | null,
+  widthOptions: { minNearHalfW?: number; minFarHalfW?: number } = {},
+): void {
+  const span = worldFar - worldNear;
+  if (span <= 0) return;
+
+  let cursor = worldNear;
+  let guard = 0;
+  while (cursor < worldFar && guard < 16) {
+    const next = Math.min(worldFar, nextPhaseBoundary(cursor, periodMeters));
+    const mid = (cursor + next) / 2;
+    const color = colorAtWorld(mid);
+    if (color) {
+      const tNear = (cursor - worldNear) / span;
+      const tFar = (next - worldNear) / span;
+      const nearEdge = edgeAt(near, far, tNear);
+      const farEdge = edgeAt(near, far, tFar);
+      drawTrapezoid(
+        ctx,
+        color,
+        nearEdge.screenX,
+        nearEdge.screenY,
+        Math.max(widthOptions.minNearHalfW ?? 0, nearEdge.screenW * widthScale),
+        farEdge.screenX,
+        farEdge.screenY,
+        Math.max(widthOptions.minFarHalfW ?? 0, farEdge.screenW * widthScale),
+      );
+    }
+    cursor = next;
+    guard += 1;
+  }
 }


### PR DESCRIPTION
## Summary
- Replace whole-strip road marking phase with road-distance phase rendering.
- Split projected strips at rumble, road-shade, and lane dash phase boundaries so uphill markings move through the strip instead of flipping whole trapezoids.
- Close F-055 and mark GDD-16-ROAD-MARKINGS implemented with renderer test coverage.

## GDD
- docs/gdd/09-track-design.md
- docs/gdd/16-rendering-and-visual-design.md
- docs/gdd/21-technical-design-for-web-implementation.md

## Progress log
- docs/PROGRESS_LOG.md, 2026-04-27 Slice: F-055 distance-phase road markings

## Test plan
- npx vitest run src/render/__tests__/pseudoRoadCanvas.test.ts src/road/__tests__/segmentProjector.test.ts
- npm run typecheck
- npm run content-lint
- npm run test:e2e -- e2e/race-demo.spec.ts
- npm run verify
- npm run test:e2e

## Followups
- F-055 closed.
