### PR TITLE
fix(garage): route results through garage hub

### DIFF
--- a/docs/GDD_COVERAGE.json
+++ b/docs/GDD_COVERAGE.json
@@ -33,6 +33,7 @@
       "testRefs": [
         "src/components/garage/__tests__/garageSummaryState.test.ts",
         "e2e/garage-summary.spec.ts",
+        "e2e/garage-flow.spec.ts",
         "e2e/title-screen.spec.ts"
       ]
     },

--- a/docs/PROGRESS_LOG.md
+++ b/docs/PROGRESS_LOG.md
@@ -23,6 +23,8 @@ Correct them by adding a new entry that references the old one.
   race actions.
 - `e2e/race-finish.spec.ts`: updated the race-finish repair handoff
   expectation to match the garage hub route.
+- `e2e/results-screen.spec.ts`: updated the seeded results-screen CTA
+  expectation and test name to match the garage hub route.
 - `e2e/garage-flow.spec.ts`: added the missing full garage-flow walk:
   finish a race, continue to `/garage`, open repairs, complete a full
   service, buy the first engine upgrade, and start the next race from
@@ -33,6 +35,7 @@ Correct them by adding a new entry that references the old one.
 ### Verified
 - `npm run test:e2e -- e2e/garage-flow.spec.ts e2e/race-finish.spec.ts e2e/garage-summary.spec.ts`
   green, 6 passed.
+- `npm run test:e2e -- e2e/results-screen.spec.ts` green, 4 passed.
 - `npm run verify` green: lint, typecheck, unit tests, and
   content-lint all passed; 2,207 unit tests passed.
 

--- a/docs/PROGRESS_LOG.md
+++ b/docs/PROGRESS_LOG.md
@@ -28,7 +28,8 @@ Correct them by adding a new entry that references the old one.
 - `e2e/garage-flow.spec.ts`: added the missing full garage-flow walk:
   finish a race, continue to `/garage`, open repairs, complete a full
   service, buy the first engine upgrade, and start the next race from
-  the garage hub.
+  the garage hub. The seeded save fixture is locally typed so schema
+  drift is caught by TypeScript.
 - `docs/GDD_COVERAGE.json`: records the new end-to-end garage flow test
   against GDD-05-GARAGE-SUMMARY.
 

--- a/docs/PROGRESS_LOG.md
+++ b/docs/PROGRESS_LOG.md
@@ -6,6 +6,54 @@ Correct them by adding a new entry that references the old one.
 
 ---
 
+## 2026-04-28: Slice: Garage results handoff
+
+**GDD sections touched:**
+[§5](gdd/05-core-gameplay-loop.md) race to results to garage loop,
+[§12](gdd/12-upgrade-and-economy-system.md) garage upgrade entry,
+[§13](gdd/13-damage-repairs-and-risk.md) between-race repair entry,
+[§20](gdd/20-hud-and-ui-ux.md) results default action.
+**Branch / PR:** `fix/garage-results-handoff`, PR pending.
+**Status:** Implemented.
+
+### Done
+- `src/app/race/results/page.tsx`: routes the primary Continue to
+  Garage action to the garage hub at `/garage` instead of the car
+  browser, so the post-race loop lands on repairs, upgrades, and next
+  race actions.
+- `e2e/race-finish.spec.ts`: updated the race-finish repair handoff
+  expectation to match the garage hub route.
+- `e2e/garage-flow.spec.ts`: added the missing full garage-flow walk:
+  finish a race, continue to `/garage`, open repairs, complete a full
+  service, buy the first engine upgrade, and start the next race from
+  the garage hub.
+- `docs/GDD_COVERAGE.json`: records the new end-to-end garage flow test
+  against GDD-05-GARAGE-SUMMARY.
+
+### Verified
+- `npm run test:e2e -- e2e/garage-flow.spec.ts e2e/race-finish.spec.ts e2e/garage-summary.spec.ts`
+  green, 6 passed.
+- `npm run verify` green: lint, typecheck, unit tests, and
+  content-lint all passed; 2,207 unit tests passed.
+
+### Decisions and assumptions
+- The garage hub is the canonical between-race destination. The car
+  browser remains available from the hub, repair shop, and upgrade shop,
+  but it is not the default post-results action.
+
+### Coverage ledger
+- GDD-05-GARAGE-SUMMARY now has full-loop Playwright coverage through
+  `e2e/garage-flow.spec.ts`.
+- Uncovered adjacent requirements: tour standings, recommended weather
+  fit, ghost status, leaderboard status, and full next-race tournament
+  data remain future garage and tour slices.
+
+### Followups created
+None.
+
+### GDD edits
+None.
+
 ## 2026-04-28: Slice: F-064 race damage garage persistence
 
 **GDD sections touched:**

--- a/docs/PROGRESS_LOG.md
+++ b/docs/PROGRESS_LOG.md
@@ -13,7 +13,7 @@ Correct them by adding a new entry that references the old one.
 [§12](gdd/12-upgrade-and-economy-system.md) garage upgrade entry,
 [§13](gdd/13-damage-repairs-and-risk.md) between-race repair entry,
 [§20](gdd/20-hud-and-ui-ux.md) results default action.
-**Branch / PR:** `fix/garage-results-handoff`, PR pending.
+**Branch / PR:** `fix/garage-results-handoff`, #33.
 **Status:** Implemented.
 
 ### Done

--- a/e2e/garage-flow.spec.ts
+++ b/e2e/garage-flow.spec.ts
@@ -1,0 +1,149 @@
+import { expect, test } from "@playwright/test";
+
+const SAVE_KEY = "vibegear2:save:v3";
+
+test.describe("garage flow", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto("/");
+    const hasStorage = await page.evaluate(
+      () => typeof window.localStorage !== "undefined",
+    );
+    test.skip(!hasStorage, "localStorage unavailable in this browser context");
+  });
+
+  test("finishes a race, services the car, buys an upgrade, and starts the next race", async ({
+    page,
+  }) => {
+    test.setTimeout(90_000);
+
+    await page.evaluate(
+      ({ key, save }) => window.localStorage.setItem(key, JSON.stringify(save)),
+      { key: SAVE_KEY, save: buildGarageFlowSave() },
+    );
+
+    await page.goto("/race?track=test/straight");
+
+    const canvas = page.getByTestId("race-canvas-element");
+    await expect(canvas).toBeVisible();
+    await expect(page.getByTestId("race-phase")).toHaveText("racing", {
+      timeout: 10_000,
+    });
+
+    await canvas.focus();
+    await page.keyboard.down("ArrowUp");
+    await expect(page).toHaveURL(/\/race\/results/, { timeout: 45_000 });
+    await page.keyboard.up("ArrowUp");
+
+    await page.getByTestId("results-cta-continue").click();
+    await expect(page).toHaveURL(/\/garage$/);
+    await expect(page.getByTestId("garage-page")).toBeVisible();
+    await expect(page.getByTestId("garage-damage-summary")).toContainText(
+      "pending",
+    );
+    await expect(page.getByTestId("garage-repair-link")).toBeVisible();
+    await expect(page.getByTestId("garage-upgrade-link")).toBeVisible();
+    await expect(page.getByTestId("garage-next-race-link")).toBeVisible();
+
+    await page.getByTestId("garage-repair-link").click();
+    await expect(page).toHaveURL(/\/garage\/repair$/);
+    await expect(page.getByTestId("garage-repair-page")).toBeVisible();
+    await page.getByTestId("garage-repair-button-full").click();
+    await expect(page.getByTestId("garage-repair-status")).toContainText(
+      "Full service complete",
+    );
+    await expect(page.getByTestId("garage-repair-damage-body")).toContainText(
+      "0% damage",
+    );
+
+    await page.getByTestId("garage-repair-back").click();
+    await expect(page).toHaveURL(/\/garage$/);
+    await page.getByTestId("garage-upgrade-link").click();
+    await expect(page).toHaveURL(/\/garage\/upgrade$/);
+    await expect(page.getByTestId("garage-upgrade-page")).toBeVisible();
+    await page.getByTestId("buy-upgrade-engine").click();
+    await expect(page.getByTestId("garage-upgrade-status")).toContainText(
+      "Installed Street Engine",
+    );
+    await expect(page.getByTestId("garage-upgrade-current-engine")).toContainText(
+      "Street",
+    );
+
+    const persisted = await page.evaluate((key) => {
+      const raw = window.localStorage.getItem(key);
+      return raw
+        ? (JSON.parse(raw) as {
+            garage?: {
+              pendingDamage?: Record<
+                string,
+                { zones?: { engine?: number; tires?: number; body?: number } }
+              >;
+              installedUpgrades?: Record<string, Record<string, number>>;
+            };
+          })
+        : null;
+    }, SAVE_KEY);
+
+    expect(
+      persisted?.garage?.pendingDamage?.["sparrow-gt"]?.zones?.body,
+    ).toBe(0);
+    expect(persisted?.garage?.installedUpgrades?.["sparrow-gt"]?.engine).toBe(1);
+
+    await page.getByTestId("garage-upgrade-back").click();
+    await page.getByTestId("garage-next-race-link").click();
+    await expect(page).toHaveURL(/\/race$/);
+    await expect(page.getByTestId("race-canvas-element")).toBeVisible();
+  });
+});
+
+function buildGarageFlowSave() {
+  return {
+    version: 3,
+    profileName: "GarageFlowTester",
+    settings: {
+      displaySpeedUnit: "kph",
+      assists: {
+        steeringAssist: false,
+        autoNitro: false,
+        weatherVisualReduction: false,
+      },
+      difficultyPreset: "normal",
+      transmissionMode: "auto",
+      audio: { master: 1, music: 1, sfx: 1 },
+      accessibility: {
+        colorBlindMode: "off",
+        reducedMotion: false,
+        largeUiText: false,
+        screenShakeScale: 1,
+      },
+    },
+    garage: {
+      credits: 5000,
+      ownedCars: ["sparrow-gt"],
+      activeCarId: "sparrow-gt",
+      installedUpgrades: {
+        "sparrow-gt": {
+          engine: 0,
+          gearbox: 0,
+          dryTires: 0,
+          wetTires: 0,
+          nitro: 0,
+          armor: 0,
+          cooling: 0,
+          aero: 0,
+        },
+      },
+      pendingDamage: {
+        "sparrow-gt": {
+          zones: { engine: 0, tires: 0, body: 0.33 },
+          total: 0.1155,
+          offRoadAccumSeconds: 0,
+        },
+      },
+      lastRaceCashEarned: 0,
+    },
+    progress: { unlockedTours: [], completedTours: [] },
+    records: {},
+    ghosts: {},
+    writeCounter: 0,
+  };
+}

--- a/e2e/garage-flow.spec.ts
+++ b/e2e/garage-flow.spec.ts
@@ -2,6 +2,47 @@ import { expect, test } from "@playwright/test";
 
 const SAVE_KEY = "vibegear2:save:v3";
 
+interface SeededSave {
+  version: number;
+  profileName: string;
+  settings: {
+    displaySpeedUnit: "kph" | "mph";
+    assists: {
+      steeringAssist: boolean;
+      autoNitro: boolean;
+      weatherVisualReduction: boolean;
+    };
+    difficultyPreset: "easy" | "normal" | "hard" | "master";
+    transmissionMode: "auto" | "manual";
+    audio: { master: number; music: number; sfx: number };
+    accessibility: {
+      colorBlindMode: "off" | "protanopia" | "deuteranopia" | "tritanopia";
+      reducedMotion: boolean;
+      largeUiText: boolean;
+      screenShakeScale: number;
+    };
+  };
+  garage: {
+    credits: number;
+    ownedCars: ReadonlyArray<string>;
+    activeCarId: string;
+    installedUpgrades: Record<string, Record<string, number>>;
+    pendingDamage: Record<
+      string,
+      {
+        zones: { engine: number; tires: number; body: number };
+        total: number;
+        offRoadAccumSeconds: number;
+      }
+    >;
+    lastRaceCashEarned: number;
+  };
+  progress: { unlockedTours: string[]; completedTours: string[] };
+  records: Record<string, unknown>;
+  ghosts: Record<string, unknown>;
+  writeCounter: number;
+}
+
 test.describe("garage flow", () => {
   test.beforeEach(async ({ page }) => {
     await page.goto("/");
@@ -95,7 +136,7 @@ test.describe("garage flow", () => {
   });
 });
 
-function buildGarageFlowSave() {
+function buildGarageFlowSave(): SeededSave {
   return {
     version: 3,
     profileName: "GarageFlowTester",

--- a/e2e/race-finish.spec.ts
+++ b/e2e/race-finish.spec.ts
@@ -132,7 +132,7 @@ test.describe("race-finish wiring (F-038)", () => {
       expect(bodyDamage).toBeGreaterThanOrEqual(0.33);
 
       await page.getByTestId("results-cta-continue").click();
-      await expect(page).toHaveURL(/\/garage\/cars/);
+      await expect(page).toHaveURL(/\/garage$/);
       await page.goto("/garage/repair");
 
       await expect(page.getByTestId("garage-repair-page")).toBeVisible();

--- a/e2e/results-screen.spec.ts
+++ b/e2e/results-screen.spec.ts
@@ -12,7 +12,7 @@ import { expect, test } from "@playwright/test";
  * Coverage:
  *   - Renders finishing order (one row per car), points, cash, bonuses,
  *     damage bars, fastest lap, and the next-race card.
- *   - "Continue to Garage" CTA navigates to /garage/cars.
+ *   - "Continue to Garage" CTA navigates to /garage.
  *   - Direct nav to /race/results with no seed renders the empty fallback.
  *   - Default focus lands on the Continue CTA.
  */
@@ -143,7 +143,7 @@ test.describe("race results screen", () => {
     await expect(cont).toBeFocused();
   });
 
-  test("Continue to Garage CTA routes to /garage/cars", async ({ page }) => {
+  test("Continue to Garage CTA routes to /garage", async ({ page }) => {
     await page.goto("/race/results");
     await page.evaluate(
       ([key, payload]) => {
@@ -155,7 +155,7 @@ test.describe("race results screen", () => {
 
     await expect(page.getByTestId("results-cta-continue")).toBeVisible();
     await page.getByTestId("results-cta-continue").click();
-    await expect(page).toHaveURL(/\/garage\/cars/);
+    await expect(page).toHaveURL(/\/garage$/);
   });
 
   test("direct nav with no result renders the empty fallback", async ({

--- a/src/app/race/results/page.tsx
+++ b/src/app/race/results/page.tsx
@@ -231,7 +231,7 @@ function ResultsView(props: ResultsViewProps): ReactElement {
 
       <nav style={ctaRowStyle} aria-label="Results actions">
         <Link
-          href="/garage/cars"
+          href="/garage"
           ref={continueRef}
           data-testid="results-cta-continue"
           style={primaryCtaStyle}


### PR DESCRIPTION
## GDD sections
- docs/gdd/05-core-gameplay-loop.md
- docs/gdd/12-upgrade-and-economy-system.md
- docs/gdd/13-damage-repairs-and-risk.md
- docs/gdd/20-hud-and-ui-ux.md

## Requirement inventory
- Results Continue now lands on `/garage`, the canonical between-race briefing hub.
- The full garage loop is covered in Playwright: finish race, continue to garage, repair, buy first engine upgrade, start next race.
- The car browser remains available from the garage surfaces, but is no longer the default post-results route.

Adjacent requirements left for later: tour standings, recommended weather fit, ghost status, leaderboard status, and full next-race tournament data.

## Progress log
- docs/PROGRESS_LOG.md: Garage results handoff

## Test plan
- [x] npm run test:e2e -- e2e/garage-flow.spec.ts e2e/race-finish.spec.ts e2e/garage-summary.spec.ts
- [x] npm run verify

## Followups
None.