### PR TITLE
feat(world): add tour entry hub

### DIFF
--- a/docs/FOLLOWUPS.md
+++ b/docs/FOLLOWUPS.md
@@ -10,6 +10,19 @@ or `obsolete` so the trail is preserved.
 
 ---
 
+## F-065: Persist active tour race progression through the four-race World Tour loop
+**Created:** 2026-04-28
+**Priority:** blocks-release
+**Status:** open
+**Notes:** The `/world` hub now renders the canonical championship,
+normalizes a fresh save so Velvet Coast is enterable, persists tour
+entry, and sends the selected tour's first track id to `/race`. The
+active tour cursor still lives in memory inside `src/game/championship.ts`.
+Wire the results screen to carry active tour state between races,
+record each race result, show aggregate standings after race four,
+call `unlockNextTour` on pass, and add `e2e/tour-flow.spec.ts` for the
+full Velvet Coast to Iron Borough unlock path.
+
 ## F-064: Persist race damage into the garage repair queue
 **Created:** 2026-04-28
 **Priority:** blocks-release

--- a/docs/GDD_COVERAGE.json
+++ b/docs/GDD_COVERAGE.json
@@ -87,6 +87,28 @@
       ]
     },
     {
+      "id": "GDD-08-WORLD-TOUR-HUB",
+      "gddSections": [
+        "docs/gdd/08-world-and-progression-design.md",
+        "docs/gdd/22-data-schemas.md",
+        "docs/gdd/24-content-plan.md"
+      ],
+      "requirement": "The world hub renders the canonical World Tour as four-race tour cards, unlocks the first tour for fresh saves, disables locked tours with the gating tour named, persists tour entry, and hands the chosen tour's first race to the race route.",
+      "coverage": ["implemented-code", "automated-test"],
+      "implementationRefs": [
+        "src/app/world/page.tsx",
+        "src/components/world/worldTourState.ts",
+        "src/data/championships/world-tour-standard.json",
+        "src/game/championship.ts"
+      ],
+      "testRefs": [
+        "src/components/world/__tests__/worldTourState.test.ts",
+        "e2e/world-tour.spec.ts",
+        "e2e/title-screen.spec.ts"
+      ],
+      "followupRefs": ["F-065"]
+    },
+    {
       "id": "GDD-12-GARAGE-UPGRADE-PURCHASE",
       "gddSections": [
         "docs/gdd/05-core-gameplay-loop.md",

--- a/docs/PROGRESS_LOG.md
+++ b/docs/PROGRESS_LOG.md
@@ -35,13 +35,13 @@ Correct them by adding a new entry that references the old one.
 
 ### Verified
 - `npx vitest run src/components/world/__tests__/worldTourState.test.ts src/app/__tests__/page.test.tsx`
-  green, 15 passed.
+  green, 16 passed.
 - `npm run typecheck` clean.
 - `npm run lint` clean.
 - `npm run test:e2e -- e2e/world-tour.spec.ts e2e/title-screen.spec.ts e2e/garage-flow.spec.ts`
   green, 8 passed.
 - `npm run verify` green: lint, typecheck, unit tests, and
-  content-lint all passed; 2,214 unit tests passed.
+  content-lint all passed; 2,215 unit tests passed.
 
 ### Decisions and assumptions
 - A fresh save treats the first championship tour as unlocked at the

--- a/docs/PROGRESS_LOG.md
+++ b/docs/PROGRESS_LOG.md
@@ -6,6 +6,65 @@ Correct them by adding a new entry that references the old one.
 
 ---
 
+## 2026-04-28: Slice: World tour entry hub
+
+**GDD sections touched:**
+[§5](gdd/05-core-gameplay-loop.md) race and garage loop entry,
+[§8](gdd/08-world-and-progression-design.md) tour unlock structure,
+[§22](gdd/22-data-schemas.md) championship and save progress fields,
+[§24](gdd/24-content-plan.md) eight-tour championship content.
+**Branch / PR:** `feat/world-tour-entry-hub`, PR pending.
+**Status:** Implemented.
+
+### Done
+- `src/components/world/worldTourState.ts`: added the testable tour
+  card builder, first-tour fresh-save normalization, and `enterWorldTour`
+  wrapper around the existing pure `enterTour` primitive.
+- `src/app/world/page.tsx`: added a localStorage-backed World Tour hub
+  that renders every tour, shows locked and completed state, names the
+  previous-tour gate, persists tour entry, and routes the selected
+  tour's first track id to `/race`.
+- `src/app/page.tsx`: exposed World Tour from the title menu.
+- `src/app/garage/page.tsx`: sends the garage Next race action through
+  `/world` now that the tour entry surface exists.
+- `e2e/world-tour.spec.ts`: covers the fresh-save tour hub, locked Iron
+  Borough gate, Velvet Coast entry, and persisted first-tour unlock.
+- `docs/FOLLOWUPS.md`: added F-065 for the remaining four-race active
+  tour progression and unlock flow.
+- `docs/GDD_COVERAGE.json`: added GDD-08-WORLD-TOUR-HUB coverage.
+
+### Verified
+- `npx vitest run src/components/world/__tests__/worldTourState.test.ts src/app/__tests__/page.test.tsx`
+  green, 15 passed.
+- `npm run typecheck` clean.
+- `npm run lint` clean.
+- `npm run test:e2e -- e2e/world-tour.spec.ts e2e/title-screen.spec.ts e2e/garage-flow.spec.ts`
+  green, 8 passed.
+- `npm run verify` green: lint, typecheck, unit tests, and
+  content-lint all passed; 2,214 unit tests passed.
+
+### Decisions and assumptions
+- A fresh save treats the first championship tour as unlocked at the
+  world hub. The helper persists that unlock when the player enters
+  Velvet Coast so the save agrees with the displayed state.
+- The hub passes the planned championship track id to `/race` even while
+  the full 32-track content set is still being authored. The race route
+  keeps its current fallback behavior until those track JSON files land.
+
+### Coverage ledger
+- Added GDD-08-WORLD-TOUR-HUB with code and automated test coverage.
+- Uncovered adjacent requirements: four-race active tour persistence,
+  aggregate standings, tour failure retry, tour completion unlocks, and
+  deterministic full tour e2e remain open under F-065 and the parent
+  tour-region dot.
+
+### Followups created
+- F-065: Persist active tour race progression through the four-race
+  World Tour loop.
+
+### GDD edits
+None.
+
 ## 2026-04-28: Slice: Garage results handoff
 
 **GDD sections touched:**

--- a/e2e/garage-flow.spec.ts
+++ b/e2e/garage-flow.spec.ts
@@ -131,8 +131,8 @@ test.describe("garage flow", () => {
 
     await page.getByTestId("garage-upgrade-back").click();
     await page.getByTestId("garage-next-race-link").click();
-    await expect(page).toHaveURL(/\/race$/);
-    await expect(page.getByTestId("race-canvas-element")).toBeVisible();
+    await expect(page).toHaveURL(/\/world$/);
+    await expect(page.getByTestId("world-page")).toBeVisible();
   });
 });
 

--- a/e2e/title-screen.spec.ts
+++ b/e2e/title-screen.spec.ts
@@ -15,6 +15,11 @@ test.describe("title screen", () => {
     await expect(startRace).toHaveText("Start Race");
     await expect(startRace).toHaveAttribute("href", "/race");
 
+    const worldTour = page.getByTestId("menu-world");
+    await expect(worldTour).toBeVisible();
+    await expect(worldTour).toHaveText("World Tour");
+    await expect(worldTour).toHaveAttribute("href", "/world");
+
     const timeTrial = page.getByTestId("menu-time-trial");
     await expect(timeTrial).toBeVisible();
     await expect(timeTrial).toHaveText("Time Trial");
@@ -43,6 +48,13 @@ test.describe("title screen", () => {
     await page.goto("/");
     await page.getByTestId("menu-garage").click();
     await expect(page).toHaveURL(/\/garage$/);
+  });
+
+  test("World Tour link navigates to /world", async ({ page }) => {
+    await page.goto("/");
+    await page.getByTestId("menu-world").click();
+    await expect(page).toHaveURL(/\/world$/);
+    await expect(page.getByTestId("world-page")).toBeVisible();
   });
 
   test("Time Trial link navigates to time-trial race mode", async ({ page }) => {

--- a/e2e/world-tour.spec.ts
+++ b/e2e/world-tour.spec.ts
@@ -1,0 +1,137 @@
+import { expect, test } from "@playwright/test";
+
+const SAVE_KEY = "vibegear2:save:v3";
+
+interface SeededSave {
+  version: number;
+  profileName: string;
+  settings: {
+    displaySpeedUnit: "kph" | "mph";
+    assists: {
+      steeringAssist: boolean;
+      autoNitro: boolean;
+      weatherVisualReduction: boolean;
+    };
+    difficultyPreset: "easy" | "normal" | "hard" | "master";
+    transmissionMode: "auto" | "manual";
+    audio: { master: number; music: number; sfx: number };
+    accessibility: {
+      colorBlindMode: "off" | "protanopia" | "deuteranopia" | "tritanopia";
+      reducedMotion: boolean;
+      largeUiText: boolean;
+      screenShakeScale: number;
+    };
+  };
+  garage: {
+    credits: number;
+    ownedCars: ReadonlyArray<string>;
+    activeCarId: string;
+    installedUpgrades: Record<string, Record<string, number>>;
+    pendingDamage: Record<string, unknown>;
+    lastRaceCashEarned: number;
+  };
+  progress: { unlockedTours: string[]; completedTours: string[] };
+  records: Record<string, unknown>;
+  ghosts: Record<string, unknown>;
+  writeCounter: number;
+}
+
+test.describe("world tour hub", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto("/");
+    const hasStorage = await page.evaluate(
+      () => typeof window.localStorage !== "undefined",
+    );
+    test.skip(!hasStorage, "localStorage unavailable in this browser context");
+  });
+
+  test("shows tour cards, locked gates, and starts the first tour", async ({
+    page,
+  }) => {
+    await page.evaluate(
+      ({ key, save }) => window.localStorage.setItem(key, JSON.stringify(save)),
+      { key: SAVE_KEY, save: buildWorldTourSave() },
+    );
+
+    await page.goto("/world");
+
+    await expect(page.getByTestId("world-page")).toBeVisible();
+    await expect(page.getByTestId("world-tour-list")).toBeVisible();
+    await expect(page.getByTestId("world-tour-velvet-coast")).toBeVisible();
+    await expect(page.getByTestId("world-tour-status-velvet-coast")).toHaveText(
+      "Available",
+    );
+    await expect(page.getByTestId("world-tour-first-track-velvet-coast")).toHaveText(
+      "Harbor Run",
+    );
+
+    await expect(page.getByTestId("world-tour-status-iron-borough")).toHaveText(
+      "Locked",
+    );
+    await expect(page.getByTestId("world-tour-lock-iron-borough")).toContainText(
+      "Complete Velvet Coast",
+    );
+    await expect(page.getByTestId("world-tour-enter-iron-borough")).toBeDisabled();
+
+    await page.getByTestId("world-tour-enter-velvet-coast").click();
+    await expect(page).toHaveURL(
+      /\/race\?track=velvet-coast%2Fharbor-run&tour=velvet-coast&raceIndex=0$/,
+    );
+
+    const persisted = await page.evaluate((key) => {
+      const raw = window.localStorage.getItem(key);
+      return raw
+        ? (JSON.parse(raw) as { progress?: { unlockedTours?: string[] } })
+        : null;
+    }, SAVE_KEY);
+
+    expect(persisted?.progress?.unlockedTours).toContain("velvet-coast");
+  });
+});
+
+function buildWorldTourSave(): SeededSave {
+  return {
+    version: 3,
+    profileName: "WorldTourTester",
+    settings: {
+      displaySpeedUnit: "kph",
+      assists: {
+        steeringAssist: false,
+        autoNitro: false,
+        weatherVisualReduction: false,
+      },
+      difficultyPreset: "normal",
+      transmissionMode: "auto",
+      audio: { master: 1, music: 1, sfx: 1 },
+      accessibility: {
+        colorBlindMode: "off",
+        reducedMotion: false,
+        largeUiText: false,
+        screenShakeScale: 1,
+      },
+    },
+    garage: {
+      credits: 5000,
+      ownedCars: ["sparrow-gt"],
+      activeCarId: "sparrow-gt",
+      installedUpgrades: {
+        "sparrow-gt": {
+          engine: 0,
+          gearbox: 0,
+          dryTires: 0,
+          wetTires: 0,
+          nitro: 0,
+          armor: 0,
+          cooling: 0,
+          aero: 0,
+        },
+      },
+      pendingDamage: {},
+      lastRaceCashEarned: 0,
+    },
+    progress: { unlockedTours: [], completedTours: [] },
+    records: {},
+    ghosts: {},
+    writeCounter: 0,
+  };
+}

--- a/src/app/__tests__/page.test.tsx
+++ b/src/app/__tests__/page.test.tsx
@@ -38,6 +38,12 @@ describe("TitlePage", () => {
     expect(match?.[0]).toContain('href="/time-trial"');
   });
 
+  it("renders World Tour as an anchor pointing at /world", () => {
+    const match = html.match(/<a[^>]*data-testid="menu-world"[^>]*>/);
+    expect(match, "menu-world anchor not found").not.toBeNull();
+    expect(match?.[0]).toContain('href="/world"');
+  });
+
   it("renders Garage as an anchor pointing at /garage", () => {
     const match = html.match(/<a[^>]*data-testid="menu-garage"[^>]*>/);
     expect(match, "menu-garage anchor not found").not.toBeNull();
@@ -50,13 +56,15 @@ describe("TitlePage", () => {
     expect(match?.[0]).toContain('href="/options"');
   });
 
-  it("places Start Race before Time Trial before Garage before Options in tab order", () => {
+  it("places Start Race before World Tour before Time Trial before Garage before Options in tab order", () => {
     const startIdx = html.indexOf('data-testid="menu-start-race"');
+    const worldIdx = html.indexOf('data-testid="menu-world"');
     const timeTrialIdx = html.indexOf('data-testid="menu-time-trial"');
     const garageIdx = html.indexOf('data-testid="menu-garage"');
     const optionsIdx = html.indexOf('data-testid="menu-options"');
     expect(startIdx).toBeGreaterThan(-1);
-    expect(timeTrialIdx).toBeGreaterThan(startIdx);
+    expect(worldIdx).toBeGreaterThan(startIdx);
+    expect(timeTrialIdx).toBeGreaterThan(worldIdx);
     expect(garageIdx).toBeGreaterThan(timeTrialIdx);
     expect(optionsIdx).toBeGreaterThan(garageIdx);
   });

--- a/src/app/garage/page.tsx
+++ b/src/app/garage/page.tsx
@@ -104,7 +104,7 @@ export default function GaragePage() {
           <Link href="/garage/upgrade" style={linkStyle} data-testid="garage-upgrade-link">
             Upgrades
           </Link>
-          <Link href="/race" style={primaryLinkStyle} data-testid="garage-next-race-link">
+          <Link href="/world" style={primaryLinkStyle} data-testid="garage-next-race-link">
             Next race
           </Link>
         </nav>
@@ -192,11 +192,11 @@ export default function GaragePage() {
           <aside style={panelStyle} data-testid="garage-next-card">
             <h2 style={sectionTitleStyle}>Next race</h2>
             <p style={mutedTextStyle}>
-              Use the race entry for the current smoke track until the
-              tour structure lands.
+              Pick the next World Tour event, then return here for repairs and
+              upgrades between races.
             </p>
-            <Link href="/race" style={primaryLinkStyle}>
-              Start race
+            <Link href="/world" style={primaryLinkStyle}>
+              Open world tour
             </Link>
           </aside>
         </div>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -7,13 +7,13 @@ import styles from "./page.module.css";
  * Title screen.
  *
  * Renders the top-level main menu items per GDD §5 and §20:
- * Start Race -> `/race`, Time Trial -> `/time-trial`, Garage ->
- * `/garage`, Options -> `/options`. The Options entry was a disabled placeholder
+ * Start Race -> `/race`, World Tour -> `/world`, Time Trial ->
+ * `/time-trial`, Garage -> `/garage`, Options -> `/options`. The Options entry was a disabled placeholder
  * (`menu-options-pending`) until the `/options` scaffold landed in
  * `VibeGear2-implement-options-screen-a9379c4a`. Its replacement keeps
  * the original `menu-options` test id that the e2e suite asserts on.
  *
- * Keyboard order is Start Race -> Time Trial -> Garage -> Options
+ * Keyboard order is Start Race -> World Tour -> Time Trial -> Garage -> Options
  * (DOM order).
  *
  * The footer carries two pieces of metadata. The pre-existing
@@ -33,6 +33,7 @@ interface MenuItem {
 
 const MENU: ReadonlyArray<MenuItem> = [
   { label: "Start Race", href: "/race", testId: "menu-start-race" },
+  { label: "World Tour", href: "/world", testId: "menu-world" },
   { label: "Time Trial", href: "/time-trial", testId: "menu-time-trial" },
   { label: "Garage", href: "/garage", testId: "menu-garage" },
   { label: "Options", href: "/options", testId: "menu-options" },

--- a/src/app/world/page.tsx
+++ b/src/app/world/page.tsx
@@ -118,6 +118,8 @@ export default function WorldPage() {
       {status.kind !== "idle" ? (
         <p
           data-testid="world-status"
+          role="status"
+          aria-live="polite"
           style={{
             ...statusStyle,
             color: status.kind === "error" ? "#ff9a9a" : "#9bd2ff",

--- a/src/app/world/page.tsx
+++ b/src/app/world/page.tsx
@@ -1,0 +1,322 @@
+"use client";
+
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+import type { CSSProperties } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
+
+import type { SaveGame } from "@/data/schemas";
+import { getChampionship } from "@/data/championships";
+import {
+  buildWorldTourView,
+  enterWorldTour,
+} from "@/components/world/worldTourState";
+import { defaultSave, loadSave, saveSave } from "@/persistence";
+
+interface PageStatus {
+  readonly kind: "idle" | "info" | "error";
+  readonly message: string;
+}
+
+const CHAMPIONSHIP_ID = "world-tour-standard";
+
+export default function WorldPage() {
+  const router = useRouter();
+  const [save, setSave] = useState<SaveGame | null>(null);
+  const [status, setStatus] = useState<PageStatus>({
+    kind: "idle",
+    message: "",
+  });
+
+  const championship = useMemo(() => getChampionship(CHAMPIONSHIP_ID), []);
+
+  useEffect(() => {
+    const outcome = loadSave();
+    if (outcome.kind === "loaded") {
+      setSave(outcome.save);
+      return;
+    }
+    setSave(defaultSave());
+    if (outcome.reason !== "missing" && outcome.reason !== "no-storage") {
+      setStatus({
+        kind: "info",
+        message: `Loaded default save (reason: ${outcome.reason}).`,
+      });
+    }
+  }, []);
+
+  const view = useMemo(
+    () => (save ? buildWorldTourView(save, championship) : null),
+    [championship, save],
+  );
+
+  const enter = useCallback(
+    (tourId: string) => {
+      if (!save) return;
+      const result = enterWorldTour(save, championship, tourId);
+      if (!result.ok) {
+        setStatus({
+          kind: "error",
+          message:
+            result.code === "tour_locked"
+              ? "That tour is locked."
+              : "That tour is not available.",
+        });
+        return;
+      }
+
+      const write = saveSave(result.save);
+      const nextSave =
+        write.kind === "ok"
+          ? { ...result.save, writeCounter: (result.save.writeCounter ?? 0) + 1 }
+          : result.save;
+      setSave(nextSave);
+
+      if (write.kind === "error") {
+        setStatus({
+          kind: "error",
+          message: `Save failed (${write.reason}); tour kept in memory only.`,
+        });
+        return;
+      }
+
+      router.push(
+        `/race?track=${encodeURIComponent(result.firstTrackId)}&tour=${encodeURIComponent(tourId)}&raceIndex=0`,
+      );
+    },
+    [championship, router, save],
+  );
+
+  if (!save || !view) {
+    return (
+      <main style={pageStyle} data-testid="world-page">
+        <h1>World Tour</h1>
+        <p data-testid="world-loading">Loading world tour</p>
+      </main>
+    );
+  }
+
+  return (
+    <main style={pageStyle} data-testid="world-page">
+      <header style={headerStyle}>
+        <div>
+          <h1 style={titleStyle}>{view.championshipName}</h1>
+          <p style={mutedTextStyle}>
+            {view.completedTourIds.length} of {view.cards.length} tours complete
+          </p>
+        </div>
+        <nav style={navStyle} aria-label="World actions">
+          <Link href="/garage" style={linkStyle} data-testid="world-garage-link">
+            Garage
+          </Link>
+          <Link href="/" style={linkStyle} data-testid="world-title-link">
+            Title
+          </Link>
+        </nav>
+      </header>
+
+      {status.kind !== "idle" ? (
+        <p
+          data-testid="world-status"
+          style={{
+            ...statusStyle,
+            color: status.kind === "error" ? "#ff9a9a" : "#9bd2ff",
+          }}
+        >
+          {status.message}
+        </p>
+      ) : null}
+
+      <ol style={tourGridStyle} data-testid="world-tour-list">
+        {view.cards.map((card) => {
+          const isLocked = card.state === "locked";
+          const statusText =
+            card.state === "completed"
+              ? "Completed"
+              : card.state === "available"
+                ? "Available"
+                : "Locked";
+          return (
+            <li key={card.id} style={tourCardStyle} data-testid={`world-tour-${card.id}`}>
+              <div style={tourHeaderStyle}>
+                <span style={tourIndexStyle}>{card.index + 1}</span>
+                <span
+                  style={{
+                    ...tourStatusStyle,
+                    borderColor:
+                      card.state === "locked"
+                        ? "#6f7788"
+                        : card.state === "completed"
+                          ? "#82d18f"
+                          : "#ffd166",
+                  }}
+                  data-testid={`world-tour-status-${card.id}`}
+                >
+                  {statusText}
+                </span>
+              </div>
+              <h2 style={sectionTitleStyle}>{card.name}</h2>
+              <dl style={summaryGridStyle}>
+                <div style={summaryRowStyle}>
+                  <dt>Races</dt>
+                  <dd>{card.trackCount}</dd>
+                </div>
+                <div style={summaryRowStyle}>
+                  <dt>Required standing</dt>
+                  <dd>Top {card.requiredStanding}</dd>
+                </div>
+                <div style={summaryRowStyle}>
+                  <dt>First race</dt>
+                  <dd data-testid={`world-tour-first-track-${card.id}`}>
+                    {card.firstTrackName}
+                  </dd>
+                </div>
+              </dl>
+              {card.lockedReason ? (
+                <p style={lockedReasonStyle} data-testid={`world-tour-lock-${card.id}`}>
+                  {card.lockedReason}
+                </p>
+              ) : null}
+              <button
+                type="button"
+                style={isLocked ? disabledButtonStyle : primaryButtonStyle}
+                disabled={isLocked}
+                title={card.lockedReason ?? `Enter ${card.name}`}
+                onClick={() => enter(card.id)}
+                data-testid={`world-tour-enter-${card.id}`}
+              >
+                Enter tour
+              </button>
+            </li>
+          );
+        })}
+      </ol>
+    </main>
+  );
+}
+
+const pageStyle: CSSProperties = {
+  minHeight: "100vh",
+  padding: "2rem",
+  color: "var(--fg, #ddd)",
+  background: "var(--bg, #111)",
+  fontFamily: "system-ui, sans-serif",
+};
+
+const headerStyle: CSSProperties = {
+  display: "flex",
+  justifyContent: "space-between",
+  alignItems: "flex-start",
+  gap: "1rem",
+  marginBottom: "1.5rem",
+  flexWrap: "wrap",
+};
+
+const titleStyle: CSSProperties = {
+  margin: 0,
+  fontSize: "2rem",
+};
+
+const sectionTitleStyle: CSSProperties = {
+  margin: "0.75rem 0 1rem",
+  fontSize: "1.25rem",
+};
+
+const mutedTextStyle: CSSProperties = {
+  margin: "0.25rem 0 0",
+  color: "#aab0bd",
+};
+
+const navStyle: CSSProperties = {
+  display: "flex",
+  gap: "0.75rem",
+  flexWrap: "wrap",
+};
+
+const linkStyle: CSSProperties = {
+  color: "#dfe8ff",
+  border: "1px solid #4f5f7a",
+  padding: "0.55rem 0.8rem",
+  textDecoration: "none",
+  background: "#172133",
+};
+
+const tourGridStyle: CSSProperties = {
+  display: "grid",
+  gridTemplateColumns: "repeat(auto-fit, minmax(240px, 1fr))",
+  gap: "1rem",
+  padding: 0,
+  margin: 0,
+  listStyle: "none",
+};
+
+const tourCardStyle: CSSProperties = {
+  border: "1px solid #2f3b4f",
+  background: "#151d2b",
+  padding: "1rem",
+  minHeight: "260px",
+  display: "flex",
+  flexDirection: "column",
+};
+
+const tourHeaderStyle: CSSProperties = {
+  display: "flex",
+  justifyContent: "space-between",
+  alignItems: "center",
+  gap: "0.75rem",
+};
+
+const tourIndexStyle: CSSProperties = {
+  width: "2rem",
+  height: "2rem",
+  display: "grid",
+  placeItems: "center",
+  background: "#26344b",
+  fontWeight: 700,
+};
+
+const tourStatusStyle: CSSProperties = {
+  border: "1px solid",
+  padding: "0.2rem 0.45rem",
+  fontSize: "0.85rem",
+  color: "#e8edf8",
+};
+
+const summaryGridStyle: CSSProperties = {
+  display: "grid",
+  gap: "0.5rem",
+  margin: "0 0 1rem",
+};
+
+const summaryRowStyle: CSSProperties = {
+  display: "flex",
+  justifyContent: "space-between",
+  gap: "1rem",
+};
+
+const lockedReasonStyle: CSSProperties = {
+  color: "#d1b48f",
+  margin: "auto 0 1rem",
+};
+
+const primaryButtonStyle: CSSProperties = {
+  marginTop: "auto",
+  border: "1px solid #f5c84c",
+  color: "#10131a",
+  background: "#ffd166",
+  padding: "0.7rem 0.9rem",
+  fontWeight: 700,
+  cursor: "pointer",
+};
+
+const disabledButtonStyle: CSSProperties = {
+  ...primaryButtonStyle,
+  borderColor: "#5c6370",
+  background: "#353b46",
+  color: "#969da8",
+  cursor: "not-allowed",
+};
+
+const statusStyle: CSSProperties = {
+  margin: "0 0 1rem",
+};

--- a/src/components/world/__tests__/worldTourState.test.ts
+++ b/src/components/world/__tests__/worldTourState.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, it } from "vitest";
+
+import type { Championship, SaveGame } from "@/data/schemas";
+import { defaultSave } from "@/persistence/save";
+
+import {
+  buildWorldTourView,
+  enterWorldTour,
+  withFirstTourUnlocked,
+} from "../worldTourState";
+
+const CHAMPIONSHIP: Championship = {
+  id: "world-tour-standard",
+  name: "World Tour",
+  difficultyPreset: "normal",
+  tours: [
+    {
+      id: "velvet-coast",
+      requiredStanding: 4,
+      tracks: [
+        "velvet-coast/harbor-run",
+        "velvet-coast/sunpier-loop",
+        "velvet-coast/cliffline-arc",
+        "velvet-coast/lighthouse-fall",
+      ],
+    },
+    {
+      id: "iron-borough",
+      requiredStanding: 4,
+      tracks: [
+        "iron-borough/freightline-ring",
+        "iron-borough/rivet-tunnel",
+        "iron-borough/foundry-mile",
+        "iron-borough/outer-exchange",
+      ],
+    },
+  ],
+};
+
+function freshSave(): SaveGame {
+  return JSON.parse(JSON.stringify(defaultSave())) as SaveGame;
+}
+
+describe("buildWorldTourView", () => {
+  it("treats the first tour as enterable for a fresh save", () => {
+    const view = buildWorldTourView(freshSave(), CHAMPIONSHIP);
+
+    expect(view.unlockedTourIds).toEqual(["velvet-coast"]);
+    expect(view.cards[0]).toMatchObject({
+      id: "velvet-coast",
+      name: "Velvet Coast",
+      firstTrackId: "velvet-coast/harbor-run",
+      firstTrackName: "Harbor Run",
+      state: "available",
+      lockedReason: null,
+    });
+  });
+
+  it("locks later tours with a gating-tour reason", () => {
+    const view = buildWorldTourView(freshSave(), CHAMPIONSHIP);
+
+    expect(view.cards[1]).toMatchObject({
+      id: "iron-borough",
+      state: "locked",
+      lockedReason: "Complete Velvet Coast to unlock this tour.",
+    });
+  });
+
+  it("marks completed tours separately from merely unlocked tours", () => {
+    const save = freshSave();
+    save.progress.unlockedTours = ["velvet-coast", "iron-borough"];
+    save.progress.completedTours = ["velvet-coast"];
+
+    const view = buildWorldTourView(save, CHAMPIONSHIP);
+
+    expect(view.cards[0]?.state).toBe("completed");
+    expect(view.cards[1]?.state).toBe("available");
+  });
+});
+
+describe("enterWorldTour", () => {
+  it("persists the first-tour unlock before entering a fresh save", () => {
+    const save = freshSave();
+    const result = enterWorldTour(save, CHAMPIONSHIP, "velvet-coast");
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.save.progress.unlockedTours).toEqual(["velvet-coast"]);
+    expect(result.activeTour).toEqual({
+      tourId: "velvet-coast",
+      raceIndex: 0,
+      results: [],
+    });
+    expect(result.firstTrackId).toBe("velvet-coast/harbor-run");
+  });
+
+  it("rejects locked tours without mutating the input save", () => {
+    const save = freshSave();
+    const before = JSON.parse(JSON.stringify(save));
+
+    const result = enterWorldTour(save, CHAMPIONSHIP, "iron-borough");
+
+    expect(result).toEqual({ ok: false, code: "tour_locked" });
+    expect(save).toEqual(before);
+  });
+
+  it("does not duplicate the first tour in an already-unlocked save", () => {
+    const save = freshSave();
+    save.progress.unlockedTours = ["velvet-coast"];
+
+    expect(withFirstTourUnlocked(save, CHAMPIONSHIP).progress.unlockedTours).toEqual([
+      "velvet-coast",
+    ]);
+  });
+});

--- a/src/components/world/__tests__/worldTourState.test.ts
+++ b/src/components/world/__tests__/worldTourState.test.ts
@@ -104,6 +104,18 @@ describe("enterWorldTour", () => {
     expect(save).toEqual(before);
   });
 
+  it("rejects a malformed tour with no first track instead of routing to a fallback", () => {
+    const save = freshSave();
+    const malformed: Championship = {
+      ...CHAMPIONSHIP,
+      tours: [{ ...CHAMPIONSHIP.tours[0]!, tracks: [] }],
+    };
+
+    const result = enterWorldTour(save, malformed, "velvet-coast");
+
+    expect(result).toEqual({ ok: false, code: "unknown_tour" });
+  });
+
   it("does not duplicate the first tour in an already-unlocked save", () => {
     const save = freshSave();
     save.progress.unlockedTours = ["velvet-coast"];

--- a/src/components/world/worldTourState.ts
+++ b/src/components/world/worldTourState.ts
@@ -1,0 +1,138 @@
+import type { Championship, ChampionshipTour, SaveGame } from "@/data/schemas";
+import { enterTour, type EnterTourResult } from "@/game/championship";
+
+export type WorldTourCardState = "available" | "locked" | "completed";
+
+export interface WorldTourCard {
+  readonly id: string;
+  readonly name: string;
+  readonly index: number;
+  readonly requiredStanding: number;
+  readonly trackCount: number;
+  readonly firstTrackId: string;
+  readonly firstTrackName: string;
+  readonly state: WorldTourCardState;
+  readonly lockedReason: string | null;
+}
+
+export interface WorldTourView {
+  readonly championshipId: string;
+  readonly championshipName: string;
+  readonly unlockedTourIds: ReadonlyArray<string>;
+  readonly completedTourIds: ReadonlyArray<string>;
+  readonly cards: ReadonlyArray<WorldTourCard>;
+}
+
+export type EnterWorldTourResult =
+  | (Extract<EnterTourResult, { ok: true }> & {
+      readonly firstTrackId: string;
+      readonly firstTrackName: string;
+    })
+  | Extract<EnterTourResult, { ok: false }>;
+
+export function buildWorldTourView(
+  save: SaveGame,
+  championship: Championship,
+): WorldTourView {
+  const unlocked = effectiveUnlockedTourIds(save, championship);
+  const completed = new Set(save.progress.completedTours);
+
+  return {
+    championshipId: championship.id,
+    championshipName: championship.name,
+    unlockedTourIds: unlocked,
+    completedTourIds: save.progress.completedTours,
+    cards: championship.tours.map((tour, index) =>
+      buildTourCard(tour, index, unlocked, completed, championship),
+    ),
+  };
+}
+
+export function enterWorldTour(
+  save: SaveGame,
+  championship: Championship,
+  tourId: string,
+): EnterWorldTourResult {
+  const normalized = withFirstTourUnlocked(save, championship);
+  const result = enterTour(normalized, championship, tourId);
+  if (!result.ok) return result;
+  const tour = championship.tours.find((candidate) => candidate.id === tourId);
+  if (!tour) return { ok: false, code: "unknown_tour" };
+  return {
+    ...result,
+    save: withFirstTourUnlocked(result.save, championship),
+    firstTrackId: tour.tracks[0] ?? "",
+    firstTrackName: formatTrackName(tour.tracks[0] ?? ""),
+  };
+}
+
+export function withFirstTourUnlocked(
+  save: SaveGame,
+  championship: Championship,
+): SaveGame {
+  const firstTourId = championship.tours[0]?.id;
+  if (!firstTourId || save.progress.unlockedTours.includes(firstTourId)) {
+    return save;
+  }
+  return {
+    ...save,
+    progress: {
+      ...save.progress,
+      unlockedTours: [firstTourId, ...save.progress.unlockedTours],
+    },
+  };
+}
+
+function buildTourCard(
+  tour: ChampionshipTour,
+  index: number,
+  unlocked: ReadonlyArray<string>,
+  completed: ReadonlySet<string>,
+  championship: Championship,
+): WorldTourCard {
+  const firstTrackId = tour.tracks[0] ?? "";
+  const isCompleted = completed.has(tour.id);
+  const isUnlocked = unlocked.includes(tour.id);
+  return {
+    id: tour.id,
+    name: formatTourName(tour.id),
+    index,
+    requiredStanding: tour.requiredStanding,
+    trackCount: tour.tracks.length,
+    firstTrackId,
+    firstTrackName: formatTrackName(firstTrackId),
+    state: isCompleted ? "completed" : isUnlocked ? "available" : "locked",
+    lockedReason: isUnlocked
+      ? null
+      : lockedReasonForTour(championship, index),
+  };
+}
+
+function effectiveUnlockedTourIds(
+  save: SaveGame,
+  championship: Championship,
+): ReadonlyArray<string> {
+  return withFirstTourUnlocked(save, championship).progress.unlockedTours;
+}
+
+function lockedReasonForTour(
+  championship: Championship,
+  index: number,
+): string {
+  const previousTour = championship.tours[index - 1];
+  if (!previousTour) return "Complete the previous tour to unlock this tour.";
+  return `Complete ${formatTourName(previousTour.id)} to unlock this tour.`;
+}
+
+function formatTourName(id: string): string {
+  return id
+    .split("-")
+    .filter(Boolean)
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+    .join(" ");
+}
+
+function formatTrackName(id: string): string {
+  const leaf = id.split("/").at(-1) ?? id;
+  return formatTourName(leaf);
+}

--- a/src/components/world/worldTourState.ts
+++ b/src/components/world/worldTourState.ts
@@ -58,11 +58,13 @@ export function enterWorldTour(
   if (!result.ok) return result;
   const tour = championship.tours.find((candidate) => candidate.id === tourId);
   if (!tour) return { ok: false, code: "unknown_tour" };
+  const firstTrackId = tour.tracks[0];
+  if (!firstTrackId) return { ok: false, code: "unknown_tour" };
   return {
     ...result,
     save: withFirstTourUnlocked(result.save, championship),
-    firstTrackId: tour.tracks[0] ?? "",
-    firstTrackName: formatTrackName(tour.tracks[0] ?? ""),
+    firstTrackId,
+    firstTrackName: formatTrackName(firstTrackId),
   };
 }
 


### PR DESCRIPTION
## GDD sections
- docs/gdd/05-core-gameplay-loop.md
- docs/gdd/08-world-and-progression-design.md
- docs/gdd/22-data-schemas.md
- docs/gdd/24-content-plan.md

## Requirement inventory
- Adds /world as the World Tour entry hub.
- Renders one card per canonical championship tour.
- Treats Velvet Coast as enterable for fresh saves and persists that first-tour unlock on entry.
- Disables locked tours with a reason naming the gating tour.
- Routes the selected tour first track id to /race.
- Routes Garage Next race through /world.

Nearby requirements left to followup:
- F-065 covers active tour state across all four races, aggregate standings, failure retry, unlockNextTour on pass, and the full tour e2e.

## Progress log
- docs/PROGRESS_LOG.md: World tour entry hub

## Test plan
- [x] npx vitest run src/components/world/__tests__/worldTourState.test.ts src/app/__tests__/page.test.tsx
- [x] npm run typecheck
- [x] npm run lint
- [x] npm run test:e2e -- e2e/world-tour.spec.ts e2e/title-screen.spec.ts e2e/garage-flow.spec.ts
- [x] npm run verify
- [x] npm run content-lint
- [x] git diff --check
- [x] grep -rn $'\\u2014\\|\\u2013' src/components/world src/app/world src/app/page.tsx src/app/__tests__/page.test.tsx src/app/garage/page.tsx e2e/world-tour.spec.ts e2e/title-screen.spec.ts e2e/garage-flow.spec.ts docs/GDD_COVERAGE.json docs/FOLLOWUPS.md docs/PROGRESS_LOG.md || true\n