### PR TITLE
feat(garage): add summary hub

### DIFF
--- a/docs/FOLLOWUPS.md
+++ b/docs/FOLLOWUPS.md
@@ -10,6 +10,35 @@ or `obsolete` so the trail is preserved.
 
 ---
 
+## F-063: Align starter selection content with the three §11 starter examples
+**Created:** 2026-04-27
+**Priority:** blocks-release
+**Status:** open
+**Notes:** The garage summary starter recovery screen can pick from cars
+with `purchasePrice: 0`, but the current catalogue only has Sparrow GT
+as a free starter. §11 names Sparrow GT, Breaker S, and Vanta XR as the
+starter examples. Decide whether all three should be free championship
+starters or whether the GDD examples should be revised, then align the
+catalogue, starter picker, save defaults, and tests in one slice.
+
+## F-062: Implement garage upgrade purchase surface
+**Created:** 2026-04-27
+**Priority:** blocks-release
+**Status:** open
+**Notes:** The garage summary surface shows installed upgrade tiers and
+links to `/garage/upgrade`, but the route is only a placeholder. Build
+the §12 upgrade purchase flow with tier costs, eligibility checks,
+credits persistence, installed tier updates, and save reload coverage.
+
+## F-061: Implement garage repair purchase surface
+**Created:** 2026-04-27
+**Priority:** blocks-release
+**Status:** open
+**Notes:** The garage summary surface links to `/garage/repair`, but the
+route is only a placeholder until the repair economy slice lands. Build
+the §13 repair purchase flow once race damage persistence exists, then
+show pending damage and repair cost in the garage summary.
+
 ## F-060: Correct live car turn sprite direction
 **Created:** 2026-04-27
 **Priority:** blocks-release

--- a/docs/GDD_COVERAGE.json
+++ b/docs/GDD_COVERAGE.json
@@ -14,6 +14,30 @@
       ]
     },
     {
+      "id": "GDD-05-GARAGE-SUMMARY",
+      "gddSections": [
+        "docs/gdd/05-core-gameplay-loop.md",
+        "docs/gdd/11-cars-and-stats.md",
+        "docs/gdd/12-upgrade-and-economy-system.md",
+        "docs/gdd/20-hud-and-ui-ux.md"
+      ],
+      "requirement": "The garage hub summarizes the active car, credits, installed upgrades, owned-car state, and next race actions before race entry.",
+      "coverage": ["implemented-code", "automated-test"],
+      "implementationRefs": [
+        "src/app/page.tsx",
+        "src/app/garage/page.tsx",
+        "src/app/garage/repair/page.tsx",
+        "src/app/garage/upgrade/page.tsx",
+        "src/components/garage/garageSummaryState.ts"
+      ],
+      "testRefs": [
+        "src/components/garage/__tests__/garageSummaryState.test.ts",
+        "e2e/garage-summary.spec.ts",
+        "e2e/title-screen.spec.ts"
+      ],
+      "followupRefs": ["F-061", "F-062", "F-063"]
+    },
+    {
       "id": "GDD-09-ELEVATION-LIVE",
       "gddSections": [
         "docs/gdd/09-track-design.md",

--- a/docs/PROGRESS_LOG.md
+++ b/docs/PROGRESS_LOG.md
@@ -6,6 +6,72 @@ Correct them by adding a new entry that references the old one.
 
 ---
 
+## 2026-04-27: Slice: Garage summary surface
+
+**GDD sections touched:**
+[§5](gdd/05-core-gameplay-loop.md) garage loop,
+[§11](gdd/11-cars-and-stats.md) car selection,
+[§12](gdd/12-upgrade-and-economy-system.md) installed upgrades,
+[§20](gdd/20-hud-and-ui-ux.md) garage layout.
+**Branch / PR:** `feat/garage-summary-flow`, PR pending.
+**Status:** Implemented.
+
+### Done
+- `src/app/page.tsx`: routes the title menu Garage entry to the new
+  garage hub instead of the car selector.
+- `src/app/garage/page.tsx`: renders the first garage hub with active
+  car, credits, owned count, repair placeholder, installed upgrade
+  tiers, next race action, and links to cars, repairs, upgrades, and
+  race entry.
+- `src/components/garage/garageSummaryState.ts`: adds deterministic
+  state projection for the garage summary and starter recovery path.
+- `src/app/garage/repair/page.tsx` and
+  `src/app/garage/upgrade/page.tsx`: add explicit placeholder routes so
+  the summary actions do not dead-end before their purchase slices land.
+- `e2e/garage-summary.spec.ts`: covers summary rendering, action link
+  routing, and recovery from a save whose active car id is no longer
+  owned or known.
+- `docs/FOLLOWUPS.md`: created followups for repair purchase, upgrade
+  purchase, and starter catalogue alignment.
+- `docs/GDD_COVERAGE.json`: added GDD-05-GARAGE-SUMMARY.
+
+### Verified
+- `npx vitest run src/components/garage/__tests__/garageSummaryState.test.ts`
+  green, 5 passed.
+- `npm run content-lint` clean.
+- `npm run verify` clean: lint, typecheck, unit tests, and content-lint
+  all passed; 2,184 unit tests passed.
+- `npm run test:e2e -- e2e/title-screen.spec.ts e2e/garage-summary.spec.ts`
+  green, 7 passed.
+
+### Decisions and assumptions
+- The garage hub ships as a summary and routing surface first. Repair
+  and upgrade purchase flows are separate PR-sized slices because they
+  need their own save mutations and economy tests.
+- Starter recovery currently uses free catalogue entries. The catalogue
+  only has Sparrow GT as `purchasePrice: 0`, so the §11 three-starter
+  wording is tracked as F-063 instead of silently changing economy
+  balance in this slice.
+
+### Coverage ledger
+- GDD-05-GARAGE-SUMMARY: covered by the new garage hub, state helper,
+  and Playwright summary flow.
+- Uncovered adjacent requirements: real repair purchasing, real
+  upgrade purchasing, standings, weather fit, ghost status, leaderboard
+  status, and full next-race tournament data remain future garage
+  slices.
+
+### Followups created
+- F-061: Implement garage repair purchase surface.
+- F-062: Implement garage upgrade purchase surface.
+- F-063: Align starter selection content with the three §11 starter
+  examples.
+
+### GDD edits
+None. This slice implements existing §5, §11, §12, and §20 intent.
+
+---
+
 ## 2026-04-27: Slice: F-048 AI difficulty scalars
 
 **GDD sections touched:**

--- a/e2e/garage-summary.spec.ts
+++ b/e2e/garage-summary.spec.ts
@@ -1,0 +1,162 @@
+import { expect, test } from "@playwright/test";
+
+const SAVE_KEY = "vibegear2:save:v3";
+
+interface SeededSave {
+  version: number;
+  profileName: string;
+  settings: {
+    displaySpeedUnit: "kph" | "mph";
+    assists: {
+      steeringAssist: boolean;
+      autoNitro: boolean;
+      weatherVisualReduction: boolean;
+    };
+    difficultyPreset: "easy" | "normal" | "hard" | "master";
+    transmissionMode: "auto" | "manual";
+    audio: { master: number; music: number; sfx: number };
+    accessibility: {
+      colorBlindMode: "off" | "deuter" | "prot" | "trit";
+      reducedMotion: boolean;
+      largeUiText: boolean;
+      screenShakeScale: number;
+    };
+  };
+  garage: {
+    credits: number;
+    ownedCars: ReadonlyArray<string>;
+    activeCarId: string;
+    installedUpgrades: Record<string, Record<string, number>>;
+  };
+  progress: { unlockedTours: string[]; completedTours: string[] };
+  records: Record<string, unknown>;
+}
+
+function buildGarageSave(overrides: Partial<SeededSave["garage"]> = {}): SeededSave {
+  return {
+    version: 3,
+    profileName: "GarageSummaryTester",
+    settings: {
+      displaySpeedUnit: "kph",
+      assists: {
+        steeringAssist: false,
+        autoNitro: false,
+        weatherVisualReduction: false,
+      },
+      difficultyPreset: "normal",
+      transmissionMode: "auto",
+      audio: { master: 1, music: 1, sfx: 1 },
+      accessibility: {
+        colorBlindMode: "off",
+        reducedMotion: false,
+        largeUiText: false,
+        screenShakeScale: 1,
+      },
+    },
+    garage: {
+      credits: 2400,
+      ownedCars: ["sparrow-gt", "breaker-s"],
+      activeCarId: "breaker-s",
+      installedUpgrades: {
+        "sparrow-gt": defaultUpgradeTiers(),
+        "breaker-s": {
+          ...defaultUpgradeTiers(),
+          engine: 2,
+          wetTires: 1,
+        },
+      },
+      ...overrides,
+    },
+    progress: { unlockedTours: [], completedTours: [] },
+    records: {},
+  };
+}
+
+function defaultUpgradeTiers(): Record<string, number> {
+  return {
+    engine: 0,
+    gearbox: 0,
+    dryTires: 0,
+    wetTires: 0,
+    nitro: 0,
+    armor: 0,
+    cooling: 0,
+    aero: 0,
+  };
+}
+
+test.describe("garage summary", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto("/");
+    const hasStorage = await page.evaluate(
+      () => typeof window.localStorage !== "undefined",
+    );
+    test.skip(!hasStorage, "localStorage unavailable in this browser context");
+  });
+
+  test("shows the active car, credits, upgrades, and action links", async ({
+    page,
+  }) => {
+    await page.evaluate(
+      ({ key, save }) => window.localStorage.setItem(key, JSON.stringify(save)),
+      { key: SAVE_KEY, save: buildGarageSave() },
+    );
+
+    await page.goto("/garage");
+
+    await expect(page.getByTestId("garage-page")).toBeVisible();
+    await expect(page.getByTestId("garage-credits")).toHaveText("2400");
+    await expect(page.getByTestId("garage-active-car")).toHaveText("Breaker S");
+    await expect(page.getByTestId("garage-owned-count")).toHaveText("2");
+    await expect(page.getByTestId("garage-upgrade-engine")).toHaveText("Tier 2");
+    await expect(page.getByTestId("garage-upgrade-wetTires")).toHaveText("Tier 1");
+
+    await page.getByTestId("garage-repair-link").click();
+    await expect(page).toHaveURL(/\/garage\/repair$/);
+    await expect(page.getByTestId("garage-repair-page")).toBeVisible();
+
+    await page.getByTestId("garage-repair-back").click();
+    await page.getByTestId("garage-upgrade-link").click();
+    await expect(page).toHaveURL(/\/garage\/upgrade$/);
+    await expect(page.getByTestId("garage-upgrade-page")).toBeVisible();
+  });
+
+  test("recovers a save with a missing active car through starter selection", async ({
+    page,
+  }) => {
+    await page.evaluate(
+      ({ key, save }) => window.localStorage.setItem(key, JSON.stringify(save)),
+      {
+        key: SAVE_KEY,
+        save: buildGarageSave({
+          activeCarId: "missing-car",
+          ownedCars: ["sparrow-gt"],
+          installedUpgrades: {},
+        }),
+      },
+    );
+
+    await page.goto("/garage");
+
+    await expect(page.getByTestId("garage-starter-pick")).toBeVisible();
+    await page.getByTestId("pick-starter-sparrow-gt").click();
+    await expect(page.getByTestId("garage-status")).toContainText(
+      "Starter car selected",
+    );
+    await expect(page.getByTestId("garage-active-car")).toHaveText("Sparrow GT");
+
+    const persisted = await page.evaluate((key) => {
+      const raw = window.localStorage.getItem(key);
+      return raw
+        ? (JSON.parse(raw) as {
+            garage?: {
+              activeCarId?: string;
+              installedUpgrades?: Record<string, Record<string, number>>;
+            };
+          })
+        : null;
+    }, SAVE_KEY);
+    expect(persisted?.garage?.activeCarId).toBe("sparrow-gt");
+    expect(persisted?.garage?.installedUpgrades?.["sparrow-gt"]?.engine).toBe(0);
+  });
+});

--- a/e2e/title-screen.spec.ts
+++ b/e2e/title-screen.spec.ts
@@ -23,7 +23,7 @@ test.describe("title screen", () => {
     const garage = page.getByTestId("menu-garage");
     await expect(garage).toBeVisible();
     await expect(garage).toHaveText("Garage");
-    await expect(garage).toHaveAttribute("href", "/garage/cars");
+    await expect(garage).toHaveAttribute("href", "/garage");
 
     const options = page.getByTestId("menu-options");
     await expect(options).toBeVisible();
@@ -39,10 +39,10 @@ test.describe("title screen", () => {
     await expect(page).toHaveURL(/\/race(\?.*)?$/);
   });
 
-  test("Garage link navigates to /garage/cars", async ({ page }) => {
+  test("Garage link navigates to /garage", async ({ page }) => {
     await page.goto("/");
     await page.getByTestId("menu-garage").click();
-    await expect(page).toHaveURL(/\/garage\/cars$/);
+    await expect(page).toHaveURL(/\/garage$/);
   });
 
   test("Time Trial link navigates to time-trial race mode", async ({ page }) => {

--- a/src/app/__tests__/page.test.tsx
+++ b/src/app/__tests__/page.test.tsx
@@ -38,10 +38,10 @@ describe("TitlePage", () => {
     expect(match?.[0]).toContain('href="/time-trial"');
   });
 
-  it("renders Garage as an anchor pointing at /garage/cars", () => {
+  it("renders Garage as an anchor pointing at /garage", () => {
     const match = html.match(/<a[^>]*data-testid="menu-garage"[^>]*>/);
     expect(match, "menu-garage anchor not found").not.toBeNull();
-    expect(match?.[0]).toContain('href="/garage/cars"');
+    expect(match?.[0]).toContain('href="/garage"');
   });
 
   it("renders Options as an anchor pointing at /options", () => {

--- a/src/app/garage/page.tsx
+++ b/src/app/garage/page.tsx
@@ -1,0 +1,315 @@
+"use client";
+
+import Link from "next/link";
+import type { CSSProperties } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
+
+import type { SaveGame } from "@/data/schemas";
+import {
+  buildGarageSummaryView,
+  selectStarterCar,
+} from "@/components/garage/garageSummaryState";
+import { defaultSave, loadSave, saveSave } from "@/persistence";
+
+interface PageStatus {
+  readonly kind: "idle" | "info" | "error";
+  readonly message: string;
+}
+
+export default function GaragePage() {
+  const [save, setSave] = useState<SaveGame | null>(null);
+  const [status, setStatus] = useState<PageStatus>({
+    kind: "idle",
+    message: "",
+  });
+
+  useEffect(() => {
+    const outcome = loadSave();
+    if (outcome.kind === "loaded") {
+      setSave(outcome.save);
+      return;
+    }
+    setSave(defaultSave());
+    if (outcome.reason !== "missing" && outcome.reason !== "no-storage") {
+      setStatus({
+        kind: "info",
+        message: `Loaded default save (reason: ${outcome.reason}).`,
+      });
+    }
+  }, []);
+
+  const view = useMemo(
+    () => (save ? buildGarageSummaryView(save) : null),
+    [save],
+  );
+
+  const persist = useCallback((next: SaveGame, message: string) => {
+    setSave(next);
+    const result = saveSave(next);
+    if (result.kind === "ok") {
+      setStatus({ kind: "info", message });
+    } else {
+      setStatus({
+        kind: "error",
+        message: `Save failed (${result.reason}); change kept in memory only.`,
+      });
+    }
+  }, []);
+
+  const pickStarter = useCallback(
+    (carId: string) => {
+      if (!save) return;
+      const next = selectStarterCar(save, carId);
+      if (!next) {
+        setStatus({
+          kind: "error",
+          message: "That car is not available as a starter.",
+        });
+        return;
+      }
+      persist(next, "Starter car selected.");
+    },
+    [persist, save],
+  );
+
+  if (!save || !view) {
+    return (
+      <main style={pageStyle} data-testid="garage-page">
+        <h1>Garage</h1>
+        <p data-testid="garage-loading">Loading garage</p>
+      </main>
+    );
+  }
+
+  return (
+    <main style={pageStyle} data-testid="garage-page">
+      <header style={headerStyle}>
+        <div>
+          <h1 style={titleStyle}>Garage</h1>
+          <p style={mutedTextStyle}>
+            Credits: <strong data-testid="garage-credits">{view.credits}</strong>
+          </p>
+        </div>
+        <nav style={navStyle} aria-label="Garage actions">
+          <Link href="/garage/cars" style={linkStyle} data-testid="garage-cars-link">
+            Cars
+          </Link>
+          <Link href="/garage/repair" style={linkStyle} data-testid="garage-repair-link">
+            Repairs
+          </Link>
+          <Link href="/garage/upgrade" style={linkStyle} data-testid="garage-upgrade-link">
+            Upgrades
+          </Link>
+          <Link href="/race" style={primaryLinkStyle} data-testid="garage-next-race-link">
+            Next race
+          </Link>
+        </nav>
+      </header>
+
+      {status.kind !== "idle" ? (
+        <p
+          data-testid="garage-status"
+          style={{
+            ...statusStyle,
+            color: status.kind === "error" ? "#ff9a9a" : "#9bd2ff",
+          }}
+        >
+          {status.message}
+        </p>
+      ) : null}
+
+      {view.needsStarterPick ? (
+        <section style={panelStyle} data-testid="garage-starter-pick">
+          <h2 style={sectionTitleStyle}>Pick your starter car</h2>
+          <p style={mutedTextStyle}>
+            Your save does not point at an owned active car. Choose an
+            available starter to continue.
+          </p>
+          <ul style={cardGridStyle}>
+            {view.starterCars.map((car) => (
+              <li key={car.id} style={cardStyle} data-testid={`starter-${car.id}`}>
+                <h3 style={cardTitleStyle}>{car.name}</h3>
+                <p style={mutedTextStyle}>Class: {car.class}</p>
+                <button
+                  type="button"
+                  style={buttonStyle}
+                  onClick={() => pickStarter(car.id)}
+                  data-testid={`pick-starter-${car.id}`}
+                >
+                  Select starter
+                </button>
+              </li>
+            ))}
+          </ul>
+        </section>
+      ) : (
+        <div style={layoutStyle}>
+          <section style={panelStyle} data-testid="garage-car-summary">
+            <h2 style={sectionTitleStyle}>Car</h2>
+            <p style={carNameStyle} data-testid="garage-active-car">
+              {view.activeCar?.name ?? view.activeCarId}
+            </p>
+            <dl style={summaryGridStyle}>
+              <div style={summaryRowStyle}>
+                <dt>Owned cars</dt>
+                <dd data-testid="garage-owned-count">{view.ownedCount}</dd>
+              </div>
+              <div style={summaryRowStyle}>
+                <dt>Repair factor</dt>
+                <dd data-testid="garage-repair-factor">
+                  {view.activeCar?.repairFactor.toFixed(2) ?? "n/a"}
+                </dd>
+              </div>
+              <div style={summaryRowStyle}>
+                <dt>Damage</dt>
+                <dd data-testid="garage-damage-summary">No race damage pending</dd>
+              </div>
+            </dl>
+          </section>
+
+          <section style={panelStyle} data-testid="garage-upgrade-summary">
+            <h2 style={sectionTitleStyle}>Installed upgrades</h2>
+            <dl style={summaryGridStyle}>
+              {view.installedTiers.map((row) => (
+                <div key={row.category} style={summaryRowStyle}>
+                  <dt>{row.label}</dt>
+                  <dd data-testid={`garage-upgrade-${row.category}`}>
+                    Tier {row.tier}
+                  </dd>
+                </div>
+              ))}
+            </dl>
+          </section>
+
+          <aside style={panelStyle} data-testid="garage-next-card">
+            <h2 style={sectionTitleStyle}>Next race</h2>
+            <p style={mutedTextStyle}>
+              Use the race entry for the current smoke track until the
+              tour structure lands.
+            </p>
+            <Link href="/race" style={primaryLinkStyle}>
+              Start race
+            </Link>
+          </aside>
+        </div>
+      )}
+    </main>
+  );
+}
+
+const pageStyle: CSSProperties = {
+  minHeight: "100vh",
+  padding: "2rem",
+  color: "var(--fg, #ddd)",
+  background: "var(--bg, #111)",
+  fontFamily: "system-ui, sans-serif",
+};
+
+const headerStyle: CSSProperties = {
+  display: "flex",
+  justifyContent: "space-between",
+  alignItems: "flex-start",
+  gap: "1rem",
+  marginBottom: "1.5rem",
+  flexWrap: "wrap",
+};
+
+const titleStyle: CSSProperties = {
+  margin: 0,
+  fontSize: "2rem",
+};
+
+const sectionTitleStyle: CSSProperties = {
+  margin: 0,
+  fontSize: "1.1rem",
+};
+
+const carNameStyle: CSSProperties = {
+  margin: "0.5rem 0 1rem",
+  fontSize: "1.5rem",
+  fontWeight: 700,
+};
+
+const mutedTextStyle: CSSProperties = {
+  color: "var(--muted, #aaa)",
+  margin: "0.25rem 0",
+};
+
+const navStyle: CSSProperties = {
+  display: "flex",
+  gap: "0.5rem",
+  flexWrap: "wrap",
+};
+
+const linkStyle: CSSProperties = {
+  border: "1px solid var(--muted, #666)",
+  borderRadius: "6px",
+  color: "var(--fg, #ddd)",
+  padding: "0.55rem 0.75rem",
+  textDecoration: "none",
+};
+
+const primaryLinkStyle: CSSProperties = {
+  ...linkStyle,
+  borderColor: "var(--accent, #8cf)",
+  color: "var(--accent, #8cf)",
+};
+
+const statusStyle: CSSProperties = {
+  margin: "0 0 1rem",
+};
+
+const layoutStyle: CSSProperties = {
+  display: "grid",
+  gridTemplateColumns: "repeat(auto-fit, minmax(16rem, 1fr))",
+  gap: "1rem",
+};
+
+const panelStyle: CSSProperties = {
+  border: "1px solid var(--muted, #444)",
+  borderRadius: "8px",
+  padding: "1rem",
+  background: "rgba(255, 255, 255, 0.03)",
+};
+
+const summaryGridStyle: CSSProperties = {
+  display: "grid",
+  gap: "0.5rem",
+  margin: 0,
+};
+
+const summaryRowStyle: CSSProperties = {
+  display: "flex",
+  justifyContent: "space-between",
+  gap: "1rem",
+};
+
+const cardGridStyle: CSSProperties = {
+  display: "grid",
+  gridTemplateColumns: "repeat(auto-fit, minmax(14rem, 1fr))",
+  gap: "1rem",
+  listStyle: "none",
+  padding: 0,
+  margin: "1rem 0 0",
+};
+
+const cardStyle: CSSProperties = {
+  border: "1px solid var(--muted, #555)",
+  borderRadius: "8px",
+  padding: "1rem",
+};
+
+const cardTitleStyle: CSSProperties = {
+  margin: 0,
+  fontSize: "1.1rem",
+};
+
+const buttonStyle: CSSProperties = {
+  marginTop: "0.75rem",
+  background: "transparent",
+  color: "var(--accent, #8cf)",
+  border: "1px solid var(--accent, #8cf)",
+  borderRadius: "6px",
+  padding: "0.55rem 0.75rem",
+  cursor: "pointer",
+};

--- a/src/app/garage/repair/page.tsx
+++ b/src/app/garage/repair/page.tsx
@@ -1,0 +1,53 @@
+import Link from "next/link";
+import type { CSSProperties } from "react";
+
+export default function GarageRepairPage() {
+  return (
+    <main style={pageStyle} data-testid="garage-repair-page">
+      <section style={panelStyle}>
+        <h1 style={titleStyle}>Garage. Repairs</h1>
+        <p style={mutedTextStyle}>
+          Full, essential, and risk-it repair choices land in the repair
+          purchase slice. The garage summary links here so the route is
+          ready for that flow.
+        </p>
+        <Link href="/garage" style={linkStyle} data-testid="garage-repair-back">
+          Back to garage
+        </Link>
+      </section>
+    </main>
+  );
+}
+
+const pageStyle: CSSProperties = {
+  minHeight: "100vh",
+  padding: "2rem",
+  color: "var(--fg, #ddd)",
+  background: "var(--bg, #111)",
+  fontFamily: "system-ui, sans-serif",
+};
+
+const panelStyle: CSSProperties = {
+  border: "1px solid var(--muted, #444)",
+  borderRadius: "8px",
+  padding: "1rem",
+  maxWidth: "38rem",
+};
+
+const titleStyle: CSSProperties = {
+  margin: "0 0 0.5rem",
+};
+
+const mutedTextStyle: CSSProperties = {
+  color: "var(--muted, #aaa)",
+};
+
+const linkStyle: CSSProperties = {
+  display: "inline-block",
+  marginTop: "1rem",
+  border: "1px solid var(--accent, #8cf)",
+  borderRadius: "6px",
+  color: "var(--accent, #8cf)",
+  padding: "0.55rem 0.75rem",
+  textDecoration: "none",
+};

--- a/src/app/garage/upgrade/page.tsx
+++ b/src/app/garage/upgrade/page.tsx
@@ -1,0 +1,53 @@
+import Link from "next/link";
+import type { CSSProperties } from "react";
+
+export default function GarageUpgradePage() {
+  return (
+    <main style={pageStyle} data-testid="garage-upgrade-page">
+      <section style={panelStyle}>
+        <h1 style={titleStyle}>Garage. Upgrades</h1>
+        <p style={mutedTextStyle}>
+          The upgrade catalogue and purchase buttons land in the next
+          garage slice. The route is available now so the summary flow
+          has stable navigation.
+        </p>
+        <Link href="/garage" style={linkStyle} data-testid="garage-upgrade-back">
+          Back to garage
+        </Link>
+      </section>
+    </main>
+  );
+}
+
+const pageStyle: CSSProperties = {
+  minHeight: "100vh",
+  padding: "2rem",
+  color: "var(--fg, #ddd)",
+  background: "var(--bg, #111)",
+  fontFamily: "system-ui, sans-serif",
+};
+
+const panelStyle: CSSProperties = {
+  border: "1px solid var(--muted, #444)",
+  borderRadius: "8px",
+  padding: "1rem",
+  maxWidth: "38rem",
+};
+
+const titleStyle: CSSProperties = {
+  margin: "0 0 0.5rem",
+};
+
+const mutedTextStyle: CSSProperties = {
+  color: "var(--muted, #aaa)",
+};
+
+const linkStyle: CSSProperties = {
+  display: "inline-block",
+  marginTop: "1rem",
+  border: "1px solid var(--accent, #8cf)",
+  borderRadius: "6px",
+  color: "var(--accent, #8cf)",
+  padding: "0.55rem 0.75rem",
+  textDecoration: "none",
+};

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -8,7 +8,7 @@ import styles from "./page.module.css";
  *
  * Renders the top-level main menu items per GDD §5 and §20:
  * Start Race -> `/race`, Time Trial -> `/time-trial`, Garage ->
- * `/garage/cars`, Options -> `/options`. The Options entry was a disabled placeholder
+ * `/garage`, Options -> `/options`. The Options entry was a disabled placeholder
  * (`menu-options-pending`) until the `/options` scaffold landed in
  * `VibeGear2-implement-options-screen-a9379c4a`. Its replacement keeps
  * the original `menu-options` test id that the e2e suite asserts on.
@@ -34,7 +34,7 @@ interface MenuItem {
 const MENU: ReadonlyArray<MenuItem> = [
   { label: "Start Race", href: "/race", testId: "menu-start-race" },
   { label: "Time Trial", href: "/time-trial", testId: "menu-time-trial" },
-  { label: "Garage", href: "/garage/cars", testId: "menu-garage" },
+  { label: "Garage", href: "/garage", testId: "menu-garage" },
   { label: "Options", href: "/options", testId: "menu-options" },
 ];
 

--- a/src/components/garage/__tests__/garageSummaryState.test.ts
+++ b/src/components/garage/__tests__/garageSummaryState.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from "vitest";
+
+import type { SaveGame } from "@/data/schemas";
+import { defaultSave } from "@/persistence";
+
+import {
+  buildGarageSummaryView,
+  selectStarterCar,
+  starterCars,
+} from "../garageSummaryState";
+
+describe("buildGarageSummaryView", () => {
+  it("summarises the active car, credits, owned count, and upgrade tiers", () => {
+    const save = defaultSave();
+    const view = buildGarageSummaryView(save);
+
+    expect(view.activeCar?.id).toBe("sparrow-gt");
+    expect(view.activeCarId).toBe("sparrow-gt");
+    expect(view.credits).toBe(0);
+    expect(view.ownedCount).toBe(1);
+    expect(view.needsStarterPick).toBe(false);
+    expect(view.installedTiers).toHaveLength(8);
+    expect(view.installedTiers.every((row) => row.tier === 0)).toBe(true);
+  });
+
+  it("asks for a starter pick when the active car id is not owned", () => {
+    const save: SaveGame = {
+      ...defaultSave(),
+      garage: {
+        ...defaultSave().garage,
+        activeCarId: "missing-car",
+      },
+    };
+
+    const view = buildGarageSummaryView(save);
+
+    expect(view.activeCar).toBeNull();
+    expect(view.needsStarterPick).toBe(true);
+    expect(view.starterCars.map((car) => car.id)).toContain("sparrow-gt");
+  });
+});
+
+describe("selectStarterCar", () => {
+  it("sets a free starter as active and seeds its upgrades", () => {
+    const save: SaveGame = {
+      ...defaultSave(),
+      garage: {
+        ...defaultSave().garage,
+        activeCarId: "missing-car",
+        ownedCars: ["sparrow-gt"],
+        installedUpgrades: {},
+      },
+    };
+
+    const next = selectStarterCar(save, "sparrow-gt");
+
+    expect(next?.garage.activeCarId).toBe("sparrow-gt");
+    expect(next?.garage.ownedCars).toContain("sparrow-gt");
+    expect(next?.garage.installedUpgrades["sparrow-gt"]?.engine).toBe(0);
+  });
+
+  it("rejects paid cars for starter repair", () => {
+    expect(selectStarterCar(defaultSave(), "vanta-xr")).toBeNull();
+  });
+});
+
+describe("starterCars", () => {
+  it("returns the currently free starter catalogue entries", () => {
+    expect(starterCars().map((car) => car.id)).toEqual(["sparrow-gt"]);
+  });
+});

--- a/src/components/garage/garageSummaryState.ts
+++ b/src/components/garage/garageSummaryState.ts
@@ -1,0 +1,116 @@
+import { CARS, getCar, STARTER_CAR_ID } from "@/data/cars";
+import type {
+  Car,
+  SaveGame,
+  UpgradeCategory,
+} from "@/data/schemas";
+
+const UPGRADE_CATEGORIES: ReadonlyArray<UpgradeCategory> = [
+  "engine",
+  "gearbox",
+  "dryTires",
+  "wetTires",
+  "nitro",
+  "armor",
+  "cooling",
+  "aero",
+];
+
+export interface GarageSummaryView {
+  readonly activeCar: Car | null;
+  readonly activeCarId: string;
+  readonly credits: number;
+  readonly ownedCount: number;
+  readonly needsStarterPick: boolean;
+  readonly starterCars: ReadonlyArray<Car>;
+  readonly installedTiers: ReadonlyArray<GarageUpgradeTier>;
+}
+
+export interface GarageUpgradeTier {
+  readonly category: UpgradeCategory;
+  readonly label: string;
+  readonly tier: number;
+}
+
+export function buildGarageSummaryView(
+  save: Readonly<SaveGame>,
+): GarageSummaryView {
+  const activeCar = getCar(save.garage.activeCarId) ?? null;
+  const ownsActive = save.garage.ownedCars.includes(save.garage.activeCarId);
+  const installed = save.garage.installedUpgrades[save.garage.activeCarId];
+
+  return {
+    activeCar,
+    activeCarId: save.garage.activeCarId,
+    credits: save.garage.credits,
+    ownedCount: save.garage.ownedCars.length,
+    needsStarterPick: activeCar === null || !ownsActive,
+    starterCars: starterCars(),
+    installedTiers: UPGRADE_CATEGORIES.map((category) => ({
+      category,
+      label: upgradeLabel(category),
+      tier: installed?.[category] ?? 0,
+    })),
+  };
+}
+
+export function selectStarterCar(
+  save: Readonly<SaveGame>,
+  carId: string,
+): SaveGame | null {
+  const car = getCar(carId);
+  if (!car || car.purchasePrice !== 0) return null;
+  const ownedCars = save.garage.ownedCars.includes(carId)
+    ? save.garage.ownedCars
+    : [...save.garage.ownedCars, carId];
+  return {
+    ...save,
+    garage: {
+      ...save.garage,
+      ownedCars,
+      activeCarId: carId,
+      installedUpgrades: {
+        ...save.garage.installedUpgrades,
+        [carId]:
+          save.garage.installedUpgrades[carId] ?? defaultUpgradeTiers(),
+      },
+    },
+  };
+}
+
+export function starterCars(): ReadonlyArray<Car> {
+  const freeCars = CARS.filter((car) => car.purchasePrice === 0);
+  if (freeCars.length > 0) return freeCars;
+  const fallback = getCar(STARTER_CAR_ID);
+  return fallback ? [fallback] : [];
+}
+
+function defaultUpgradeTiers(): Record<UpgradeCategory, number> {
+  return {
+    engine: 0,
+    gearbox: 0,
+    dryTires: 0,
+    wetTires: 0,
+    nitro: 0,
+    armor: 0,
+    cooling: 0,
+    aero: 0,
+  };
+}
+
+function upgradeLabel(category: UpgradeCategory): string {
+  switch (category) {
+    case "dryTires":
+      return "Dry tires";
+    case "wetTires":
+      return "Wet tires";
+    case "nitro":
+      return "Nitro system";
+    case "armor":
+      return "Chassis armor";
+    case "aero":
+      return "Aero kit";
+    default:
+      return `${category.charAt(0).toUpperCase()}${category.slice(1)}`;
+  }
+}


### PR DESCRIPTION
## Summary
- Add /garage summary hub for active car, credits, installed upgrades, starter recovery, and next-race navigation.
- Route title screen Garage to the hub and keep /garage/cars as the car selector action.
- Add placeholder repair and upgrade routes, plus followups for the purchase flows and starter catalogue alignment.

## GDD
- docs/gdd/05-core-gameplay-loop.md
- docs/gdd/11-cars-and-stats.md
- docs/gdd/12-upgrade-and-economy-system.md
- docs/gdd/20-hud-and-ui-ux.md

## Progress Log
- docs/PROGRESS_LOG.md: 2026-04-27 Slice: Garage summary surface

## Test Plan
- npx vitest run src/components/garage/__tests__/garageSummaryState.test.ts
- npm run content-lint
- npm run verify
- npm run test:e2e -- e2e/title-screen.spec.ts e2e/garage-summary.spec.ts

## Followups
- F-061: Implement garage repair purchase surface.
- F-062: Implement garage upgrade purchase surface.
- F-063: Align starter selection content with the three §11 starter examples.