### PR TITLE
F-056 uphill lane-marking duty cycle

### DIFF
--- a/docs/FOLLOWUPS.md
+++ b/docs/FOLLOWUPS.md
@@ -10,6 +10,23 @@ or `obsolete` so the trail is preserved.
 
 ---
 
+## F-056: Shorten lane dash duty cycle during uphill texture-phase rendering
+**Created:** 2026-04-27
+**Priority:** polish
+**Status:** done (2026-04-27)
+**Notes:** Manual race observation after F-055: uphill road markings were
+still changing dramatically, but farther apart. The centerline and edge
+context looked stable for longer spans, then popped into a very large
+near-camera wedge while climbing. The issue was not segment-index phase;
+it was that lane dashes used the full `LANE_STRIPE_LEN` period as the
+visible dash span. `src/render/pseudoRoadCanvas.ts` now treats the lane
+marking as a short visible duty inside the longer repeat cycle, so a dash
+entering the foreground is physically short instead of filling an entire
+48 m phase. `src/render/__tests__/pseudoRoadCanvas.test.ts` pins both an
+in-strip duty boundary and the near-camera short-dash case.
+
+---
+
 ## F-055: Replace temporary procedural road markings with texture-phase markings
 **Created:** 2026-04-27
 **Priority:** polish

--- a/docs/GDD_COVERAGE.json
+++ b/docs/GDD_COVERAGE.json
@@ -47,7 +47,7 @@
       "coverage": ["implemented-code", "automated-test"],
       "implementationRefs": ["src/render/pseudoRoadCanvas.ts"],
       "testRefs": ["src/render/__tests__/pseudoRoadCanvas.test.ts"],
-      "followupRefs": ["F-055"]
+      "followupRefs": ["F-055", "F-056"]
     },
     {
       "id": "GDD-16-CAR-SPRITE-ATLAS",

--- a/docs/PROGRESS_LOG.md
+++ b/docs/PROGRESS_LOG.md
@@ -6,6 +6,56 @@ Correct them by adding a new entry that references the old one.
 
 ---
 
+## 2026-04-27: Slice: F-056 uphill lane-marking duty cycle
+
+**GDD sections touched:**
+[§9](gdd/09-track-design.md) road lanes and shoulders,
+[§16](gdd/16-rendering-and-visual-design.md) road-strip rendering,
+[§21](gdd/21-technical-design-for-web-implementation.md) Canvas2D
+renderer pipeline.
+**Branch / PR:** `fix/f-056-uphill-marking-continuity`, PR pending.
+**Status:** Implemented.
+
+### Done
+- `src/render/pseudoRoadCanvas.ts`: changed lane markings from a full
+  48 m visible phase to a short visible duty inside the existing repeat
+  cycle. The projected dash now enters the near camera as a short mark
+  instead of filling a whole uphill strip.
+- `src/render/__tests__/pseudoRoadCanvas.test.ts`: added renderer
+  geometry regressions for in-strip duty boundaries and near-camera
+  short dashes.
+- `docs/FOLLOWUPS.md`: added and closed F-056 for the observed uphill
+  marking pulse.
+- `docs/GDD_COVERAGE.json`: linked F-056 to GDD-16-ROAD-MARKINGS.
+
+### Verified
+- `npx vitest run src/render/__tests__/pseudoRoadCanvas.test.ts` green,
+  21 passed.
+- `npx vitest run src/render/__tests__/pseudoRoadCanvas.test.ts src/road/__tests__/segmentProjector.test.ts`
+  green, 56 passed.
+- `npm run test:e2e -- e2e/race-demo.spec.ts` green, 3 passed.
+- `npm run verify` clean: lint, typecheck, unit tests, and content-lint
+  all passed; 2,164 unit tests passed.
+
+### Decisions and assumptions
+- F-055 correctly moved phase to road distance, but the dash duty was
+  still too large for a lane mark. This slice preserves world-distance
+  phase while making the visible dash span physically short.
+
+### Coverage ledger
+- GDD-16-ROAD-MARKINGS: covered by short-duty lane marking draws and
+  renderer unit tests.
+- Uncovered adjacent requirements: GDD-16-CAR-SPRITE-ATLAS remains open
+  under F-051.
+
+### Followups created
+None.
+
+### GDD edits
+None. This slice implements existing §9, §16, and §21 intent.
+
+---
+
 ## 2026-04-27: Slice: CONTRIBUTING.md guide
 
 **GDD sections touched:**

--- a/src/render/__tests__/pseudoRoadCanvas.test.ts
+++ b/src/render/__tests__/pseudoRoadCanvas.test.ts
@@ -415,7 +415,7 @@ describe("drawRoad procedural markings", () => {
     expect(laneFills.length).toBeLessThanOrEqual(3);
   });
 
-  it("splits a lane dash at the road-distance phase boundary inside a strip", () => {
+  it("splits a lane dash at the road-distance duty boundary inside a strip", () => {
     const spy = makeCanvasSpy();
     const colors = {
       skyTop: "#000001",
@@ -448,6 +448,47 @@ describe("drawRoad procedural markings", () => {
     );
     expect(laneFills).toHaveLength(1);
     const lanePath = laneFills[0]!.path;
+    expect(lanePath[0]![1]).toBeCloseTo(380, 6);
+    expect(lanePath[1]![1]).toBeCloseTo(380, 6);
+    expect(lanePath[2]![1]).toBeCloseTo(330, 6);
+    expect(lanePath[3]![1]).toBeCloseTo(330, 6);
+  });
+
+  it("keeps a near-camera lane dash short instead of filling the whole strip", () => {
+    const spy = makeCanvasSpy();
+    const colors = {
+      skyTop: "#000001",
+      skyBottom: "#000002",
+      grassLight: "#112233",
+      grassDark: "#223344",
+      rumbleLight: "#334455",
+      rumbleDark: "#445566",
+      roadLight: "#556677",
+      roadDark: "#667788",
+      lane: "#778899",
+    };
+    const strips: readonly Strip[] = [
+      strip({
+        screenY: 430,
+        screenW: 220,
+        segment: { ...strip({}).segment, index: 9, worldZ: 54 },
+      }),
+      strip({
+        screenY: 330,
+        screenW: 120,
+        segment: { ...strip({}).segment, index: 10, worldZ: 66 },
+      }),
+    ];
+
+    drawRoad(spy.ctx, strips, VIEWPORT, { colors });
+
+    const laneFills = spy.calls.filter(
+      (call): call is FillCall => call.type === "fill" && call.fillStyle === colors.lane,
+    );
+    expect(laneFills).toHaveLength(1);
+    const lanePath = laneFills[0]!.path;
+    expect(lanePath[0]![1]).toBeCloseTo(430, 6);
+    expect(lanePath[1]![1]).toBeCloseTo(430, 6);
     expect(lanePath[2]![1]).toBeCloseTo(380, 6);
     expect(lanePath[3]![1]).toBeCloseTo(380, 6);
   });

--- a/src/render/pseudoRoadCanvas.ts
+++ b/src/render/pseudoRoadCanvas.ts
@@ -71,6 +71,8 @@ export const PLAYER_CAR_HEIGHT_FRACTION = 0.18;
 export const PLAYER_CAR_WIDTH_TO_HEIGHT = 1.15;
 export const ROADSIDE_DRAW_PERIOD = 10;
 export const ROADSIDE_MAX_HEIGHT_FRACTION = 0.22;
+const LANE_DASH_CYCLE_METERS = LANE_STRIPE_LEN * SEGMENT_LENGTH;
+const LANE_DASH_VISIBLE_METERS = SEGMENT_LENGTH * 2;
 
 export interface RoadColors {
   skyTop: string;
@@ -696,16 +698,17 @@ function drawStripPair(
       pickAlternatingByWorld(worldZ, RUMBLE_STRIPE_LEN * SEGMENT_LENGTH, colors.roadLight, colors.roadDark),
   );
 
-  drawPhasedTrapezoids(
+  drawDutyCycleTrapezoids(
     ctx,
     near,
     far,
     worldNear,
     worldFar,
     0.03,
-    LANE_STRIPE_LEN * SEGMENT_LENGTH,
+    LANE_DASH_CYCLE_METERS,
+    LANE_DASH_VISIBLE_METERS,
     (worldZ) =>
-      Math.floor(worldZ / (LANE_STRIPE_LEN * SEGMENT_LENGTH)) % 2 === 0
+      modulo(worldZ, LANE_DASH_CYCLE_METERS) < LANE_DASH_VISIBLE_METERS
         ? colors.lane
         : null,
     { minNearHalfW: 1, minFarHalfW: 0.5 },
@@ -723,6 +726,21 @@ function pickAlternatingByWorld(
 
 function nextPhaseBoundary(worldZ: number, periodMeters: number): number {
   return (Math.floor(worldZ / periodMeters) + 1) * periodMeters;
+}
+
+function modulo(value: number, period: number): number {
+  return ((value % period) + period) % period;
+}
+
+function nextDutyBoundary(
+  worldZ: number,
+  cycleMeters: number,
+  visibleMeters: number,
+): number {
+  const phase = modulo(worldZ, cycleMeters);
+  const cycleStart = worldZ - phase;
+  if (phase < visibleMeters) return cycleStart + visibleMeters;
+  return cycleStart + cycleMeters;
 }
 
 function lerpNumber(start: number, end: number, t: number): number {
@@ -755,6 +773,62 @@ function drawPhasedTrapezoids(
   let guard = 0;
   while (cursor < worldFar && guard < 16) {
     const next = Math.min(worldFar, nextPhaseBoundary(cursor, periodMeters));
+    const mid = (cursor + next) / 2;
+    const color = colorAtWorld(mid);
+    if (color) {
+      const tNear = (cursor - worldNear) / span;
+      const tFar = (next - worldNear) / span;
+      const nearEdge = edgeAt(near, far, tNear);
+      const farEdge = edgeAt(near, far, tFar);
+      drawTrapezoid(
+        ctx,
+        color,
+        nearEdge.screenX,
+        nearEdge.screenY,
+        Math.max(widthOptions.minNearHalfW ?? 0, nearEdge.screenW * widthScale),
+        farEdge.screenX,
+        farEdge.screenY,
+        Math.max(widthOptions.minFarHalfW ?? 0, farEdge.screenW * widthScale),
+      );
+    }
+    cursor = next;
+    guard += 1;
+  }
+}
+
+function drawDutyCycleTrapezoids(
+  ctx: CanvasRenderingContext2D,
+  near: StripEdge,
+  far: StripEdge,
+  worldNear: number,
+  worldFar: number,
+  widthScale: number,
+  cycleMeters: number,
+  visibleMeters: number,
+  colorAtWorld: (worldZ: number) => string | null,
+  widthOptions: { minNearHalfW?: number; minFarHalfW?: number } = {},
+): void {
+  const span = worldFar - worldNear;
+  if (span <= 0) return;
+  if (cycleMeters <= 0 || visibleMeters <= 0 || visibleMeters >= cycleMeters) {
+    drawPhasedTrapezoids(
+      ctx,
+      near,
+      far,
+      worldNear,
+      worldFar,
+      widthScale,
+      cycleMeters,
+      colorAtWorld,
+      widthOptions,
+    );
+    return;
+  }
+
+  let cursor = worldNear;
+  let guard = 0;
+  while (cursor < worldFar && guard < 32) {
+    const next = Math.min(worldFar, nextDutyBoundary(cursor, cycleMeters, visibleMeters));
     const mid = (cursor + next) / 2;
     const color = colorAtWorld(mid);
     if (color) {

--- a/src/render/pseudoRoadCanvas.ts
+++ b/src/render/pseudoRoadCanvas.ts
@@ -810,7 +810,8 @@ function drawDutyCycleTrapezoids(
 ): void {
   const span = worldFar - worldNear;
   if (span <= 0) return;
-  if (cycleMeters <= 0 || visibleMeters <= 0 || visibleMeters >= cycleMeters) {
+  if (cycleMeters <= 0 || visibleMeters <= 0) return;
+  if (visibleMeters >= cycleMeters) {
     drawPhasedTrapezoids(
       ctx,
       near,


### PR DESCRIPTION
## Summary
- shorten lane dash visible duty inside the existing road-distance phase cycle
- add renderer geometry tests for in-strip duty boundaries and near-camera short dashes
- add and close F-056 in the backlog and link it to GDD-16-ROAD-MARKINGS

## GDD
- docs/gdd/09-track-design.md
- docs/gdd/16-rendering-and-visual-design.md
- docs/gdd/21-technical-design-for-web-implementation.md

## Progress log
- docs/PROGRESS_LOG.md: 2026-04-27 F-056 uphill lane-marking duty cycle

## Test plan
- npx vitest run src/render/__tests__/pseudoRoadCanvas.test.ts
- npx vitest run src/render/__tests__/pseudoRoadCanvas.test.ts src/road/__tests__/segmentProjector.test.ts
- npm run test:e2e -- e2e/race-demo.spec.ts
- npm run verify
- npm run content-lint
- perl dash scan over touched files
- git diff --check