### PR TITLE
F-051 car atlas sprite overlays

### DIFF
--- a/docs/FOLLOWUPS.md
+++ b/docs/FOLLOWUPS.md
@@ -10,6 +10,21 @@ or `obsolete` so the trail is preserved.
 
 ---
 
+## F-058: Add weather-specific car trail and spray variants
+**Created:** 2026-04-27
+**Priority:** polish
+**Status:** open
+**Notes:** F-051 ships the live and ghost car sprite atlas path with
+directional, damage, brake, and nitro frames. §16 also calls for wet
+spray and snow trail variants. Those are not frame rows in the current
+Sparrow sheet and should land with the later weather VFX work so the
+renderer can select them from actual weather state rather than a fake
+always-on decoration. Add weather-specific atlas or effect assets,
+thread weather state into the car overlay draw path, and cover clear,
+wet, and snow cases in renderer tests.
+
+---
+
 ## F-057: Fix turn-induced foreground road shear
 **Created:** 2026-04-27
 **Priority:** polish

--- a/docs/FOLLOWUPS.md
+++ b/docs/FOLLOWUPS.md
@@ -145,7 +145,7 @@ roadside sign colour.
 ## F-051: Replace live and ghost car placeholders with atlas sprites
 **Created:** 2026-04-26
 **Priority:** polish
-**Status:** open
+**Status:** done (2026-04-27)
 **Notes:** The live player car and Time Trial ghost still use original
 Canvas2D placeholder shapes. §16 expects 12 to 16 directional car
 frames, damage variants, brake lights, nitro effects, and weather
@@ -153,6 +153,17 @@ variants. Replace the live `playerCar` overlay and the F-022 ghost
 rectangle with frames from the same loaded sprite atlas, selected from
 steering and road curve state. Keep the current Canvas2D shape only as
 a missing-asset fallback.
+
+Closed by `feat/f-051-car-atlas-sprites`. `public/art/cars/sparrow.svg`
+now supplies an original 12-frame clean row plus dented, battered,
+brake, and nitro frames behind the existing `src/data/atlas/cars.json`
+metadata. The race route loads that atlas once per mount and passes it
+to `drawRoad`; live and ghost overlays draw atlas frames when the image
+is available, with the old procedural live car and blue ghost rectangle
+kept as missing-asset fallbacks. The live frame selection combines
+current steering input with upcoming road curve so the car sprite leans
+with driver intent and track shape. Renderer tests cover both atlas
+draw paths and existing fallback paths.
 
 ---
 

--- a/docs/GDD_COVERAGE.json
+++ b/docs/GDD_COVERAGE.json
@@ -56,7 +56,19 @@
         "docs/gdd/17-art-direction.md"
       ],
       "requirement": "Live and ghost cars use original directional sprite atlas frames with damage, brake, nitro, and weather variants.",
-      "coverage": ["open-followup"],
+      "coverage": ["implemented-code", "automated-test"],
+      "implementationRefs": [
+        "public/art/cars/sparrow.svg",
+        "public/art.manifest.json",
+        "src/data/atlas/cars.json",
+        "src/app/race/page.tsx",
+        "src/render/pseudoRoadCanvas.ts",
+        "src/render/spriteAtlas.ts"
+      ],
+      "testRefs": [
+        "src/render/__tests__/pseudoRoadCanvas.test.ts",
+        "src/render/__tests__/spriteAtlas.test.ts"
+      ],
       "followupRefs": ["F-051"]
     },
     {

--- a/docs/GDD_COVERAGE.json
+++ b/docs/GDD_COVERAGE.json
@@ -55,7 +55,7 @@
         "docs/gdd/16-rendering-and-visual-design.md",
         "docs/gdd/17-art-direction.md"
       ],
-      "requirement": "Live and ghost cars use original directional sprite atlas frames with damage, brake, nitro, and weather variants.",
+      "requirement": "Live and ghost cars use original directional sprite atlas frames with damage, brake, and nitro variants.",
       "coverage": ["implemented-code", "automated-test"],
       "implementationRefs": [
         "public/art/cars/sparrow.svg",
@@ -70,6 +70,16 @@
         "src/render/__tests__/spriteAtlas.test.ts"
       ],
       "followupRefs": ["F-051"]
+    },
+    {
+      "id": "GDD-16-CAR-WEATHER-VARIANTS",
+      "gddSections": [
+        "docs/gdd/16-rendering-and-visual-design.md",
+        "docs/gdd/17-art-direction.md"
+      ],
+      "requirement": "Cars render wet spray and snow trail variants from weather-aware visual state.",
+      "coverage": ["open-followup"],
+      "followupRefs": ["F-058"]
     },
     {
       "id": "GDD-16-PARALLAX-ROADSIDE",

--- a/docs/PROGRESS_LOG.md
+++ b/docs/PROGRESS_LOG.md
@@ -14,7 +14,7 @@ scaling,
 [§17](gdd/17-art-direction.md) car design language and asset export,
 [§21](gdd/21-technical-design-for-web-implementation.md) sprite atlas
 renderer pipeline.
-**Branch / PR:** `feat/f-051-car-atlas-sprites`, PR pending.
+**Branch / PR:** `feat/f-051-car-atlas-sprites`, PR #22.
 **Status:** Implemented.
 
 ### Done

--- a/docs/PROGRESS_LOG.md
+++ b/docs/PROGRESS_LOG.md
@@ -6,6 +6,64 @@ Correct them by adding a new entry that references the old one.
 
 ---
 
+## 2026-04-27: Slice: F-051 car atlas sprite overlays
+
+**GDD sections touched:**
+[§16](gdd/16-rendering-and-visual-design.md) car sprites and sprite
+scaling,
+[§17](gdd/17-art-direction.md) car design language and asset export,
+[§21](gdd/21-technical-design-for-web-implementation.md) sprite atlas
+renderer pipeline.
+**Branch / PR:** `feat/f-051-car-atlas-sprites`, PR pending.
+**Status:** Implemented.
+
+### Done
+- `public/art/cars/sparrow.svg`: added an original car sprite sheet with
+  12 clean directional frames plus dented, battered, brake, and nitro
+  variants.
+- `public/art.manifest.json`: added provenance and licence metadata for
+  the shipped car sprite sheet.
+- `src/data/atlas/cars.json`: pointed the existing atlas metadata at the
+  shipped SVG sprite sheet.
+- `src/render/pseudoRoadCanvas.ts`: draws live and ghost car overlays
+  from atlas frames when a loaded atlas image is available, while keeping
+  the existing procedural live car and blue ghost rectangle as fallback
+  paths.
+- `src/app/race/page.tsx`: loads the car atlas once per race mount and
+  selects a frame from current steering input plus upcoming road curve.
+- `docs/FOLLOWUPS.md`: closed F-051.
+- `docs/GDD_COVERAGE.json`: marked GDD-16-CAR-SPRITE-ATLAS as
+  implemented with renderer test coverage.
+
+### Verified
+- `npx vitest run src/render/__tests__/pseudoRoadCanvas.test.ts src/render/__tests__/spriteAtlas.test.ts`
+  green, 39 passed.
+- `npm run typecheck` clean.
+- `npm run content-lint` clean.
+- `npm run verify` clean: lint, typecheck, unit tests, and content-lint
+  all passed; 2,167 unit tests passed.
+- `npm run test:e2e -- e2e/race-demo.spec.ts` green, 3 passed.
+
+### Decisions and assumptions
+- The first atlas asset ships as an SVG sprite sheet because the Canvas
+  path already accepts browser `Image` sources and the metadata uses
+  source rectangles. The renderer still falls back cleanly if the asset
+  cannot load.
+
+### Coverage ledger
+- GDD-16-CAR-SPRITE-ATLAS: covered by the shipped car atlas, live and
+  ghost renderer wiring, and renderer unit tests.
+- Uncovered adjacent requirements: weather-specific spray and snow trail
+  variants remain owned by the later weather VFX slices.
+
+### Followups created
+None.
+
+### GDD edits
+None. This slice implements existing §16, §17, and §21 intent.
+
+---
+
 ## 2026-04-27: Slice: F-057 turn foreground projection continuity
 
 **GDD sections touched:**

--- a/docs/PROGRESS_LOG.md
+++ b/docs/PROGRESS_LOG.md
@@ -34,6 +34,9 @@ renderer pipeline.
 - `docs/FOLLOWUPS.md`: closed F-051.
 - `docs/GDD_COVERAGE.json`: marked GDD-16-CAR-SPRITE-ATLAS as
   implemented with renderer test coverage.
+- `docs/FOLLOWUPS.md` and `docs/GDD_COVERAGE.json`: added F-058 for
+  the weather-specific car spray and snow trail variants that remain
+  outside this atlas overlay slice.
 
 ### Verified
 - `npx vitest run src/render/__tests__/pseudoRoadCanvas.test.ts src/render/__tests__/spriteAtlas.test.ts`
@@ -54,10 +57,10 @@ renderer pipeline.
 - GDD-16-CAR-SPRITE-ATLAS: covered by the shipped car atlas, live and
   ghost renderer wiring, and renderer unit tests.
 - Uncovered adjacent requirements: weather-specific spray and snow trail
-  variants remain owned by the later weather VFX slices.
+  variants are tracked under F-058.
 
 ### Followups created
-None.
+- F-058: add weather-specific car trail and spray variants.
 
 ### GDD edits
 None. This slice implements existing §16, §17, and §21 intent.

--- a/public/art.manifest.json
+++ b/public/art.manifest.json
@@ -1,0 +1,12 @@
+[
+  {
+    "id": "sparrow-car-sprite-atlas",
+    "src": "/art/cars/sparrow.svg",
+    "path": "art/cars/sparrow.svg",
+    "kind": "image",
+    "license": "CC-BY-4.0",
+    "source": "original by VibeGear2 project contributors in this repository",
+    "originality": "Original stylized compact sports coupe sprite sheet drawn for VibeGear2 on 2026-04-27. It uses simple geometric shapes and does not trace or copy a commercial game asset, real vehicle, logo, or manufacturer design.",
+    "date": "2026-04-27"
+  }
+]

--- a/public/art/cars/sparrow.svg
+++ b/public/art/cars/sparrow.svg
@@ -1,0 +1,76 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="768" height="384" viewBox="0 0 768 384">
+  <rect width="768" height="384" fill="none"/>
+  <defs>
+    <g id="shadow">
+      <ellipse cx="0" cy="13" rx="29" ry="5" fill="#10151f" opacity="0.55"/>
+    </g>
+    <g id="clean">
+      <path d="M-26 12 L26 12 L20 -8 L11 -14 L-11 -14 L-20 -8 Z" fill="#f2c94c"/>
+      <path d="M-14 -7 L14 -7 L9 4 L-9 4 Z" fill="#18243d"/>
+      <path d="M-22 7 L-12 7 L-12 11 L-22 11 Z" fill="#ff3d38"/>
+      <path d="M12 7 L22 7 L22 11 L12 11 Z" fill="#ff3d38"/>
+      <path d="M-24 12 L-18 15 L18 15 L24 12 Z" fill="#111827"/>
+      <path d="M-18 -5 L18 -5" stroke="#ffe56e" stroke-width="2"/>
+    </g>
+    <g id="dented">
+      <use href="#clean"/>
+      <path d="M-23 -1 L-17 4 L-21 7" fill="none" stroke="#9b7a18" stroke-width="2"/>
+      <rect x="13" y="7" width="9" height="4" fill="#d72f31"/>
+    </g>
+    <g id="battered">
+      <use href="#clean"/>
+      <path d="M-24 -2 L-15 5 L-23 8" fill="none" stroke="#6f5c22" stroke-width="2"/>
+      <path d="M14 -4 L22 1 L18 7" fill="none" stroke="#6f5c22" stroke-width="2"/>
+      <rect x="-22" y="7" width="10" height="4" fill="#b83232"/>
+      <rect x="13" y="7" width="9" height="4" fill="#b83232"/>
+    </g>
+    <g id="brake">
+      <use href="#clean"/>
+      <rect x="-24" y="6" width="13" height="6" fill="#ff4a44"/>
+      <rect x="11" y="6" width="13" height="6" fill="#ff4a44"/>
+    </g>
+    <g id="nitro">
+      <use href="#clean"/>
+      <path d="M-14 15 L0 26 L14 15 Z" fill="#44d7ff" opacity="0.75"/>
+      <path d="M-8 15 L0 23 L8 15 Z" fill="#e75cff" opacity="0.8"/>
+    </g>
+  </defs>
+  <g transform="translate(32 16) skewX(0)"><use href="#shadow"/><use href="#clean"/></g>
+  <g transform="translate(96 16) skewX(4)"><use href="#shadow"/><use href="#clean"/></g>
+  <g transform="translate(160 16) skewX(8)"><use href="#shadow"/><use href="#clean"/></g>
+  <g transform="translate(224 16) skewX(12)"><use href="#shadow"/><use href="#clean"/></g>
+  <g transform="translate(288 16) skewX(8)"><use href="#shadow"/><use href="#clean"/></g>
+  <g transform="translate(352 16) skewX(4)"><use href="#shadow"/><use href="#clean"/></g>
+  <g transform="translate(416 16) skewX(0)"><use href="#shadow"/><use href="#clean"/></g>
+  <g transform="translate(480 16) skewX(-4)"><use href="#shadow"/><use href="#clean"/></g>
+  <g transform="translate(544 16) skewX(-8)"><use href="#shadow"/><use href="#clean"/></g>
+  <g transform="translate(608 16) skewX(-12)"><use href="#shadow"/><use href="#clean"/></g>
+  <g transform="translate(672 16) skewX(-8)"><use href="#shadow"/><use href="#clean"/></g>
+  <g transform="translate(736 16) skewX(-4)"><use href="#shadow"/><use href="#clean"/></g>
+  <g transform="translate(32 48) skewX(0)"><use href="#shadow"/><use href="#dented"/></g>
+  <g transform="translate(96 48) skewX(4)"><use href="#shadow"/><use href="#dented"/></g>
+  <g transform="translate(160 48) skewX(8)"><use href="#shadow"/><use href="#dented"/></g>
+  <g transform="translate(224 48) skewX(12)"><use href="#shadow"/><use href="#dented"/></g>
+  <g transform="translate(288 48) skewX(8)"><use href="#shadow"/><use href="#dented"/></g>
+  <g transform="translate(352 48) skewX(4)"><use href="#shadow"/><use href="#dented"/></g>
+  <g transform="translate(416 48) skewX(0)"><use href="#shadow"/><use href="#dented"/></g>
+  <g transform="translate(480 48) skewX(-4)"><use href="#shadow"/><use href="#dented"/></g>
+  <g transform="translate(544 48) skewX(-8)"><use href="#shadow"/><use href="#dented"/></g>
+  <g transform="translate(608 48) skewX(-12)"><use href="#shadow"/><use href="#dented"/></g>
+  <g transform="translate(672 48) skewX(-8)"><use href="#shadow"/><use href="#dented"/></g>
+  <g transform="translate(736 48) skewX(-4)"><use href="#shadow"/><use href="#dented"/></g>
+  <g transform="translate(32 80) skewX(0)"><use href="#shadow"/><use href="#battered"/></g>
+  <g transform="translate(96 80) skewX(4)"><use href="#shadow"/><use href="#battered"/></g>
+  <g transform="translate(160 80) skewX(8)"><use href="#shadow"/><use href="#battered"/></g>
+  <g transform="translate(224 80) skewX(12)"><use href="#shadow"/><use href="#battered"/></g>
+  <g transform="translate(288 80) skewX(8)"><use href="#shadow"/><use href="#battered"/></g>
+  <g transform="translate(352 80) skewX(4)"><use href="#shadow"/><use href="#battered"/></g>
+  <g transform="translate(416 80) skewX(0)"><use href="#shadow"/><use href="#battered"/></g>
+  <g transform="translate(480 80) skewX(-4)"><use href="#shadow"/><use href="#battered"/></g>
+  <g transform="translate(544 80) skewX(-8)"><use href="#shadow"/><use href="#battered"/></g>
+  <g transform="translate(608 80) skewX(-12)"><use href="#shadow"/><use href="#battered"/></g>
+  <g transform="translate(672 80) skewX(-8)"><use href="#shadow"/><use href="#battered"/></g>
+  <g transform="translate(736 80) skewX(-4)"><use href="#shadow"/><use href="#battered"/></g>
+  <g transform="translate(32 112)"><use href="#shadow"/><use href="#brake"/></g>
+  <g transform="translate(96 112)"><use href="#shadow"/><use href="#nitro"/></g>
+</svg>

--- a/src/app/race/page.tsx
+++ b/src/app/race/page.tsx
@@ -42,7 +42,8 @@ import { usePauseActions } from "@/components/pause/usePauseActions";
 import { usePauseToggle } from "@/components/pause/usePauseToggle";
 import { saveRaceResult } from "@/components/results/raceResultStorage";
 import { TRACK_IDS, TRACK_RAW, loadTrack } from "@/data";
-import { TrackSchema, type Track } from "@/data/schemas";
+import carsAtlasFixture from "@/data/atlas/cars.json";
+import { AtlasMetaSchema, TrackSchema, type Track } from "@/data/schemas";
 import {
   applyTimeTrialResult,
   buildFinalCarInputsFromSession,
@@ -76,12 +77,14 @@ import {
   fitToBox,
   project,
   projectCar,
+  upcomingCurvature,
   type Camera,
   type CompiledTrack,
   type MinimapPoint,
   type Viewport,
 } from "@/road";
 import { drawRoad } from "@/render/pseudoRoadCanvas";
+import { loadAtlas, type LoadedAtlas } from "@/render/spriteAtlas";
 import { drawMinimap, type MinimapCar } from "@/render/hudMinimap";
 import type { ParallaxLayer } from "@/render/parallax";
 import { drawSplitsWidget } from "@/render/hudSplits";
@@ -95,6 +98,7 @@ const VIEWPORT_WIDTH = 800;
 const VIEWPORT_HEIGHT = 480;
 const DEFAULT_TRACK_ID = "test/elevation";
 const PLAYER_ID = "player";
+const CARS_ATLAS_META = AtlasMetaSchema.parse(carsAtlasFixture);
 
 /**
  * §20 minimap layout. The wireframe places the minimap in the bottom-left
@@ -109,6 +113,15 @@ const MINIMAP_BOX = Object.freeze({
   w: MINIMAP_SIZE,
   h: MINIMAP_SIZE,
 });
+
+function playerCarFrameIndex(steer: number, roadCurve: number): number {
+  const visualSteer = Math.max(-1, Math.min(1, steer + roadCurve * 0.35));
+  if (visualSteer <= -0.66) return 10;
+  if (visualSteer <= -0.25) return 11;
+  if (visualSteer >= 0.66) return 2;
+  if (visualSteer >= 0.25) return 1;
+  return 0;
+}
 
 function createLayerCanvas(
   width: number,
@@ -374,6 +387,8 @@ function RaceCanvas({ track, lapsOverride, mode }: RaceCanvasProps): ReactElemen
   const ghostOverlayRef = useRef<GhostOverlay>(null);
   const ghostOverlayTickRef = useRef<number | null>(null);
   const timeTrialRecorderRef = useRef<TimeTrialRecorder | null>(null);
+  const lastSteerRef = useRef<number>(0);
+  const carAtlasRef = useRef<LoadedAtlas | null>(null);
   // Imperative pause-menu effects, populated inside the loop effect
   // below so the hook layer can stay decoupled from the loop / session
   // / config refs. The hook reads these getters once per click; mid-
@@ -401,6 +416,16 @@ function RaceCanvas({ track, lapsOverride, mode }: RaceCanvasProps): ReactElemen
     position: number;
   }>(() => ({ speed: 0, lap: 1, totalLaps: initialTotalLaps, position: 1 }));
   const [resultMs, setResultMs] = useState<number | null>(null);
+
+  useEffect(() => {
+    let active = true;
+    void loadAtlas(CARS_ATLAS_META).then((atlas) => {
+      if (active) carAtlasRef.current = atlas;
+    });
+    return () => {
+      active = false;
+    };
+  }, []);
 
   const pause = usePauseToggle({ loop: () => handleRef.current });
 
@@ -645,6 +670,7 @@ function RaceCanvas({ track, lapsOverride, mode }: RaceCanvasProps): ReactElemen
         const session = sessionRef.current;
         if (!session) return;
         const input = inputManager.sample();
+        lastSteerRef.current = input.steer;
         const next = stepRaceSession(session, input, config, dt);
         sessionRef.current = next;
         timeTrialRecorderRef.current?.observe({
@@ -660,6 +686,10 @@ function RaceCanvas({ track, lapsOverride, mode }: RaceCanvasProps): ReactElemen
         camera.x = session.player.car.x;
 
         const strips = project(track.compiled.segments, camera, viewport);
+        const playerFrameIndex = playerCarFrameIndex(
+          lastSteerRef.current,
+          upcomingCurvature(track.compiled.segments, camera.z, SEGMENT_LENGTH * 5),
+        );
         if (
           timeTrialEnabled &&
           session.race.phase === "racing" &&
@@ -680,8 +710,17 @@ function RaceCanvas({ track, lapsOverride, mode }: RaceCanvasProps): ReactElemen
         }
         drawRoad(ctx, strips, viewport, {
           parallax: { layers: parallaxLayers, camera },
-          ghostCar: ghostOverlayRef.current,
-          playerCar: {},
+          ghostCar: ghostOverlayRef.current
+            ? {
+                ...ghostOverlayRef.current,
+                atlas: carAtlasRef.current,
+                frameIndex: playerFrameIndex,
+              }
+            : null,
+          playerCar: {
+            atlas: carAtlasRef.current,
+            frameIndex: playerFrameIndex,
+          },
         });
 
         const cars: RankedCar[] = [

--- a/src/data/atlas/cars.json
+++ b/src/data/atlas/cars.json
@@ -1,5 +1,5 @@
 {
-  "image": "art/cars/sparrow.png",
+  "image": "art/cars/sparrow.svg",
   "width": 768,
   "height": 384,
   "sprites": {

--- a/src/render/__tests__/pseudoRoadCanvas.test.ts
+++ b/src/render/__tests__/pseudoRoadCanvas.test.ts
@@ -20,12 +20,14 @@
 import { describe, expect, it } from "vitest";
 
 import type { Strip, Viewport } from "@/road/types";
+import type { LoadedAtlas } from "../spriteAtlas";
 
 import {
   GHOST_CAR_DEFAULT_ALPHA,
   GHOST_CAR_DEFAULT_FILL,
   PLAYER_CAR_DEFAULT_FILL,
   PLAYER_CAR_DEFAULT_SHADOW,
+  PLAYER_CAR_DEFAULT_SPRITE_ID,
   PLAYER_CAR_DEFAULT_TAIL_LIGHT,
   PLAYER_CAR_DEFAULT_TIRE,
   PLAYER_CAR_DEFAULT_WINDSHIELD,
@@ -54,7 +56,20 @@ interface FillCall {
   path: readonly [number, number][];
 }
 
-type DrawCall = FillRectCall | FillCall;
+interface DrawImageCall {
+  type: "drawImage";
+  globalAlpha: number;
+  sx: number;
+  sy: number;
+  sw: number;
+  sh: number;
+  dx: number;
+  dy: number;
+  dw: number;
+  dh: number;
+}
+
+type DrawCall = FillRectCall | FillCall | DrawImageCall;
 
 interface CanvasSpy {
   ctx: CanvasRenderingContext2D;
@@ -110,7 +125,19 @@ function makeCanvasSpy(): CanvasSpy {
         addColorStop(): void {},
       };
     },
-    drawImage(): void {},
+    drawImage(
+      _image: CanvasImageSource,
+      sx: number,
+      sy: number,
+      sw: number,
+      sh: number,
+      dx: number,
+      dy: number,
+      dw: number,
+      dh: number,
+    ): void {
+      calls.push({ type: "drawImage", globalAlpha, sx, sy, sw, sh, dx, dy, dw, dh });
+    },
   } as unknown as CanvasRenderingContext2D;
   return {
     ctx,
@@ -126,6 +153,24 @@ function makeCanvasSpy(): CanvasSpy {
  * because it is independent of the strip array.
  */
 const EMPTY_STRIPS: readonly Strip[] = [];
+
+function loadedCarAtlas(): LoadedAtlas {
+  return {
+    image: {} as HTMLImageElement,
+    fallback: false,
+    meta: {
+      image: "art/cars/sparrow.svg",
+      width: 128,
+      height: 32,
+      sprites: {
+        [PLAYER_CAR_DEFAULT_SPRITE_ID]: [
+          { x: 0, y: 0, w: 64, h: 32 },
+          { x: 64, y: 0, w: 64, h: 32 },
+        ],
+      },
+    },
+  };
+}
 
 function strip(overrides: Partial<Strip>): Strip {
   return {
@@ -213,6 +258,32 @@ describe("drawRoad ghost car overlay", () => {
     );
     expect(ghostRect).toBeDefined();
     expect(ghostRect!.fillStyle).toBe("#ff8800");
+  });
+
+  it("draws the ghost from the loaded car atlas when available", () => {
+    const spy = makeCanvasSpy();
+    drawRoad(spy.ctx, EMPTY_STRIPS, VIEWPORT, {
+      ghostCar: {
+        screenX: 100,
+        screenY: 200,
+        screenW: 64,
+        alpha: 0.25,
+        atlas: loadedCarAtlas(),
+        frameIndex: 1,
+      },
+    });
+
+    const draw = spy.calls.find((c): c is DrawImageCall => c.type === "drawImage");
+    expect(draw).toBeDefined();
+    expect(draw!.globalAlpha).toBeCloseTo(0.25, 6);
+    expect(draw!.sx).toBe(64);
+    expect(draw!.sy).toBe(0);
+    expect(draw!.sw).toBe(64);
+    expect(draw!.sh).toBe(32);
+    expect(draw!.dx).toBeCloseTo(68, 6);
+    expect(draw!.dy).toBeCloseTo(168, 6);
+    expect(draw!.dw).toBeCloseTo(64, 6);
+    expect(draw!.dh).toBeCloseTo(32, 6);
   });
 
   it("clamps an out-of-range alpha to [0, 1]", () => {
@@ -662,6 +733,23 @@ describe("drawRoad player car overlay", () => {
     expect(fills[3]!.fillStyle).toBe("#aa3300");
     expect(fills[4]!.fillStyle).toBe("#223344");
     expect(spy.finalAlpha()).toBeCloseTo(1, 6);
+  });
+
+  it("draws the live player car from the loaded atlas when available", () => {
+    const spy = makeCanvasSpy();
+    drawRoad(spy.ctx, EMPTY_STRIPS, VIEWPORT, {
+      playerCar: { atlas: loadedCarAtlas(), frameIndex: 1 },
+    });
+
+    const draw = spy.calls.find((c): c is DrawImageCall => c.type === "drawImage");
+    const width =
+      VIEWPORT.height * PLAYER_CAR_HEIGHT_FRACTION * PLAYER_CAR_WIDTH_TO_HEIGHT;
+    expect(draw).toBeDefined();
+    expect(draw!.globalAlpha).toBeCloseTo(1, 6);
+    expect(draw!.sx).toBe(64);
+    expect(draw!.dw).toBeCloseTo(width, 6);
+    expect(draw!.dh).toBeCloseTo(width * 0.5, 6);
+    expect(draw!.dx).toBeCloseTo(VIEWPORT.width / 2 - width / 2, 6);
   });
 
   it("does not paint the live player car when omitted or null", () => {

--- a/src/render/__tests__/spriteAtlas.test.ts
+++ b/src/render/__tests__/spriteAtlas.test.ts
@@ -59,7 +59,7 @@ describe("AtlasMetaSchema", () => {
 
   it("rejects an empty frames array", () => {
     const broken = {
-      image: "art/cars/sparrow.png",
+      image: "art/cars/sparrow.svg",
       width: 64,
       height: 64,
       sprites: { sparrow: [] },
@@ -69,7 +69,7 @@ describe("AtlasMetaSchema", () => {
 
   it("rejects an empty sprites map", () => {
     const broken = {
-      image: "art/cars/sparrow.png",
+      image: "art/cars/sparrow.svg",
       width: 64,
       height: 64,
       sprites: {},
@@ -79,7 +79,7 @@ describe("AtlasMetaSchema", () => {
 
   it("rejects a non-positive frame width", () => {
     const broken = {
-      image: "art/cars/sparrow.png",
+      image: "art/cars/sparrow.svg",
       width: 64,
       height: 64,
       sprites: { sparrow: [{ x: 0, y: 0, w: 0, h: 32 }] },
@@ -96,7 +96,7 @@ describe("loadAtlas", () => {
     expect(result.fallback).toBe(false);
     expect(result.image).not.toBeNull();
     expect(result.meta).toBe(meta);
-    expect(lastSrc()).toBe("/art/cars/sparrow.png");
+    expect(lastSrc()).toBe("/art/cars/sparrow.svg");
   });
 
   it("resolves with fallback when the image errors and logs once", async () => {
@@ -110,19 +110,19 @@ describe("loadAtlas", () => {
     expect(result.fallback).toBe(true);
     expect(result.image).toBeNull();
     expect(errorSpy).toHaveBeenCalledTimes(1);
-    expect(errorSpy).toHaveBeenCalledWith("[atlas]", "/art/cars/sparrow.png");
+    expect(errorSpy).toHaveBeenCalledWith("[atlas]", "/art/cars/sparrow.svg");
   });
 
   it("normalises a leading-slash image path", async () => {
     const meta: AtlasMeta = {
-      image: "/art/cars/sparrow.png",
+      image: "/art/cars/sparrow.svg",
       width: 64,
       height: 64,
       sprites: { sparrow: [{ x: 0, y: 0, w: 64, h: 64 }] },
     };
     const { ctor, lastSrc } = makeImageCtor("load");
     await loadAtlas(meta, { ImageCtor: ctor });
-    expect(lastSrc()).toBe("/art/cars/sparrow.png");
+    expect(lastSrc()).toBe("/art/cars/sparrow.svg");
   });
 
   it("falls back when no Image constructor is available", async () => {

--- a/src/render/pseudoRoadCanvas.ts
+++ b/src/render/pseudoRoadCanvas.ts
@@ -29,6 +29,7 @@ import type { Camera, Strip, Viewport } from "@/road/types";
 
 import { drawDust, type DustState } from "./dust";
 import { drawParallax, type ParallaxLayer } from "./parallax";
+import { frame, type LoadedAtlas } from "./spriteAtlas";
 import { drawVfx, type VfxState } from "./vfx";
 
 /**
@@ -69,6 +70,7 @@ export const PLAYER_CAR_DEFAULT_TAIL_LIGHT = "#ff3d38";
  */
 export const PLAYER_CAR_HEIGHT_FRACTION = 0.18;
 export const PLAYER_CAR_WIDTH_TO_HEIGHT = 1.15;
+export const PLAYER_CAR_DEFAULT_SPRITE_ID = "sparrow_clean";
 export const ROADSIDE_DRAW_PERIOD = 10;
 export const ROADSIDE_MAX_HEIGHT_FRACTION = 0.22;
 const LANE_DASH_CYCLE_METERS = LANE_STRIPE_LEN * SEGMENT_LENGTH;
@@ -147,6 +149,9 @@ export interface DrawRoadOptions {
     screenW: number;
     alpha?: number;
     fill?: string;
+    atlas?: LoadedAtlas | null;
+    spriteId?: string;
+    frameIndex?: number;
   } | null;
   /**
    * Optional live player car overlay. Pseudo-3D road strips represent the
@@ -161,6 +166,9 @@ export interface DrawRoadOptions {
     tire?: string;
     tailLight?: string;
     windshield?: string;
+    atlas?: LoadedAtlas | null;
+    spriteId?: string;
+    frameIndex?: number;
   } | null;
 }
 
@@ -496,9 +504,27 @@ function drawGhostCar(
   if (alpha <= 0) return;
 
   const fill = ghost.fill ?? GHOST_CAR_DEFAULT_FILL;
+  if (ghost.atlas?.image) {
+    const sprite = frame(
+      ghost.atlas,
+      ghost.spriteId ?? PLAYER_CAR_DEFAULT_SPRITE_ID,
+      ghost.frameIndex ?? 0,
+    );
+    drawAtlasCarFrame(
+      ctx,
+      ghost.atlas.image,
+      sprite,
+      ghost.screenX,
+      ghost.screenY,
+      ghost.screenW,
+      alpha,
+    );
+    return;
+  }
+
   // 1:0.5 aspect places the rectangle centered on the projected ground
   // point with the silhouette sitting just above it; matches the §17
-  // car-silhouette aspect well enough to read as a vehicle.
+  // car-silhouette aspect well enough to read as a fallback vehicle.
   const halfW = ghost.screenW / 2;
   const heightPx = ghost.screenW / 2;
 
@@ -536,6 +562,16 @@ function drawPlayerCar(
   const bottomY = viewport.height - Math.max(14, viewport.height * 0.035);
   const topY = bottomY - height;
   const halfW = width / 2;
+
+  if (car.atlas?.image) {
+    const sprite = frame(
+      car.atlas,
+      car.spriteId ?? PLAYER_CAR_DEFAULT_SPRITE_ID,
+      car.frameIndex ?? 0,
+    );
+    drawAtlasCarFrame(ctx, car.atlas.image, sprite, centerX, bottomY, width, 1);
+    return;
+  }
 
   const prevFill = ctx.fillStyle;
   try {
@@ -592,6 +628,33 @@ function drawPlayerCar(
     ctx.fillRect(centerX + halfW * 0.36, bottomY - height * 0.24, width * 0.16, height * 0.08);
   } finally {
     ctx.fillStyle = prevFill;
+  }
+}
+
+function drawAtlasCarFrame(
+  ctx: CanvasRenderingContext2D,
+  image: HTMLImageElement,
+  sprite: ReturnType<typeof frame>,
+  anchorX: number,
+  anchorY: number,
+  width: number,
+  alpha: number,
+): void {
+  if (!Number.isFinite(width) || width <= 0) return;
+  if (!Number.isFinite(anchorX) || !Number.isFinite(anchorY)) return;
+
+  const height = width * (sprite.h / sprite.w);
+  const pivotX = sprite.anchor?.x ?? 0.5;
+  const pivotY = sprite.anchor?.y ?? 1;
+  const dx = anchorX - width * pivotX;
+  const dy = anchorY - height * pivotY;
+
+  const prevAlpha = ctx.globalAlpha;
+  try {
+    ctx.globalAlpha = Math.max(0, Math.min(1, alpha));
+    ctx.drawImage(image, sprite.x, sprite.y, sprite.w, sprite.h, dx, dy, width, height);
+  } finally {
+    ctx.globalAlpha = prevAlpha;
   }
 }
 


### PR DESCRIPTION
## Summary
- Adds an original Sparrow car sprite sheet and public asset manifest entry.
- Draws live and ghost car overlays from the loaded cars atlas when available.
- Keeps the existing procedural live car and ghost rectangle as missing-asset fallbacks.
- Selects the live frame from steering input plus upcoming road curve.

## GDD
- §16 car sprites and sprite scaling
- §17 car design language and asset export guidance
- §21 sprite atlas renderer pipeline

## Requirement inventory
- Handles live and ghost car atlas rendering for the current default car.
- Includes clean, dented, battered, brake, and nitro frame rows in the shipped source sheet.
- Leaves weather-specific spray and snow trail variants to later weather VFX work.

## Progress log
- docs/PROGRESS_LOG.md: F-051 car atlas sprite overlays

## Test plan
- [x] npx vitest run src/render/__tests__/pseudoRoadCanvas.test.ts src/render/__tests__/spriteAtlas.test.ts
- [x] npm run typecheck
- [x] npm run content-lint
- [x] npm run verify
- [x] npm run test:e2e -- e2e/race-demo.spec.ts
- [x] perl dash scan on touched files
- [x] git diff --check

## Followups
- F-051 closed in docs/FOLLOWUPS.md
