### PR TITLE
F-064 race damage garage persistence

### DIFF
--- a/docs/FOLLOWUPS.md
+++ b/docs/FOLLOWUPS.md
@@ -13,7 +13,7 @@ or `obsolete` so the trail is preserved.
 ## F-064: Persist race damage into the garage repair queue
 **Created:** 2026-04-28
 **Priority:** blocks-release
-**Status:** open
+**Status:** done (2026-04-28)
 **Notes:** The F-061 repair shop consumes `garage.pendingDamage` and
 persists full or essential repairs, but the live race finish path still
 credits cash and records PBs without writing the player's final
@@ -21,6 +21,12 @@ credits cash and records PBs without writing the player's final
 and retire paths in `src/app/race/page.tsx` so finished races store the
 active car's pending damage and `lastRaceCashEarned`, then cover the
 race to results to garage repair path in Playwright.
+
+Closed by `feat/f-064-race-damage-persistence`. Race sessions now start
+from the active car's queued garage damage, and both natural-finish and
+retire paths write final player damage plus the actual credited payout
+back into `garage.pendingDamage` and `lastRaceCashEarned`. Playwright
+covers race finish to results to garage repair.
 
 ## F-063: Align starter selection content with the three §11 starter examples
 **Created:** 2026-04-27

--- a/docs/GDD_COVERAGE.json
+++ b/docs/GDD_COVERAGE.json
@@ -62,8 +62,28 @@
         "e2e/garage-repairs.spec.ts",
         "e2e/garage-summary.spec.ts",
         "src/game/__tests__/economy.test.ts"
+      ]
+    },
+    {
+      "id": "GDD-13-RACE-DAMAGE-PERSISTENCE",
+      "gddSections": [
+        "docs/gdd/05-core-gameplay-loop.md",
+        "docs/gdd/12-upgrade-and-economy-system.md",
+        "docs/gdd/13-damage-repairs-and-risk.md",
+        "docs/gdd/22-data-schemas.md"
       ],
-      "followupRefs": ["F-061", "F-064"]
+      "requirement": "Race finish and retire paths persist the active car's final damage into the garage repair queue, record the credited race payout for the essential-repair cap, and seed the next race from queued active-car damage.",
+      "coverage": ["implemented-code", "automated-test"],
+      "implementationRefs": [
+        "src/app/race/page.tsx",
+        "src/game/raceDamagePersistence.ts",
+        "src/game/raceSession.ts"
+      ],
+      "testRefs": [
+        "src/game/__tests__/raceDamagePersistence.test.ts",
+        "src/game/__tests__/raceSession.test.ts",
+        "e2e/race-finish.spec.ts"
+      ]
     },
     {
       "id": "GDD-12-GARAGE-UPGRADE-PURCHASE",

--- a/docs/PROGRESS_LOG.md
+++ b/docs/PROGRESS_LOG.md
@@ -6,6 +6,64 @@ Correct them by adding a new entry that references the old one.
 
 ---
 
+## 2026-04-28: Slice: F-064 race damage garage persistence
+
+**GDD sections touched:**
+[§5](gdd/05-core-gameplay-loop.md) race to results to repairs loop,
+[§12](gdd/12-upgrade-and-economy-system.md) essential repair cap,
+[§13](gdd/13-damage-repairs-and-risk.md) repair decisions and damage risk,
+[§22](gdd/22-data-schemas.md) save repair queue.
+**Branch / PR:** `feat/f-064-race-damage-persistence`, PR pending.
+**Status:** Implemented.
+
+### Done
+- `src/game/raceDamagePersistence.ts`: added pure helpers to read active
+  car pending damage, project damage into the results builder, normalize
+  final damage, and write final damage plus race payout into the garage
+  queue.
+- `src/game/raceSession.ts`: lets the player session start from queued
+  active-car damage while preserving pristine defaults for fresh saves.
+- `src/app/race/page.tsx`: threads initial damage into result damage
+  deltas and writes final `session.player.damage` from both natural
+  finish and retire paths.
+- `e2e/race-finish.spec.ts`: covers race finish to results to garage
+  repair, including localStorage damage queue and repair-page readback.
+- `docs/FOLLOWUPS.md`: closed F-064.
+- `docs/GDD_COVERAGE.json`: added
+  `GDD-13-RACE-DAMAGE-PERSISTENCE` and removed the stale open repair
+  followup refs.
+
+### Verified
+- `npx vitest run src/game/__tests__/raceDamagePersistence.test.ts src/game/__tests__/raceSession.test.ts src/game/__tests__/raceResult.test.ts`
+  green, 162 passed.
+- `npm run lint` clean.
+- `npm run typecheck` clean.
+- `npm run test:e2e -- e2e/race-finish.spec.ts e2e/garage-repairs.spec.ts`
+  green, 4 passed.
+
+### Decisions and assumptions
+- The persisted repair queue stores the final active-car damage for the
+  completed race. That means an already damaged car starts the next race
+  damaged, and any additional race damage accumulates before the queue is
+  overwritten with the new final state.
+- Time Trial keeps skipping economy writes, so it does not write repair
+  queue damage or last race cash.
+
+### Coverage ledger
+- Added GDD-13-RACE-DAMAGE-PERSISTENCE with code and automated test
+  coverage.
+- GDD-13-GARAGE-REPAIR-PURCHASE no longer tracks F-064 as an open
+  followup.
+- Uncovered adjacent requirements: tour standings, recommended weather
+  fit, ghost status, leaderboard status, and full next-race tournament
+  data remain future garage slices.
+
+### Followups created
+None.
+
+### GDD edits
+None.
+
 ## 2026-04-28: Slice: F-061 garage repair purchase surface
 
 **GDD sections touched:**

--- a/e2e/race-finish.spec.ts
+++ b/e2e/race-finish.spec.ts
@@ -1,5 +1,7 @@
 import { expect, test } from "@playwright/test";
 
+const SAVE_KEY = "vibegear2:save:v3";
+
 /**
  * Natural race-finish e2e per F-038. Drives a single-lap race on
  * `test/straight` with the throttle held down so the player reaches the
@@ -80,6 +82,63 @@ test.describe("race-finish wiring (F-038)", () => {
       const creditsRow = page.getByTestId("results-credits-awarded");
       await expect(creditsRow).toBeVisible();
       await expect(creditsRow).not.toHaveText(/^0 cr$/);
+    },
+  );
+
+  test(
+    "natural finish persists active car damage for the repair shop",
+    async ({ page }) => {
+      test.setTimeout(70_000);
+
+      await page.goto("/");
+      await page.evaluate(
+        ({ key, save }) => window.localStorage.setItem(key, JSON.stringify(save)),
+        { key: SAVE_KEY, save: buildRaceDamageSave() },
+      );
+
+      await page.goto("/race?track=test/straight");
+
+      const canvas = page.getByTestId("race-canvas-element");
+      await expect(canvas).toBeVisible();
+      await expect(page.getByTestId("race-phase")).toHaveText("racing", {
+        timeout: 10_000,
+      });
+
+      await canvas.focus();
+      await page.keyboard.down("ArrowUp");
+      await expect(page).toHaveURL(/\/race\/results/, { timeout: 45_000 });
+      await page.keyboard.up("ArrowUp");
+
+      const persisted = await page.evaluate((key) => {
+        const raw = window.localStorage.getItem(key);
+        return raw
+          ? (JSON.parse(raw) as {
+              garage?: {
+                credits?: number;
+                lastRaceCashEarned?: number;
+                pendingDamage?: Record<
+                  string,
+                  { zones?: { engine?: number; tires?: number; body?: number } }
+                >;
+              };
+            })
+          : null;
+      }, SAVE_KEY);
+
+      expect(persisted?.garage?.credits).toBeGreaterThan(1000);
+      expect(persisted?.garage?.lastRaceCashEarned).toBeGreaterThan(0);
+      const bodyDamage =
+        persisted?.garage?.pendingDamage?.["sparrow-gt"]?.zones?.body ?? 0;
+      expect(bodyDamage).toBeGreaterThanOrEqual(0.33);
+
+      await page.getByTestId("results-cta-continue").click();
+      await expect(page).toHaveURL(/\/garage\/cars/);
+      await page.goto("/garage/repair");
+
+      await expect(page.getByTestId("garage-repair-page")).toBeVisible();
+      await expect(page.getByTestId("garage-repair-damage-body")).toContainText(
+        `${Math.round(bodyDamage * 100)}% damage`,
+      );
     },
   );
 });
@@ -163,3 +222,56 @@ test.describe("race-finish wiring (F-029 multi-lap)", () => {
     },
   );
 });
+
+function buildRaceDamageSave() {
+  return {
+    version: 3,
+    profileName: "RaceDamageTester",
+    settings: {
+      displaySpeedUnit: "kph",
+      assists: {
+        steeringAssist: false,
+        autoNitro: false,
+        weatherVisualReduction: false,
+      },
+      difficultyPreset: "normal",
+      transmissionMode: "auto",
+      audio: { master: 1, music: 1, sfx: 1 },
+      accessibility: {
+        colorBlindMode: "off",
+        reducedMotion: false,
+        largeUiText: false,
+        screenShakeScale: 1,
+      },
+    },
+    garage: {
+      credits: 1000,
+      ownedCars: ["sparrow-gt"],
+      activeCarId: "sparrow-gt",
+      installedUpgrades: {
+        "sparrow-gt": {
+          engine: 0,
+          gearbox: 0,
+          dryTires: 0,
+          wetTires: 0,
+          nitro: 0,
+          armor: 0,
+          cooling: 0,
+          aero: 0,
+        },
+      },
+      pendingDamage: {
+        "sparrow-gt": {
+          zones: { engine: 0, tires: 0, body: 0.33 },
+          total: 0.1155,
+          offRoadAccumSeconds: 0,
+        },
+      },
+      lastRaceCashEarned: 0,
+    },
+    progress: { unlockedTours: [], completedTours: [] },
+    records: {},
+    ghosts: {},
+    writeCounter: 0,
+  };
+}

--- a/src/app/race/page.tsx
+++ b/src/app/race/page.tsx
@@ -53,8 +53,11 @@ import {
   createInputManager,
   createRaceSession,
   createTimeTrialRecorder,
+  damageDeltaFromState,
   deriveHudState,
   deriveSplitsState,
+  pendingDamageForActiveCar,
+  applyRaceDamageToGarage,
   applyRaceResultRecords,
   retireRaceSession,
   startLoop,
@@ -94,6 +97,7 @@ import { defaultSave, loadSave, saveSave } from "@/persistence/save";
 import { awardCredits, baseRewardForTrackDifficulty } from "@/game/economy";
 import type { SaveGame } from "@/data/schemas";
 import type { RaceResult } from "@/game/raceResult";
+import type { DamageState } from "@/game/damage";
 
 const VIEWPORT_WIDTH = 800;
 const VIEWPORT_HEIGHT = 480;
@@ -297,8 +301,10 @@ function commitRaceCredits(input: {
   save: SaveGame;
   difficulty: string;
   baseTrackReward: number;
+  damageAfter?: Readonly<DamageState>;
+  activeCarId?: string | null;
 }): RaceResult {
-  const { result, save, difficulty, baseTrackReward } = input;
+  const { result, save, difficulty, baseTrackReward, damageAfter, activeCarId } = input;
   const playerRecord = result.finishingOrder.find(
     (record) => record.carId === result.playerCarId,
   );
@@ -327,7 +333,17 @@ function commitRaceCredits(input: {
   // Persist the credited save plus any PB patch emitted by the result
   // builder. Storage failure is non-fatal here: the player still sees
   // the receipt, and the next race finish can retry from a loaded save.
-  saveSave(applyRaceResultRecords(award.state, result));
+  const recordsSave = applyRaceResultRecords(award.state, result);
+  const nextSave =
+    damageAfter === undefined
+      ? recordsSave
+      : applyRaceDamageToGarage({
+          save: recordsSave,
+          carId: activeCarId ?? recordsSave.garage.activeCarId,
+          damage: damageAfter,
+          lastRaceCashEarned: award.cashEarned ?? 0,
+        });
+  saveSave(nextSave);
 
   return {
     ...result,
@@ -468,6 +484,7 @@ function RaceCanvas({ track, lapsOverride, mode }: RaceCanvasProps): ReactElemen
     const persistedAssists = persistedSettings.assists;
     const persistedDifficulty = persistedSettings.difficultyPreset;
     const persistedKeyBindings = readKeyBindings(sessionSave);
+    const initialPlayerDamage = pendingDamageForActiveCar(sessionSave);
     const timeTrialEnabled = mode === "timeTrial";
     const raceSeed = 1;
     let timeTrialSaveSnapshot = sessionSave;
@@ -478,6 +495,7 @@ function RaceCanvas({ track, lapsOverride, mode }: RaceCanvasProps): ReactElemen
         stats: STARTER_STATS,
         assists: persistedAssists,
         difficultyPreset: persistedDifficulty,
+        initialDamage: initialPlayerDamage,
       },
       ai: [{ driver: DEMO_DRIVER, stats: STARTER_STATS }],
       seed: raceSeed,
@@ -621,6 +639,8 @@ function RaceCanvas({ track, lapsOverride, mode }: RaceCanvasProps): ReactElemen
         track: trackForResult,
         playerCarId: PLAYER_ID,
         playerStartPosition: 1,
+        damageBefore: damageDeltaFromState(initialPlayerDamage),
+        damageAfter: damageDeltaFromState(retired.player.damage),
         recordPBs: false,
       });
       // F-034: credit the wallet (DNF cars receive the §12 participation
@@ -635,6 +655,8 @@ function RaceCanvas({ track, lapsOverride, mode }: RaceCanvasProps): ReactElemen
             // a `difficultyPreset` field reads as `'normal'`.
             difficulty: persistedDifficulty ?? "normal",
             baseTrackReward: baseRewardForTrackDifficulty(track.compiled.difficulty),
+            damageAfter: retired.player.damage,
+            activeCarId: save.garage.activeCarId,
           });
       saveRaceResult(committed);
       // Flip the natural-finish guard so the render callback's finish
@@ -826,6 +848,8 @@ function RaceCanvas({ track, lapsOverride, mode }: RaceCanvasProps): ReactElemen
               track: trackForResult,
               playerCarId: PLAYER_ID,
               playerStartPosition: 1,
+              damageBefore: damageDeltaFromState(initialPlayerDamage),
+              damageAfter: damageDeltaFromState(session.player.damage),
               recordPBs: session.player.status === "finished",
             });
             // F-034: credit the wallet from the same numbers the
@@ -843,6 +867,8 @@ function RaceCanvas({ track, lapsOverride, mode }: RaceCanvasProps): ReactElemen
                   baseTrackReward: baseRewardForTrackDifficulty(
                     track.compiled.difficulty,
                   ),
+                  damageAfter: session.player.damage,
+                  activeCarId: save.garage.activeCarId,
                 });
             saveRaceResult(committed);
             // Tear down the loop / input before the route hop so the

--- a/src/app/race/page.tsx
+++ b/src/app/race/page.tsx
@@ -97,7 +97,7 @@ import { defaultSave, loadSave, saveSave } from "@/persistence/save";
 import { awardCredits, baseRewardForTrackDifficulty } from "@/game/economy";
 import type { SaveGame } from "@/data/schemas";
 import type { RaceResult } from "@/game/raceResult";
-import type { DamageState } from "@/game/damage";
+import { PRISTINE_DAMAGE_STATE, type DamageState } from "@/game/damage";
 
 const VIEWPORT_WIDTH = 800;
 const VIEWPORT_HEIGHT = 480;
@@ -484,8 +484,10 @@ function RaceCanvas({ track, lapsOverride, mode }: RaceCanvasProps): ReactElemen
     const persistedAssists = persistedSettings.assists;
     const persistedDifficulty = persistedSettings.difficultyPreset;
     const persistedKeyBindings = readKeyBindings(sessionSave);
-    const initialPlayerDamage = pendingDamageForActiveCar(sessionSave);
     const timeTrialEnabled = mode === "timeTrial";
+    const initialPlayerDamage = timeTrialEnabled
+      ? PRISTINE_DAMAGE_STATE
+      : pendingDamageForActiveCar(sessionSave);
     const raceSeed = 1;
     let timeTrialSaveSnapshot = sessionSave;
 

--- a/src/game/__tests__/raceDamagePersistence.test.ts
+++ b/src/game/__tests__/raceDamagePersistence.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from "vitest";
+
+import { defaultSave } from "@/persistence/save";
+
+import { createDamageState } from "../damage";
+import {
+  applyRaceDamageToGarage,
+  damageDeltaFromState,
+  pendingDamageForActiveCar,
+} from "../raceDamagePersistence";
+
+describe("race damage garage persistence", () => {
+  it("reads active-car pending damage from the save", () => {
+    const seed = createDamageState({ engine: 0.25, tires: 0.1, body: 0.4 });
+    const save = {
+      ...defaultSave(),
+      garage: {
+        ...defaultSave().garage,
+        pendingDamage: {
+          "sparrow-gt": {
+            ...seed,
+            total: 0.99,
+            offRoadAccumSeconds: 3.5,
+          },
+        },
+      },
+    };
+
+    const damage = pendingDamageForActiveCar(save);
+
+    expect(damage.zones).toEqual(seed.zones);
+    expect(damage.total).toBe(seed.total);
+    expect(damage.offRoadAccumSeconds).toBe(3.5);
+  });
+
+  it("stores final active-car damage and the credited race payout", () => {
+    const save = defaultSave();
+    const damage = {
+      ...createDamageState({ engine: 0.2, tires: 0.15, body: 0.3 }),
+      offRoadAccumSeconds: 4.25,
+    };
+
+    const next = applyRaceDamageToGarage({
+      save,
+      carId: "sparrow-gt",
+      damage,
+      lastRaceCashEarned: 1775.9,
+    });
+
+    expect(next).not.toBe(save);
+    expect(next.garage.pendingDamage?.["sparrow-gt"]).toEqual(damage);
+    expect(next.garage.lastRaceCashEarned).toBe(1775);
+  });
+
+  it("does not create repair queue entries for unowned cars", () => {
+    const save = defaultSave();
+
+    const next = applyRaceDamageToGarage({
+      save,
+      carId: "bastion-lm",
+      damage: createDamageState({ body: 0.7 }),
+      lastRaceCashEarned: 500,
+    });
+
+    expect(next).toBe(save);
+  });
+
+  it("projects damage state zones into results-builder damage scalars", () => {
+    const damage = createDamageState({ engine: 0.2, tires: 0.4, body: 0.6 });
+
+    expect(damageDeltaFromState(damage)).toEqual({
+      engine: 0.2,
+      tires: 0.4,
+      body: 0.6,
+    });
+  });
+});

--- a/src/game/__tests__/raceDamagePersistence.test.ts
+++ b/src/game/__tests__/raceDamagePersistence.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from "vitest";
 
 import { defaultSave } from "@/persistence/save";
 
-import { createDamageState } from "../damage";
+import { createDamageState, PRISTINE_DAMAGE_STATE } from "../damage";
 import {
   applyRaceDamageToGarage,
   damageDeltaFromState,
@@ -50,6 +50,10 @@ describe("race damage garage persistence", () => {
     expect(next).not.toBe(save);
     expect(next.garage.pendingDamage?.["sparrow-gt"]).toEqual(damage);
     expect(next.garage.lastRaceCashEarned).toBe(1775);
+  });
+
+  it("returns the frozen pristine state when no active-car damage is queued", () => {
+    expect(pendingDamageForActiveCar(defaultSave())).toBe(PRISTINE_DAMAGE_STATE);
   });
 
   it("does not create repair queue entries for unowned cars", () => {

--- a/src/game/__tests__/raceSession.test.ts
+++ b/src/game/__tests__/raceSession.test.ts
@@ -1649,6 +1649,19 @@ describe("stepRaceSession (§13 damage wiring, F-047)", () => {
     expect(session.ai[0]?.damage).toBe(PRISTINE_DAMAGE_STATE);
   });
 
+  it("can seed the player with active garage damage at session creation", () => {
+    const initialDamage = createDamageState({ engine: 0.2, tires: 0.1, body: 0.3 });
+    const config = buildConfig({
+      countdownSec: 0,
+      player: { stats: STARTER_STATS, initialDamage },
+    });
+
+    const session = createRaceSession(config);
+
+    expect(session.player.damage).toBe(initialDamage);
+    expect(session.ai[0]?.damage).toBe(PRISTINE_DAMAGE_STATE);
+  });
+
   it("leaves damage at PRISTINE when the player races a clean lap with no contact", () => {
     // Single-lap straight track, no AI: a full-throttle clean run never
     // touches the grass and never makes contact, so the §13 damage path

--- a/src/game/index.ts
+++ b/src/game/index.ts
@@ -21,6 +21,7 @@ export * from "./ghostDriver";
 export * from "./timeTrial";
 export * from "./assists";
 export * from "./difficultyPresets";
+export * from "./raceDamagePersistence";
 // `raceBonuses` is the owner of the §5 bonus pipeline; `raceResult` is
 // the §20 results-screen builder that consumes it. The two re-export the
 // same `RaceBonus` / `RaceBonusKind` and the four bonus constants, so

--- a/src/game/raceDamagePersistence.ts
+++ b/src/game/raceDamagePersistence.ts
@@ -1,0 +1,74 @@
+import type { SaveGame } from "@/data/schemas";
+
+import {
+  createDamageState,
+  type DamageState,
+  type DamageZone,
+} from "./damage";
+import type { DamageDelta } from "./raceResult";
+
+const DAMAGE_ZONES: readonly DamageZone[] = ["engine", "tires", "body"];
+
+export function damageDeltaFromState(
+  damage: Readonly<DamageState>,
+): DamageDelta {
+  return {
+    engine: damage.zones.engine,
+    tires: damage.zones.tires,
+    body: damage.zones.body,
+  };
+}
+
+export function pendingDamageForActiveCar(save: SaveGame): DamageState {
+  const activeCarId = save.garage.activeCarId;
+  if (!activeCarId) return createDamageState({});
+  const pending = save.garage.pendingDamage?.[activeCarId] ?? null;
+  if (pending === null) return createDamageState({});
+  return normalizeDamageState(pending);
+}
+
+export function applyRaceDamageToGarage(input: {
+  save: SaveGame;
+  carId: string | null | undefined;
+  damage: Readonly<DamageState>;
+  lastRaceCashEarned: number;
+}): SaveGame {
+  const { save, carId, damage, lastRaceCashEarned } = input;
+  if (!carId || !save.garage.ownedCars.includes(carId)) {
+    return save;
+  }
+
+  return {
+    ...save,
+    garage: {
+      ...save.garage,
+      pendingDamage: {
+        ...(save.garage.pendingDamage ?? {}),
+        [carId]: normalizeDamageState(damage),
+      },
+      lastRaceCashEarned: cleanCash(lastRaceCashEarned),
+    },
+  };
+}
+
+function normalizeDamageState(damage: Readonly<DamageState>): DamageState {
+  const zones: Partial<Record<DamageZone, number>> = {};
+  for (const zone of DAMAGE_ZONES) {
+    zones[zone] = damage.zones[zone];
+  }
+  const normalized = createDamageState(zones);
+  return {
+    ...normalized,
+    offRoadAccumSeconds: cleanSeconds(damage.offRoadAccumSeconds),
+  };
+}
+
+function cleanCash(value: number): number {
+  if (!Number.isFinite(value) || value <= 0) return 0;
+  return Math.floor(value);
+}
+
+function cleanSeconds(value: number): number {
+  if (!Number.isFinite(value) || value <= 0) return 0;
+  return value;
+}

--- a/src/game/raceDamagePersistence.ts
+++ b/src/game/raceDamagePersistence.ts
@@ -2,6 +2,7 @@ import type { SaveGame } from "@/data/schemas";
 
 import {
   createDamageState,
+  PRISTINE_DAMAGE_STATE,
   type DamageState,
   type DamageZone,
 } from "./damage";
@@ -21,9 +22,9 @@ export function damageDeltaFromState(
 
 export function pendingDamageForActiveCar(save: SaveGame): DamageState {
   const activeCarId = save.garage.activeCarId;
-  if (!activeCarId) return createDamageState({});
+  if (!activeCarId) return PRISTINE_DAMAGE_STATE;
   const pending = save.garage.pendingDamage?.[activeCarId] ?? null;
-  if (pending === null) return createDamageState({});
+  if (pending === null) return PRISTINE_DAMAGE_STATE;
   return normalizeDamageState(pending);
 }
 

--- a/src/game/raceSession.ts
+++ b/src/game/raceSession.ts
@@ -169,6 +169,12 @@ export interface RaceSessionPlayer {
    * to title -> options -> resume to apply a new preset.
    */
   difficultyPreset?: PlayerDifficultyPreset | null;
+  /**
+   * Persisted active-car damage loaded from the garage repair queue at
+   * race start. Defaults to pristine for fresh saves and non-economy
+   * sessions.
+   */
+  initialDamage?: Readonly<DamageState> | null;
 }
 
 export interface RaceSessionAI {
@@ -605,7 +611,7 @@ export function createRaceSession(config: RaceSessionConfig): RaceSessionState {
     dnfReason: null,
     lapTimes: [],
     finishedAtMs: null,
-    damage: PRISTINE_DAMAGE_STATE,
+    damage: config.player.initialDamage ?? PRISTINE_DAMAGE_STATE,
   };
 
   const ai: RaceSessionAICar[] = config.ai.map((entry, index) => {


### PR DESCRIPTION
## GDD sections
- docs/gdd/05-core-gameplay-loop.md: race to results to repairs loop.
- docs/gdd/12-upgrade-and-economy-system.md: essential repair cap uses last race payout.
- docs/gdd/13-damage-repairs-and-risk.md: damage carries into repair decisions.
- docs/gdd/22-data-schemas.md: garage.pendingDamage and lastRaceCashEarned save fields.

## Requirement inventory
- Completed and retired economy races persist the active car final RaceSessionState.player.damage into garage.pendingDamage.
- The persisted payout for the race is stored in garage.lastRaceCashEarned for the essential repair cap.
- New race sessions seed the player from queued active-car damage, so skipping repairs carries risk into the next race.
- Time Trial remains non-economy and does not write repair queue damage or payout.

## Progress log
- docs/PROGRESS_LOG.md: 2026-04-28 slice entry for F-064 race damage garage persistence.

## Test plan
- [x] npx vitest run src/game/__tests__/raceDamagePersistence.test.ts src/game/__tests__/raceSession.test.ts src/game/__tests__/raceResult.test.ts
- [x] npm run lint
- [x] npm run typecheck
- [x] npm run test:e2e -- e2e/race-finish.spec.ts e2e/garage-repairs.spec.ts
- [x] npm run verify
- [x] grep -rn $'\\u2014\\|\\u2013' . --exclude-dir=.git --exclude-dir=node_modules --exclude-dir=.next || true\n- [x] git diff --check\n\n## Followups\n- Closed F-064.\n- Created none.