### PR TITLE
feat(garage): add starter eligibility roster

### DIFF
--- a/docs/FOLLOWUPS.md
+++ b/docs/FOLLOWUPS.md
@@ -13,13 +13,19 @@ or `obsolete` so the trail is preserved.
 ## F-063: Align starter selection content with the three §11 starter examples
 **Created:** 2026-04-27
 **Priority:** blocks-release
-**Status:** open
+**Status:** done (2026-04-28)
 **Notes:** The garage summary starter recovery screen can pick from cars
 with `purchasePrice: 0`, but the current catalogue only has Sparrow GT
 as a free starter. §11 names Sparrow GT, Breaker S, and Vanta XR as the
 starter examples. Decide whether all three should be free championship
 starters or whether the GDD examples should be revised, then align the
 catalogue, starter picker, save defaults, and tests in one slice.
+
+Closed by `feat/f-063-starter-eligibility`. The car registry now exports
+the three §11 starter-choice ids separately from `purchasePrice`, so
+Breaker S and Vanta XR can appear in starter recovery without becoming
+free purchases in the car shop. Content, garage state, and Playwright
+tests pin the three-choice roster.
 
 ## F-062: Implement garage upgrade purchase surface
 **Created:** 2026-04-27

--- a/docs/GDD_COVERAGE.json
+++ b/docs/GDD_COVERAGE.json
@@ -35,7 +35,7 @@
         "e2e/garage-summary.spec.ts",
         "e2e/title-screen.spec.ts"
       ],
-      "followupRefs": ["F-061", "F-062", "F-063"]
+      "followupRefs": ["F-061", "F-062"]
     },
     {
       "id": "GDD-09-ELEVATION-LIVE",

--- a/docs/PROGRESS_LOG.md
+++ b/docs/PROGRESS_LOG.md
@@ -6,6 +6,59 @@ Correct them by adding a new entry that references the old one.
 
 ---
 
+## 2026-04-28: Slice: F-063 starter eligibility
+
+**GDD sections touched:**
+[§5](gdd/05-core-gameplay-loop.md) starter car choice,
+[§11](gdd/11-cars-and-stats.md) three starter examples,
+[§20](gdd/20-hud-and-ui-ux.md) garage starter recovery.
+**Branch / PR:** `feat/f-063-starter-eligibility`, PR pending.
+**Status:** Implemented.
+
+### Done
+- `src/data/cars/index.ts`: exports `STARTER_CAR_IDS` for the three
+  §11 starter-choice cars while keeping `STARTER_CAR_ID` as the fresh
+  save default.
+- `src/components/garage/garageSummaryState.ts`: uses
+  `STARTER_CAR_IDS` for starter recovery instead of inferring starter
+  eligibility from `purchasePrice`.
+- `src/data/__tests__/cars-content.test.ts` and
+  `src/components/garage/__tests__/garageSummaryState.test.ts`: pin the
+  three starter-choice ids and reject non-starter cars.
+- `e2e/garage-summary.spec.ts`: asserts the starter recovery UI exposes
+  Sparrow GT, Breaker S, and Vanta XR.
+- `docs/FOLLOWUPS.md`: closed F-063.
+- `docs/GDD_COVERAGE.json`: removed F-063 from the garage summary open
+  followup refs.
+
+### Verified
+- `npx vitest run src/data/__tests__/cars-content.test.ts src/components/garage/__tests__/garageSummaryState.test.ts`
+  green, 35 passed.
+- `npm run content-lint` clean.
+- `npm run test:e2e -- e2e/garage-summary.spec.ts` green, 2 passed.
+- `npm run verify` clean: lint, typecheck, unit tests, and content-lint
+  all passed; 2,185 unit tests passed.
+
+### Decisions and assumptions
+- Starter eligibility is separate from purchase price. This preserves
+  the current car shop economy while allowing the championship starter
+  picker to offer the three §11 examples.
+
+### Coverage ledger
+- GDD-05-GARAGE-SUMMARY remains covered for starter recovery.
+- Uncovered adjacent requirements: real repair purchasing, real
+  upgrade purchasing, standings, weather fit, ghost status, leaderboard
+  status, and full next-race tournament data remain future garage
+  slices.
+
+### Followups created
+None.
+
+### GDD edits
+None.
+
+---
+
 ## 2026-04-27: Slice: Garage summary review fixes
 
 **GDD sections touched:**

--- a/e2e/garage-summary.spec.ts
+++ b/e2e/garage-summary.spec.ts
@@ -139,6 +139,9 @@ test.describe("garage summary", () => {
     await page.goto("/garage");
 
     await expect(page.getByTestId("garage-starter-pick")).toBeVisible();
+    await expect(page.getByTestId("starter-sparrow-gt")).toBeVisible();
+    await expect(page.getByTestId("starter-breaker-s")).toBeVisible();
+    await expect(page.getByTestId("starter-vanta-xr")).toBeVisible();
     await page.getByTestId("pick-starter-sparrow-gt").click();
     await expect(page.getByTestId("garage-status")).toContainText(
       "Starter car selected",

--- a/src/components/garage/__tests__/garageSummaryState.test.ts
+++ b/src/components/garage/__tests__/garageSummaryState.test.ts
@@ -41,7 +41,7 @@ describe("buildGarageSummaryView", () => {
 });
 
 describe("selectStarterCar", () => {
-  it("sets a free starter as active and seeds its upgrades", () => {
+  it("sets a starter-choice car as active and seeds its upgrades", () => {
     const save: SaveGame = {
       ...defaultSave(),
       garage: {
@@ -52,20 +52,24 @@ describe("selectStarterCar", () => {
       },
     };
 
-    const next = selectStarterCar(save, "sparrow-gt");
+    const next = selectStarterCar(save, "vanta-xr");
 
-    expect(next?.garage.activeCarId).toBe("sparrow-gt");
-    expect(next?.garage.ownedCars).toContain("sparrow-gt");
-    expect(next?.garage.installedUpgrades["sparrow-gt"]?.engine).toBe(0);
+    expect(next?.garage.activeCarId).toBe("vanta-xr");
+    expect(next?.garage.ownedCars).toContain("vanta-xr");
+    expect(next?.garage.installedUpgrades["vanta-xr"]?.engine).toBe(0);
   });
 
-  it("rejects paid cars for starter selection", () => {
-    expect(selectStarterCar(defaultSave(), "vanta-xr")).toBeNull();
+  it("rejects non-starter cars for starter selection", () => {
+    expect(selectStarterCar(defaultSave(), "bastion-lm")).toBeNull();
   });
 });
 
 describe("starterCars", () => {
-  it("returns the currently free starter catalogue entries", () => {
-    expect(starterCars().map((car) => car.id)).toEqual(["sparrow-gt"]);
+  it("returns the §11 starter-choice catalogue entries", () => {
+    expect(starterCars().map((car) => car.id)).toEqual([
+      "sparrow-gt",
+      "breaker-s",
+      "vanta-xr",
+    ]);
   });
 });

--- a/src/components/garage/garageSummaryState.ts
+++ b/src/components/garage/garageSummaryState.ts
@@ -72,10 +72,18 @@ export function selectStarterCar(
 }
 
 export function starterCars(): ReadonlyArray<Car> {
-  return STARTER_CAR_IDS.flatMap((carId) => {
+  const cars = STARTER_CAR_IDS.flatMap((carId) => {
     const car = getCar(carId);
     return car ? [car] : [];
   });
+
+  if (cars.length === 0) {
+    throw new Error(
+      `No configured starter cars could be resolved from STARTER_CAR_IDS: ${STARTER_CAR_IDS.join(", ")}`,
+    );
+  }
+
+  return cars;
 }
 
 function isStarterCarId(carId: string): boolean {

--- a/src/components/garage/garageSummaryState.ts
+++ b/src/components/garage/garageSummaryState.ts
@@ -1,4 +1,4 @@
-import { CARS, getCar, STARTER_CAR_ID } from "@/data/cars";
+import { STARTER_CAR_IDS, getCar } from "@/data/cars";
 import type {
   Car,
   SaveGame,
@@ -52,7 +52,7 @@ export function selectStarterCar(
   carId: string,
 ): SaveGame | null {
   const car = getCar(carId);
-  if (!car || car.purchasePrice !== 0) return null;
+  if (!car || !isStarterCarId(carId)) return null;
   const ownedCars = save.garage.ownedCars.includes(carId)
     ? save.garage.ownedCars
     : [...save.garage.ownedCars, carId];
@@ -72,10 +72,14 @@ export function selectStarterCar(
 }
 
 export function starterCars(): ReadonlyArray<Car> {
-  const freeCars = CARS.filter((car) => car.purchasePrice === 0);
-  if (freeCars.length > 0) return freeCars;
-  const fallback = getCar(STARTER_CAR_ID);
-  return fallback ? [fallback] : [];
+  return STARTER_CAR_IDS.flatMap((carId) => {
+    const car = getCar(carId);
+    return car ? [car] : [];
+  });
+}
+
+function isStarterCarId(carId: string): boolean {
+  return STARTER_CAR_IDS.some((starterId) => starterId === carId);
 }
 
 function defaultUpgradeTiers(): Record<UpgradeCategory, number> {

--- a/src/data/__tests__/cars-content.test.ts
+++ b/src/data/__tests__/cars-content.test.ts
@@ -19,6 +19,7 @@ import { describe, expect, it } from "vitest";
 import {
   CARS,
   CARS_BY_ID,
+  STARTER_CAR_IDS,
   STARTER_CAR_ID,
   getCar,
 } from "@/data/cars";
@@ -124,6 +125,13 @@ describe("car catalogue", () => {
     const starters = CARS.filter((c) => c.purchasePrice === 0);
     expect(starters.length).toBe(1);
     expect(starters[0]?.id).toBe(STARTER_CAR_ID);
+  });
+
+  it("lists the three §11 starter choice examples", () => {
+    expect(STARTER_CAR_IDS).toEqual(["sparrow-gt", "breaker-s", "vanta-xr"]);
+    for (const starterId of STARTER_CAR_IDS) {
+      expect(getCar(starterId)).toBeDefined();
+    }
   });
 });
 

--- a/src/data/__tests__/cars-content.test.ts
+++ b/src/data/__tests__/cars-content.test.ts
@@ -129,6 +129,7 @@ describe("car catalogue", () => {
 
   it("lists the three §11 starter choice examples", () => {
     expect(STARTER_CAR_IDS).toEqual(["sparrow-gt", "breaker-s", "vanta-xr"]);
+    expect(STARTER_CAR_IDS[0]).toBe(STARTER_CAR_ID);
     for (const starterId of STARTER_CAR_IDS) {
       expect(getCar(starterId)).toBeDefined();
     }

--- a/src/data/cars/index.ts
+++ b/src/data/cars/index.ts
@@ -19,8 +19,10 @@ import tempestR from "./tempest-r.json";
 import vantaXr from "./vanta-xr.json";
 
 /**
- * Ordered car list for UI presentation. Starters first (purchasePrice 0
- * granted on new save, then ascending price), late-game cars after.
+ * Ordered car list for UI presentation. The three §11 starter choices
+ * appear first, with Sparrow GT granted on a fresh save and the other
+ * starter choices available through the championship starter picker.
+ * Late-game cars follow after.
  */
 export const CARS: readonly Car[] = [
   sparrowGt as Car,
@@ -46,3 +48,10 @@ export function getCar(id: string): Car | undefined {
 
 /** The id of the starter car granted on new save. */
 export const STARTER_CAR_ID = "sparrow-gt";
+
+/** The §11 starter-choice roster shown by garage starter recovery. */
+export const STARTER_CAR_IDS = [
+  "sparrow-gt",
+  "breaker-s",
+  "vanta-xr",
+] as const;

--- a/src/data/cars/index.ts
+++ b/src/data/cars/index.ts
@@ -51,7 +51,7 @@ export const STARTER_CAR_ID = "sparrow-gt";
 
 /** The §11 starter-choice roster shown by garage starter recovery. */
 export const STARTER_CAR_IDS = [
-  "sparrow-gt",
+  STARTER_CAR_ID,
   "breaker-s",
   "vanta-xr",
 ] as const;


### PR DESCRIPTION
## Summary
- Add STARTER_CAR_IDS for the three §11 starter choices while keeping Sparrow GT as the fresh-save default.
- Use the starter eligibility list for garage starter recovery instead of purchasePrice.
- Close F-063 and add unit plus e2e coverage for the three starter choices.

## GDD
- docs/gdd/05-core-gameplay-loop.md
- docs/gdd/11-cars-and-stats.md
- docs/gdd/20-hud-and-ui-ux.md

## Progress Log
- docs/PROGRESS_LOG.md: 2026-04-28 Slice: F-063 starter eligibility

## Test Plan
- npx vitest run src/data/__tests__/cars-content.test.ts src/components/garage/__tests__/garageSummaryState.test.ts
- npm run content-lint
- npm run test:e2e -- e2e/garage-summary.spec.ts
- npm run verify