### PR TITLE
F-058 weather car trails

### DIFF
--- a/docs/FOLLOWUPS.md
+++ b/docs/FOLLOWUPS.md
@@ -50,7 +50,7 @@ regressions.
 ## F-058: Add weather-specific car trail and spray variants
 **Created:** 2026-04-27
 **Priority:** polish
-**Status:** open
+**Status:** done (2026-04-27)
 **Notes:** F-051 ships the live and ghost car sprite atlas path with
 directional, damage, brake, and nitro frames. §16 also calls for wet
 spray and snow trail variants. Those are not frame rows in the current
@@ -59,6 +59,12 @@ renderer can select them from actual weather state rather than a fake
 always-on decoration. Add weather-specific atlas or effect assets,
 thread weather state into the car overlay draw path, and cover clear,
 wet, and snow cases in renderer tests.
+
+Closed by `feat/f-058-weather-car-trails`. `drawRoad` now accepts active
+weather on the live `playerCar` overlay, paints rain / heavy-rain spray
+and snow mist behind the car, and draws no extra trail in clear weather.
+The race route passes the active race weather from track/session setup,
+and renderer tests cover clear, wet, and snow cases.
 
 ---
 

--- a/docs/FOLLOWUPS.md
+++ b/docs/FOLLOWUPS.md
@@ -63,8 +63,9 @@ wet, and snow cases in renderer tests.
 Closed by `feat/f-058-weather-car-trails`. `drawRoad` now accepts active
 weather on the live `playerCar` overlay, paints rain / heavy-rain spray
 and snow mist behind the car, and draws no extra trail in clear weather.
-The race route passes the active race weather from track/session setup,
-and renderer tests cover clear, wet, and snow cases.
+Fog is explicitly treated as a no-trail condition. The race route passes
+the active race weather from track/session setup, and renderer tests
+cover clear, fog, wet, and snow cases.
 
 ---
 

--- a/docs/GDD_COVERAGE.json
+++ b/docs/GDD_COVERAGE.json
@@ -79,7 +79,12 @@
         "docs/gdd/17-art-direction.md"
       ],
       "requirement": "Cars render wet spray and snow trail variants from weather-aware visual state.",
-      "coverage": ["open-followup"],
+      "coverage": ["implemented-code", "automated-test"],
+      "implementationRefs": [
+        "src/app/race/page.tsx",
+        "src/render/pseudoRoadCanvas.ts"
+      ],
+      "testRefs": ["src/render/__tests__/pseudoRoadCanvas.test.ts"],
       "followupRefs": ["F-058"]
     },
     {

--- a/docs/PROGRESS_LOG.md
+++ b/docs/PROGRESS_LOG.md
@@ -6,11 +6,64 @@ Correct them by adding a new entry that references the old one.
 
 ---
 
+## 2026-04-27: Slice: F-058 weather car trails
+
+**GDD sections touched:**
+[§14](gdd/14-weather-and-environmental-systems.md) weather visual
+effects,
+[§16](gdd/16-rendering-and-visual-design.md) car sprite weather
+variants,
+[§21](gdd/21-technical-design-for-web-implementation.md) Canvas2D
+renderer pipeline.
+**Branch / PR:** `feat/f-058-weather-car-trails`, PR pending.
+**Status:** Implemented.
+
+### Done
+- `src/render/pseudoRoadCanvas.ts`: added weather-aware live car trail
+  rendering. Clear, dusk, and night draw no trail; rain variants draw
+  blue-white spray; snow draws pale mist behind the car.
+- `src/app/race/page.tsx`: passes the active race weather from the
+  race config / compiled track into the live player car draw path.
+- `src/render/__tests__/pseudoRoadCanvas.test.ts`: covers clear, wet,
+  and snow trail behavior plus alpha restoration.
+- `docs/FOLLOWUPS.md`: closed F-058.
+- `docs/GDD_COVERAGE.json`: marked GDD-16-CAR-WEATHER-VARIANTS as
+  implemented with renderer test coverage.
+
+### Verified
+- `npx vitest run src/render/__tests__/pseudoRoadCanvas.test.ts`
+  green, 26 passed.
+- `npm run content-lint` clean.
+- `npm run verify` clean: lint, typecheck, unit tests, and content-lint
+  all passed; 2,174 unit tests passed.
+- `npm run test:e2e -- e2e/race-demo.spec.ts` green, 3 passed.
+
+### Decisions and assumptions
+- Weather trails are renderer effects attached to the live player car,
+  not extra sprite atlas rows. This matches the current Canvas2D effect
+  stack and lets weather state drive the effect directly.
+- Dusk and night do not imply spray or snow by themselves, so they draw
+  no car trail until a later lighting slice adds glow or headlight VFX.
+
+### Coverage ledger
+- GDD-16-CAR-WEATHER-VARIANTS: covered by weather-aware live car trails
+  and renderer tests.
+- Uncovered adjacent requirements: rain streaks, road sheen, snowfall,
+  fog fade, night bloom, and weather physics remain broader §14 work.
+
+### Followups created
+None.
+
+### GDD edits
+None. This slice implements existing §14, §16, and §21 intent.
+
+---
+
 ## 2026-04-27: Slice: F-060 car turn direction
 
 **GDD sections touched:**
 [§16](gdd/16-rendering-and-visual-design.md) car sprite direction.
-**Branch / PR:** `fix/f-060-car-turn-direction`, PR pending.
+**Branch / PR:** `fix/f-060-car-turn-direction`, PR #24.
 **Status:** Implemented.
 
 ### Done

--- a/docs/PROGRESS_LOG.md
+++ b/docs/PROGRESS_LOG.md
@@ -25,17 +25,17 @@ renderer pipeline.
 - `src/app/race/page.tsx`: passes the active race weather from the
   race config / compiled track into the live player car draw path.
 - `src/render/__tests__/pseudoRoadCanvas.test.ts`: covers clear, wet,
-  and snow trail behavior plus alpha restoration.
+  fog, wet, and snow trail behavior plus alpha restoration.
 - `docs/FOLLOWUPS.md`: closed F-058.
 - `docs/GDD_COVERAGE.json`: marked GDD-16-CAR-WEATHER-VARIANTS as
   implemented with renderer test coverage.
 
 ### Verified
 - `npx vitest run src/render/__tests__/pseudoRoadCanvas.test.ts`
-  green, 26 passed.
+  green, 27 passed.
 - `npm run content-lint` clean.
 - `npm run verify` clean: lint, typecheck, unit tests, and content-lint
-  all passed; 2,174 unit tests passed.
+  all passed; 2,175 unit tests passed.
 - `npm run test:e2e -- e2e/race-demo.spec.ts` green, 3 passed.
 
 ### Decisions and assumptions

--- a/src/app/race/page.tsx
+++ b/src/app/race/page.tsx
@@ -483,6 +483,7 @@ function RaceCanvas({ track, lapsOverride, mode }: RaceCanvasProps): ReactElemen
       seed: raceSeed,
       ...(lapsOverride !== null ? { totalLaps: lapsOverride } : {}),
     };
+    const activeWeather = config.weather ?? track.compiled.weatherOptions[0] ?? "clear";
 
     const resetTimeTrialRuntime = (): void => {
       ghostOverlayRef.current = null;
@@ -712,6 +713,7 @@ function RaceCanvas({ track, lapsOverride, mode }: RaceCanvasProps): ReactElemen
           playerCar: {
             atlas: carAtlasRef.current,
             frameIndex: playerFrameIndex,
+            weather: activeWeather,
           },
         });
 

--- a/src/render/__tests__/pseudoRoadCanvas.test.ts
+++ b/src/render/__tests__/pseudoRoadCanvas.test.ts
@@ -775,6 +775,18 @@ describe("drawRoad player car overlay", () => {
     expect(fills.some((call) => call.fillStyle === "#edf7ff")).toBe(false);
   });
 
+  it("does not paint weather trails in fog", () => {
+    const spy = makeCanvasSpy();
+    drawRoad(spy.ctx, EMPTY_STRIPS, VIEWPORT, {
+      playerCar: { weather: "fog" },
+    });
+
+    const fills = spy.calls.filter((c): c is FillCall => c.type === "fill");
+    expect(fills).toHaveLength(5);
+    expect(fills.some((call) => call.fillStyle === "#d8f4ff")).toBe(false);
+    expect(fills.some((call) => call.fillStyle === "#edf7ff")).toBe(false);
+  });
+
   it("draws the live player car from the loaded atlas when available", () => {
     const spy = makeCanvasSpy();
     drawRoad(spy.ctx, EMPTY_STRIPS, VIEWPORT, {

--- a/src/render/__tests__/pseudoRoadCanvas.test.ts
+++ b/src/render/__tests__/pseudoRoadCanvas.test.ts
@@ -735,6 +735,46 @@ describe("drawRoad player car overlay", () => {
     expect(spy.finalAlpha()).toBeCloseTo(1, 6);
   });
 
+  it("paints wet spray behind the live player car in rainy weather", () => {
+    const spy = makeCanvasSpy();
+    drawRoad(spy.ctx, EMPTY_STRIPS, VIEWPORT, {
+      playerCar: { weather: "heavy_rain" },
+    });
+
+    const fills = spy.calls.filter((c): c is FillCall => c.type === "fill");
+    expect(fills[0]!.fillStyle).toBe("#d8f4ff");
+    expect(fills[0]!.globalAlpha).toBeCloseTo(0.7, 6);
+    expect(fills[1]!.fillStyle).toBe("#d8f4ff");
+    expect(fills[1]!.globalAlpha).toBeCloseTo(0.7, 6);
+    expect(fills[2]!.fillStyle).toBe(PLAYER_CAR_DEFAULT_TIRE);
+    expect(spy.finalAlpha()).toBeCloseTo(1, 6);
+  });
+
+  it("paints snow mist behind the live player car in snow", () => {
+    const spy = makeCanvasSpy();
+    drawRoad(spy.ctx, EMPTY_STRIPS, VIEWPORT, {
+      playerCar: { weather: "snow" },
+    });
+
+    const fills = spy.calls.filter((c): c is FillCall => c.type === "fill");
+    expect(fills[0]!.fillStyle).toBe("#edf7ff");
+    expect(fills[0]!.globalAlpha).toBeCloseTo(0.62, 6);
+    expect(fills[1]!.fillStyle).toBe(PLAYER_CAR_DEFAULT_TIRE);
+    expect(spy.finalAlpha()).toBeCloseTo(1, 6);
+  });
+
+  it("does not paint weather trails in clear weather", () => {
+    const spy = makeCanvasSpy();
+    drawRoad(spy.ctx, EMPTY_STRIPS, VIEWPORT, {
+      playerCar: { weather: "clear" },
+    });
+
+    const fills = spy.calls.filter((c): c is FillCall => c.type === "fill");
+    expect(fills).toHaveLength(5);
+    expect(fills.some((call) => call.fillStyle === "#d8f4ff")).toBe(false);
+    expect(fills.some((call) => call.fillStyle === "#edf7ff")).toBe(false);
+  });
+
   it("draws the live player car from the loaded atlas when available", () => {
     const spy = makeCanvasSpy();
     drawRoad(spy.ctx, EMPTY_STRIPS, VIEWPORT, {

--- a/src/render/pseudoRoadCanvas.ts
+++ b/src/render/pseudoRoadCanvas.ts
@@ -663,6 +663,10 @@ function drawCarWeatherTrail(
       return;
     }
 
+    if (weather !== "light_rain" && weather !== "rain" && weather !== "heavy_rain") {
+      return;
+    }
+
     ctx.globalAlpha = weather === "heavy_rain" ? 0.7 : 0.52;
     ctx.fillStyle = "#d8f4ff";
     ctx.beginPath();

--- a/src/render/pseudoRoadCanvas.ts
+++ b/src/render/pseudoRoadCanvas.ts
@@ -26,6 +26,7 @@ import {
   SPRITE_BASE_SCALE,
 } from "@/road/constants";
 import type { Camera, Strip, Viewport } from "@/road/types";
+import type { WeatherOption } from "@/data/schemas";
 
 import { drawDust, type DustState } from "./dust";
 import { drawParallax, type ParallaxLayer } from "./parallax";
@@ -166,6 +167,7 @@ export interface DrawRoadOptions {
     tire?: string;
     tailLight?: string;
     windshield?: string;
+    weather?: WeatherOption;
     atlas?: LoadedAtlas | null;
     spriteId?: string;
     frameIndex?: number;
@@ -563,6 +565,8 @@ function drawPlayerCar(
   const topY = bottomY - height;
   const halfW = width / 2;
 
+  drawCarWeatherTrail(ctx, centerX, bottomY, width, height, car.weather);
+
   if (car.atlas?.image) {
     const sprite = frame(
       car.atlas,
@@ -628,6 +632,54 @@ function drawPlayerCar(
     ctx.fillRect(centerX + halfW * 0.36, bottomY - height * 0.24, width * 0.16, height * 0.08);
   } finally {
     ctx.fillStyle = prevFill;
+  }
+}
+
+function drawCarWeatherTrail(
+  ctx: CanvasRenderingContext2D,
+  centerX: number,
+  bottomY: number,
+  width: number,
+  height: number,
+  weather: WeatherOption | undefined,
+): void {
+  if (!weather || weather === "clear" || weather === "dusk" || weather === "night") {
+    return;
+  }
+
+  const prevFill = ctx.fillStyle;
+  const prevAlpha = ctx.globalAlpha;
+  try {
+    if (weather === "snow") {
+      ctx.globalAlpha = 0.62;
+      ctx.fillStyle = "#edf7ff";
+      ctx.beginPath();
+      ctx.moveTo(centerX - width * 0.36, bottomY - height * 0.12);
+      ctx.lineTo(centerX + width * 0.36, bottomY - height * 0.12);
+      ctx.lineTo(centerX + width * 0.52, bottomY + height * 0.06);
+      ctx.lineTo(centerX - width * 0.52, bottomY + height * 0.06);
+      ctx.closePath();
+      ctx.fill();
+      return;
+    }
+
+    ctx.globalAlpha = weather === "heavy_rain" ? 0.7 : 0.52;
+    ctx.fillStyle = "#d8f4ff";
+    ctx.beginPath();
+    ctx.moveTo(centerX - width * 0.56, bottomY - height * 0.08);
+    ctx.lineTo(centerX - width * 0.18, bottomY - height * 0.02);
+    ctx.lineTo(centerX - width * 0.62, bottomY + height * 0.14);
+    ctx.closePath();
+    ctx.fill();
+    ctx.beginPath();
+    ctx.moveTo(centerX + width * 0.56, bottomY - height * 0.08);
+    ctx.lineTo(centerX + width * 0.18, bottomY - height * 0.02);
+    ctx.lineTo(centerX + width * 0.62, bottomY + height * 0.14);
+    ctx.closePath();
+    ctx.fill();
+  } finally {
+    ctx.fillStyle = prevFill;
+    ctx.globalAlpha = prevAlpha;
   }
 }
 


### PR DESCRIPTION
Summary
- Add weather-aware live player car trails for rain, heavy rain, and snow.
- Pass active race weather into the road renderer.
- Close F-058 and mark GDD-16-CAR-WEATHER-VARIANTS implemented with tests.

GDD
- docs/gdd/14-weather-and-environmental-systems.md: weather visual effects.
- docs/gdd/16-rendering-and-visual-design.md: car sprite weather variants.
- docs/gdd/21-technical-design-for-web-implementation.md: Canvas2D renderer pipeline.

Verification
- npx vitest run src/render/__tests__/pseudoRoadCanvas.test.ts
- npm run content-lint
- npm run verify
- npm run test:e2e -- e2e/race-demo.spec.ts

Followups
- Closed F-058.
- Broader rain streaks, road sheen, snowfall, fog fade, night bloom, and weather physics remain future weather work.