### PR TITLE
F-057 turn foreground projection continuity

### DIFF
--- a/docs/FOLLOWUPS.md
+++ b/docs/FOLLOWUPS.md
@@ -10,6 +10,22 @@ or `obsolete` so the trail is preserved.
 
 ---
 
+## F-057: Fix turn-induced foreground road shear
+**Created:** 2026-04-27
+**Priority:** polish
+**Status:** done (2026-04-27)
+**Notes:** Manual race observation: steering left or right could make
+the foreground road edge shear diagonally across the lower viewport. The
+projector extended foreground road width to the screen bottom but kept
+the bottom centerline pinned to the closest visible strip's `screenX`.
+On turns or lateral camera offsets, that made the near edge follow a
+different centerline than the next strip pair. `src/road/segmentProjector.ts`
+now extrapolates the foreground centerline and half-width from the
+nearest two visible strips. `src/road/__tests__/segmentProjector.test.ts`
+pins the lateral-motion regression.
+
+---
+
 ## F-056: Shorten lane dash duty cycle during uphill texture-phase rendering
 **Created:** 2026-04-27
 **Priority:** polish

--- a/docs/GDD_COVERAGE.json
+++ b/docs/GDD_COVERAGE.json
@@ -34,7 +34,7 @@
         "src/road/__tests__/segmentProjector.test.ts",
         "e2e/race-demo.spec.ts"
       ],
-      "followupRefs": ["F-050", "F-054"]
+      "followupRefs": ["F-050", "F-054", "F-057"]
     },
     {
       "id": "GDD-16-ROAD-MARKINGS",

--- a/docs/PROGRESS_LOG.md
+++ b/docs/PROGRESS_LOG.md
@@ -6,6 +6,60 @@ Correct them by adding a new entry that references the old one.
 
 ---
 
+## 2026-04-27: Slice: F-057 turn foreground projection continuity
+
+**GDD sections touched:**
+[§9](gdd/09-track-design.md) road curvature and readable edges,
+[§16](gdd/16-rendering-and-visual-design.md) segment-based projection
+and foreground speed cues,
+[§21](gdd/21-technical-design-for-web-implementation.md) Canvas2D
+renderer pipeline.
+**Branch / PR:** `fix/f-057-turn-foreground-shear`, PR pending.
+**Status:** Implemented.
+
+### Done
+- `src/road/segmentProjector.ts`: changed the foreground endpoint to
+  extrapolate both centerline `screenX` and half-width from the nearest
+  two visible projected strips. Turning left or right no longer pins
+  the screen-bottom road center to a stale near-strip center.
+- `src/road/__tests__/segmentProjector.test.ts`: added a lateral-road
+  motion regression that proves the foreground endpoint follows the
+  projected centerline instead of shearing away from it.
+- `docs/FOLLOWUPS.md`: added and closed F-057 for the observed turn
+  foreground shear.
+- `docs/GDD_COVERAGE.json`: linked F-057 to GDD-09-ELEVATION-LIVE
+  because the same projection contract owns grade, curve, and
+  foreground road continuity.
+
+### Verified
+- `npx vitest run src/road/__tests__/segmentProjector.test.ts` green,
+  36 passed.
+- `npx vitest run src/render/__tests__/pseudoRoadCanvas.test.ts src/road/__tests__/segmentProjector.test.ts`
+  green, 57 passed.
+- `npm run verify` clean: lint, typecheck, unit tests, and content-lint
+  all passed; 2,165 unit tests passed.
+- `npm run test:e2e -- e2e/race-demo.spec.ts` green, 3 passed.
+
+### Decisions and assumptions
+- The fix stays in the projector rather than the Canvas2D renderer
+  because the renderer should consume a consistent strip-pair contract.
+  The bottom endpoint now follows the same projected centerline as the
+  visible road.
+
+### Coverage ledger
+- GDD-09-ELEVATION-LIVE: extended to cover foreground centerline
+  continuity while turning.
+- Uncovered adjacent requirements: GDD-16-CAR-SPRITE-ATLAS remains open
+  under F-051.
+
+### Followups created
+None.
+
+### GDD edits
+None. This slice implements existing §9, §16, and §21 intent.
+
+---
+
 ## 2026-04-27: Slice: F-056 uphill lane-marking duty cycle
 
 **GDD sections touched:**

--- a/docs/PROGRESS_LOG.md
+++ b/docs/PROGRESS_LOG.md
@@ -14,7 +14,7 @@ Correct them by adding a new entry that references the old one.
 and foreground speed cues,
 [§21](gdd/21-technical-design-for-web-implementation.md) Canvas2D
 renderer pipeline.
-**Branch / PR:** `fix/f-057-turn-foreground-shear`, PR pending.
+**Branch / PR:** `fix/f-057-turn-foreground-shear`, PR #21.
 **Status:** Implemented.
 
 ### Done

--- a/src/road/__tests__/segmentProjector.test.ts
+++ b/src/road/__tests__/segmentProjector.test.ts
@@ -201,6 +201,27 @@ describe("project (pseudo-3D segment projector)", () => {
     expect(near.foreground!.screenW).toBeCloseTo(expected, 6);
   });
 
+  it("extrapolates the foreground centerline through lateral road motion", () => {
+    const segs = flatTrack(16, { curve: 0.02 });
+    const strips = project(segs, makeCamera({ x: 1.4 }), VIEWPORT, {
+      drawDistance: 8,
+    });
+    const visible = strips.filter((s) => s.visible);
+    expect(visible.length).toBeGreaterThan(1);
+
+    const near = visible[0]!;
+    const far = visible[1]!;
+    expect(near.foreground).toBeDefined();
+
+    const extrapolation =
+      (VIEWPORT.height - near.screenY) / (near.screenY - far.screenY);
+    const expectedX =
+      near.screenX + (near.screenX - far.screenX) * extrapolation;
+
+    expect(Math.abs(expectedX - near.screenX)).toBeGreaterThan(5);
+    expect(near.foreground!.screenX).toBeCloseTo(expectedX, 6);
+  });
+
   it("keeps an ahead marker continuous through a dip-to-climb transition", () => {
     const segs = flatTrack(96);
     for (let i = 0; i < 16; i++) {

--- a/src/road/segmentProjector.ts
+++ b/src/road/segmentProjector.ts
@@ -200,16 +200,22 @@ function attachForegroundProjection(strips: Strip[], viewport: Viewport): void {
   if (near.screenY >= viewport.height) return;
 
   const far = strips.slice(nearIndex + 1).find((strip) => strip.visible);
-  const projectedHalfW =
+  const extrapolation =
     far && near.screenY > far.screenY
-      ? near.screenW +
-        ((near.screenW - far.screenW) * (viewport.height - near.screenY)) /
-          (near.screenY - far.screenY)
+      ? (viewport.height - near.screenY) / (near.screenY - far.screenY)
+      : 0;
+  const projectedX =
+    far && extrapolation > 0
+      ? near.screenX + (near.screenX - far.screenX) * extrapolation
+      : near.screenX;
+  const projectedHalfW =
+    far && extrapolation > 0
+      ? near.screenW + (near.screenW - far.screenW) * extrapolation
       : near.screenW;
   const screenW = Math.max(near.screenW, projectedHalfW);
 
   near.foreground = {
-    screenX: near.screenX,
+    screenX: projectedX,
     screenY: viewport.height,
     screenW,
   };


### PR DESCRIPTION
## Summary
- Extrapolates the foreground road endpoint centerline and half-width from the nearest two visible projected strips.
- Adds a projector regression for lateral road motion so turning cannot pin the bottom road center to a stale near-strip x.
- Logs F-057 and links the projection coverage ledger entry.

## GDD
- §9 road curvature and readable edges
- §16 segment-based projection and foreground speed cues
- §21 Canvas2D renderer pipeline

## Requirement inventory
- Handles foreground road continuity when steering left or right.
- Keeps the renderer on the existing strip-pair projection contract.
- Leaves the existing F-051 car sprite atlas followup open.

## Progress log
- docs/PROGRESS_LOG.md: F-057 turn foreground projection continuity

## Test plan
- [x] npx vitest run src/road/__tests__/segmentProjector.test.ts
- [x] npx vitest run src/render/__tests__/pseudoRoadCanvas.test.ts src/road/__tests__/segmentProjector.test.ts
- [x] npm run content-lint
- [x] npm run verify
- [x] npm run test:e2e -- e2e/race-demo.spec.ts
- [x] perl dash scan on touched files
- [x] git diff --check

## Followups
- F-057 added and closed in docs/FOLLOWUPS.md
