### PR TITLE
F-060 car turn direction

### DIFF
--- a/docs/FOLLOWUPS.md
+++ b/docs/FOLLOWUPS.md
@@ -10,6 +10,22 @@ or `obsolete` so the trail is preserved.
 
 ---
 
+## F-060: Correct live car turn sprite direction
+**Created:** 2026-04-27
+**Priority:** blocks-release
+**Status:** done (2026-04-27)
+**Notes:** Manual race observation after F-059: the live car sprite still
+turned visually backward. Moving right selected frames that looked like a
+left turn, and moving left selected frames that looked like a right turn.
+
+Closed by `fix/f-060-car-turn-direction`. The live car frame mapper now
+matches the actual Sparrow atlas row: positive steering selects the
+positive-skew frames near the start of the row, and negative steering
+selects the negative-skew frames near the row end. Unit tests pin right,
+left, and curve-influenced frame selection.
+
+---
+
 ## F-059: Fix turn-at-crest road warp and reversed car sprite lean
 **Created:** 2026-04-27
 **Priority:** blocks-release

--- a/docs/GDD_COVERAGE.json
+++ b/docs/GDD_COVERAGE.json
@@ -70,7 +70,7 @@
         "src/render/__tests__/spriteAtlas.test.ts",
         "src/render/__tests__/carFrame.test.ts"
       ],
-      "followupRefs": ["F-051", "F-059"]
+      "followupRefs": ["F-051", "F-059", "F-060"]
     },
     {
       "id": "GDD-16-CAR-WEATHER-VARIANTS",

--- a/docs/PROGRESS_LOG.md
+++ b/docs/PROGRESS_LOG.md
@@ -6,6 +6,49 @@ Correct them by adding a new entry that references the old one.
 
 ---
 
+## 2026-04-27: Slice: F-060 car turn direction
+
+**GDD sections touched:**
+[§16](gdd/16-rendering-and-visual-design.md) car sprite direction.
+**Branch / PR:** `fix/f-060-car-turn-direction`, PR pending.
+**Status:** Implemented.
+
+### Done
+- `src/render/carFrame.ts`: corrected the live car atlas frame mapper
+  so positive steering uses the Sparrow row's positive-skew right-turn
+  frames, and negative steering uses the row-end left-turn frames.
+- `src/render/__tests__/carFrame.test.ts`: updated right, left, and
+  curve-influenced frame selection regressions to match the actual
+  atlas direction.
+- `docs/FOLLOWUPS.md`: added and closed F-060.
+- `docs/GDD_COVERAGE.json`: linked F-060 to car sprite atlas coverage.
+
+### Verified
+- `npx vitest run src/render/__tests__/carFrame.test.ts` green, 4
+  passed.
+- `npm run content-lint` clean.
+- `npm run verify` clean: lint, typecheck, unit tests, and content-lint
+  all passed; 2,171 unit tests passed.
+- `npm run test:e2e -- e2e/race-demo.spec.ts` green, 3 passed.
+
+### Decisions and assumptions
+- The visible turn direction is defined by the authored Sparrow atlas
+  row, not by the previous F-059 row-end assumption.
+
+### Coverage ledger
+- GDD-16-CAR-SPRITE-ATLAS: extended to cover live car left/right turn
+  direction against the atlas row.
+- Uncovered adjacent requirements: weather-specific spray and snow trail
+  variants remain tracked under F-058.
+
+### Followups created
+None.
+
+### GDD edits
+None. This slice implements existing §16 intent.
+
+---
+
 ## 2026-04-27: Slice: F-059 turn crest road warp
 
 **GDD sections touched:**

--- a/src/render/__tests__/carFrame.test.ts
+++ b/src/render/__tests__/carFrame.test.ts
@@ -8,17 +8,17 @@ describe("playerCarFrameIndex", () => {
   });
 
   it("maps rightward steering to right-leaning atlas frames", () => {
-    expect(playerCarFrameIndex(0.35, 0)).toBe(11);
-    expect(playerCarFrameIndex(0.85, 0)).toBe(10);
+    expect(playerCarFrameIndex(0.35, 0)).toBe(1);
+    expect(playerCarFrameIndex(0.85, 0)).toBe(2);
   });
 
   it("maps leftward steering to left-leaning atlas frames", () => {
-    expect(playerCarFrameIndex(-0.35, 0)).toBe(1);
-    expect(playerCarFrameIndex(-0.85, 0)).toBe(2);
+    expect(playerCarFrameIndex(-0.35, 0)).toBe(11);
+    expect(playerCarFrameIndex(-0.85, 0)).toBe(10);
   });
 
   it("combines upcoming road curve with driver steering", () => {
-    expect(playerCarFrameIndex(0, 1)).toBe(11);
-    expect(playerCarFrameIndex(0, -1)).toBe(1);
+    expect(playerCarFrameIndex(0, 1)).toBe(1);
+    expect(playerCarFrameIndex(0, -1)).toBe(11);
   });
 });

--- a/src/render/carFrame.ts
+++ b/src/render/carFrame.ts
@@ -3,15 +3,15 @@
  *
  * The Sparrow atlas row is authored as center, right lean, then wraps
  * through left lean at the end of the row. Positive steer means the
- * car moves right on screen, so it must select the negative-skew frames
- * near the row end.
+ * car moves right on screen, so it must select the positive-skew frames
+ * near the start of the row.
  */
 
 export function playerCarFrameIndex(steer: number, roadCurve: number): number {
   const visualSteer = Math.max(-1, Math.min(1, steer + roadCurve * 0.35));
-  if (visualSteer <= -0.66) return 2;
-  if (visualSteer <= -0.25) return 1;
-  if (visualSteer >= 0.66) return 10;
-  if (visualSteer >= 0.25) return 11;
+  if (visualSteer <= -0.66) return 10;
+  if (visualSteer <= -0.25) return 11;
+  if (visualSteer >= 0.66) return 2;
+  if (visualSteer >= 0.25) return 1;
   return 0;
 }


### PR DESCRIPTION
Summary
- Correct live player car frame selection so right input uses the atlas right-turn frames and left input uses the atlas left-turn frames.
- Add and close F-060, and link it in the GDD coverage ledger.

GDD
- docs/gdd/16-rendering-and-visual-design.md: car sprite direction.

Verification
- npx vitest run src/render/__tests__/carFrame.test.ts
- npm run content-lint
- npm run verify
- npm run test:e2e -- e2e/race-demo.spec.ts

Followups
- Added and closed F-060.