### PR TITLE
F-059 turn crest road warp

### DIFF
--- a/docs/FOLLOWUPS.md
+++ b/docs/FOLLOWUPS.md
@@ -10,6 +10,27 @@ or `obsolete` so the trail is preserved.
 
 ---
 
+## F-059: Fix turn-at-crest road warp and reversed car sprite lean
+**Created:** 2026-04-27
+**Priority:** blocks-release
+**Status:** done (2026-04-27)
+**Notes:** Manual race observation after F-057 and F-051: while turning
+left or right near a crest, the foreground road could warp sideways as
+if the near road edge was being pulled by distant curve projection. The
+player car atlas also leaned the opposite direction from lateral input:
+rightward movement selected left-looking frames and leftward movement
+selected right-looking frames.
+
+Closed by `fix/f-059-turn-crest-road-warp`. The projector now anchors
+the foreground endpoint to the camera-local road plane at the bottom of
+the viewport instead of extrapolating that endpoint from farther visible
+strips. The live car frame mapper also reverses the Sparrow atlas
+left/right indices so positive steer selects right-leaning frames and
+negative steer selects left-leaning frames. Unit tests cover both
+regressions.
+
+---
+
 ## F-058: Add weather-specific car trail and spray variants
 **Created:** 2026-04-27
 **Priority:** polish

--- a/docs/GDD_COVERAGE.json
+++ b/docs/GDD_COVERAGE.json
@@ -34,7 +34,7 @@
         "src/road/__tests__/segmentProjector.test.ts",
         "e2e/race-demo.spec.ts"
       ],
-      "followupRefs": ["F-050", "F-054", "F-057"]
+      "followupRefs": ["F-050", "F-054", "F-057", "F-059"]
     },
     {
       "id": "GDD-16-ROAD-MARKINGS",
@@ -67,9 +67,10 @@
       ],
       "testRefs": [
         "src/render/__tests__/pseudoRoadCanvas.test.ts",
-        "src/render/__tests__/spriteAtlas.test.ts"
+        "src/render/__tests__/spriteAtlas.test.ts",
+        "src/render/__tests__/carFrame.test.ts"
       ],
-      "followupRefs": ["F-051"]
+      "followupRefs": ["F-051", "F-059"]
     },
     {
       "id": "GDD-16-CAR-WEATHER-VARIANTS",

--- a/docs/PROGRESS_LOG.md
+++ b/docs/PROGRESS_LOG.md
@@ -48,8 +48,8 @@ renderer pipeline.
 - The screen-bottom foreground edge represents the camera-local road
   plane, not a distant projected curve sample. This keeps the bottom of
   the road stable while still letting the road ahead curve and crest.
-- The Sparrow atlas row uses right-leaning frames near the start of the
-  row and left-leaning frames near the end, so the runtime mapping must
+- The Sparrow atlas row uses left-leaning frames near the start of the
+  row and right-leaning frames near the end, so the runtime mapping must
   invert the previous F-051 sign choice.
 
 ### Coverage ledger

--- a/docs/PROGRESS_LOG.md
+++ b/docs/PROGRESS_LOG.md
@@ -6,6 +6,68 @@ Correct them by adding a new entry that references the old one.
 
 ---
 
+## 2026-04-27: Slice: F-059 turn crest road warp
+
+**GDD sections touched:**
+[§9](gdd/09-track-design.md) road curvature and readable edges,
+[§16](gdd/16-rendering-and-visual-design.md) segment-based projection
+and car sprite direction,
+[§21](gdd/21-technical-design-for-web-implementation.md) Canvas2D
+renderer pipeline.
+**Branch / PR:** `fix/f-059-turn-crest-road-warp`, PR pending.
+**Status:** Implemented.
+
+### Done
+- `src/road/segmentProjector.ts`: changed the foreground projection
+  endpoint to anchor to the camera-local road plane at the screen
+  bottom. The foreground road no longer extrapolates from farther curve
+  or crest strips.
+- `src/road/__tests__/segmentProjector.test.ts`: updated the foreground
+  regression to assert the camera-local bottom endpoint.
+- `src/render/carFrame.ts`: moved live car atlas frame selection into a
+  testable helper and reversed the left/right frame mapping so lateral
+  movement matches the sprite lean.
+- `src/app/race/page.tsx`: now imports the tested car frame helper for
+  live and ghost overlay frame selection.
+- `src/render/__tests__/carFrame.test.ts`: added frame-selection
+  regressions for neutral, left, right, and curve-influenced lean.
+- `docs/FOLLOWUPS.md`: added and closed F-059.
+- `docs/GDD_COVERAGE.json`: linked F-059 to elevation projection and
+  car sprite atlas coverage.
+
+### Verified
+- `npx vitest run src/road/__tests__/segmentProjector.test.ts src/render/__tests__/carFrame.test.ts`
+  green, 40 passed.
+- `npx vitest run src/render/__tests__/pseudoRoadCanvas.test.ts src/render/__tests__/carFrame.test.ts src/road/__tests__/segmentProjector.test.ts`
+  green, 63 passed.
+- `npm run verify` clean: lint, typecheck, unit tests, and content-lint
+  all passed; 2,171 unit tests passed.
+- `npm run test:e2e -- e2e/race-demo.spec.ts` green, 3 passed.
+
+### Decisions and assumptions
+- The screen-bottom foreground edge represents the camera-local road
+  plane, not a distant projected curve sample. This keeps the bottom of
+  the road stable while still letting the road ahead curve and crest.
+- The Sparrow atlas row uses right-leaning frames near the start of the
+  row and left-leaning frames near the end, so the runtime mapping must
+  invert the previous F-051 sign choice.
+
+### Coverage ledger
+- GDD-09-ELEVATION-LIVE: extended to cover turn and crest foreground
+  stability.
+- GDD-16-CAR-SPRITE-ATLAS: extended to cover correct left/right atlas
+  frame direction.
+- Uncovered adjacent requirements: weather-specific spray and snow trail
+  variants remain tracked under F-058.
+
+### Followups created
+None.
+
+### GDD edits
+None. This slice implements existing §9, §16, and §21 intent.
+
+---
+
 ## 2026-04-27: Slice: F-051 car atlas sprite overlays
 
 **GDD sections touched:**

--- a/src/app/race/page.tsx
+++ b/src/app/race/page.tsx
@@ -84,6 +84,7 @@ import {
   type Viewport,
 } from "@/road";
 import { drawRoad } from "@/render/pseudoRoadCanvas";
+import { playerCarFrameIndex } from "@/render/carFrame";
 import { loadAtlas, type LoadedAtlas } from "@/render/spriteAtlas";
 import { drawMinimap, type MinimapCar } from "@/render/hudMinimap";
 import type { ParallaxLayer } from "@/render/parallax";
@@ -113,15 +114,6 @@ const MINIMAP_BOX = Object.freeze({
   w: MINIMAP_SIZE,
   h: MINIMAP_SIZE,
 });
-
-function playerCarFrameIndex(steer: number, roadCurve: number): number {
-  const visualSteer = Math.max(-1, Math.min(1, steer + roadCurve * 0.35));
-  if (visualSteer <= -0.66) return 10;
-  if (visualSteer <= -0.25) return 11;
-  if (visualSteer >= 0.66) return 2;
-  if (visualSteer >= 0.25) return 1;
-  return 0;
-}
 
 function createLayerCanvas(
   width: number,

--- a/src/render/__tests__/carFrame.test.ts
+++ b/src/render/__tests__/carFrame.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vitest";
+
+import { playerCarFrameIndex } from "../carFrame";
+
+describe("playerCarFrameIndex", () => {
+  it("uses the centered atlas frame for neutral steering and flat road", () => {
+    expect(playerCarFrameIndex(0, 0)).toBe(0);
+  });
+
+  it("maps rightward steering to right-leaning atlas frames", () => {
+    expect(playerCarFrameIndex(0.35, 0)).toBe(11);
+    expect(playerCarFrameIndex(0.85, 0)).toBe(10);
+  });
+
+  it("maps leftward steering to left-leaning atlas frames", () => {
+    expect(playerCarFrameIndex(-0.35, 0)).toBe(1);
+    expect(playerCarFrameIndex(-0.85, 0)).toBe(2);
+  });
+
+  it("combines upcoming road curve with driver steering", () => {
+    expect(playerCarFrameIndex(0, 1)).toBe(11);
+    expect(playerCarFrameIndex(0, -1)).toBe(1);
+  });
+});

--- a/src/render/carFrame.ts
+++ b/src/render/carFrame.ts
@@ -1,0 +1,17 @@
+/**
+ * Frame selection helpers for the live car atlas overlay.
+ *
+ * The Sparrow atlas row is authored as center, right lean, then wraps
+ * through left lean at the end of the row. Positive steer means the
+ * car moves right on screen, so it must select the negative-skew frames
+ * near the row end.
+ */
+
+export function playerCarFrameIndex(steer: number, roadCurve: number): number {
+  const visualSteer = Math.max(-1, Math.min(1, steer + roadCurve * 0.35));
+  if (visualSteer <= -0.66) return 2;
+  if (visualSteer <= -0.25) return 1;
+  if (visualSteer >= 0.66) return 10;
+  if (visualSteer >= 0.25) return 11;
+  return 0;
+}

--- a/src/road/__tests__/segmentProjector.test.ts
+++ b/src/road/__tests__/segmentProjector.test.ts
@@ -201,22 +201,24 @@ describe("project (pseudo-3D segment projector)", () => {
     expect(near.foreground!.screenW).toBeCloseTo(expected, 6);
   });
 
-  it("extrapolates the foreground centerline through lateral road motion", () => {
+  it("anchors the foreground endpoint to the camera-local road plane", () => {
     const segs = flatTrack(16, { curve: 0.02 });
-    const strips = project(segs, makeCamera({ x: 1.4 }), VIEWPORT, {
+    const camera = makeCamera({ x: 1.4 });
+    const strips = project(segs, camera, VIEWPORT, {
       drawDistance: 8,
     });
     const visible = strips.filter((s) => s.visible);
     expect(visible.length).toBeGreaterThan(1);
 
     const near = visible[0]!;
-    const far = visible[1]!;
     expect(near.foreground).toBeDefined();
 
-    const extrapolation =
-      (VIEWPORT.height - near.screenY) / (near.screenY - far.screenY);
-    const expectedX =
-      near.screenX + (near.screenX - far.screenX) * extrapolation;
+    const halfW = VIEWPORT.width / 2;
+    const halfH = VIEWPORT.height / 2;
+    const screenBottomZ =
+      (camera.depth * camera.y * halfH) / (VIEWPORT.height - halfH);
+    const expectedScale = camera.depth / screenBottomZ;
+    const expectedX = halfW + expectedScale * -camera.x * halfW;
 
     expect(Math.abs(expectedX - near.screenX)).toBeGreaterThan(5);
     expect(near.foreground!.screenX).toBeCloseTo(expectedX, 6);

--- a/src/road/segmentProjector.ts
+++ b/src/road/segmentProjector.ts
@@ -181,7 +181,7 @@ export function project(
     maxY = strip.screenY;
   }
 
-  attachForegroundProjection(strips, viewport);
+  attachForegroundProjection(strips, viewport, camera);
 
   return strips;
 }
@@ -192,32 +192,32 @@ export function project(
  * the rest of the strip list instead of patching the lower viewport with
  * hard-coded road geometry.
  */
-function attachForegroundProjection(strips: Strip[], viewport: Viewport): void {
+function attachForegroundProjection(
+  strips: Strip[],
+  viewport: Viewport,
+  camera: Camera,
+): void {
   const nearIndex = strips.findIndex((strip) => strip.visible);
   if (nearIndex < 0) return;
 
   const near = strips[nearIndex]!;
   if (near.screenY >= viewport.height) return;
 
-  const far = strips.slice(nearIndex + 1).find((strip) => strip.visible);
-  const extrapolation =
-    far && near.screenY > far.screenY
-      ? (viewport.height - near.screenY) / (near.screenY - far.screenY)
-      : 0;
-  const projectedX =
-    far && extrapolation > 0
-      ? near.screenX + (near.screenX - far.screenX) * extrapolation
-      : near.screenX;
-  const projectedHalfW =
-    far && extrapolation > 0
-      ? near.screenW + (near.screenW - far.screenW) * extrapolation
-      : near.screenW;
-  const screenW = Math.max(near.screenW, projectedHalfW);
+  const halfW = viewport.width / 2;
+  const halfH = viewport.height / 2;
+  const bottomDelta = viewport.height - halfH;
+  const cameraHeight = Number.isFinite(camera.y) && camera.y > 0 ? camera.y : 1;
+  const screenBottomZ =
+    bottomDelta > 0
+      ? (camera.depth * cameraHeight * halfH) / bottomDelta
+      : camera.depth;
+  const sz = Math.max(camera.depth, screenBottomZ);
+  const scale = camera.depth / sz;
 
   near.foreground = {
-    screenX: projectedX,
+    screenX: halfW + scale * -camera.x * halfW,
     screenY: viewport.height,
-    screenW,
+    screenW: Math.max(near.screenW, scale * ROAD_WIDTH * halfW),
   };
 }
 


### PR DESCRIPTION
## Summary
- Anchor the foreground road endpoint to the camera-local road plane so turns near crests do not drag the screen-bottom road from distant strips.
- Move car atlas frame selection into a tested helper and correct the left/right sprite lean mapping.
- Add and close F-059 in the backlog, progress log, and coverage ledger.

## GDD
- docs/gdd/09-track-design.md
- docs/gdd/16-rendering-and-visual-design.md
- docs/gdd/21-technical-design-for-web-implementation.md

## Verification
- npx vitest run src/road/__tests__/segmentProjector.test.ts src/render/__tests__/carFrame.test.ts
- npx vitest run src/render/__tests__/pseudoRoadCanvas.test.ts src/render/__tests__/carFrame.test.ts src/road/__tests__/segmentProjector.test.ts
- npm run verify
- npm run test:e2e -- e2e/race-demo.spec.ts
- npm run content-lint
- git diff --check
- grep -rn unicode dash scan on touched files

## Followups
- None.