### PR TITLE
F-061 garage repair purchase surface

### DIFF
--- a/docs/FOLLOWUPS.md
+++ b/docs/FOLLOWUPS.md
@@ -10,6 +10,18 @@ or `obsolete` so the trail is preserved.
 
 ---
 
+## F-064: Persist race damage into the garage repair queue
+**Created:** 2026-04-28
+**Priority:** blocks-release
+**Status:** open
+**Notes:** The F-061 repair shop consumes `garage.pendingDamage` and
+persists full or essential repairs, but the live race finish path still
+credits cash and records PBs without writing the player's final
+`RaceSessionState.player.damage` into that queue. Wire the natural-finish
+and retire paths in `src/app/race/page.tsx` so finished races store the
+active car's pending damage and `lastRaceCashEarned`, then cover the
+race to results to garage repair path in Playwright.
+
 ## F-063: Align starter selection content with the three §11 starter examples
 **Created:** 2026-04-27
 **Priority:** blocks-release
@@ -45,11 +57,20 @@ updates through `saveSave`; Playwright covers purchase and reload.
 ## F-061: Implement garage repair purchase surface
 **Created:** 2026-04-27
 **Priority:** blocks-release
-**Status:** open
+**Status:** done (2026-04-28)
 **Notes:** The garage summary surface links to `/garage/repair`, but the
 route is only a placeholder until the repair economy slice lands. Build
 the §13 repair purchase flow once race damage persistence exists, then
 show pending damage and repair cost in the garage summary.
+
+Closed by `feat/f-061-garage-repairs`. `/garage/repair` now loads the
+active save, reads `garage.pendingDamage` for the active car, shows
+per-zone damage and full-service costs, quotes full and essential
+repairs through `applyRepairCost`, applies the §12 essential-repair cap
+from `lastRaceCashEarned`, debits credits, and persists the repaired
+damage state. The garage hub now reflects active-car pending damage.
+Race-finish production of `pendingDamage` is tracked separately as
+F-064 so the purchase surface and the race handoff stay PR-sized.
 
 ## F-060: Correct live car turn sprite direction
 **Created:** 2026-04-27

--- a/docs/GDD_COVERAGE.json
+++ b/docs/GDD_COVERAGE.json
@@ -34,8 +34,36 @@
         "src/components/garage/__tests__/garageSummaryState.test.ts",
         "e2e/garage-summary.spec.ts",
         "e2e/title-screen.spec.ts"
+      ]
+    },
+    {
+      "id": "GDD-13-GARAGE-REPAIR-PURCHASE",
+      "gddSections": [
+        "docs/gdd/05-core-gameplay-loop.md",
+        "docs/gdd/12-upgrade-and-economy-system.md",
+        "docs/gdd/13-damage-repairs-and-risk.md",
+        "docs/gdd/22-data-schemas.md"
       ],
-      "followupRefs": ["F-061"]
+      "requirement": "The garage repair shop shows active-car pending damage, quotes full and essential repairs, applies the essential-repair cap from last race cash, debits credits, persists repaired damage, and reflects pending damage on the garage hub.",
+      "coverage": ["implemented-code", "automated-test"],
+      "implementationRefs": [
+        "src/app/garage/repair/page.tsx",
+        "src/app/garage/page.tsx",
+        "src/components/garage/garageRepairState.ts",
+        "src/components/garage/garageSummaryState.ts",
+        "src/data/schemas.ts",
+        "src/persistence/save.ts",
+        "src/game/economy.ts"
+      ],
+      "testRefs": [
+        "src/components/garage/__tests__/garageRepairState.test.ts",
+        "src/components/garage/__tests__/garageSummaryState.test.ts",
+        "src/data/schemas.test.ts",
+        "e2e/garage-repairs.spec.ts",
+        "e2e/garage-summary.spec.ts",
+        "src/game/__tests__/economy.test.ts"
+      ],
+      "followupRefs": ["F-061", "F-064"]
     },
     {
       "id": "GDD-12-GARAGE-UPGRADE-PURCHASE",

--- a/docs/PROGRESS_LOG.md
+++ b/docs/PROGRESS_LOG.md
@@ -6,6 +6,75 @@ Correct them by adding a new entry that references the old one.
 
 ---
 
+## 2026-04-28: Slice: F-061 garage repair purchase surface
+
+**GDD sections touched:**
+[§5](gdd/05-core-gameplay-loop.md) garage repair loop,
+[§12](gdd/12-upgrade-and-economy-system.md) repair costs and
+essential repair cap,
+[§13](gdd/13-damage-repairs-and-risk.md) full service and quick patch,
+[§22](gdd/22-data-schemas.md) save repair queue.
+**Branch / PR:** `feat/f-061-garage-repairs`, PR pending.
+**Status:** Implemented.
+
+### Done
+- `src/data/schemas.ts` and `src/persistence/save.ts`: added optional
+  `garage.pendingDamage` plus `lastRaceCashEarned` so the garage can
+  persist per-car damage and seed fresh saves without breaking older
+  v3 saves.
+- `src/components/garage/garageRepairState.ts`: builds repair quotes
+  from the active save, calls `applyRepairCost` for full service and
+  essential repair, surfaces cap savings, and stores post-repair damage
+  back into the save.
+- `src/app/garage/repair/page.tsx`: replaced the placeholder with a
+  localStorage-backed repair shop that shows per-zone damage, debits
+  credits, persists repairs, and handles missing active-car saves.
+- `src/components/garage/garageSummaryState.ts` and
+  `src/app/garage/page.tsx`: show active-car pending damage on the
+  garage hub instead of the old static placeholder.
+- `e2e/garage-repairs.spec.ts`: seeds damage, buys an essential repair,
+  checks cap savings, verifies credits and remaining body damage, and
+  reloads to prove persistence.
+- `docs/FOLLOWUPS.md`: closed F-061 and opened F-064 for the remaining
+  race-finish damage producer.
+- `docs/GDD_COVERAGE.json`: added
+  `GDD-13-GARAGE-REPAIR-PURCHASE` and removed F-061 from the garage
+  summary open followups.
+
+### Verified
+- `npx vitest run src/components/garage/__tests__/garageRepairState.test.ts src/components/garage/__tests__/garageSummaryState.test.ts src/data/schemas.test.ts src/persistence/save.test.ts`
+  green, 88 passed.
+- `npm run lint` clean.
+- `npm run typecheck` clean.
+- `npm run test:e2e -- e2e/garage-repairs.spec.ts e2e/garage-summary.spec.ts`
+  green, 3 passed.
+
+### Decisions and assumptions
+- Full service maps to all current damage zones (`engine`, `tires`,
+  `body`). Essential repair maps to the performance-critical zones
+  (`engine`, `tires`) so it can leave body damage as the §13 quick-patch
+  tradeoff.
+- The repair surface consumes `garage.pendingDamage` now. Race-finish
+  production of that queue remains a separate slice because it touches
+  the race result commit path and needs its own browser flow.
+
+### Coverage ledger
+- Added GDD-13-GARAGE-REPAIR-PURCHASE with code and automated test
+  coverage.
+- GDD-05-GARAGE-SUMMARY no longer tracks F-061.
+- Uncovered adjacent requirements: race-finish damage persistence,
+  standings, weather fit, ghost status, leaderboard status, and full
+  next-race tournament data remain future garage slices.
+
+### Followups created
+- F-064: Persist race damage into the garage repair queue.
+
+### GDD edits
+- `docs/gdd/22-data-schemas.md`: documented `garage.pendingDamage` and
+  `garage.lastRaceCashEarned` in the SaveGame example and notes.
+
+---
+
 ## 2026-04-28: Slice: F-062 garage upgrade purchase surface
 
 **GDD sections touched:**

--- a/docs/PROGRESS_LOG.md
+++ b/docs/PROGRESS_LOG.md
@@ -14,7 +14,7 @@ Correct them by adding a new entry that references the old one.
 essential repair cap,
 [§13](gdd/13-damage-repairs-and-risk.md) full service and quick patch,
 [§22](gdd/22-data-schemas.md) save repair queue.
-**Branch / PR:** `feat/f-061-garage-repairs`, PR pending.
+**Branch / PR:** `feat/f-061-garage-repairs`, #31.
 **Status:** Implemented.
 
 ### Done

--- a/docs/PROGRESS_LOG.md
+++ b/docs/PROGRESS_LOG.md
@@ -43,11 +43,13 @@ essential repair cap,
 
 ### Verified
 - `npx vitest run src/components/garage/__tests__/garageRepairState.test.ts src/components/garage/__tests__/garageSummaryState.test.ts src/data/schemas.test.ts src/persistence/save.test.ts`
-  green, 88 passed.
+  green, 91 passed.
 - `npm run lint` clean.
 - `npm run typecheck` clean.
 - `npm run test:e2e -- e2e/garage-repairs.spec.ts e2e/garage-summary.spec.ts`
   green, 3 passed.
+- `npm run verify` clean: lint, typecheck, unit tests, and
+  content-lint all passed; 2,201 unit tests passed.
 
 ### Decisions and assumptions
 - Full service maps to all current damage zones (`engine`, `tires`,

--- a/docs/gdd/22-data-schemas.md
+++ b/docs/gdd/22-data-schemas.md
@@ -200,7 +200,19 @@ the new `ghosts` map is filled with `{}`.
         "cooling": 0,
         "aero": 0
       }
-    }
+    },
+    "pendingDamage": {
+      "sparrow-gt": {
+        "zones": {
+          "engine": 0.2,
+          "tires": 0.1,
+          "body": 0.25
+        },
+        "total": 0.1975,
+        "offRoadAccumSeconds": 0
+      }
+    },
+    "lastRaceCashEarned": 2200
   },
   "progress": {
     "unlockedTours": ["velvet-coast", "iron-borough"],
@@ -222,6 +234,14 @@ optional in the runtime schema so a v1 save mid-migration still validates.
 Consumers that read settings should default missing fields to the documented
 v2 defaults; the v1 -> v2 migration always populates them, so a fully
 migrated save will never have them missing in practice.
+
+`garage.pendingDamage` is the repair queue keyed by car id. It stores
+per-zone damage values in `[0, 1]`, a weighted `total`, and the
+off-road accumulator used by the §13 damage model. It is optional so
+older v3 saves still validate; a fully fresh save seeds it to `{}`.
+`garage.lastRaceCashEarned` is the previous credited race payout used by
+the §12 essential-repair cap. It is optional for older saves and seeded
+to `0` on fresh saves.
 
 `writeCounter` is the cross-tab last-write-wins advisory described in
 `docs/gdd/21-technical-design-for-web-implementation.md` "Cross-tab

--- a/e2e/garage-repairs.spec.ts
+++ b/e2e/garage-repairs.spec.ts
@@ -35,15 +35,16 @@ interface SeededSave {
         offRoadAccumSeconds: number;
       }
     >;
+    lastRaceCashEarned?: number;
   };
   progress: { unlockedTours: string[]; completedTours: string[] };
   records: Record<string, unknown>;
 }
 
-function buildGarageSave(overrides: Partial<SeededSave["garage"]> = {}): SeededSave {
+function buildGarageSave(): SeededSave {
   return {
     version: 3,
-    profileName: "GarageSummaryTester",
+    profileName: "GarageRepairTester",
     settings: {
       displaySpeedUnit: "kph",
       assists: {
@@ -62,29 +63,24 @@ function buildGarageSave(overrides: Partial<SeededSave["garage"]> = {}): SeededS
       },
     },
     garage: {
-      credits: 2400,
-      ownedCars: ["sparrow-gt", "breaker-s"],
-      activeCarId: "breaker-s",
+      credits: 5000,
+      ownedCars: ["sparrow-gt"],
+      activeCarId: "sparrow-gt",
       installedUpgrades: {
         "sparrow-gt": defaultUpgradeTiers(),
-        "breaker-s": {
-          ...defaultUpgradeTiers(),
-          engine: 2,
-          wetTires: 1,
-        },
       },
       pendingDamage: {
-        "breaker-s": {
+        "sparrow-gt": {
           zones: {
-            engine: 0.25,
-            tires: 0.1,
+            engine: 0.5,
+            tires: 0.25,
             body: 0.5,
           },
-          total: 0.31,
-          offRoadAccumSeconds: 0,
+          total: 0.45,
+          offRoadAccumSeconds: 2,
         },
       },
-      ...overrides,
+      lastRaceCashEarned: 2000,
     },
     progress: { unlockedTours: [], completedTours: [] },
     records: {},
@@ -104,7 +100,7 @@ function defaultUpgradeTiers(): Record<string, number> {
   };
 }
 
-test.describe("garage summary", () => {
+test.describe("garage repair shop", () => {
   test.beforeEach(async ({ page }) => {
     await page.goto("/");
     const hasStorage = await page.evaluate(
@@ -113,7 +109,7 @@ test.describe("garage summary", () => {
     test.skip(!hasStorage, "localStorage unavailable in this browser context");
   });
 
-  test("shows the active car, credits, upgrades, and action links", async ({
+  test("buys an essential repair and persists remaining damage", async ({
     page,
   }) => {
     await page.evaluate(
@@ -121,67 +117,64 @@ test.describe("garage summary", () => {
       { key: SAVE_KEY, save: buildGarageSave() },
     );
 
-    await page.goto("/garage");
+    await page.goto("/garage/repair");
 
-    await expect(page.getByTestId("garage-page")).toBeVisible();
-    await expect(page.getByTestId("garage-credits")).toHaveText("2400");
-    await expect(page.getByTestId("garage-active-car")).toHaveText("Breaker S");
-    await expect(page.getByTestId("garage-owned-count")).toHaveText("2");
-    await expect(page.getByTestId("garage-damage-summary")).toHaveText(
-      "31% pending",
-    );
-    await expect(page.getByTestId("garage-upgrade-engine")).toHaveText("Tier 2");
-    await expect(page.getByTestId("garage-upgrade-wetTires")).toHaveText("Tier 1");
-
-    await page.getByTestId("garage-repair-link").click();
-    await expect(page).toHaveURL(/\/garage\/repair$/);
     await expect(page.getByTestId("garage-repair-page")).toBeVisible();
-
-    await page.getByTestId("garage-repair-back").click();
-    await page.getByTestId("garage-upgrade-link").click();
-    await expect(page).toHaveURL(/\/garage\/upgrade$/);
-    await expect(page.getByTestId("garage-upgrade-page")).toBeVisible();
-  });
-
-  test("recovers a save with a missing active car through starter selection", async ({
-    page,
-  }) => {
-    await page.evaluate(
-      ({ key, save }) => window.localStorage.setItem(key, JSON.stringify(save)),
-      {
-        key: SAVE_KEY,
-        save: buildGarageSave({
-          activeCarId: "missing-car",
-          ownedCars: ["sparrow-gt"],
-          installedUpgrades: {},
-        }),
-      },
+    await expect(page.getByTestId("garage-repair-credits")).toHaveText("5000");
+    await expect(page.getByTestId("garage-repair-damage-engine")).toContainText(
+      "50% damage",
+    );
+    await expect(page.getByTestId("garage-repair-cost-essential")).toHaveText(
+      "800",
+    );
+    await expect(page.getByTestId("garage-repair-saved-essential")).toContainText(
+      "saved 100",
     );
 
-    await page.goto("/garage");
+    await page.getByTestId("garage-repair-button-essential").click();
 
-    await expect(page.getByTestId("garage-starter-pick")).toBeVisible();
-    await expect(page.getByTestId("starter-sparrow-gt")).toBeVisible();
-    await expect(page.getByTestId("starter-breaker-s")).toBeVisible();
-    await expect(page.getByTestId("starter-vanta-xr")).toBeVisible();
-    await page.getByTestId("pick-starter-sparrow-gt").click();
-    await expect(page.getByTestId("garage-status")).toContainText(
-      "Starter car selected",
+    await expect(page.getByTestId("garage-repair-status")).toContainText(
+      "Essential repair complete",
     );
-    await expect(page.getByTestId("garage-active-car")).toHaveText("Sparrow GT");
+    await expect(page.getByTestId("garage-repair-credits")).toHaveText("4200");
+    await expect(page.getByTestId("garage-repair-damage-engine")).toContainText(
+      "0% damage",
+    );
+    await expect(page.getByTestId("garage-repair-damage-body")).toContainText(
+      "50% damage",
+    );
 
     const persisted = await page.evaluate((key) => {
       const raw = window.localStorage.getItem(key);
       return raw
         ? (JSON.parse(raw) as {
             garage?: {
-              activeCarId?: string;
-              installedUpgrades?: Record<string, Record<string, number>>;
+              credits?: number;
+              pendingDamage?: Record<
+                string,
+                { zones?: { engine?: number; tires?: number; body?: number } }
+              >;
             };
           })
         : null;
     }, SAVE_KEY);
-    expect(persisted?.garage?.activeCarId).toBe("sparrow-gt");
-    expect(persisted?.garage?.installedUpgrades?.["sparrow-gt"]?.engine).toBe(0);
+
+    expect(persisted?.garage?.credits).toBe(4200);
+    expect(
+      persisted?.garage?.pendingDamage?.["sparrow-gt"]?.zones?.engine,
+    ).toBe(0);
+    expect(
+      persisted?.garage?.pendingDamage?.["sparrow-gt"]?.zones?.tires,
+    ).toBe(0);
+    expect(
+      persisted?.garage?.pendingDamage?.["sparrow-gt"]?.zones?.body,
+    ).toBe(0.5);
+
+    await page.reload();
+
+    await expect(page.getByTestId("garage-repair-credits")).toHaveText("4200");
+    await expect(page.getByTestId("garage-repair-damage-body")).toContainText(
+      "50% damage",
+    );
   });
 });

--- a/src/app/garage/page.tsx
+++ b/src/app/garage/page.tsx
@@ -166,7 +166,11 @@ export default function GaragePage() {
               </div>
               <div style={summaryRowStyle}>
                 <dt>Damage</dt>
-                <dd data-testid="garage-damage-summary">No race damage pending</dd>
+                <dd data-testid="garage-damage-summary">
+                  {view.damagePercent > 0
+                    ? `${view.damagePercent}% pending`
+                    : "No race damage pending"}
+                </dd>
               </div>
             </dl>
           </section>

--- a/src/app/garage/repair/page.tsx
+++ b/src/app/garage/repair/page.tsx
@@ -1,21 +1,220 @@
+"use client";
+
 import Link from "next/link";
 import type { CSSProperties } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
+
+import type { SaveGame } from "@/data/schemas";
+import {
+  buildGarageRepairView,
+  repairFailureMessage,
+  repairGarageDamage,
+  type GarageRepairKind,
+  type GarageRepairQuote,
+} from "@/components/garage/garageRepairState";
+import { defaultSave, loadSave, saveSave } from "@/persistence";
+
+interface PageStatus {
+  readonly kind: "idle" | "info" | "error";
+  readonly message: string;
+}
 
 export default function GarageRepairPage() {
+  const [save, setSave] = useState<SaveGame | null>(null);
+  const [status, setStatus] = useState<PageStatus>({
+    kind: "idle",
+    message: "",
+  });
+
+  useEffect(() => {
+    const outcome = loadSave();
+    if (outcome.kind === "loaded") {
+      setSave(outcome.save);
+      return;
+    }
+    setSave(defaultSave());
+    if (outcome.reason !== "missing" && outcome.reason !== "no-storage") {
+      setStatus({
+        kind: "info",
+        message: `Loaded default save (reason: ${outcome.reason}).`,
+      });
+    }
+  }, []);
+
+  const view = useMemo(
+    () => (save ? buildGarageRepairView(save) : null),
+    [save],
+  );
+
+  const persist = useCallback((next: SaveGame, message: string) => {
+    const result = saveSave(next);
+    if (result.kind === "ok") {
+      setSave({
+        ...next,
+        writeCounter: (next.writeCounter ?? 0) + 1,
+      });
+      setStatus({ kind: "info", message });
+    } else {
+      setSave(next);
+      setStatus({
+        kind: "error",
+        message: `Save failed (${result.reason}); change kept in memory only.`,
+      });
+    }
+  }, []);
+
+  const repair = useCallback(
+    (kind: GarageRepairKind) => {
+      if (!save) return;
+      const result = repairGarageDamage(save, kind);
+      if (!result.ok) {
+        setStatus({
+          kind: "error",
+          message: repairFailureMessage(result.failure),
+        });
+        return;
+      }
+      const label = kind === "essential" ? "Essential repair" : "Full service";
+      persist(result.state, `${label} complete (${result.cashSpent ?? 0} credits).`);
+    },
+    [persist, save],
+  );
+
+  if (!save || !view) {
+    return (
+      <main style={pageStyle} data-testid="garage-repair-page">
+        <h1>Garage. Repairs</h1>
+        <p data-testid="garage-loading">Loading repairs</p>
+      </main>
+    );
+  }
+
   return (
     <main style={pageStyle} data-testid="garage-repair-page">
-      <section style={panelStyle}>
-        <h1 style={titleStyle}>Garage. Repairs</h1>
-        <p style={mutedTextStyle}>
-          Full, essential, and risk-it repair choices land in the repair
-          purchase slice. The garage summary links here so the route is
-          ready for that flow.
+      <header style={headerStyle}>
+        <div>
+          <h1 style={titleStyle}>Garage. Repairs</h1>
+          <p style={mutedTextStyle}>
+            Active car:{" "}
+            <strong data-testid="garage-repair-active-car">
+              {view.activeCar?.name ?? view.activeCarId}
+            </strong>
+            . Credits:{" "}
+            <strong data-testid="garage-repair-credits">{view.credits}</strong>.
+          </p>
+        </div>
+        <nav style={navStyle} aria-label="Garage repair actions">
+          <Link href="/garage" style={linkStyle} data-testid="garage-repair-back">
+            Back to garage
+          </Link>
+          <Link href="/garage/cars" style={linkStyle}>
+            Cars
+          </Link>
+        </nav>
+      </header>
+
+      {status.kind !== "idle" ? (
+        <p
+          data-testid="garage-repair-status"
+          style={{
+            ...statusStyle,
+            color: status.kind === "error" ? "#ff9a9a" : "#9bd2ff",
+          }}
+          role="status"
+          aria-live={status.kind === "error" ? "assertive" : "polite"}
+        >
+          {status.message}
         </p>
-        <Link href="/garage" style={linkStyle} data-testid="garage-repair-back">
-          Back to garage
-        </Link>
-      </section>
+      ) : null}
+
+      {!view.canUseShop ? (
+        <section style={panelStyle} data-testid="garage-repair-blocked">
+          <h2 style={sectionTitleStyle}>Choose an owned car</h2>
+          <p style={mutedTextStyle}>
+            The active car is missing from your garage. Pick a starter or
+            select an owned car before repairing damage.
+          </p>
+          <Link href="/garage" style={primaryLinkStyle}>
+            Return to garage
+          </Link>
+        </section>
+      ) : (
+        <div style={layoutStyle}>
+          <section style={panelStyle}>
+            <h2 style={sectionTitleStyle}>Damage</h2>
+            <dl style={summaryGridStyle}>
+              {view.rows.map((row) => (
+                <div key={row.zone} style={summaryRowStyle}>
+                  <dt>{row.label}</dt>
+                  <dd data-testid={`garage-repair-damage-${row.zone}`}>
+                    {row.damagePercent}% damage. Full repair {row.fullCost} credits.
+                  </dd>
+                </div>
+              ))}
+            </dl>
+          </section>
+
+          <RepairCard
+            quote={view.full}
+            onRepair={() => repair("full")}
+            testId="full"
+          />
+          <RepairCard
+            quote={view.essential}
+            onRepair={() => repair("essential")}
+            testId="essential"
+          />
+        </div>
+      )}
     </main>
+  );
+}
+
+function RepairCard({
+  quote,
+  onRepair,
+  testId,
+}: {
+  readonly quote: GarageRepairQuote;
+  readonly onRepair: () => void;
+  readonly testId: string;
+}) {
+  const enabled = quote.disabledReason === "";
+  return (
+    <section style={panelStyle} data-testid={`garage-repair-${testId}`}>
+      <h2 style={sectionTitleStyle}>{quote.label}</h2>
+      <p style={mutedTextStyle}>
+        Cost: <strong data-testid={`garage-repair-cost-${testId}`}>{quote.cost}</strong>
+        {quote.saved > 0 ? (
+          <span data-testid={`garage-repair-saved-${testId}`}>
+            {" "}
+            (catch-up cap saved {quote.saved})
+          </span>
+        ) : null}
+      </p>
+      <ul style={breakdownStyle}>
+        {quote.breakdown.map((entry) => (
+          <li key={entry.zone}>
+            {entry.zone}: {entry.credits}
+          </li>
+        ))}
+      </ul>
+      {quote.disabledReason ? (
+        <p style={reasonStyle} data-testid={`garage-repair-reason-${testId}`}>
+          {quote.disabledReason}
+        </p>
+      ) : null}
+      <button
+        type="button"
+        disabled={!enabled}
+        title={quote.disabledReason}
+        style={buttonStyle(enabled)}
+        data-testid={`garage-repair-button-${testId}`}
+        onClick={onRepair}
+      >
+        {quote.label}
+      </button>
+    </section>
   );
 }
 
@@ -27,27 +226,97 @@ const pageStyle: CSSProperties = {
   fontFamily: "system-ui, sans-serif",
 };
 
-const panelStyle: CSSProperties = {
-  border: "1px solid var(--muted, #444)",
-  borderRadius: "8px",
-  padding: "1rem",
-  maxWidth: "38rem",
+const headerStyle: CSSProperties = {
+  display: "flex",
+  justifyContent: "space-between",
+  alignItems: "flex-start",
+  gap: "1rem",
+  marginBottom: "1.5rem",
+  flexWrap: "wrap",
 };
 
 const titleStyle: CSSProperties = {
-  margin: "0 0 0.5rem",
+  margin: 0,
+  fontSize: "2rem",
+};
+
+const sectionTitleStyle: CSSProperties = {
+  margin: 0,
+  fontSize: "1.1rem",
 };
 
 const mutedTextStyle: CSSProperties = {
   color: "var(--muted, #aaa)",
+  margin: "0.35rem 0",
+};
+
+const navStyle: CSSProperties = {
+  display: "flex",
+  gap: "0.5rem",
+  flexWrap: "wrap",
 };
 
 const linkStyle: CSSProperties = {
-  display: "inline-block",
-  marginTop: "1rem",
-  border: "1px solid var(--accent, #8cf)",
+  border: "1px solid var(--muted, #666)",
   borderRadius: "6px",
-  color: "var(--accent, #8cf)",
+  color: "var(--fg, #ddd)",
   padding: "0.55rem 0.75rem",
   textDecoration: "none",
 };
+
+const primaryLinkStyle: CSSProperties = {
+  ...linkStyle,
+  display: "inline-block",
+  marginTop: "0.75rem",
+  borderColor: "var(--accent, #8cf)",
+  color: "var(--accent, #8cf)",
+};
+
+const statusStyle: CSSProperties = {
+  margin: "0 0 1rem",
+};
+
+const layoutStyle: CSSProperties = {
+  display: "grid",
+  gridTemplateColumns: "repeat(auto-fit, minmax(18rem, 1fr))",
+  gap: "1rem",
+};
+
+const panelStyle: CSSProperties = {
+  border: "1px solid var(--muted, #444)",
+  borderRadius: "8px",
+  padding: "1rem",
+};
+
+const summaryGridStyle: CSSProperties = {
+  display: "grid",
+  gap: "0.55rem",
+  margin: "0.75rem 0",
+};
+
+const summaryRowStyle: CSSProperties = {
+  display: "flex",
+  justifyContent: "space-between",
+  gap: "1rem",
+};
+
+const breakdownStyle: CSSProperties = {
+  margin: "0.75rem 0",
+  paddingLeft: "1.25rem",
+};
+
+const reasonStyle: CSSProperties = {
+  color: "#f5c37a",
+  margin: "0.35rem 0",
+};
+
+function buttonStyle(enabled: boolean): CSSProperties {
+  return {
+    border: `1px solid ${enabled ? "var(--accent, #8cf)" : "var(--muted, #555)"}`,
+    borderRadius: "6px",
+    color: enabled ? "var(--accent, #8cf)" : "var(--muted, #888)",
+    background: "transparent",
+    padding: "0.55rem 0.75rem",
+    cursor: enabled ? "pointer" : "not-allowed",
+  };
+}

--- a/src/components/garage/__tests__/garageRepairState.test.ts
+++ b/src/components/garage/__tests__/garageRepairState.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, it } from "vitest";
+
+import type { SaveGame } from "@/data/schemas";
+import { defaultSave } from "@/persistence";
+
+import {
+  buildGarageRepairView,
+  repairGarageDamage,
+  repairFailureMessage,
+} from "../garageRepairState";
+
+function damagedSave(): SaveGame {
+  return {
+    ...defaultSave(),
+    garage: {
+      ...defaultSave().garage,
+      credits: 5000,
+      lastRaceCashEarned: 2000,
+      pendingDamage: {
+        "sparrow-gt": {
+          zones: {
+            engine: 0.5,
+            tires: 0.25,
+            body: 0.5,
+          },
+          total: 0.45,
+          offRoadAccumSeconds: 2,
+        },
+      },
+    },
+  };
+}
+
+describe("buildGarageRepairView", () => {
+  it("quotes full and essential repairs for the active car", () => {
+    const view = buildGarageRepairView(damagedSave());
+
+    expect(view.activeCar?.id).toBe("sparrow-gt");
+    expect(view.canUseShop).toBe(true);
+    expect(view.rows.map((row) => row.damagePercent)).toEqual([50, 25, 50]);
+    expect(view.full.cost).toBe(1350);
+    expect(view.full.disabledReason).toBe("");
+    expect(view.essential.cost).toBe(800);
+    expect(view.essential.saved).toBe(100);
+    expect(view.essential.breakdown).toEqual([
+      { zone: "engine", credits: 667 },
+      { zone: "tires", credits: 133 },
+    ]);
+  });
+
+  it("blocks repair when the active car is missing", () => {
+    const view = buildGarageRepairView({
+      ...defaultSave(),
+      garage: {
+        ...defaultSave().garage,
+        activeCarId: "missing-car",
+      },
+    });
+
+    expect(view.activeCar).toBeNull();
+    expect(view.canUseShop).toBe(false);
+    expect(view.full.disabledReason).toBe("Select an owned active car first.");
+  });
+});
+
+describe("repairGarageDamage", () => {
+  it("stores post-repair damage after a full repair", () => {
+    const result = repairGarageDamage(damagedSave(), "full");
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.cashSpent).toBe(1350);
+    expect(result.state.garage.credits).toBe(3650);
+    expect(
+      result.state.garage.pendingDamage?.["sparrow-gt"]?.zones,
+    ).toEqual({
+      engine: 0,
+      tires: 0,
+      body: 0,
+    });
+    expect(
+      result.state.garage.pendingDamage?.["sparrow-gt"]?.offRoadAccumSeconds,
+    ).toBe(2);
+  });
+
+  it("repairs only essential zones for an essential repair", () => {
+    const result = repairGarageDamage(damagedSave(), "essential");
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.cashSpent).toBe(800);
+    expect(
+      result.state.garage.pendingDamage?.["sparrow-gt"]?.zones,
+    ).toEqual({
+      engine: 0,
+      tires: 0,
+      body: 0.5,
+    });
+  });
+});
+
+describe("repairFailureMessage", () => {
+  it("formats insufficient-credit failures", () => {
+    expect(
+      repairFailureMessage({
+        code: "insufficient_credits",
+        required: 1350,
+        available: 100,
+      }),
+    ).toBe("Not enough credits. Need 1350, have 100.");
+  });
+});

--- a/src/components/garage/__tests__/garageRepairState.test.ts
+++ b/src/components/garage/__tests__/garageRepairState.test.ts
@@ -97,6 +97,55 @@ describe("repairGarageDamage", () => {
       body: 0.5,
     });
   });
+
+  it("rejects a repair when the active car is not owned", () => {
+    const save: SaveGame = {
+      ...damagedSave(),
+      garage: {
+        ...damagedSave().garage,
+        activeCarId: "breaker-s",
+        pendingDamage: {
+          "breaker-s": {
+            zones: {
+              engine: 0.5,
+              tires: 0,
+              body: 0,
+            },
+            total: 0.225,
+            offRoadAccumSeconds: 0,
+          },
+        },
+      },
+    };
+
+    const result = repairGarageDamage(save, "full");
+
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.failure).toEqual({
+      code: "car_not_owned",
+      carId: "breaker-s",
+    });
+  });
+
+  it("rejects a repair when the active car is missing from the catalogue", () => {
+    const save: SaveGame = {
+      ...damagedSave(),
+      garage: {
+        ...damagedSave().garage,
+        activeCarId: "missing-car",
+      },
+    };
+
+    const result = repairGarageDamage(save, "full");
+
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.failure).toEqual({
+      code: "unknown_car",
+      carId: "missing-car",
+    });
+  });
 });
 
 describe("repairFailureMessage", () => {

--- a/src/components/garage/__tests__/garageSummaryState.test.ts
+++ b/src/components/garage/__tests__/garageSummaryState.test.ts
@@ -18,9 +18,34 @@ describe("buildGarageSummaryView", () => {
     expect(view.activeCarId).toBe("sparrow-gt");
     expect(view.credits).toBe(0);
     expect(view.ownedCount).toBe(1);
+    expect(view.damagePercent).toBe(0);
     expect(view.needsStarterPick).toBe(false);
     expect(view.installedTiers).toHaveLength(8);
     expect(view.installedTiers.every((row) => row.tier === 0)).toBe(true);
+  });
+
+  it("summarises pending active-car damage", () => {
+    const save: SaveGame = {
+      ...defaultSave(),
+      garage: {
+        ...defaultSave().garage,
+        pendingDamage: {
+          "sparrow-gt": {
+            zones: {
+              engine: 0.25,
+              tires: 0.1,
+              body: 0.5,
+            },
+            total: 0.31,
+            offRoadAccumSeconds: 0,
+          },
+        },
+      },
+    };
+
+    const view = buildGarageSummaryView(save);
+
+    expect(view.damagePercent).toBe(31);
   });
 
   it("asks for a starter pick when the active car id is not owned", () => {

--- a/src/components/garage/__tests__/garageSummaryState.test.ts
+++ b/src/components/garage/__tests__/garageSummaryState.test.ts
@@ -48,6 +48,30 @@ describe("buildGarageSummaryView", () => {
     expect(view.damagePercent).toBe(31);
   });
 
+  it("derives pending damage from zones instead of trusting stored total", () => {
+    const save: SaveGame = {
+      ...defaultSave(),
+      garage: {
+        ...defaultSave().garage,
+        pendingDamage: {
+          "sparrow-gt": {
+            zones: {
+              engine: 0.5,
+              tires: 0,
+              body: 0,
+            },
+            total: 0,
+            offRoadAccumSeconds: 0,
+          },
+        },
+      },
+    };
+
+    const view = buildGarageSummaryView(save);
+
+    expect(view.damagePercent).toBe(23);
+  });
+
   it("asks for a starter pick when the active car id is not owned", () => {
     const save: SaveGame = {
       ...defaultSave(),

--- a/src/components/garage/garageRepairState.ts
+++ b/src/components/garage/garageRepairState.ts
@@ -1,0 +1,240 @@
+import { getCar } from "@/data/cars";
+import type { Car, SaveGame } from "@/data/schemas";
+import {
+  applyRepairCost,
+  type EconomyFailure,
+  type EconomyResult,
+} from "@/game/economy";
+import {
+  createDamageState,
+  type DamageState,
+  type DamageZone,
+} from "@/game/damage";
+
+const REPAIR_ZONES: ReadonlyArray<DamageZone> = ["engine", "tires", "body"];
+const ESSENTIAL_ZONES: ReadonlyArray<DamageZone> = ["engine", "tires"];
+
+export type GarageRepairKind = "full" | "essential";
+
+export interface GarageRepairView {
+  readonly activeCar: Car | null;
+  readonly activeCarId: string;
+  readonly credits: number;
+  readonly canUseShop: boolean;
+  readonly damage: DamageState;
+  readonly rows: ReadonlyArray<GarageRepairZoneRow>;
+  readonly full: GarageRepairQuote;
+  readonly essential: GarageRepairQuote;
+}
+
+export interface GarageRepairZoneRow {
+  readonly zone: DamageZone;
+  readonly label: string;
+  readonly damagePercent: number;
+  readonly fullCost: number;
+}
+
+export interface GarageRepairQuote {
+  readonly kind: GarageRepairKind;
+  readonly label: string;
+  readonly zones: ReadonlyArray<DamageZone>;
+  readonly cost: number;
+  readonly saved: number;
+  readonly disabledReason: string;
+  readonly breakdown: ReadonlyArray<{ zone: DamageZone; credits: number }>;
+}
+
+export function buildGarageRepairView(
+  save: Readonly<SaveGame>,
+): GarageRepairView {
+  const activeCar = getCar(save.garage.activeCarId) ?? null;
+  const ownsActive = save.garage.ownedCars.includes(save.garage.activeCarId);
+  const damage = pendingDamageFor(save, save.garage.activeCarId);
+  const quoteBase = quoteSave(save);
+  const full = quoteRepair(quoteBase, save.garage.activeCarId, damage, "full");
+  const essential = quoteRepair(
+    quoteBase,
+    save.garage.activeCarId,
+    damage,
+    "essential",
+  );
+  const fullByZone = new Map(
+    full.breakdown.map((entry) => [entry.zone, entry.credits] as const),
+  );
+
+  return {
+    activeCar,
+    activeCarId: save.garage.activeCarId,
+    credits: save.garage.credits,
+    canUseShop: activeCar !== null && ownsActive,
+    damage,
+    rows: REPAIR_ZONES.map((zone) => ({
+      zone,
+      label: zoneLabel(zone),
+      damagePercent: Math.round((damage.zones[zone] ?? 0) * 100),
+      fullCost: fullByZone.get(zone) ?? 0,
+    })),
+    full: withDisabledReason(full, save, activeCar, ownsActive, damage),
+    essential: withDisabledReason(essential, save, activeCar, ownsActive, damage),
+  };
+}
+
+export function repairGarageDamage(
+  save: Readonly<SaveGame>,
+  kind: GarageRepairKind,
+): EconomyResult {
+  const activeCarId = save.garage.activeCarId;
+  const result = applyRepairCost(cloneSaveForRepair(save), {
+    carId: activeCarId,
+    damage: pendingDamageFor(save, activeCarId),
+    tourTier: 1,
+    zones: kind === "essential" ? ESSENTIAL_ZONES : REPAIR_ZONES,
+    repairKind: kind,
+    lastRaceCashEarned: save.garage.lastRaceCashEarned ?? 0,
+  });
+
+  if (!result.ok) return result;
+
+  return {
+    ...result,
+    state: {
+      ...result.state,
+      garage: {
+        ...result.state.garage,
+        pendingDamage: {
+          ...(result.state.garage.pendingDamage ?? {}),
+          [activeCarId]: result.damage ?? pendingDamageFor(save, activeCarId),
+        },
+      },
+    },
+  };
+}
+
+export function repairFailureMessage(failure: EconomyFailure): string {
+  switch (failure.code) {
+    case "insufficient_credits":
+      return `Not enough credits. Need ${failure.required}, have ${failure.available}.`;
+    case "unknown_car":
+      return `Unknown car: ${failure.carId}.`;
+    case "unknown_zone":
+      return `Unknown repair zone: ${failure.zone}.`;
+    case "car_not_owned":
+      return `You do not own ${failure.carId}.`;
+    case "unknown_upgrade":
+      return `Unknown upgrade: ${failure.upgradeId}.`;
+    case "tier_skip":
+      return `Upgrade tier ${failure.attempted} is not available yet.`;
+    case "upgrade_at_cap":
+      return `Upgrade is capped at tier ${failure.cap}.`;
+  }
+}
+
+function pendingDamageFor(
+  save: Readonly<SaveGame>,
+  carId: string,
+): DamageState {
+  const pending = save.garage.pendingDamage?.[carId];
+  if (!pending) return createDamageState({});
+  return {
+    ...createDamageState({
+      engine: pending.zones.engine,
+      tires: pending.zones.tires,
+      body: pending.zones.body,
+    }),
+    offRoadAccumSeconds: pending.offRoadAccumSeconds,
+  };
+}
+
+function quoteSave(save: Readonly<SaveGame>): SaveGame {
+  return {
+    ...save,
+    garage: {
+      ...save.garage,
+      credits: Number.MAX_SAFE_INTEGER,
+    },
+  };
+}
+
+function quoteRepair(
+  save: SaveGame,
+  carId: string,
+  damage: DamageState,
+  kind: GarageRepairKind,
+): GarageRepairQuote {
+  const zones = kind === "essential" ? ESSENTIAL_ZONES : REPAIR_ZONES;
+  const result = applyRepairCost(save, {
+    carId,
+    damage,
+    tourTier: 1,
+    zones,
+    repairKind: kind,
+    lastRaceCashEarned: save.garage.lastRaceCashEarned ?? 0,
+  });
+
+  if (!result.ok) {
+    return {
+      kind,
+      label: kind === "essential" ? "Essential repair" : "Full service",
+      zones,
+      cost: 0,
+      saved: 0,
+      disabledReason: repairFailureMessage(result.failure),
+      breakdown: zones.map((zone) => ({ zone, credits: 0 })),
+    };
+  }
+
+  return {
+    kind,
+    label: kind === "essential" ? "Essential repair" : "Full service",
+    zones,
+    cost: result.cashSpent ?? 0,
+    saved: result.cashSaved ?? 0,
+    disabledReason: "",
+    breakdown: result.repairBreakdown ?? [],
+  };
+}
+
+function withDisabledReason(
+  quote: GarageRepairQuote,
+  save: Readonly<SaveGame>,
+  activeCar: Car | null,
+  ownsActive: boolean,
+  damage: DamageState,
+): GarageRepairQuote {
+  if (activeCar === null) {
+    return { ...quote, disabledReason: "Select an owned active car first." };
+  }
+  if (!ownsActive) {
+    return { ...quote, disabledReason: "You do not own the active car." };
+  }
+  const hasDamage = quote.zones.some((zone) => (damage.zones[zone] ?? 0) > 0);
+  if (!hasDamage) {
+    return { ...quote, disabledReason: "No damage in these zones." };
+  }
+  if (quote.cost > save.garage.credits) {
+    const needed = quote.cost - save.garage.credits;
+    return {
+      ...quote,
+      disabledReason: `Need ${needed} more ${needed === 1 ? "credit" : "credits"}.`,
+    };
+  }
+  return quote;
+}
+
+function cloneSaveForRepair(save: Readonly<SaveGame>): SaveGame {
+  return {
+    ...save,
+    garage: { ...save.garage },
+  };
+}
+
+function zoneLabel(zone: DamageZone): string {
+  switch (zone) {
+    case "engine":
+      return "Engine";
+    case "tires":
+      return "Tires";
+    case "body":
+      return "Body";
+  }
+}

--- a/src/components/garage/garageRepairState.ts
+++ b/src/components/garage/garageRepairState.ts
@@ -84,6 +84,16 @@ export function repairGarageDamage(
   kind: GarageRepairKind,
 ): EconomyResult {
   const activeCarId = save.garage.activeCarId;
+  if (!getCar(activeCarId)) {
+    return { ok: false, failure: { code: "unknown_car", carId: activeCarId } };
+  }
+  if (!save.garage.ownedCars.includes(activeCarId)) {
+    return {
+      ok: false,
+      failure: { code: "car_not_owned", carId: activeCarId },
+    };
+  }
+
   const result = applyRepairCost(cloneSaveForRepair(save), {
     carId: activeCarId,
     damage: pendingDamageFor(save, activeCarId),

--- a/src/components/garage/garageSummaryState.ts
+++ b/src/components/garage/garageSummaryState.ts
@@ -14,6 +14,7 @@ export interface GarageSummaryView {
   readonly activeCarId: string;
   readonly credits: number;
   readonly ownedCount: number;
+  readonly damagePercent: number;
   readonly needsStarterPick: boolean;
   readonly starterCars: ReadonlyArray<Car>;
   readonly installedTiers: ReadonlyArray<GarageUpgradeTier>;
@@ -31,12 +32,14 @@ export function buildGarageSummaryView(
   const activeCar = getCar(save.garage.activeCarId) ?? null;
   const ownsActive = save.garage.ownedCars.includes(save.garage.activeCarId);
   const installed = save.garage.installedUpgrades[save.garage.activeCarId];
+  const pendingDamage = save.garage.pendingDamage?.[save.garage.activeCarId];
 
   return {
     activeCar,
     activeCarId: save.garage.activeCarId,
     credits: save.garage.credits,
     ownedCount: save.garage.ownedCars.length,
+    damagePercent: Math.round((pendingDamage?.total ?? 0) * 100),
     needsStarterPick: activeCar === null || !ownsActive,
     starterCars: starterCars(),
     installedTiers: UPGRADE_CATEGORIES.map((category) => ({

--- a/src/components/garage/garageSummaryState.ts
+++ b/src/components/garage/garageSummaryState.ts
@@ -5,6 +5,7 @@ import type {
   UpgradeCategory,
 } from "@/data/schemas";
 import { UpgradeCategorySchema } from "@/data/schemas";
+import { createDamageState } from "@/game/damage";
 
 const UPGRADE_CATEGORIES: ReadonlyArray<UpgradeCategory> =
   UpgradeCategorySchema.options;
@@ -32,14 +33,13 @@ export function buildGarageSummaryView(
   const activeCar = getCar(save.garage.activeCarId) ?? null;
   const ownsActive = save.garage.ownedCars.includes(save.garage.activeCarId);
   const installed = save.garage.installedUpgrades[save.garage.activeCarId];
-  const pendingDamage = save.garage.pendingDamage?.[save.garage.activeCarId];
 
   return {
     activeCar,
     activeCarId: save.garage.activeCarId,
     credits: save.garage.credits,
     ownedCount: save.garage.ownedCars.length,
-    damagePercent: Math.round((pendingDamage?.total ?? 0) * 100),
+    damagePercent: activeCarDamagePercent(save, save.garage.activeCarId),
     needsStarterPick: activeCar === null || !ownsActive,
     starterCars: starterCars(),
     installedTiers: UPGRADE_CATEGORIES.map((category) => ({
@@ -97,6 +97,21 @@ function defaultUpgradeTiers(): Record<UpgradeCategory, number> {
   return Object.fromEntries(
     UPGRADE_CATEGORIES.map((category) => [category, 0]),
   ) as Record<UpgradeCategory, number>;
+}
+
+function activeCarDamagePercent(
+  save: Readonly<SaveGame>,
+  carId: string,
+): number {
+  const pending = save.garage.pendingDamage?.[carId];
+  if (!pending) return 0;
+  return Math.round(
+    createDamageState({
+      engine: pending.zones.engine,
+      tires: pending.zones.tires,
+      body: pending.zones.body,
+    }).total * 100,
+  );
 }
 
 function upgradeLabel(category: UpgradeCategory): string {

--- a/src/data/examples/saveGame.example.json
+++ b/src/data/examples/saveGame.example.json
@@ -48,7 +48,19 @@
         "cooling": 0,
         "aero": 0
       }
-    }
+    },
+    "pendingDamage": {
+      "sparrow-gt": {
+        "zones": {
+          "engine": 0.2,
+          "tires": 0.1,
+          "body": 0.25
+        },
+        "total": 0.1975,
+        "offRoadAccumSeconds": 0
+      }
+    },
+    "lastRaceCashEarned": 2200
   },
   "progress": {
     "unlockedTours": ["velvet-coast", "iron-borough"],

--- a/src/data/schemas.test.ts
+++ b/src/data/schemas.test.ts
@@ -180,6 +180,51 @@ describe("SaveGameSchema", () => {
     expect(SaveGameSchema.safeParse(broken).success).toBe(false);
   });
 
+  it("accepts optional garage repair state", () => {
+    const withRepairState = {
+      ...saveGameExample,
+      garage: {
+        ...saveGameExample.garage,
+        pendingDamage: {
+          "sparrow-gt": {
+            zones: {
+              engine: 0.5,
+              tires: 0.25,
+              body: 0.5,
+            },
+            total: 0.45,
+            offRoadAccumSeconds: 2,
+          },
+        },
+        lastRaceCashEarned: 2000,
+      },
+    };
+
+    expect(SaveGameSchema.safeParse(withRepairState).success).toBe(true);
+  });
+
+  it("rejects garage repair damage outside the unit interval", () => {
+    const broken = {
+      ...saveGameExample,
+      garage: {
+        ...saveGameExample.garage,
+        pendingDamage: {
+          "sparrow-gt": {
+            zones: {
+              engine: 1.5,
+              tires: 0,
+              body: 0,
+            },
+            total: 1.5,
+            offRoadAccumSeconds: 0,
+          },
+        },
+      },
+    };
+
+    expect(SaveGameSchema.safeParse(broken).success).toBe(false);
+  });
+
   it("accepts a record with optional bestSplitsMs (sector splits)", () => {
     const withSplits = {
       ...saveGameExample,

--- a/src/data/schemas.ts
+++ b/src/data/schemas.ts
@@ -599,11 +599,25 @@ const installedUpgradesObject = z.object(
   ) as Record<UpgradeCategory, typeof nonNegInt>,
 );
 
+const saveDamageZonesObject = z.object({
+  engine: unitInterval,
+  tires: unitInterval,
+  body: unitInterval,
+});
+
+const saveDamageStateObject = z.object({
+  zones: saveDamageZonesObject,
+  total: unitInterval,
+  offRoadAccumSeconds: z.number().nonnegative(),
+});
+
 export const SaveGameGarageSchema = z.object({
   credits: nonNegInt,
   ownedCars: z.array(slug).min(1),
   activeCarId: slug,
   installedUpgrades: z.record(slug, installedUpgradesObject),
+  pendingDamage: z.record(slug, saveDamageStateObject).optional(),
+  lastRaceCashEarned: nonNegInt.optional(),
 });
 export type SaveGameGarage = z.infer<typeof SaveGameGarageSchema>;
 

--- a/src/persistence/save.ts
+++ b/src/persistence/save.ts
@@ -142,6 +142,8 @@ export function defaultSave(): SaveGame {
           aero: 0,
         },
       },
+      pendingDamage: {},
+      lastRaceCashEarned: 0,
     },
     progress: {
       unlockedTours: [],


### PR DESCRIPTION
## Summary
- Replace `/garage/repair` placeholder with a localStorage-backed repair shop for the active car.
- Add persisted `garage.pendingDamage` and `lastRaceCashEarned` save fields for repair quotes and cap handling.
- Show pending active-car damage on the garage hub and close F-061.

## GDD links
- `docs/gdd/05-core-gameplay-loop.md`: repairs between race and upgrade steps.
- `docs/gdd/12-upgrade-and-economy-system.md`: repair costs and essential-repair cap.
- `docs/gdd/13-damage-repairs-and-risk.md`: full service and quick patch decisions.
- `docs/gdd/22-data-schemas.md`: SaveGame repair queue fields.

## Requirement inventory
Handled in this PR:
- Garage repair page shows active-car damage by zone.
- Full service quotes and repairs engine, tires, and body.
- Essential repair quotes and repairs engine and tires first.
- Essential repair uses the existing cap from last race cash.
- Repair purchases debit credits and persist post-repair damage.
- Garage summary reports active-car pending damage.

Left to followup:
- F-064 wires race-finish damage into `garage.pendingDamage` and stores `lastRaceCashEarned` from the live result commit path.
- Standings, weather fit, ghost status, leaderboard status, and full next-race tournament data remain later garage slices.

## Progress log
- `docs/PROGRESS_LOG.md`: `2026-04-28: Slice: F-061 garage repair purchase surface`

## Test plan
- [x] `npx vitest run src/components/garage/__tests__/garageRepairState.test.ts src/components/garage/__tests__/garageSummaryState.test.ts src/data/schemas.test.ts src/persistence/save.test.ts`
- [x] `npm run lint`
- [x] `npm run typecheck`
- [x] `npm run test:e2e -- e2e/garage-repairs.spec.ts e2e/garage-summary.spec.ts`
- [x] `npm run verify`
- [x] `grep -rn $'\u2014\|\u2013' . --exclude-dir=.git --exclude-dir=node_modules --exclude-dir=.next || true`
- [x] `git diff --check`
