### PR TITLE
feat(garage): add upgrade purchase shop

### DIFF
--- a/docs/FOLLOWUPS.md
+++ b/docs/FOLLOWUPS.md
@@ -30,11 +30,17 @@ tests pin the three-choice roster.
 ## F-062: Implement garage upgrade purchase surface
 **Created:** 2026-04-27
 **Priority:** blocks-release
-**Status:** open
+**Status:** done (2026-04-28)
 **Notes:** The garage summary surface shows installed upgrade tiers and
 links to `/garage/upgrade`, but the route is only a placeholder. Build
 the §12 upgrade purchase flow with tier costs, eligibility checks,
 credits persistence, installed tier updates, and save reload coverage.
+
+Closed by `feat/f-062-garage-upgrades`. `/garage/upgrade` now loads the
+active save, lists each §12 upgrade category with current tier, next
+tier, cap, cost, and effect summary, and buys the next eligible tier via
+`purchaseAndInstall`. The route persists wallet and installed tier
+updates through `saveSave`; Playwright covers purchase and reload.
 
 ## F-061: Implement garage repair purchase surface
 **Created:** 2026-04-27

--- a/docs/GDD_COVERAGE.json
+++ b/docs/GDD_COVERAGE.json
@@ -55,8 +55,7 @@
         "src/components/garage/__tests__/garageUpgradeState.test.ts",
         "e2e/garage-upgrades.spec.ts",
         "src/game/__tests__/economy.test.ts"
-      ],
-      "followupRefs": ["F-062"]
+      ]
     },
     {
       "id": "GDD-09-ELEVATION-LIVE",

--- a/docs/GDD_COVERAGE.json
+++ b/docs/GDD_COVERAGE.json
@@ -35,7 +35,28 @@
         "e2e/garage-summary.spec.ts",
         "e2e/title-screen.spec.ts"
       ],
-      "followupRefs": ["F-061", "F-062"]
+      "followupRefs": ["F-061"]
+    },
+    {
+      "id": "GDD-12-GARAGE-UPGRADE-PURCHASE",
+      "gddSections": [
+        "docs/gdd/05-core-gameplay-loop.md",
+        "docs/gdd/12-upgrade-and-economy-system.md",
+        "docs/gdd/20-hud-and-ui-ux.md"
+      ],
+      "requirement": "The garage upgrade shop shows current versus next tier for each upgrade category, enforces sequential install and car caps, debits credits, persists installed tiers, and explains lockouts inline.",
+      "coverage": ["implemented-code", "automated-test"],
+      "implementationRefs": [
+        "src/app/garage/upgrade/page.tsx",
+        "src/components/garage/garageUpgradeState.ts",
+        "src/game/economy.ts"
+      ],
+      "testRefs": [
+        "src/components/garage/__tests__/garageUpgradeState.test.ts",
+        "e2e/garage-upgrades.spec.ts",
+        "src/game/__tests__/economy.test.ts"
+      ],
+      "followupRefs": ["F-062"]
     },
     {
       "id": "GDD-09-ELEVATION-LIVE",

--- a/docs/PROGRESS_LOG.md
+++ b/docs/PROGRESS_LOG.md
@@ -6,6 +6,67 @@ Correct them by adding a new entry that references the old one.
 
 ---
 
+## 2026-04-28: Slice: F-062 garage upgrade purchase surface
+
+**GDD sections touched:**
+[§5](gdd/05-core-gameplay-loop.md) garage loop,
+[§12](gdd/12-upgrade-and-economy-system.md) upgrade categories and
+sequential tiers,
+[§20](gdd/20-hud-and-ui-ux.md) upgrade shop.
+**Branch / PR:** `feat/f-062-garage-upgrades`, PR pending.
+**Status:** Implemented.
+
+### Done
+- `src/components/garage/garageUpgradeState.ts`: builds the upgrade
+  shop view from the active save, including current tier, next tier,
+  per-car cap, cost, effects, and disabled reason.
+- `src/app/garage/upgrade/page.tsx`: replaced the placeholder route
+  with a localStorage-backed purchase surface that calls
+  `purchaseAndInstall`, persists via `saveSave`, and reports economy
+  failures inline.
+- `src/components/garage/__tests__/garageUpgradeState.test.ts`:
+  covers next-tier eligibility, insufficient credits, caps, missing
+  active car state, and failure-message formatting.
+- `e2e/garage-upgrades.spec.ts`: seeds a garage save, buys Street
+  Engine, verifies credits and installed tier, and reloads to prove the
+  persisted state survives.
+- `docs/FOLLOWUPS.md`: closed F-062.
+- `docs/GDD_COVERAGE.json`: added
+  `GDD-12-GARAGE-UPGRADE-PURCHASE` and removed F-062 from the garage
+  summary open followups.
+
+### Verified
+- `npx vitest run src/components/garage/__tests__/garageUpgradeState.test.ts src/components/garage/__tests__/garageSummaryState.test.ts`
+  green, 10 passed.
+- `npm run lint` clean.
+- `npm run typecheck` clean.
+- `npm run test:e2e -- e2e/garage-upgrades.spec.ts e2e/garage-summary.spec.ts`
+  green, 3 passed.
+
+### Decisions and assumptions
+- Purchase and install remain folded into one action for MVP because
+  `purchaseAndInstall` is the current canonical economy surface.
+- The upgrade shop stays tied to the active owned car. Missing or
+  unowned active car saves route the player back to garage recovery
+  rather than allowing detached purchases.
+
+### Coverage ledger
+- Added GDD-12-GARAGE-UPGRADE-PURCHASE with code and automated test
+  coverage.
+- GDD-05-GARAGE-SUMMARY now only tracks F-061 for the remaining
+  placeholder repair route.
+- Uncovered adjacent requirements: real repair purchasing, standings,
+  weather fit, ghost status, leaderboard status, and full next-race
+  tournament data remain future garage slices.
+
+### Followups created
+None.
+
+### GDD edits
+None.
+
+---
+
 ## 2026-04-28: Slice: F-063 starter eligibility
 
 **GDD sections touched:**

--- a/e2e/garage-upgrades.spec.ts
+++ b/e2e/garage-upgrades.spec.ts
@@ -1,0 +1,146 @@
+import { expect, test } from "@playwright/test";
+
+const SAVE_KEY = "vibegear2:save:v3";
+
+interface SeededSave {
+  version: number;
+  profileName: string;
+  settings: {
+    displaySpeedUnit: "kph" | "mph";
+    assists: {
+      steeringAssist: boolean;
+      autoNitro: boolean;
+      weatherVisualReduction: boolean;
+    };
+    difficultyPreset: "easy" | "normal" | "hard" | "master";
+    transmissionMode: "auto" | "manual";
+    audio: { master: number; music: number; sfx: number };
+    accessibility: {
+      colorBlindMode: "off" | "protanopia" | "deuteranopia" | "tritanopia";
+      reducedMotion: boolean;
+      largeUiText: boolean;
+      screenShakeScale: number;
+    };
+  };
+  garage: {
+    credits: number;
+    ownedCars: ReadonlyArray<string>;
+    activeCarId: string;
+    installedUpgrades: Record<string, Record<string, number>>;
+  };
+  progress: { unlockedTours: string[]; completedTours: string[] };
+  records: Record<string, unknown>;
+}
+
+function buildGarageSave(
+  overrides: Partial<SeededSave["garage"]> = {},
+): SeededSave {
+  return {
+    version: 3,
+    profileName: "GarageUpgradeTester",
+    settings: {
+      displaySpeedUnit: "kph",
+      assists: {
+        steeringAssist: false,
+        autoNitro: false,
+        weatherVisualReduction: false,
+      },
+      difficultyPreset: "normal",
+      transmissionMode: "auto",
+      audio: { master: 1, music: 1, sfx: 1 },
+      accessibility: {
+        colorBlindMode: "off",
+        reducedMotion: false,
+        largeUiText: false,
+        screenShakeScale: 1,
+      },
+    },
+    garage: {
+      credits: 3500,
+      ownedCars: ["sparrow-gt"],
+      activeCarId: "sparrow-gt",
+      installedUpgrades: {
+        "sparrow-gt": defaultUpgradeTiers(),
+      },
+      ...overrides,
+    },
+    progress: { unlockedTours: [], completedTours: [] },
+    records: {},
+  };
+}
+
+function defaultUpgradeTiers(): Record<string, number> {
+  return {
+    engine: 0,
+    gearbox: 0,
+    dryTires: 0,
+    wetTires: 0,
+    nitro: 0,
+    armor: 0,
+    cooling: 0,
+    aero: 0,
+  };
+}
+
+test.describe("garage upgrade shop", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto("/");
+    const hasStorage = await page.evaluate(
+      () => typeof window.localStorage !== "undefined",
+    );
+    test.skip(!hasStorage, "localStorage unavailable in this browser context");
+  });
+
+  test("buys the next upgrade tier and persists it", async ({ page }) => {
+    await page.evaluate(
+      ({ key, save }) => window.localStorage.setItem(key, JSON.stringify(save)),
+      { key: SAVE_KEY, save: buildGarageSave() },
+    );
+
+    await page.goto("/garage/upgrade");
+
+    await expect(page.getByTestId("garage-upgrade-page")).toBeVisible();
+    await expect(page.getByTestId("garage-upgrade-credits")).toHaveText("3500");
+    await expect(page.getByTestId("garage-upgrade-current-engine")).toContainText(
+      "Stock",
+    );
+    await expect(page.getByTestId("garage-upgrade-next-engine")).toHaveText(
+      "Street (3000 credits)",
+    );
+
+    await page.getByTestId("buy-upgrade-engine").click();
+
+    await expect(page.getByTestId("garage-upgrade-status")).toContainText(
+      "Installed Street Engine",
+    );
+    await expect(page.getByTestId("garage-upgrade-credits")).toHaveText("500");
+    await expect(page.getByTestId("garage-upgrade-current-engine")).toContainText(
+      "Street",
+    );
+    await expect(page.getByTestId("garage-upgrade-reason-engine")).toHaveText(
+      "Need 5500 more credits.",
+    );
+
+    const persisted = await page.evaluate((key) => {
+      const raw = window.localStorage.getItem(key);
+      return raw
+        ? (JSON.parse(raw) as {
+            garage?: {
+              credits?: number;
+              installedUpgrades?: Record<string, Record<string, number>>;
+            };
+          })
+        : null;
+    }, SAVE_KEY);
+
+    expect(persisted?.garage?.credits).toBe(500);
+    expect(persisted?.garage?.installedUpgrades?.["sparrow-gt"]?.engine).toBe(1);
+
+    await page.reload();
+
+    await expect(page.getByTestId("garage-upgrade-credits")).toHaveText("500");
+    await expect(page.getByTestId("garage-upgrade-current-engine")).toContainText(
+      "Street",
+    );
+  });
+});

--- a/src/app/garage/upgrade/page.tsx
+++ b/src/app/garage/upgrade/page.tsx
@@ -117,6 +117,8 @@ export default function GarageUpgradePage() {
             ...statusStyle,
             color: status.kind === "error" ? "#ff9a9a" : "#9bd2ff",
           }}
+          role="status"
+          aria-live={status.kind === "error" ? "assertive" : "polite"}
         >
           {status.message}
         </p>

--- a/src/app/garage/upgrade/page.tsx
+++ b/src/app/garage/upgrade/page.tsx
@@ -1,20 +1,196 @@
+"use client";
+
 import Link from "next/link";
 import type { CSSProperties } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
+
+import type { SaveGame } from "@/data/schemas";
+import {
+  buildGarageUpgradeView,
+  upgradeFailureMessage,
+} from "@/components/garage/garageUpgradeState";
+import { purchaseAndInstall } from "@/game/economy";
+import { defaultSave, loadSave, saveSave } from "@/persistence";
+
+interface PageStatus {
+  readonly kind: "idle" | "info" | "error";
+  readonly message: string;
+}
 
 export default function GarageUpgradePage() {
+  const [save, setSave] = useState<SaveGame | null>(null);
+  const [status, setStatus] = useState<PageStatus>({
+    kind: "idle",
+    message: "",
+  });
+
+  useEffect(() => {
+    const outcome = loadSave();
+    if (outcome.kind === "loaded") {
+      setSave(outcome.save);
+      return;
+    }
+    setSave(defaultSave());
+    if (outcome.reason !== "missing" && outcome.reason !== "no-storage") {
+      setStatus({
+        kind: "info",
+        message: `Loaded default save (reason: ${outcome.reason}).`,
+      });
+    }
+  }, []);
+
+  const view = useMemo(
+    () => (save ? buildGarageUpgradeView(save) : null),
+    [save],
+  );
+
+  const persist = useCallback((next: SaveGame, message: string) => {
+    const result = saveSave(next);
+    if (result.kind === "ok") {
+      setSave({
+        ...next,
+        writeCounter: (next.writeCounter ?? 0) + 1,
+      });
+      setStatus({ kind: "info", message });
+    } else {
+      setSave(next);
+      setStatus({
+        kind: "error",
+        message: `Save failed (${result.reason}); change kept in memory only.`,
+      });
+    }
+  }, []);
+
+  const buyUpgrade = useCallback(
+    (upgradeId: string, upgradeName: string) => {
+      if (!save || !view?.activeCar) return;
+      const result = purchaseAndInstall(save, upgradeId, view.activeCar.id);
+      if (!result.ok) {
+        setStatus({
+          kind: "error",
+          message: upgradeFailureMessage(result.failure),
+        });
+        return;
+      }
+      persist(result.state, `Installed ${upgradeName}.`);
+    },
+    [persist, save, view?.activeCar],
+  );
+
+  if (!save || !view) {
+    return (
+      <main style={pageStyle} data-testid="garage-upgrade-page">
+        <h1>Garage. Upgrades</h1>
+        <p data-testid="garage-loading">Loading upgrades</p>
+      </main>
+    );
+  }
+
   return (
     <main style={pageStyle} data-testid="garage-upgrade-page">
-      <section style={panelStyle}>
-        <h1 style={titleStyle}>Garage. Upgrades</h1>
-        <p style={mutedTextStyle}>
-          The upgrade catalogue and purchase buttons land in the next
-          garage slice. The route is available now so the summary flow
-          has stable navigation.
+      <header style={headerStyle}>
+        <div>
+          <h1 style={titleStyle}>Garage. Upgrades</h1>
+          <p style={mutedTextStyle}>
+            Active car:{" "}
+            <strong data-testid="garage-upgrade-active-car">
+              {view.activeCar?.name ?? view.activeCarId}
+            </strong>
+            . Credits:{" "}
+            <strong data-testid="garage-upgrade-credits">{view.credits}</strong>.
+          </p>
+        </div>
+        <nav style={navStyle} aria-label="Garage upgrade actions">
+          <Link href="/garage" style={linkStyle} data-testid="garage-upgrade-back">
+            Back to garage
+          </Link>
+          <Link href="/garage/cars" style={linkStyle} data-testid="garage-upgrade-cars">
+            Cars
+          </Link>
+        </nav>
+      </header>
+
+      {status.kind !== "idle" ? (
+        <p
+          data-testid="garage-upgrade-status"
+          style={{
+            ...statusStyle,
+            color: status.kind === "error" ? "#ff9a9a" : "#9bd2ff",
+          }}
+        >
+          {status.message}
         </p>
-        <Link href="/garage" style={linkStyle} data-testid="garage-upgrade-back">
-          Back to garage
-        </Link>
-      </section>
+      ) : null}
+
+      {!view.canUseShop ? (
+        <section style={panelStyle} data-testid="garage-upgrade-blocked">
+          <h2 style={sectionTitleStyle}>Choose an owned car</h2>
+          <p style={mutedTextStyle}>
+            The active car is missing from your garage. Pick a starter or
+            select an owned car before buying upgrades.
+          </p>
+          <Link href="/garage" style={primaryLinkStyle}>
+            Return to garage
+          </Link>
+        </section>
+      ) : (
+        <ul style={listStyle} data-testid="garage-upgrade-list">
+          {view.rows.map((row) => (
+            <li
+              key={row.category}
+              style={cardStyle}
+              data-testid={`garage-upgrade-row-${row.category}`}
+            >
+              <div>
+                <h2 style={sectionTitleStyle}>{row.label}</h2>
+                <dl style={summaryGridStyle}>
+                  <div style={summaryRowStyle}>
+                    <dt>Current</dt>
+                    <dd data-testid={`garage-upgrade-current-${row.category}`}>
+                      {row.currentLabel} (tier {row.currentTier})
+                    </dd>
+                  </div>
+                  <div style={summaryRowStyle}>
+                    <dt>Next</dt>
+                    <dd data-testid={`garage-upgrade-next-${row.category}`}>
+                      {row.nextLabel}
+                    </dd>
+                  </div>
+                  <div style={summaryRowStyle}>
+                    <dt>Cap</dt>
+                    <dd data-testid={`garage-upgrade-cap-${row.category}`}>
+                      Tier {row.cap}
+                    </dd>
+                  </div>
+                </dl>
+                <p style={mutedTextStyle}>{row.effectsLabel}</p>
+                {row.disabledReason ? (
+                  <p
+                    style={reasonStyle}
+                    data-testid={`garage-upgrade-reason-${row.category}`}
+                  >
+                    {row.disabledReason}
+                  </p>
+                ) : null}
+              </div>
+              <button
+                type="button"
+                disabled={!row.canPurchase || !row.nextUpgrade}
+                title={row.disabledReason}
+                style={buttonStyle(row.canPurchase)}
+                data-testid={`buy-upgrade-${row.category}`}
+                onClick={() => {
+                  if (row.nextUpgrade) {
+                    buyUpgrade(row.nextUpgrade.id, row.nextUpgrade.name);
+                  }
+                }}
+              >
+                {row.nextUpgrade ? `Buy ${row.nextUpgrade.name}` : "Max installed"}
+              </button>
+            </li>
+          ))}
+        </ul>
+      )}
     </main>
   );
 }
@@ -27,27 +203,106 @@ const pageStyle: CSSProperties = {
   fontFamily: "system-ui, sans-serif",
 };
 
-const panelStyle: CSSProperties = {
-  border: "1px solid var(--muted, #444)",
-  borderRadius: "8px",
-  padding: "1rem",
-  maxWidth: "38rem",
+const headerStyle: CSSProperties = {
+  display: "flex",
+  justifyContent: "space-between",
+  alignItems: "flex-start",
+  gap: "1rem",
+  marginBottom: "1.5rem",
+  flexWrap: "wrap",
 };
 
 const titleStyle: CSSProperties = {
-  margin: "0 0 0.5rem",
+  margin: 0,
+  fontSize: "2rem",
+};
+
+const sectionTitleStyle: CSSProperties = {
+  margin: 0,
+  fontSize: "1.1rem",
 };
 
 const mutedTextStyle: CSSProperties = {
   color: "var(--muted, #aaa)",
+  margin: "0.35rem 0",
+};
+
+const navStyle: CSSProperties = {
+  display: "flex",
+  gap: "0.5rem",
+  flexWrap: "wrap",
 };
 
 const linkStyle: CSSProperties = {
-  display: "inline-block",
-  marginTop: "1rem",
-  border: "1px solid var(--accent, #8cf)",
+  border: "1px solid var(--muted, #666)",
   borderRadius: "6px",
-  color: "var(--accent, #8cf)",
+  color: "var(--fg, #ddd)",
   padding: "0.55rem 0.75rem",
   textDecoration: "none",
 };
+
+const primaryLinkStyle: CSSProperties = {
+  ...linkStyle,
+  display: "inline-block",
+  marginTop: "0.75rem",
+  borderColor: "var(--accent, #8cf)",
+  color: "var(--accent, #8cf)",
+};
+
+const statusStyle: CSSProperties = {
+  margin: "0 0 1rem",
+};
+
+const panelStyle: CSSProperties = {
+  border: "1px solid var(--muted, #444)",
+  borderRadius: "8px",
+  padding: "1rem",
+  maxWidth: "42rem",
+};
+
+const listStyle: CSSProperties = {
+  listStyle: "none",
+  display: "grid",
+  gridTemplateColumns: "repeat(auto-fit, minmax(20rem, 1fr))",
+  gap: "1rem",
+  padding: 0,
+  margin: 0,
+};
+
+const cardStyle: CSSProperties = {
+  border: "1px solid var(--muted, #444)",
+  borderRadius: "8px",
+  padding: "1rem",
+  display: "grid",
+  gap: "1rem",
+  alignContent: "space-between",
+};
+
+const summaryGridStyle: CSSProperties = {
+  display: "grid",
+  gap: "0.35rem",
+  margin: "0.75rem 0",
+};
+
+const summaryRowStyle: CSSProperties = {
+  display: "flex",
+  justifyContent: "space-between",
+  gap: "1rem",
+};
+
+const reasonStyle: CSSProperties = {
+  color: "#f5c37a",
+  margin: "0.35rem 0 0",
+};
+
+function buttonStyle(enabled: boolean): CSSProperties {
+  return {
+    justifySelf: "start",
+    border: `1px solid ${enabled ? "var(--accent, #8cf)" : "var(--muted, #555)"}`,
+    borderRadius: "6px",
+    color: enabled ? "var(--accent, #8cf)" : "var(--muted, #888)",
+    background: "transparent",
+    padding: "0.55rem 0.75rem",
+    cursor: enabled ? "pointer" : "not-allowed",
+  };
+}

--- a/src/components/garage/__tests__/garageUpgradeState.test.ts
+++ b/src/components/garage/__tests__/garageUpgradeState.test.ts
@@ -1,0 +1,116 @@
+import { describe, expect, it } from "vitest";
+
+import type { SaveGame } from "@/data/schemas";
+import { defaultSave } from "@/persistence";
+
+import {
+  buildGarageUpgradeView,
+  upgradeFailureMessage,
+} from "../garageUpgradeState";
+
+describe("buildGarageUpgradeView", () => {
+  it("lists every upgrade category with the next purchasable tier", () => {
+    const save: SaveGame = {
+      ...defaultSave(),
+      garage: {
+        ...defaultSave().garage,
+        credits: 3500,
+      },
+    };
+
+    const view = buildGarageUpgradeView(save);
+    const engine = view.rows.find((row) => row.category === "engine");
+
+    expect(view.activeCar?.id).toBe("sparrow-gt");
+    expect(view.credits).toBe(3500);
+    expect(view.canUseShop).toBe(true);
+    expect(view.rows).toHaveLength(8);
+    expect(engine?.currentTier).toBe(0);
+    expect(engine?.currentLabel).toBe("Stock");
+    expect(engine?.nextUpgrade?.id).toBe("engine-street");
+    expect(engine?.nextLabel).toBe("Street (3000 credits)");
+    expect(engine?.effectsLabel).toContain("accel +4%");
+    expect(engine?.canPurchase).toBe(true);
+    expect(engine?.disabledReason).toBe("");
+  });
+
+  it("disables a next tier when credits are short", () => {
+    const save: SaveGame = {
+      ...defaultSave(),
+      garage: {
+        ...defaultSave().garage,
+        credits: 2999,
+      },
+    };
+
+    const view = buildGarageUpgradeView(save);
+    const engine = view.rows.find((row) => row.category === "engine");
+
+    expect(engine?.canPurchase).toBe(false);
+    expect(engine?.disabledReason).toBe("Need 1 more credits.");
+  });
+
+  it("surfaces category caps from the active car", () => {
+    const save: SaveGame = {
+      ...defaultSave(),
+      garage: {
+        ...defaultSave().garage,
+        credits: 25000,
+        installedUpgrades: {
+          ...defaultSave().garage.installedUpgrades,
+          "sparrow-gt": {
+            ...defaultSave().garage.installedUpgrades["sparrow-gt"]!,
+            aero: 3,
+          },
+        },
+      },
+    };
+
+    const view = buildGarageUpgradeView(save);
+    const aero = view.rows.find((row) => row.category === "aero");
+
+    expect(aero?.cap).toBe(3);
+    expect(aero?.currentTier).toBe(3);
+    expect(aero?.nextUpgrade).toBeNull();
+    expect(aero?.nextLabel).toBe("Max installed");
+    expect(aero?.canPurchase).toBe(false);
+    expect(aero?.disabledReason).toBe(
+      "This car is already at its category cap.",
+    );
+  });
+
+  it("blocks the shop when the active car is missing or unowned", () => {
+    const view = buildGarageUpgradeView({
+      ...defaultSave(),
+      garage: {
+        ...defaultSave().garage,
+        activeCarId: "missing-car",
+      },
+    });
+
+    expect(view.activeCar).toBeNull();
+    expect(view.canUseShop).toBe(false);
+    expect(view.rows.every((row) => !row.canPurchase)).toBe(true);
+    expect(view.rows[0]?.disabledReason).toBe("Select an owned active car first.");
+  });
+});
+
+describe("upgradeFailureMessage", () => {
+  it("formats actionable economy failures", () => {
+    expect(
+      upgradeFailureMessage({
+        code: "insufficient_credits",
+        required: 3000,
+        available: 1200,
+      }),
+    ).toBe("Not enough credits. Need 3000, have 1200.");
+    expect(
+      upgradeFailureMessage({
+        code: "tier_skip",
+        category: "engine",
+        required: 2,
+        attempted: 4,
+      }),
+    ).toBe("Engine must be installed in order. Next tier is 2.");
+  });
+});

--- a/src/components/garage/__tests__/garageUpgradeState.test.ts
+++ b/src/components/garage/__tests__/garageUpgradeState.test.ts
@@ -29,7 +29,7 @@ describe("buildGarageUpgradeView", () => {
     expect(engine?.currentLabel).toBe("Stock");
     expect(engine?.nextUpgrade?.id).toBe("engine-street");
     expect(engine?.nextLabel).toBe("Street (3000 credits)");
-    expect(engine?.effectsLabel).toContain("accel +4%");
+    expect(engine?.effectsLabel).toContain("acceleration +4%");
     expect(engine?.canPurchase).toBe(true);
     expect(engine?.disabledReason).toBe("");
   });
@@ -47,7 +47,7 @@ describe("buildGarageUpgradeView", () => {
     const engine = view.rows.find((row) => row.category === "engine");
 
     expect(engine?.canPurchase).toBe(false);
-    expect(engine?.disabledReason).toBe("Need 1 more credits.");
+    expect(engine?.disabledReason).toBe("Need 1 more credit.");
   });
 
   it("surfaces category caps from the active car", () => {

--- a/src/components/garage/garageUpgradeState.ts
+++ b/src/components/garage/garageUpgradeState.ts
@@ -128,7 +128,8 @@ function disabledReason(input: {
   if (input.atCap) return "This car is already at its category cap.";
   if (input.nextUpgrade === null) return "No next tier exists.";
   if (input.credits < input.nextUpgrade.cost) {
-    return `Need ${input.nextUpgrade.cost - input.credits} more credits.`;
+    const creditsNeeded = input.nextUpgrade.cost - input.credits;
+    return `Need ${creditsNeeded} more ${creditsNeeded === 1 ? "credit" : "credits"}.`;
   }
   return "";
 }
@@ -173,29 +174,29 @@ function formatEffects(effects: Upgrade["effects"]): string {
   );
   if (entries.length === 0) return "No numeric effect listed";
   return entries
-    .map(([key, value]) => `${effectLabel(key)} +${Math.round(value * 100)}%`)
+    .map(
+      ([key, value]) =>
+        `${effectLabel(key as keyof Upgrade["effects"])} +${Math.round(value * 100)}%`,
+    )
     .join(", ");
 }
 
-function effectLabel(key: string): string {
-  switch (key) {
-    case "topSpeed":
-      return "top speed";
-    case "gripDry":
-      return "dry grip";
-    case "gripWet":
-      return "wet grip";
-    case "nitroPower":
-      return "nitro power";
-    case "nitroDuration":
-      return "nitro duration";
-    case "collisionResistance":
-      return "collision resistance";
-    case "heatResistance":
-      return "heat resistance";
-    case "highSpeedStability":
-      return "high-speed stability";
-    default:
-      return key;
-  }
+function effectLabel(key: keyof Upgrade["effects"]): string {
+  const labels: Partial<Record<keyof Upgrade["effects"], string>> = {
+    accel: "acceleration",
+    brake: "braking",
+    gripDry: "dry grip",
+    gripWet: "wet grip",
+    stability: "stability",
+    durability: "durability",
+    nitroEfficiency: "nitro efficiency",
+    topSpeed: "top speed",
+  };
+
+  return (
+    labels[key] ??
+    String(key)
+      .replace(/([A-Z])/g, " $1")
+      .toLowerCase()
+  );
 }

--- a/src/components/garage/garageUpgradeState.ts
+++ b/src/components/garage/garageUpgradeState.ts
@@ -1,0 +1,201 @@
+import { getCar } from "@/data/cars";
+import type {
+  Car,
+  SaveGame,
+  Upgrade,
+  UpgradeCategory,
+} from "@/data/schemas";
+import { UpgradeCategorySchema } from "@/data/schemas";
+import { UPGRADES } from "@/data/upgrades";
+import type { EconomyFailure } from "@/game/economy";
+
+const UPGRADE_CATEGORIES: ReadonlyArray<UpgradeCategory> =
+  UpgradeCategorySchema.options;
+
+export interface GarageUpgradeView {
+  readonly activeCar: Car | null;
+  readonly activeCarId: string;
+  readonly credits: number;
+  readonly canUseShop: boolean;
+  readonly rows: ReadonlyArray<GarageUpgradeRow>;
+}
+
+export interface GarageUpgradeRow {
+  readonly category: UpgradeCategory;
+  readonly label: string;
+  readonly currentTier: number;
+  readonly cap: number;
+  readonly nextUpgrade: Upgrade | null;
+  readonly currentLabel: string;
+  readonly nextLabel: string;
+  readonly effectsLabel: string;
+  readonly canPurchase: boolean;
+  readonly disabledReason: string;
+}
+
+export function buildGarageUpgradeView(
+  save: Readonly<SaveGame>,
+): GarageUpgradeView {
+  const activeCar = getCar(save.garage.activeCarId) ?? null;
+  const ownsActive = save.garage.ownedCars.includes(save.garage.activeCarId);
+  const installed = save.garage.installedUpgrades[save.garage.activeCarId];
+  const rows = UPGRADE_CATEGORIES.map((category) => {
+    const currentTier = installed?.[category] ?? 0;
+    const cap = activeCar?.upgradeCaps[category] ?? 0;
+    const nextUpgrade = upgradeFor(category, currentTier + 1);
+    const atCap = activeCar !== null && currentTier >= cap;
+    const cost = nextUpgrade?.cost ?? 0;
+    const canPurchase =
+      activeCar !== null &&
+      ownsActive &&
+      nextUpgrade !== null &&
+      !atCap &&
+      currentTier + 1 === nextUpgrade.tier &&
+      save.garage.credits >= cost;
+
+    return {
+      category,
+      label: upgradeLabel(category),
+      currentTier,
+      cap,
+      nextUpgrade: atCap ? null : nextUpgrade,
+      currentLabel: tierLabel(currentTier),
+      nextLabel: atCap
+        ? "Max installed"
+        : nextUpgrade
+          ? `${tierLabel(nextUpgrade.tier)} (${nextUpgrade.cost} credits)`
+          : "No upgrade available",
+      effectsLabel: nextUpgrade ? formatEffects(nextUpgrade.effects) : "No further effect",
+      canPurchase,
+      disabledReason: disabledReason({
+        activeCar,
+        ownsActive,
+        atCap,
+        nextUpgrade,
+        credits: save.garage.credits,
+      }),
+    } satisfies GarageUpgradeRow;
+  });
+
+  return {
+    activeCar,
+    activeCarId: save.garage.activeCarId,
+    credits: save.garage.credits,
+    canUseShop: activeCar !== null && ownsActive,
+    rows,
+  };
+}
+
+export function upgradeFailureMessage(failure: EconomyFailure): string {
+  switch (failure.code) {
+    case "insufficient_credits":
+      return `Not enough credits. Need ${failure.required}, have ${failure.available}.`;
+    case "upgrade_at_cap":
+      return `${upgradeLabel(failure.category)} is capped at tier ${failure.cap} for this car.`;
+    case "tier_skip":
+      return `${upgradeLabel(failure.category)} must be installed in order. Next tier is ${failure.required}.`;
+    case "unknown_car":
+      return `Unknown car: ${failure.carId}.`;
+    case "unknown_upgrade":
+      return `Unknown upgrade: ${failure.upgradeId}.`;
+    case "car_not_owned":
+      return `You do not own ${failure.carId}.`;
+    case "unknown_zone":
+      return `Unknown repair zone: ${failure.zone}.`;
+  }
+}
+
+function upgradeFor(
+  category: UpgradeCategory,
+  tier: number,
+): Upgrade | null {
+  return (
+    UPGRADES.find(
+      (upgrade) => upgrade.category === category && upgrade.tier === tier,
+    ) ?? null
+  );
+}
+
+function disabledReason(input: {
+  readonly activeCar: Car | null;
+  readonly ownsActive: boolean;
+  readonly atCap: boolean;
+  readonly nextUpgrade: Upgrade | null;
+  readonly credits: number;
+}): string {
+  if (input.activeCar === null) return "Select an owned active car first.";
+  if (!input.ownsActive) return "You do not own the active car.";
+  if (input.atCap) return "This car is already at its category cap.";
+  if (input.nextUpgrade === null) return "No next tier exists.";
+  if (input.credits < input.nextUpgrade.cost) {
+    return `Need ${input.nextUpgrade.cost - input.credits} more credits.`;
+  }
+  return "";
+}
+
+function upgradeLabel(category: UpgradeCategory): string {
+  switch (category) {
+    case "dryTires":
+      return "Dry tires";
+    case "wetTires":
+      return "Wet tires";
+    case "nitro":
+      return "Nitro system";
+    case "armor":
+      return "Chassis armor";
+    case "aero":
+      return "Aero kit";
+    default:
+      return `${category.charAt(0).toUpperCase()}${category.slice(1)}`;
+  }
+}
+
+function tierLabel(tier: number): string {
+  switch (tier) {
+    case 0:
+      return "Stock";
+    case 1:
+      return "Street";
+    case 2:
+      return "Sport";
+    case 3:
+      return "Factory";
+    case 4:
+      return "Extreme";
+    default:
+      return `Tier ${tier}`;
+  }
+}
+
+function formatEffects(effects: Upgrade["effects"]): string {
+  const entries = Object.entries(effects).filter(
+    ([, value]) => typeof value === "number" && value !== 0,
+  );
+  if (entries.length === 0) return "No numeric effect listed";
+  return entries
+    .map(([key, value]) => `${effectLabel(key)} +${Math.round(value * 100)}%`)
+    .join(", ");
+}
+
+function effectLabel(key: string): string {
+  switch (key) {
+    case "topSpeed":
+      return "top speed";
+    case "gripDry":
+      return "dry grip";
+    case "gripWet":
+      return "wet grip";
+    case "nitroPower":
+      return "nitro power";
+    case "nitroDuration":
+      return "nitro duration";
+    case "collisionResistance":
+      return "collision resistance";
+    case "heatResistance":
+      return "heat resistance";
+    case "highSpeedStability":
+      return "high-speed stability";
+    default:
+      return key;
+  }
+}


### PR DESCRIPTION
## Summary
- add the real /garage/upgrade purchase surface for active owned cars
- show current tier, next tier, cap, cost, effect summary, and inline lockout reason for each upgrade category
- persist purchase results through saveSave and close F-062 in tracking docs

## GDD
- docs/gdd/05-core-gameplay-loop.md
- docs/gdd/12-upgrade-and-economy-system.md
- docs/gdd/20-hud-and-ui-ux.md
- docs/GDD_COVERAGE.json: GDD-12-GARAGE-UPGRADE-PURCHASE

## Test plan
- npx vitest run src/components/garage/__tests__/garageUpgradeState.test.ts src/components/garage/__tests__/garageSummaryState.test.ts
- npm run lint
- npm run typecheck
- npm run content-lint
- npm run test:e2e -- e2e/garage-upgrades.spec.ts e2e/garage-summary.spec.ts
- npm run verify

## Followups
- closes F-062
