### PR TITLE
F-048 AI difficulty scalars

### DIFF
--- a/docs/FOLLOWUPS.md
+++ b/docs/FOLLOWUPS.md
@@ -277,7 +277,7 @@ covers the full localStorage round-trip.
 ## F-048: Apply `CPU_DIFFICULTY_MODIFIERS` scalars in the AI runtime
 **Created:** 2026-04-26
 **Priority:** nice-to-have
-**Status:** in-progress
+**Status:** done (2026-04-27)
 **Notes:** `src/game/aiDifficulty.ts` exposes
 `CPU_DIFFICULTY_MODIFIERS` keyed by `PlayerDifficultyPreset` (Easy /
 Normal / Hard / Master). The runtime side of the §23 wiring needs
@@ -298,16 +298,22 @@ three call-sites; the `paceScalar` slice landed in
   ceiling. Tests cover Hard > Easy under matched inputs, the
   per-driver composition, the topSpeed clamp, and the
   identity-default byte-equivalence with the omitted-arg path.
-- `mistakeScalar`: **open.** Stack on `AIDriver.mistakeRate` once
-  the mistake-injection pipeline lands. Clean_line is currently
-  zero-randomness; the consumer arrives with `aggressive`,
-  `chaotic`, and `bully` archetypes (full-AI dot owns it).
-- `recoveryScalar`: **open.** Stack on the rubber-banding catch-up
-  term once it lands. §15 lists rubber-banding as deferred; no
-  consumer module exists yet.
+- `mistakeScalar`: **done.** Closed by
+  `feat/f-048-ai-difficulty-scalars`. `tickAI` now stacks
+  `cpuModifiers.mistakeScalar` on top of `AIDriver.mistakeRate` and
+  feeds a deterministic lane-target mistake hook from `AIState.seed`.
+  The hook is intentionally generic; archetype-specific mistake shapes
+  remain owned by the full-AI dot.
+- `recoveryScalar`: **done.** Closed by
+  `feat/f-048-ai-difficulty-scalars`. `tickAI` now stacks
+  `cpuModifiers.recoveryScalar` on a light trailing-gap pace lift when
+  the AI is behind the player. The term stays bounded and remains under
+  the chassis top-speed clamp so it cannot create impossible pace.
 
-Close this followup once `mistakeScalar` and `recoveryScalar`
-also consume their respective scalars at their consumer sites.
+F-048 is closed. Remaining broader AI work stays in
+`VibeGear2-implement-full-ai-fab57b84`: overtake / lane-shift
+behavior, archetype-specific mistakes, nitro usage, weather skill, and
+full grid behavior.
 
 ---
 

--- a/docs/GDD_COVERAGE.json
+++ b/docs/GDD_COVERAGE.json
@@ -88,6 +88,26 @@
       "followupRefs": ["F-058"]
     },
     {
+      "id": "GDD-15-CPU-DIFFICULTY-RUNTIME",
+      "gddSections": [
+        "docs/gdd/15-cpu-opponents-and-ai.md",
+        "docs/gdd/23-balancing-tables.md"
+      ],
+      "requirement": "CPU difficulty tiers affect AI pace, light recovery, and mistake frequency through the §23 modifier table.",
+      "coverage": ["implemented-code", "automated-test"],
+      "implementationRefs": [
+        "src/game/ai.ts",
+        "src/game/aiDifficulty.ts",
+        "src/game/raceSession.ts"
+      ],
+      "testRefs": [
+        "src/game/__tests__/ai.test.ts",
+        "src/game/__tests__/aiDifficulty.test.ts",
+        "src/data/__tests__/balancing.test.ts"
+      ],
+      "followupRefs": ["F-048"]
+    },
+    {
       "id": "GDD-16-PARALLAX-ROADSIDE",
       "gddSections": [
         "docs/gdd/09-track-design.md",

--- a/docs/PROGRESS_LOG.md
+++ b/docs/PROGRESS_LOG.md
@@ -6,6 +6,65 @@ Correct them by adding a new entry that references the old one.
 
 ---
 
+## 2026-04-27: Slice: F-048 AI difficulty scalars
+
+**GDD sections touched:**
+[§15](gdd/15-cpu-opponents-and-ai.md) CPU difficulty tiers,
+[§23](gdd/23-balancing-tables.md) CPU difficulty modifiers,
+[§21](gdd/21-technical-design-for-web-implementation.md) deterministic
+runtime.
+**Branch / PR:** `feat/f-048-ai-difficulty-scalars`, PR pending.
+**Status:** Implemented.
+
+### Done
+- `src/game/ai.ts`: consumes all three §23 CPU difficulty scalar
+  columns. `paceScalar` remains stacked on target speed,
+  `mistakeScalar` now stacks on `AIDriver.mistakeRate` for a
+  deterministic lane-target mistake hook, and `recoveryScalar` now
+  stacks on a bounded light trailing-gap pace lift.
+- `src/game/__tests__/ai.test.ts`: covers Easy producing more
+  deterministic mistakes than Hard, positive mistake-rate seed
+  advancement, and Master recovery being larger than Easy under a
+  matched trailing gap.
+- `src/game/aiDifficulty.ts` and
+  `src/data/__tests__/balancing.test.ts`: updated comments so the
+  §23 modifier docs match the runtime consumers.
+- `docs/FOLLOWUPS.md`: closed F-048.
+- `docs/GDD_COVERAGE.json`: added GDD-15-CPU-DIFFICULTY-RUNTIME.
+
+### Verified
+- `npx vitest run src/game/__tests__/ai.test.ts` green, 27 passed.
+- `npx vitest run src/game/__tests__/ai.test.ts src/game/__tests__/aiDifficulty.test.ts src/data/__tests__/balancing.test.ts`
+  green, 115 passed.
+- `npm run content-lint` clean.
+- `npm run verify` clean: lint, typecheck, unit tests, and content-lint
+  all passed; 2,179 unit tests passed.
+- `npm run test:e2e -- e2e/race-demo.spec.ts` green, 3 passed.
+
+### Decisions and assumptions
+- The recovery hook is intentionally light and bounded under the
+  existing top-speed clamp. It makes the §23 scalar observable without
+  adding impossible pace or the full rubber-banding policy in this
+  slice.
+- The shared mistake hook perturbs the lane target only. Specific
+  miss-apex, early-brake, wasted-nitro, and weather-mismatch mistakes
+  remain part of the full-AI slice.
+
+### Coverage ledger
+- GDD-15-CPU-DIFFICULTY-RUNTIME: covered by runtime wiring and AI unit
+  tests.
+- Uncovered adjacent requirements: overtake / lane-shift behavior,
+  archetype-specific mistake shapes, nitro use, weather skill, and full
+  grid behavior remain under `VibeGear2-implement-full-ai-fab57b84`.
+
+### Followups created
+None.
+
+### GDD edits
+None. This slice implements existing §15, §21, and §23 intent.
+
+---
+
 ## 2026-04-27: Slice: F-058 weather car trails
 
 **GDD sections touched:**

--- a/src/data/__tests__/balancing.test.ts
+++ b/src/data/__tests__/balancing.test.ts
@@ -26,10 +26,8 @@
  *  5. CPU difficulty modifiers (§23) -> `CPU_DIFFICULTY_MODIFIERS`
  *     in `src/game/aiDifficulty.ts`. The §23 column gives
  *     pace / recovery / mistake scalars per `Easy / Normal / Hard /
- *     Master` ladder. The catch-up consumer (`recoveryScalar`) and
- *     mistake-injection consumer (`mistakeScalar`) have not landed
- *     yet (rubber-banding and randomised mistakes are deferred §15
- *     slices); the table here is the binding the wiring slices read.
+ *     Master` ladder. `tickAI` consumes all three scalars; the table
+ *     here keeps future balancing edits visible.
  *  6. Track difficulty rating rubric (§23) -> qualitative weights, no
  *     runtime consumer; out of scope here.
  *

--- a/src/game/__tests__/ai.test.ts
+++ b/src/game/__tests__/ai.test.ts
@@ -515,6 +515,115 @@ describe("tickAI (§23 CPU difficulty tier paceScalar)", () => {
   });
 });
 
+describe("tickAI (§23 CPU difficulty mistakeScalar and recoveryScalar)", () => {
+  it("Easy tier produces more deterministic lane-target mistakes than Hard", () => {
+    const mistakeDriver: AIDriver = {
+      ...CLEAN_LINE_DRIVER,
+      mistakeRate: 0.5,
+    };
+    const countMistakes = (
+      modifiers: ReturnType<typeof getCpuModifiers>,
+    ): number => {
+      let aiState = freshAi({ seed: 123 });
+      let count = 0;
+      for (let i = 0; i < 300; i += 1) {
+        const result = tickAI(
+          mistakeDriver,
+          aiState,
+          freshCar({ speed: 20, z: i * 6 }),
+          PLAYER_FAR_BEHIND,
+          STRAIGHT_TRACK,
+          RACING,
+          STARTER_STATS,
+          DEFAULT_AI_TRACK_CONTEXT,
+          0,
+          modifiers,
+        );
+        if (result.input.steer !== 0) count += 1;
+        aiState = result.nextAiState;
+      }
+      return count;
+    };
+
+    expect(countMistakes(getCpuModifiers("easy"))).toBeGreaterThan(
+      countMistakes(getCpuModifiers("hard")),
+    );
+  });
+
+  it("advances the AI seed only when a positive mistake rate is consumed", () => {
+    const noMistake = tickAI(
+      CLEAN_LINE_DRIVER,
+      freshAi({ seed: 7 }),
+      freshCar({ speed: 20 }),
+      PLAYER_FAR_BEHIND,
+      STRAIGHT_TRACK,
+      RACING,
+      STARTER_STATS,
+    );
+    const mistakeDriver: AIDriver = {
+      ...CLEAN_LINE_DRIVER,
+      mistakeRate: 0.5,
+    };
+    const withMistakeRate = tickAI(
+      mistakeDriver,
+      freshAi({ seed: 7 }),
+      freshCar({ speed: 20 }),
+      PLAYER_FAR_BEHIND,
+      STRAIGHT_TRACK,
+      RACING,
+      STARTER_STATS,
+    );
+
+    expect(noMistake.nextAiState.seed).toBe(7);
+    expect(withMistakeRate.nextAiState.seed).not.toBe(7);
+  });
+
+  it("Master recovery term is larger than Easy under matched trailing gap", () => {
+    const easyRecoveryOnly = {
+      ...getCpuModifiers("easy"),
+      paceScalar: 1,
+      mistakeScalar: 1,
+    };
+    const masterRecoveryOnly = {
+      ...getCpuModifiers("master"),
+      paceScalar: 1,
+      mistakeScalar: 1,
+    };
+    const aiCar = freshCar({ z: 900, speed: 30 });
+    const playerAhead: PlayerView = {
+      car: freshCar({ z: aiCar.z + 240, speed: 30 }),
+    };
+    const easy = tickAI(
+      CLEAN_LINE_DRIVER,
+      freshAi(),
+      aiCar,
+      playerAhead,
+      SWEEPER_TRACK,
+      RACING,
+      STARTER_STATS,
+      DEFAULT_AI_TRACK_CONTEXT,
+      0,
+      easyRecoveryOnly,
+    );
+    const master = tickAI(
+      CLEAN_LINE_DRIVER,
+      freshAi(),
+      aiCar,
+      playerAhead,
+      SWEEPER_TRACK,
+      RACING,
+      STARTER_STATS,
+      DEFAULT_AI_TRACK_CONTEXT,
+      0,
+      masterRecoveryOnly,
+    );
+
+    expect(master.nextAiState.targetSpeed).toBeGreaterThan(
+      easy.nextAiState.targetSpeed,
+    );
+  });
+});
+
 describe("AI_TUNING (constants are sane)", () => {
   it("MAX_RACING_LINE_OFFSET keeps the AI inside the road", () => {
     expect(AI_TUNING.MAX_RACING_LINE_OFFSET).toBeLessThan(
@@ -524,5 +633,11 @@ describe("AI_TUNING (constants are sane)", () => {
 
   it("MIN_AI_SPEED is positive so a curve cannot stop the AI", () => {
     expect(AI_TUNING.MIN_AI_SPEED).toBeGreaterThan(0);
+  });
+
+  it("MAX_MISTAKE_OFFSET stays within the recoverable road width", () => {
+    expect(AI_TUNING.MAX_MISTAKE_OFFSET).toBeLessThan(
+      DEFAULT_AI_TRACK_CONTEXT.roadHalfWidth,
+    );
   });
 });

--- a/src/game/ai.ts
+++ b/src/game/ai.ts
@@ -228,7 +228,7 @@ export function tickAI(
   driver: Readonly<AIDriver>,
   aiState: Readonly<AIState>,
   aiCar: Readonly<CarState>,
-  _player: Readonly<PlayerView>,
+  player: Readonly<PlayerView>,
   track: Readonly<CompiledSegmentBuffer>,
   race: Readonly<RaceState>,
   stats: Readonly<CarBaseStats>,
@@ -280,7 +280,7 @@ export function tickAI(
     context.roadHalfWidth,
   );
 
-  const playerLeadMeters = Math.max(0, _player.car.z - aiCar.z);
+  const playerLeadMeters = Math.max(0, player.car.z - aiCar.z);
   const recoveryPaceBonus =
     clamp(
       playerLeadMeters / AI_TUNING.RECOVERY_GAP_FOR_MAX_BONUS,

--- a/src/game/ai.ts
+++ b/src/game/ai.ts
@@ -20,36 +20,33 @@
  *   tickAI(driver, aiState, aiCar, player, track, race, dt)
  *     -> { input, nextAiState }
  *
- * No globals, no time source, no RNG. Same arguments produce identical
- * outputs across runs, satisfying the §21 replay/ghost determinism
- * requirement (AGENTS.md RULE 8 "Determinism is mandatory"). The clean
- * line slice contains zero randomness; the `seed` field on `AIState` is
- * carried through so later mistake-prone archetypes can stream a
- * dedicated PRNG without a breaking signature change.
+ * No globals or time source. Same arguments, including `AIState.seed`,
+ * produce identical outputs across runs, satisfying the §21
+ * replay/ghost determinism requirement (AGENTS.md RULE 8 "Determinism
+ * is mandatory"). The `seed` field on `AIState` is the dedicated
+ * deterministic PRNG channel for the shared AI mistake hook.
  *
  * §23 "CPU difficulty modifiers" wiring: `tickAI` accepts an optional
  * `cpuModifiers` parameter (the §15-tier scalars from
- * `aiDifficulty.getCpuModifiers`) and stacks `cpuModifiers.paceScalar`
- * on top of the per-driver `AIDriver.paceScalar` at the targetSpeed
- * compute site. `mistakeScalar` and `recoveryScalar` are reserved on
- * the same shape but have no consumer yet (mistake injection lands
- * with the aggressive / chaotic / bully archetypes; rubber-banding
- * lands with the §15 deferred catch-up slice). Defaults to identity
- * (`getCpuModifiers("normal")`) so existing callers keep their
- * pre-binding behaviour bit-for-bit; `raceSession` resolves the
- * tier once per session via `resolveCpuModifiers` and forwards the
- * cached reference into every AI tick.
+ * `aiDifficulty.getCpuModifiers`) and stacks all three scalar columns
+ * on top of per-driver AI data. `paceScalar` raises or lowers target
+ * speed, `recoveryScalar` scales the light catch-up term when an AI
+ * trails the player, and `mistakeScalar` scales the per-driver
+ * `mistakeRate` for deterministic lane-target mistakes. Defaults to
+ * identity (`getCpuModifiers("normal")`) so existing callers keep
+ * Normal behavior unchanged.
  *
  * Out of scope for this slice (deferred to follow-up AI dots):
  * - Overtake / lane-shift behaviour. §15 lists it; the clean_line single
  *   AI may collide with the player. Collision avoidance lands with the
  *   full grid slice.
  * - Nitro firing. The clean_line AI never fires nitro in this slice.
- * - Mistake injection (miss apex, brake too early in fog, etc.). The
- *   §23 `mistakeScalar` consumer lands with that pipeline.
+ * - Archetype-specific mistake shapes (miss apex, brake too early in
+ *   fog, etc.). This slice ships the shared deterministic lane-target
+ *   mistake hook.
  * - Weather skill modulation of `paceScalar`.
- * - Rubber-banding catch-up logic. The §23 `recoveryScalar` consumer
- *   lands with that slice.
+ * - Full rubber-banding policy. This slice ships the light catch-up
+ *   pace hook so the §23 `recoveryScalar` row is consumed.
  */
 
 import type { AIDriver, CarBaseStats } from "@/data/schemas";
@@ -62,14 +59,14 @@ import {
 import { NEUTRAL_INPUT, type Input } from "./input";
 import type { CarState } from "./physics";
 import type { RaceState } from "./raceState";
+import { createRng } from "./rng";
 
 /**
  * Identity §23 CPU modifiers row used as the default when a caller does
  * not supply tier-resolved scalars. Equivalent to
  * `getCpuModifiers("normal")`: each scalar is `1.0` so the per-driver
- * `paceScalar` (and future `mistakeScalar` / `recoveryScalar` consumers)
- * pass through untouched, preserving pre-binding behaviour bit-for-bit
- * for any caller that has not yet adopted the tier wiring.
+ * `paceScalar`, `mistakeRate`, and light recovery term pass through
+ * unchanged for any caller that has not yet adopted the tier wiring.
  */
 export const IDENTITY_CPU_MODIFIERS: CpuDifficultyModifiers =
   getCpuModifiers("normal");
@@ -162,6 +159,20 @@ export const AI_TUNING = Object.freeze({
    * a damping term.
    */
   STEER_GAIN: 1.5,
+  /**
+   * Maximum lane-target offset injected by a deterministic mistake, in
+   * meters. Kept below the road half-width so a mistake nudges the AI
+   * toward a worse line without teleporting it off the road.
+   */
+  MAX_MISTAKE_OFFSET: ROAD_WIDTH * 0.35,
+  /**
+   * Maximum pace lift from the light catch-up term before the §23
+   * `recoveryScalar` row is applied. The term only applies while the AI
+   * trails the player and remains below the chassis top-speed clamp.
+   */
+  MAX_RECOVERY_PACE_BONUS: 0.05,
+  /** Player gap, in meters, that reaches the maximum recovery term. */
+  RECOVERY_GAP_FOR_MAX_BONUS: 240,
 });
 
 /**
@@ -242,11 +253,42 @@ export function tickAI(
   // converts a `-0` from the multiplication on a perfectly straight
   // segment back to `+0` so call-sites can `expect(steer).toBe(0)`.
   const rawIdealOffset = -authoredCurve * AI_TUNING.MAX_RACING_LINE_OFFSET;
-  const idealLateralOffset = clamp(
+  const baseIdealLateralOffset = clamp(
     rawIdealOffset === 0 ? 0 : rawIdealOffset,
     -context.roadHalfWidth,
     context.roadHalfWidth,
   );
+  const effectiveMistakeRate = clamp(
+    driver.mistakeRate * cpuModifiers.mistakeScalar,
+    0,
+    1,
+  );
+  let nextSeed = aiState.seed;
+  let mistakeOffset = 0;
+  if (race.phase === "racing" && effectiveMistakeRate > 0) {
+    const mistakeRng = createRng(aiState.seed);
+    const mistakeActive = mistakeRng.nextBool(effectiveMistakeRate);
+    const mistakeDirection = mistakeRng.next() < 0.5 ? -1 : 1;
+    mistakeOffset = mistakeActive
+      ? mistakeDirection * AI_TUNING.MAX_MISTAKE_OFFSET
+      : 0;
+    nextSeed = mistakeRng.state;
+  }
+  const idealLateralOffset = clamp(
+    baseIdealLateralOffset + mistakeOffset,
+    -context.roadHalfWidth,
+    context.roadHalfWidth,
+  );
+
+  const playerLeadMeters = Math.max(0, _player.car.z - aiCar.z);
+  const recoveryPaceBonus =
+    clamp(
+      playerLeadMeters / AI_TUNING.RECOVERY_GAP_FOR_MAX_BONUS,
+      0,
+      1,
+    ) *
+    AI_TUNING.MAX_RECOVERY_PACE_BONUS *
+    cpuModifiers.recoveryScalar;
 
   // Target speed per segment. §15 "AI chooses a lane offset target" plus
   // a per-driver `paceScalar` from §22 maps onto a curve-aware target
@@ -261,7 +303,11 @@ export function tickAI(
   // authored `paceScalar > 1` still cannot exceed the chassis ceiling.
   const curvePenalty = 1 - AI_TUNING.CLEAN_LINE_CURVE_DECEL * Math.abs(authoredCurve);
   const composedPaceScalar = driver.paceScalar * cpuModifiers.paceScalar;
-  const rawTarget = stats.topSpeed * Math.max(0, curvePenalty) * composedPaceScalar;
+  const rawTarget =
+    stats.topSpeed *
+    Math.max(0, curvePenalty) *
+    composedPaceScalar *
+    (1 + recoveryPaceBonus);
   const targetSpeed = clamp(rawTarget, AI_TUNING.MIN_AI_SPEED, stats.topSpeed);
 
   // The state we will return regardless of phase. Mirrors the car so
@@ -272,7 +318,7 @@ export function tickAI(
     speed: aiCar.speed,
     intent: aiState.intent,
     targetSpeed,
-    seed: aiState.seed,
+    seed: nextSeed,
   };
 
   // Countdown: do not integrate inputs. Per the dot stress-test item 10

--- a/src/game/aiDifficulty.ts
+++ b/src/game/aiDifficulty.ts
@@ -21,30 +21,28 @@
  *     captures archetype identity (rocket > clean_line > cautious);
  *     the tier scalar captures player-facing difficulty.
  *
- *   - `recoveryScalar`: tier-level multiplier on rubber-banding catch
- *     up rate. > 1 makes the AI close gaps faster (Hard, Master);
- *     < 1 lets the player extend a lead (Easy). The catch-up
- *     consumer has not landed yet (rubber-banding is a deferred
- *     §15 slice); this scalar is the binding §23 owes the runtime.
+ *   - `recoveryScalar`: tier-level multiplier on the light AI catch-up
+ *     rate. > 1 makes the AI close gaps faster (Hard, Master); < 1
+ *     lets the player extend a lead (Easy). The shared consumer lives
+ *     in `tickAI`; full rubber-banding policy is still a deferred §15
+ *     slice.
  *
  *   - `mistakeScalar`: tier-level multiplier on per-driver
  *     `AIDriver.mistakeRate`. > 1 makes the AI fumble more (Easy:
  *     a `mistakeRate = 0.08` driver effectively runs at
  *     `0.08 * 1.4 = 0.112`); < 1 cleans them up (Master: same
- *     driver at `0.08 * 0.45 = 0.036`). The mistake-injection
- *     consumer has not landed yet (clean_line slice has zero
- *     randomness); this scalar is the binding §23 owes the runtime.
+ *     driver at `0.08 * 0.45 = 0.036`). The shared deterministic
+ *     lane-target mistake hook lives in `tickAI`; archetype-specific
+ *     mistake shapes remain a deferred §15 slice.
  *
  * Determinism: no `Math.random`, no `Date.now`, no globals.
  * `getCpuModifiers(presetId)` returns the same frozen object reference
  * every call so callers can lean on identity comparison.
  *
  * The module is intentionally consumer-agnostic in this slice: the
- * AI controller, catch-up logic, and mistake injection wire the
- * scalars in follow-up slices so the §15 slice surface does not have
- * to bump alongside this binding. Adding a new tier row, renaming a
- * scalar, or moving the §23 numbers requires updating both the
- * table here and the `aiDifficulty.test.ts` unit pin (and the §23
+ * The AI controller consumes all three scalars. Adding a new tier row,
+ * renaming a scalar, or moving the §23 numbers requires updating both
+ * the table here and the `aiDifficulty.test.ts` unit pin (and the §23
  * cross-check in `src/data/__tests__/balancing.test.ts`).
  *
  * Distinct from `src/game/difficultyPresets.ts`. That module owns the
@@ -73,15 +71,13 @@ export interface CpuDifficultyModifiers {
   /**
    * Multiplier on rubber-banding catch-up rate. `1.0` is Normal;
    * > 1.0 makes the AI close gaps faster (Hard, Master); < 1.0
-   * lets the player extend a lead (Easy). The catch-up consumer
-   * has not landed yet; the scalar is reserved here.
+   * lets the player extend a lead (Easy).
    */
   readonly recoveryScalar: number;
   /**
    * Multiplier on per-driver `AIDriver.mistakeRate`. `1.0` is
    * Normal; > 1.0 makes the AI fumble more (Easy); < 1.0 cleans
-   * them up (Hard, Master). The mistake-injection consumer has not
-   * landed yet; the scalar is reserved here.
+   * them up (Hard, Master).
    */
   readonly mistakeScalar: number;
 }

--- a/src/game/aiDifficulty.ts
+++ b/src/game/aiDifficulty.ts
@@ -39,7 +39,6 @@
  * `getCpuModifiers(presetId)` returns the same frozen object reference
  * every call so callers can lean on identity comparison.
  *
- * The module is intentionally consumer-agnostic in this slice: the
  * The AI controller consumes all three scalars. Adding a new tier row,
  * renaming a scalar, or moving the §23 numbers requires updating both
  * the table here and the `aiDifficulty.test.ts` unit pin (and the §23


### PR DESCRIPTION
## GDD sections
- §15 CPU opponents and AI
- §21 deterministic runtime
- §23 CPU difficulty modifiers

## Requirement inventory
- Consumes `paceScalar`, `recoveryScalar`, and `mistakeScalar` from `CPU_DIFFICULTY_MODIFIERS` in the AI runtime.
- Keeps the recovery term light, bounded, and under the chassis top-speed clamp.
- Keeps AI mistake behavior deterministic through `AIState.seed`.
- Leaves overtake behavior, archetype-specific mistakes, nitro use, weather skill, and full grid behavior to `VibeGear2-implement-full-ai-fab57b84`.

## Progress log
- `docs/PROGRESS_LOG.md`: 2026-04-27 slice `F-048 AI difficulty scalars`

## Test plan
- [x] `npx vitest run src/game/__tests__/ai.test.ts`
- [x] `npx vitest run src/game/__tests__/ai.test.ts src/game/__tests__/aiDifficulty.test.ts src/data/__tests__/balancing.test.ts`
- [x] `npm run content-lint`
- [x] `npm run verify`
- [x] `npm run test:e2e -- e2e/race-demo.spec.ts`

## Followups
- Closes F-048.
- No new followups created.