### PR TITLE
fix(garage): land summary review fixes

### DIFF
--- a/docs/PROGRESS_LOG.md
+++ b/docs/PROGRESS_LOG.md
@@ -6,6 +6,58 @@ Correct them by adding a new entry that references the old one.
 
 ---
 
+## 2026-04-27: Slice: Garage summary review fixes
+
+**GDD sections touched:**
+[§5](gdd/05-core-gameplay-loop.md) garage loop,
+[§11](gdd/11-cars-and-stats.md) starter cars,
+[§12](gdd/12-upgrade-and-economy-system.md) upgrade categories,
+[§21](gdd/21-technical-design-for-web-implementation.md) save
+consistency.
+**Branch / PR:** `fix/garage-summary-review-fixes`, PR pending.
+**Status:** Implemented.
+
+### Done
+- `src/components/garage/garageSummaryState.ts`: derives garage
+  upgrade categories from `UpgradeCategorySchema.options` so the hub
+  cannot drift from the save schema.
+- `src/app/garage/page.tsx`: keeps in-memory garage state aligned with
+  the `writeCounter` increment applied by `saveSave` after a successful
+  write.
+- `e2e/garage-summary.spec.ts`: aligns the seeded `colorBlindMode`
+  union with the persisted save schema.
+- `src/components/garage/__tests__/garageSummaryState.test.ts`:
+  renames the paid-car rejection case from starter repair to starter
+  selection.
+
+### Verified
+- `npx vitest run src/components/garage/__tests__/garageSummaryState.test.ts src/app/__tests__/page.test.tsx`
+  green, 13 passed.
+- `npm run content-lint` clean.
+- `npm run test:e2e -- e2e/garage-summary.spec.ts` green, 2 passed.
+- `npm run verify` clean: lint, typecheck, unit tests, and content-lint
+  all passed; 2,184 unit tests passed.
+
+### Decisions and assumptions
+- This is a follow-up hotfix because PR #27 merged before the
+  review-fix commit reached main.
+
+### Coverage ledger
+- GDD-05-GARAGE-SUMMARY remains covered. This slice tightens the same
+  implementation and tests after review.
+- Uncovered adjacent requirements: real repair purchasing, real
+  upgrade purchasing, standings, weather fit, ghost status, leaderboard
+  status, full next-race tournament data, and §11 starter catalogue
+  alignment remain future garage slices.
+
+### Followups created
+None.
+
+### GDD edits
+None.
+
+---
+
 ## 2026-04-27: Slice: Garage summary surface
 
 **GDD sections touched:**

--- a/docs/PROGRESS_LOG.md
+++ b/docs/PROGRESS_LOG.md
@@ -34,7 +34,8 @@ consistency.
 - `npx vitest run src/components/garage/__tests__/garageSummaryState.test.ts src/app/__tests__/page.test.tsx`
   green, 13 passed.
 - `npm run content-lint` clean.
-- `npm run test:e2e -- e2e/garage-summary.spec.ts` green, 2 passed.
+- `npm run test:e2e -- e2e/garage-summary.spec.ts e2e/save-persistence.spec.ts`
+  green, 4 passed.
 - `npm run verify` clean: lint, typecheck, unit tests, and content-lint
   all passed; 2,184 unit tests passed.
 

--- a/e2e/garage-summary.spec.ts
+++ b/e2e/garage-summary.spec.ts
@@ -16,7 +16,7 @@ interface SeededSave {
     transmissionMode: "auto" | "manual";
     audio: { master: number; music: number; sfx: number };
     accessibility: {
-      colorBlindMode: "off" | "deuter" | "prot" | "trit";
+      colorBlindMode: "off" | "protanopia" | "deuteranopia" | "tritanopia";
       reducedMotion: boolean;
       largeUiText: boolean;
       screenShakeScale: number;

--- a/e2e/save-persistence.spec.ts
+++ b/e2e/save-persistence.spec.ts
@@ -39,7 +39,7 @@ interface SeededSave {
     transmissionMode: "auto" | "manual";
     audio: { master: number; music: number; sfx: number };
     accessibility: {
-      colorBlindMode: "off" | "deuter" | "prot" | "trit";
+      colorBlindMode: "off" | "protanopia" | "deuteranopia" | "tritanopia";
       reducedMotion: boolean;
       largeUiText: boolean;
       screenShakeScale: number;

--- a/src/app/garage/page.tsx
+++ b/src/app/garage/page.tsx
@@ -44,11 +44,15 @@ export default function GaragePage() {
   );
 
   const persist = useCallback((next: SaveGame, message: string) => {
-    setSave(next);
     const result = saveSave(next);
     if (result.kind === "ok") {
+      setSave({
+        ...next,
+        writeCounter: (next.writeCounter ?? 0) + 1,
+      });
       setStatus({ kind: "info", message });
     } else {
+      setSave(next);
       setStatus({
         kind: "error",
         message: `Save failed (${result.reason}); change kept in memory only.`,

--- a/src/components/garage/__tests__/garageSummaryState.test.ts
+++ b/src/components/garage/__tests__/garageSummaryState.test.ts
@@ -59,7 +59,7 @@ describe("selectStarterCar", () => {
     expect(next?.garage.installedUpgrades["sparrow-gt"]?.engine).toBe(0);
   });
 
-  it("rejects paid cars for starter repair", () => {
+  it("rejects paid cars for starter selection", () => {
     expect(selectStarterCar(defaultSave(), "vanta-xr")).toBeNull();
   });
 });

--- a/src/components/garage/garageSummaryState.ts
+++ b/src/components/garage/garageSummaryState.ts
@@ -4,17 +4,10 @@ import type {
   SaveGame,
   UpgradeCategory,
 } from "@/data/schemas";
+import { UpgradeCategorySchema } from "@/data/schemas";
 
-const UPGRADE_CATEGORIES: ReadonlyArray<UpgradeCategory> = [
-  "engine",
-  "gearbox",
-  "dryTires",
-  "wetTires",
-  "nitro",
-  "armor",
-  "cooling",
-  "aero",
-];
+const UPGRADE_CATEGORIES: ReadonlyArray<UpgradeCategory> =
+  UpgradeCategorySchema.options;
 
 export interface GarageSummaryView {
   readonly activeCar: Car | null;
@@ -86,16 +79,9 @@ export function starterCars(): ReadonlyArray<Car> {
 }
 
 function defaultUpgradeTiers(): Record<UpgradeCategory, number> {
-  return {
-    engine: 0,
-    gearbox: 0,
-    dryTires: 0,
-    wetTires: 0,
-    nitro: 0,
-    armor: 0,
-    cooling: 0,
-    aero: 0,
-  };
+  return Object.fromEntries(
+    UPGRADE_CATEGORIES.map((category) => [category, 0]),
+  ) as Record<UpgradeCategory, number>;
 }
 
 function upgradeLabel(category: UpgradeCategory): string {


### PR DESCRIPTION
## Summary
- Land the four garage summary review fixes that missed main because PR #27 merged before the review-fix commit.
- Derive upgrade categories from the schema and keep garage save state aligned with writeCounter after saveSave.
- Align the Playwright save seed enum and rename the starter selection unit test.

## GDD
- docs/gdd/05-core-gameplay-loop.md
- docs/gdd/11-cars-and-stats.md
- docs/gdd/12-upgrade-and-economy-system.md
- docs/gdd/21-technical-design-for-web-implementation.md

## Progress Log
- docs/PROGRESS_LOG.md: 2026-04-27 Slice: Garage summary review fixes

## Test Plan
- npx vitest run src/components/garage/__tests__/garageSummaryState.test.ts src/app/__tests__/page.test.tsx
- npm run content-lint
- npm run test:e2e -- e2e/garage-summary.spec.ts
- npm run verify