### PR TITLE
feat(world): persist active tour progression

### DIFF
--- a/docs/FOLLOWUPS.md
+++ b/docs/FOLLOWUPS.md
@@ -13,7 +13,7 @@ or `obsolete` so the trail is preserved.
 ## F-065: Persist active tour race progression through the four-race World Tour loop
 **Created:** 2026-04-28
 **Priority:** blocks-release
-**Status:** open
+**Status:** done (2026-04-28)
 **Notes:** The `/world` hub now renders the canonical championship,
 normalizes a fresh save so Velvet Coast is enterable, persists tour
 entry, and sends the selected tour's first track id to `/race`. The
@@ -22,6 +22,12 @@ Wire the results screen to carry active tour state between races,
 record each race result, show aggregate standings after race four,
 call `unlockNextTour` on pass, and add `e2e/tour-flow.spec.ts` for the
 full Velvet Coast to Iron Borough unlock path.
+
+Closed by `feat/f-065-active-tour-progression`. Tour entry now persists
+`progress.activeTour`, race finish advances or clears the active cursor,
+the results screen links to the next tour race and reports tour-clear
+state, passing the fourth Velvet Coast race unlocks Iron Borough, and
+Playwright covers the final Velvet Coast to Iron Borough unlock path.
 
 ## F-064: Persist race damage into the garage repair queue
 **Created:** 2026-04-28

--- a/docs/GDD_COVERAGE.json
+++ b/docs/GDD_COVERAGE.json
@@ -87,6 +87,33 @@
       ]
     },
     {
+      "id": "GDD-08-TOUR-PROGRESSION",
+      "gddSections": [
+        "docs/gdd/05-core-gameplay-loop.md",
+        "docs/gdd/08-world-and-progression-design.md",
+        "docs/gdd/22-data-schemas.md"
+      ],
+      "requirement": "World Tour race results persist active tour progress, advance to the next race, aggregate tour completion, clear the active cursor, and unlock the next tour on pass.",
+      "coverage": ["implemented-code", "automated-test"],
+      "implementationRefs": [
+        "src/app/race/page.tsx",
+        "src/app/race/results/page.tsx",
+        "src/components/world/worldTourState.ts",
+        "src/game/tourProgress.ts",
+        "src/game/championship.ts",
+        "src/game/raceResult.ts",
+        "src/data/schemas.ts"
+      ],
+      "testRefs": [
+        "src/game/__tests__/tourProgress.test.ts",
+        "src/game/__tests__/raceResult.test.ts",
+        "src/components/world/__tests__/worldTourState.test.ts",
+        "src/data/schemas.test.ts",
+        "e2e/tour-flow.spec.ts",
+        "e2e/results-screen.spec.ts"
+      ]
+    },
+    {
       "id": "GDD-08-WORLD-TOUR-HUB",
       "gddSections": [
         "docs/gdd/08-world-and-progression-design.md",
@@ -105,8 +132,7 @@
         "src/components/world/__tests__/worldTourState.test.ts",
         "e2e/world-tour.spec.ts",
         "e2e/title-screen.spec.ts"
-      ],
-      "followupRefs": ["F-065"]
+      ]
     },
     {
       "id": "GDD-12-GARAGE-UPGRADE-PURCHASE",

--- a/docs/PROGRESS_LOG.md
+++ b/docs/PROGRESS_LOG.md
@@ -6,6 +6,67 @@ Correct them by adding a new entry that references the old one.
 
 ---
 
+## 2026-04-28: Slice: F-065 active tour progression
+
+**GDD sections touched:**
+[§5](gdd/05-core-gameplay-loop.md) race to results loop,
+[§8](gdd/08-world-and-progression-design.md) tour unlock structure,
+[§20](gdd/20-hud-and-ui-ux.md) results next-race flow,
+[§22](gdd/22-data-schemas.md) save progress fields.
+**Branch / PR:** `feat/f-065-active-tour-progression`, PR pending.
+**Status:** Implemented.
+
+### Done
+- `src/data/schemas.ts`: added optional `progress.activeTour` with the
+  persisted tour cursor and recorded per-race outcomes.
+- `src/components/world/worldTourState.ts`: persists the seeded active
+  tour when the player enters a tour.
+- `src/game/tourProgress.ts`: added the pure active-tour commit helper
+  that advances races one through three, clears the cursor after race
+  four, and unlocks the next tour on pass.
+- `src/app/race/page.tsx`: resolves tour race URLs against planned
+  championship track ids, uses the temporary straight-track runtime
+  placeholder for unimplemented tour tracks, and applies tour progress
+  during natural finish and retire commits.
+- `src/app/race/results/page.tsx`: shows tour completion state and adds
+  the Continue tour action when another tour race is queued.
+- `e2e/tour-flow.spec.ts`: covers the final Velvet Coast race unlocking
+  Iron Borough.
+- `docs/FOLLOWUPS.md`: marked F-065 done.
+- `docs/GDD_COVERAGE.json`: added GDD-08-TOUR-PROGRESSION coverage.
+
+### Verified
+- `npx vitest run src/game/__tests__/tourProgress.test.ts src/game/__tests__/raceResult.test.ts src/components/world/__tests__/worldTourState.test.ts src/data/schemas.test.ts`
+  green, 115 passed.
+- `npm run typecheck` clean.
+- `npm run lint` clean.
+- `npm run verify` green: lint, typecheck, unit tests, and
+  content-lint all passed; 2,220 unit tests passed.
+- `npm run test:e2e -- e2e/results-screen.spec.ts e2e/world-tour.spec.ts e2e/tour-flow.spec.ts`
+  green, 7 passed.
+
+### Decisions and assumptions
+- Planned World Tour track ids are preserved in results and URLs even
+  before all 32 track JSON files exist. The race runtime temporarily
+  runs unresolved tour tracks on `test/straight` so tour progression can
+  ship without blocking on track content.
+- Tour completion bonus wiring reads the persisted per-race cash ledger
+  from `progress.activeTour.results`, so the fourth-race completion
+  bonus is based on all completed tour races.
+
+### Coverage ledger
+- Added GDD-08-TOUR-PROGRESSION with unit and Playwright coverage.
+- GDD-08-WORLD-TOUR-HUB no longer has F-065 as an open followup.
+- Uncovered adjacent requirements: full authored World Tour track JSON
+  and richer tour standings UI remain future slices.
+
+### Followups created
+None.
+
+### GDD edits
+- Updated [§22](gdd/22-data-schemas.md) with the optional
+  `progress.activeTour` save shape.
+
 ## 2026-04-28: Slice: World tour entry hub
 
 **GDD sections touched:**

--- a/docs/gdd/22-data-schemas.md
+++ b/docs/gdd/22-data-schemas.md
@@ -216,7 +216,19 @@ the new `ghosts` map is filled with `{}`.
   },
   "progress": {
     "unlockedTours": ["velvet-coast", "iron-borough"],
-    "completedTours": ["velvet-coast"]
+    "completedTours": ["velvet-coast"],
+    "activeTour": {
+      "tourId": "iron-borough",
+      "raceIndex": 1,
+      "results": [
+        {
+          "trackId": "iron-borough/freightline-ring",
+          "placement": 2,
+          "dnf": false,
+          "cashEarned": 1800
+        }
+      ]
+    }
   },
   "records": {
     "velvet-coast/harbor-run": {
@@ -242,6 +254,13 @@ older v3 saves still validate; a fully fresh save seeds it to `{}`.
 `garage.lastRaceCashEarned` is the previous credited race payout used by
 the §12 essential-repair cap. It is optional for older saves and seeded
 to `0` on fresh saves.
+
+`progress.activeTour` is optional and exists only while a four-race tour
+is in progress. `raceIndex` points at the next tour race to run, and
+`results` stores completed race outcomes in order, including the cash
+receipt used by the tour-clear bonus, so the results screen can resume,
+aggregate standings, unlock the next tour on pass, and clear the cursor
+after the fourth race.
 
 `writeCounter` is the cross-tab last-write-wins advisory described in
 `docs/gdd/21-technical-design-for-web-implementation.md` "Cross-tab

--- a/e2e/results-screen.spec.ts
+++ b/e2e/results-screen.spec.ts
@@ -64,6 +64,21 @@ const SEED_RESULT = {
   recordsUpdated: { trackId: "test-circuit", bestLapMs: 30_000 },
 };
 
+const SEED_TOUR_RESULT = {
+  ...SEED_RESULT,
+  trackId: "velvet-coast/harbor-run",
+  nextRace: { trackId: "velvet-coast/sunpier-loop", laps: 3 },
+  tourProgress: {
+    tourId: "velvet-coast",
+    raceIndex: 0,
+    nextRaceIndex: 1,
+    completed: false,
+    passed: null,
+    playerStanding: null,
+    unlockedTourId: null,
+  },
+};
+
 test.describe("race results screen", () => {
   test("renders all seven §20 fields and both CTAs", async ({ page }) => {
     await page.goto("/race/results");
@@ -156,6 +171,25 @@ test.describe("race results screen", () => {
     await expect(page.getByTestId("results-cta-continue")).toBeVisible();
     await page.getByTestId("results-cta-continue").click();
     await expect(page).toHaveURL(/\/garage$/);
+  });
+
+  test("Continue tour CTA routes to the next tour race", async ({ page }) => {
+    await page.goto("/race/results");
+    await page.evaluate(
+      ([key, payload]) => {
+        sessionStorage.setItem(key, payload);
+      },
+      [STORAGE_KEY, JSON.stringify(SEED_TOUR_RESULT)] as const,
+    );
+    await page.reload();
+
+    const continueTour = page.getByTestId("results-cta-continue-tour");
+    await expect(continueTour).toBeVisible();
+    await expect(continueTour).toBeFocused();
+    await continueTour.click();
+    await expect(page).toHaveURL(
+      /\/race\?track=velvet-coast%2Fsunpier-loop&tour=velvet-coast&raceIndex=1$/,
+    );
   });
 
   test("direct nav with no result renders the empty fallback", async ({

--- a/e2e/tour-flow.spec.ts
+++ b/e2e/tour-flow.spec.ts
@@ -1,0 +1,137 @@
+import { expect, test } from "@playwright/test";
+
+const SAVE_KEY = "vibegear2:save:v3";
+
+test.describe("World Tour race progression", () => {
+  test("final Velvet Coast race unlocks Iron Borough", async ({ page }) => {
+    test.setTimeout(70_000);
+
+    await page.goto("/");
+    await page.evaluate(
+      ({ key, save }) => window.localStorage.setItem(key, JSON.stringify(save)),
+      { key: SAVE_KEY, save: buildFinalRaceSave() },
+    );
+
+    await page.goto(
+      "/race?track=velvet-coast%2Flighthouse-fall&tour=velvet-coast&raceIndex=3",
+    );
+
+    const canvas = page.getByTestId("race-canvas-element");
+    await expect(canvas).toBeVisible();
+    await expect(page.getByTestId("race-canvas")).toHaveAttribute(
+      "data-track",
+      "velvet-coast/lighthouse-fall",
+    );
+    await expect(page.getByTestId("race-phase")).toHaveText("racing", {
+      timeout: 10_000,
+    });
+
+    await canvas.focus();
+    await page.keyboard.down("ArrowUp");
+    await expect(page).toHaveURL(/\/race\/results/, { timeout: 45_000 });
+    await page.keyboard.up("ArrowUp");
+
+    await expect(page.getByTestId("results-tour-complete")).toContainText(
+      "Tour complete",
+    );
+    await expect(page.getByTestId("results-tour-complete")).toContainText(
+      "Iron Borough",
+    );
+
+    const persisted = await page.evaluate((key) => {
+      const raw = window.localStorage.getItem(key);
+      return raw
+        ? (JSON.parse(raw) as {
+            progress?: {
+              activeTour?: unknown;
+              completedTours?: string[];
+              unlockedTours?: string[];
+            };
+          })
+        : null;
+    }, SAVE_KEY);
+
+    expect(persisted?.progress?.activeTour).toBeUndefined();
+    expect(persisted?.progress?.completedTours).toContain("velvet-coast");
+    expect(persisted?.progress?.unlockedTours).toContain("iron-borough");
+
+    await page.goto("/world");
+    await expect(page.getByTestId("world-tour-status-iron-borough")).toHaveText(
+      "Available",
+    );
+  });
+});
+
+function buildFinalRaceSave() {
+  return {
+    version: 3,
+    profileName: "TourFlowTester",
+    settings: {
+      displaySpeedUnit: "kph",
+      assists: {
+        steeringAssist: false,
+        autoNitro: false,
+        weatherVisualReduction: false,
+      },
+      difficultyPreset: "normal",
+      transmissionMode: "auto",
+      audio: { master: 1, music: 1, sfx: 1 },
+      accessibility: {
+        colorBlindMode: "off",
+        reducedMotion: false,
+        largeUiText: false,
+        screenShakeScale: 1,
+      },
+    },
+    garage: {
+      credits: 5000,
+      ownedCars: ["sparrow-gt"],
+      activeCarId: "sparrow-gt",
+      installedUpgrades: {
+        "sparrow-gt": {
+          engine: 0,
+          gearbox: 0,
+          dryTires: 0,
+          wetTires: 0,
+          nitro: 0,
+          armor: 0,
+          cooling: 0,
+          aero: 0,
+        },
+      },
+      pendingDamage: {},
+      lastRaceCashEarned: 0,
+    },
+    progress: {
+      unlockedTours: ["velvet-coast"],
+      completedTours: [],
+      activeTour: {
+        tourId: "velvet-coast",
+        raceIndex: 3,
+        results: [
+          {
+            trackId: "velvet-coast/harbor-run",
+            placement: 1,
+            dnf: false,
+            cashEarned: 1000,
+          },
+          {
+            trackId: "velvet-coast/sunpier-loop",
+            placement: 1,
+            dnf: false,
+            cashEarned: 1000,
+          },
+          {
+            trackId: "velvet-coast/cliffline-arc",
+            placement: 1,
+            dnf: false,
+            cashEarned: 1000,
+          },
+        ],
+      },
+    },
+    records: {},
+    ghosts: {},
+    writeCounter: 0,
+  };
+}

--- a/src/app/race/page.tsx
+++ b/src/app/race/page.tsx
@@ -41,7 +41,7 @@ import { readKeyBindings } from "@/components/options/controlsPaneState";
 import { usePauseActions } from "@/components/pause/usePauseActions";
 import { usePauseToggle } from "@/components/pause/usePauseToggle";
 import { saveRaceResult } from "@/components/results/raceResultStorage";
-import { TRACK_IDS, TRACK_RAW, loadTrack } from "@/data";
+import { TRACK_IDS, TRACK_RAW, getChampionship, loadTrack } from "@/data";
 import carsAtlasFixture from "@/data/atlas/cars.json";
 import { AtlasMetaSchema, TrackSchema, type Track } from "@/data/schemas";
 import {
@@ -59,6 +59,7 @@ import {
   pendingDamageForActiveCar,
   applyRaceDamageToGarage,
   applyRaceResultRecords,
+  applyTourRaceResult,
   retireRaceSession,
   startLoop,
   stepRaceSession,
@@ -102,6 +103,8 @@ import { PRISTINE_DAMAGE_STATE, type DamageState } from "@/game/damage";
 const VIEWPORT_WIDTH = 800;
 const VIEWPORT_HEIGHT = 480;
 const DEFAULT_TRACK_ID = "test/elevation";
+const TOUR_PLACEHOLDER_TRACK_ID = "test/straight";
+const WORLD_TOUR_CHAMPIONSHIP_ID = "world-tour-standard";
 const PLAYER_ID = "player";
 const CARS_ATLAS_META = AtlasMetaSchema.parse(carsAtlasFixture);
 
@@ -223,14 +226,49 @@ const DEMO_DRIVER: AIDriver = Object.freeze({
 
 interface ResolvedTrack {
   id: string;
+  runtimeId: string;
   version: number;
   compiled: CompiledTrack;
 }
 
-function resolveTrack(requestedId: string | null): ResolvedTrack {
-  const id = requestedId && TRACK_IDS.includes(requestedId) ? requestedId : DEFAULT_TRACK_ID;
-  const parsed = TrackSchema.parse(TRACK_RAW[id]);
-  return { id, version: parsed.version, compiled: loadTrack(id) };
+interface TourRaceContext {
+  championship: ReturnType<typeof getChampionship>;
+  tourId: string;
+  raceIndex: number;
+  plannedTrackId: string;
+}
+
+function resolveTourRaceContext(
+  tourId: string | null,
+  raceIndexRaw: string | null,
+): TourRaceContext | null {
+  if (!tourId) return null;
+  const championship = getChampionship(WORLD_TOUR_CHAMPIONSHIP_ID);
+  const tour = championship.tours.find((candidate) => candidate.id === tourId);
+  if (!tour) return null;
+  const raceIndex =
+    raceIndexRaw === null ? 0 : Number.parseInt(raceIndexRaw, 10);
+  if (!Number.isInteger(raceIndex) || raceIndex < 0) return null;
+  const plannedTrackId = tour.tracks[raceIndex];
+  if (!plannedTrackId) return null;
+  return { championship, tourId, raceIndex, plannedTrackId };
+}
+
+function resolveTrack(
+  requestedId: string | null,
+  tourContext: TourRaceContext | null,
+): ResolvedTrack {
+  const knownId =
+    requestedId && TRACK_IDS.includes(requestedId) ? requestedId : null;
+  const useTourPlaceholder =
+    knownId === null &&
+    requestedId !== null &&
+    tourContext !== null &&
+    requestedId === tourContext.plannedTrackId;
+  const runtimeId = knownId ?? (useTourPlaceholder ? TOUR_PLACEHOLDER_TRACK_ID : DEFAULT_TRACK_ID);
+  const id = useTourPlaceholder ? requestedId : runtimeId;
+  const parsed = TrackSchema.parse(TRACK_RAW[runtimeId]);
+  return { id, runtimeId, version: parsed.version, compiled: loadTrack(runtimeId) };
 }
 
 type RaceMode = "race" | "timeTrial";
@@ -303,8 +341,20 @@ function commitRaceCredits(input: {
   baseTrackReward: number;
   damageAfter?: Readonly<DamageState>;
   activeCarId?: string | null;
+  transformCommit?: (save: SaveGame, result: RaceResult) => {
+    readonly save: SaveGame;
+    readonly result: RaceResult;
+  };
 }): RaceResult {
-  const { result, save, difficulty, baseTrackReward, damageAfter, activeCarId } = input;
+  const {
+    result,
+    save,
+    difficulty,
+    baseTrackReward,
+    damageAfter,
+    activeCarId,
+    transformCommit,
+  } = input;
   const playerRecord = result.finishingOrder.find(
     (record) => record.carId === result.playerCarId,
   );
@@ -343,12 +393,18 @@ function commitRaceCredits(input: {
           damage: damageAfter,
           lastRaceCashEarned: award.cashEarned ?? 0,
         });
-  saveSave(nextSave);
-
-  return {
+  const creditedResult = {
     ...result,
     creditsAwarded: award.cashEarned ?? 0,
   };
+  const transformed =
+    transformCommit?.(nextSave, creditedResult) ?? {
+      save: nextSave,
+      result: creditedResult,
+    };
+  saveSave(transformed.save);
+
+  return transformed.result;
 }
 
 export default function RacePage(): ReactElement {
@@ -374,19 +430,41 @@ function RaceShell(): ReactElement {
   const requestedId = search?.get("track") ?? null;
   const lapsRaw = search?.get("laps") ?? null;
   const modeRaw = search?.get("mode") ?? null;
-  const track = useMemo(() => resolveTrack(requestedId), [requestedId]);
+  const tourId = search?.get("tour") ?? null;
+  const raceIndexRaw = search?.get("raceIndex") ?? null;
+  const tourContext = useMemo(
+    () => resolveTourRaceContext(tourId, raceIndexRaw),
+    [tourId, raceIndexRaw],
+  );
+  const track = useMemo(
+    () => resolveTrack(requestedId, tourContext),
+    [requestedId, tourContext],
+  );
   const lapsOverride = useMemo(() => resolveLapsOverride(lapsRaw), [lapsRaw]);
   const mode = useMemo(() => resolveRaceMode(modeRaw), [modeRaw]);
-  return <RaceCanvas track={track} lapsOverride={lapsOverride} mode={mode} />;
+  return (
+    <RaceCanvas
+      track={track}
+      lapsOverride={lapsOverride}
+      mode={mode}
+      tourContext={tourContext}
+    />
+  );
 }
 
 interface RaceCanvasProps {
   track: ResolvedTrack;
   lapsOverride: number | null;
   mode: RaceMode;
+  tourContext: TourRaceContext | null;
 }
 
-function RaceCanvas({ track, lapsOverride, mode }: RaceCanvasProps): ReactElement {
+function RaceCanvas({
+  track,
+  lapsOverride,
+  mode,
+  tourContext,
+}: RaceCanvasProps): ReactElement {
   const router = useRouter();
   const canvasRef = useRef<HTMLCanvasElement | null>(null);
   const handleRef = useRef<LoopHandle | null>(null);
@@ -644,6 +722,9 @@ function RaceCanvas({ track, lapsOverride, mode }: RaceCanvasProps): ReactElemen
         damageBefore: damageDeltaFromState(initialPlayerDamage),
         damageAfter: damageDeltaFromState(retired.player.damage),
         recordPBs: false,
+        championship: tourContext?.championship,
+        tourId: tourContext?.tourId,
+        currentTrackIndex: tourContext?.raceIndex,
       });
       // F-034: credit the wallet (DNF cars receive the §12 participation
       // cash) and mirror the delta onto `RaceResult.creditsAwarded` so
@@ -659,6 +740,16 @@ function RaceCanvas({ track, lapsOverride, mode }: RaceCanvasProps): ReactElemen
             baseTrackReward: baseRewardForTrackDifficulty(track.compiled.difficulty),
             damageAfter: retired.player.damage,
             activeCarId: save.garage.activeCarId,
+            transformCommit:
+              tourContext === null
+                ? undefined
+                : (nextSave, nextResult) =>
+                    applyTourRaceResult({
+                      save: nextSave,
+                      result: nextResult,
+                      championship: tourContext.championship,
+                      playerCarId: save.garage.activeCarId,
+                    }),
           });
       saveRaceResult(committed);
       // Flip the natural-finish guard so the render callback's finish
@@ -853,6 +944,9 @@ function RaceCanvas({ track, lapsOverride, mode }: RaceCanvasProps): ReactElemen
               damageBefore: damageDeltaFromState(initialPlayerDamage),
               damageAfter: damageDeltaFromState(session.player.damage),
               recordPBs: session.player.status === "finished",
+              championship: tourContext?.championship,
+              tourId: tourContext?.tourId,
+              currentTrackIndex: tourContext?.raceIndex,
             });
             // F-034: credit the wallet from the same numbers the
             // results screen will render. The `commitRaceCredits`
@@ -871,6 +965,16 @@ function RaceCanvas({ track, lapsOverride, mode }: RaceCanvasProps): ReactElemen
                   ),
                   damageAfter: session.player.damage,
                   activeCarId: save.garage.activeCarId,
+                  transformCommit:
+                    tourContext === null
+                      ? undefined
+                      : (nextSave, nextResult) =>
+                          applyTourRaceResult({
+                            save: nextSave,
+                            result: nextResult,
+                            championship: tourContext.championship,
+                            playerCarId: save.garage.activeCarId,
+                          }),
                 });
             saveRaceResult(committed);
             // Tear down the loop / input before the route hop so the
@@ -898,7 +1002,7 @@ function RaceCanvas({ track, lapsOverride, mode }: RaceCanvasProps): ReactElemen
       sessionRef.current = null;
       inputManager.dispose();
     };
-  }, [track, router, lapsOverride, initialTotalLaps, mode]);
+  }, [track, router, lapsOverride, initialTotalLaps, mode, tourContext]);
 
   return (
     <main

--- a/src/app/race/results/page.tsx
+++ b/src/app/race/results/page.tsx
@@ -134,6 +134,20 @@ function ResultsView(props: ResultsViewProps): ReactElement {
   );
   const playerFinished = playerRow?.status === "finished";
   const playerBestLapMs = playerRow?.bestLapMs ?? null;
+  const tourProgress = result.tourProgress ?? null;
+  const continueTourHref =
+    result.nextRace && tourProgress && tourProgress.nextRaceIndex !== null
+      ? `/race?track=${encodeURIComponent(
+          result.nextRace.trackId,
+        )}&tour=${encodeURIComponent(tourProgress.tourId)}&raceIndex=${
+          tourProgress.nextRaceIndex
+        }`
+      : null;
+  const tourCompleteLabel = tourProgress?.completed
+    ? tourProgress.passed
+      ? `Tour complete. Standing ${tourProgress.playerStanding ?? "?"}.`
+      : `Tour failed. Standing ${tourProgress.playerStanding ?? "?"}.`
+    : null;
 
   return (
     <main
@@ -219,6 +233,14 @@ function ResultsView(props: ResultsViewProps): ReactElement {
               No upcoming race scheduled.
             </p>
           )}
+          {tourCompleteLabel ? (
+            <p data-testid="results-tour-complete" style={nextStyle}>
+              {tourCompleteLabel}
+              {tourProgress?.unlockedTourId
+                ? ` Unlocked ${formatTourName(tourProgress.unlockedTourId)}.`
+                : ""}
+            </p>
+          ) : null}
 
           <LeaderboardPanel
             trackId={result.trackId}
@@ -230,11 +252,22 @@ function ResultsView(props: ResultsViewProps): ReactElement {
       </section>
 
       <nav style={ctaRowStyle} aria-label="Results actions">
+        {continueTourHref ? (
+          <Link
+            href={continueTourHref}
+            ref={continueRef}
+            data-testid="results-cta-continue-tour"
+            style={primaryCtaStyle}
+            onClick={() => clearRaceResult()}
+          >
+            Continue tour
+          </Link>
+        ) : null}
         <Link
           href="/garage"
-          ref={continueRef}
+          ref={continueTourHref ? undefined : continueRef}
           data-testid="results-cta-continue"
-          style={primaryCtaStyle}
+          style={continueTourHref ? secondaryCtaStyle : primaryCtaStyle}
           onClick={() => clearRaceResult()}
         >
           Continue to Garage
@@ -293,6 +326,14 @@ function formatMs(ms: number): string {
   const seconds = Math.floor((total % 60_000) / 1000);
   const millis = total % 1000;
   return `${pad2(minutes)}:${pad2(seconds)}.${pad3(millis)}`;
+}
+
+function formatTourName(id: string): string {
+  return id
+    .split("-")
+    .filter(Boolean)
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+    .join(" ");
 }
 
 function pad2(value: number): string {

--- a/src/components/world/__tests__/worldTourState.test.ts
+++ b/src/components/world/__tests__/worldTourState.test.ts
@@ -86,6 +86,11 @@ describe("enterWorldTour", () => {
     expect(result.ok).toBe(true);
     if (!result.ok) return;
     expect(result.save.progress.unlockedTours).toEqual(["velvet-coast"]);
+    expect(result.save.progress.activeTour).toEqual({
+      tourId: "velvet-coast",
+      raceIndex: 0,
+      results: [],
+    });
     expect(result.activeTour).toEqual({
       tourId: "velvet-coast",
       raceIndex: 0,

--- a/src/components/world/worldTourState.ts
+++ b/src/components/world/worldTourState.ts
@@ -60,9 +60,19 @@ export function enterWorldTour(
   if (!tour) return { ok: false, code: "unknown_tour" };
   const firstTrackId = tour.tracks[0];
   if (!firstTrackId) return { ok: false, code: "unknown_tour" };
+  const unlockedSave = withFirstTourUnlocked(result.save, championship);
   return {
     ...result,
-    save: withFirstTourUnlocked(result.save, championship),
+    save: {
+      ...unlockedSave,
+      progress: {
+        ...unlockedSave.progress,
+        activeTour: {
+          ...result.activeTour,
+          results: [...result.activeTour.results],
+        },
+      },
+    },
     firstTrackId,
     firstTrackName: formatTrackName(firstTrackId),
   };

--- a/src/data/schemas.test.ts
+++ b/src/data/schemas.test.ts
@@ -203,6 +203,35 @@ describe("SaveGameSchema", () => {
     expect(SaveGameSchema.safeParse(withRepairState).success).toBe(true);
   });
 
+  it("accepts an optional active tour cursor", () => {
+    const withActiveTour = {
+      ...saveGameExample,
+      progress: {
+        ...saveGameExample.progress,
+        activeTour: {
+          tourId: "velvet-coast",
+          raceIndex: 2,
+          results: [
+            {
+              trackId: "velvet-coast/harbor-run",
+              placement: 1,
+              dnf: false,
+              cashEarned: 1500,
+            },
+            {
+              trackId: "velvet-coast/sunpier-loop",
+              placement: 2,
+              dnf: false,
+              cashEarned: 1200,
+            },
+          ],
+        },
+      },
+    };
+
+    expect(SaveGameSchema.safeParse(withActiveTour).success).toBe(true);
+  });
+
   it("rejects garage repair damage outside the unit interval", () => {
     const broken = {
       ...saveGameExample,

--- a/src/data/schemas.ts
+++ b/src/data/schemas.ts
@@ -621,9 +621,34 @@ export const SaveGameGarageSchema = z.object({
 });
 export type SaveGameGarage = z.infer<typeof SaveGameGarageSchema>;
 
+export const SaveGameActiveTourRaceResultSchema = z.object({
+  trackId: slug,
+  placement: nonNegInt,
+  dnf: z.boolean(),
+  cashEarned: nonNegInt.optional(),
+});
+export type SaveGameActiveTourRaceResult = z.infer<
+  typeof SaveGameActiveTourRaceResultSchema
+>;
+
+export const SaveGameActiveTourSchema = z.object({
+  tourId: slug,
+  raceIndex: nonNegInt,
+  results: z.array(SaveGameActiveTourRaceResultSchema),
+});
+export type SaveGameActiveTour = z.infer<typeof SaveGameActiveTourSchema>;
+
 export const SaveGameProgressSchema = z.object({
   unlockedTours: z.array(slug),
   completedTours: z.array(slug),
+  /**
+   * Active World Tour cursor, persisted while the player is between
+   * races in a four-race tour. `raceIndex` points at the next race to
+   * run, and `results` stores completed race outcomes in order so the
+   * results screen can resume, finish, and unlock tours deterministically.
+   * Optional so saves without an in-progress tour still load cleanly.
+   */
+  activeTour: SaveGameActiveTourSchema.optional(),
   /**
    * One-shot tour-stipend claim ledger per `docs/gdd/12-upgrade-and-economy-system.md`
    * "Catch-up mechanisms". Maps a tour id to `true` once the under-threshold

--- a/src/game/__tests__/raceResult.test.ts
+++ b/src/game/__tests__/raceResult.test.ts
@@ -516,6 +516,12 @@ describe("buildRaceResult: next race card", () => {
       makeInput({ championship, tourId: "t1", currentTrackIndex: 0 }),
     );
     expect(result.nextRace?.trackId).toBe("next-circuit");
+    expect(result.tourProgress).toMatchObject({
+      tourId: "t1",
+      raceIndex: 0,
+      nextRaceIndex: 1,
+      completed: false,
+    });
   });
 
   it("falls back to indexOf when currentTrackIndex omitted", () => {
@@ -530,6 +536,12 @@ describe("buildRaceResult: next race card", () => {
       makeInput({ championship, tourId: "t1", currentTrackIndex: 2 }),
     );
     expect(result.nextRace).toBe(null);
+    expect(result.tourProgress).toMatchObject({
+      tourId: "t1",
+      raceIndex: 2,
+      nextRaceIndex: null,
+      completed: true,
+    });
   });
 
   it("returns null when the tour id is not in the championship", () => {

--- a/src/game/__tests__/tourProgress.test.ts
+++ b/src/game/__tests__/tourProgress.test.ts
@@ -1,0 +1,170 @@
+import { describe, expect, it } from "vitest";
+
+import type { Championship, SaveGame } from "@/data/schemas";
+import { defaultSave } from "@/persistence/save";
+
+import { applyTourRaceResult } from "../tourProgress";
+import type { RaceResult } from "../raceResult";
+
+const CHAMPIONSHIP: Championship = {
+  id: "world-tour-standard",
+  name: "World Tour",
+  difficultyPreset: "normal",
+  tours: [
+    {
+      id: "velvet-coast",
+      requiredStanding: 4,
+      tracks: [
+        "velvet-coast/harbor-run",
+        "velvet-coast/sunpier-loop",
+        "velvet-coast/cliffline-arc",
+        "velvet-coast/lighthouse-fall",
+      ],
+    },
+    {
+      id: "iron-borough",
+      requiredStanding: 4,
+      tracks: ["iron-borough/freightline-ring"],
+    },
+  ],
+};
+
+function freshSave(): SaveGame {
+  return JSON.parse(JSON.stringify(defaultSave())) as SaveGame;
+}
+
+function saveWithActiveTour(raceIndex = 0, placement = 1): SaveGame {
+  const save = freshSave();
+  save.progress.unlockedTours = ["velvet-coast"];
+  save.progress.activeTour = {
+    tourId: "velvet-coast",
+    raceIndex,
+    results: CHAMPIONSHIP.tours[0]!.tracks.slice(0, raceIndex).map((trackId) => ({
+      trackId,
+      placement,
+      dnf: false,
+      cashEarned: 1000,
+    })),
+  };
+  return save;
+}
+
+function result(trackId: string, placement = 1): RaceResult {
+  return {
+    trackId,
+    totalLaps: 1,
+    finishingOrder: [
+      {
+        carId: "player",
+        status: "finished",
+        raceTimeMs: 60_000,
+        bestLapMs: 60_000,
+      },
+    ],
+    playerCarId: "player",
+    playerPlacement: placement,
+    pointsEarned: 25,
+    cashEarned: 1000,
+    cashBaseEarned: 1000,
+    creditsAwarded: 1000,
+    bonuses: [],
+    damageTaken: { engine: 0, tires: 0, body: 0 },
+    fastestLap: null,
+    nextRace: null,
+    recordsUpdated: null,
+  };
+}
+
+describe("applyTourRaceResult", () => {
+  it("advances the active tour and annotates the next race", () => {
+    const save = saveWithActiveTour(0);
+    const applied = applyTourRaceResult({
+      save,
+      result: result("velvet-coast/harbor-run", 2),
+      championship: CHAMPIONSHIP,
+    });
+
+    expect(applied.save.progress.activeTour).toEqual({
+      tourId: "velvet-coast",
+      raceIndex: 1,
+      results: [
+        {
+          trackId: "velvet-coast/harbor-run",
+          placement: 2,
+          dnf: false,
+          cashEarned: 1000,
+        },
+      ],
+    });
+    expect(applied.result.tourProgress).toMatchObject({
+      tourId: "velvet-coast",
+      raceIndex: 0,
+      nextRaceIndex: 1,
+      completed: false,
+    });
+  });
+
+  it("clears the active tour and unlocks the next tour after a passing final race", () => {
+    const save = saveWithActiveTour(3);
+    const applied = applyTourRaceResult({
+      save,
+      result: result("velvet-coast/lighthouse-fall", 1),
+      championship: CHAMPIONSHIP,
+    });
+
+    expect(applied.save.progress.activeTour).toBeUndefined();
+    expect(applied.save.progress.completedTours).toEqual(["velvet-coast"]);
+    expect(applied.save.progress.unlockedTours).toEqual([
+      "velvet-coast",
+      "iron-borough",
+    ]);
+    expect(applied.result.tourProgress).toMatchObject({
+      tourId: "velvet-coast",
+      raceIndex: 3,
+      nextRaceIndex: null,
+      completed: true,
+      passed: true,
+      playerStanding: 1,
+      unlockedTourId: "iron-borough",
+    });
+    expect(applied.summary?.bonuses[0]).toMatchObject({
+      kind: "tourComplete",
+    });
+    expect(applied.summary?.bonuses[0]?.cashCredits).toBeGreaterThan(
+      result("velvet-coast/lighthouse-fall", 1).cashEarned / 2,
+    );
+  });
+
+  it("clears the active tour without unlocking on a failed final race", () => {
+    const save = saveWithActiveTour(3, 9);
+    const applied = applyTourRaceResult({
+      save,
+      result: result("velvet-coast/lighthouse-fall", 9),
+      championship: CHAMPIONSHIP,
+    });
+
+    expect(applied.save.progress.activeTour).toBeUndefined();
+    expect(applied.save.progress.completedTours).toEqual([]);
+    expect(applied.save.progress.unlockedTours).toEqual(["velvet-coast"]);
+    expect(applied.result.tourProgress).toMatchObject({
+      completed: true,
+      passed: false,
+      unlockedTourId: null,
+    });
+  });
+
+  it("does nothing when no active tour is stored", () => {
+    const save = freshSave();
+    const raceResult = result("test/straight");
+
+    const applied = applyTourRaceResult({
+      save,
+      result: raceResult,
+      championship: CHAMPIONSHIP,
+    });
+
+    expect(applied.save).toBe(save);
+    expect(applied.result).toBe(raceResult);
+    expect(applied.summary).toBeNull();
+  });
+});

--- a/src/game/championship.ts
+++ b/src/game/championship.ts
@@ -34,13 +34,10 @@
  *   itself. Idempotent: re-running on an already-completed tour does
  *   not double-add ids.
  *
- * The runtime `ActiveTour` shape is defined here rather than on
- * `SaveGameSchema` because the per-tour state is in-flight only: the
- * persistence schema records `unlockedTours` / `completedTours` /
- * `stipendsClaimed`, but the active-tour cursor lives in memory between
- * race-finishes (a future "resume tour" affordance can promote this to
- * a schema field; for now the §20 results screen rebuilds it from the
- * championship + the player's last race outcome on demand).
+ * The runtime `ActiveTour` shape mirrors `SaveGameProgress.activeTour`.
+ * `enterTour` returns the seeded cursor, and the caller persists it when
+ * a tour begins. The race-finish path advances the cursor after each
+ * result and clears it once the tour is complete.
  *
  * All functions never mutate the input `save` reference, never call
  * `Date.now`, `Math.random`, or any IO. Same inputs always produce
@@ -81,13 +78,15 @@ export interface TourRaceResult {
   placement: number;
   /** True when the player retired or wrecked. Forces points to 0. */
   dnf: boolean;
+  /** Cash receipt for the race, used by the tour-completion bonus. */
+  cashEarned?: number;
 }
 
 /**
  * Cursor state for a tour in progress. Created by `enterTour`; advanced
  * by `recordResult` once per race; consumed by `tourComplete` after the
- * final race. Lives in memory between race-finishes (see module header
- * for the persistence boundary).
+ * final race. The persisted save stores the same shape under
+ * `progress.activeTour` between race-finishes.
  *
  * `raceIndex` is 0-indexed and points at the *next* race to run. After
  * the final race it equals `tour.tracks.length`; the §20 results screen
@@ -195,8 +194,8 @@ function findTour(
 /**
  * Enter the named tour. Verifies the tour exists in the championship
  * and is in `save.progress.unlockedTours`; on success returns a fresh
- * `SaveGame` (the cursor `ActiveTour` lives in memory) plus the seeded
- * cursor and the §12 stipend amount granted (if any).
+ * `SaveGame` plus the seeded cursor and the §12 stipend amount granted
+ * (if any).
  *
  * The first tour of a championship (index 0) must already appear in
  * `save.progress.unlockedTours` for the player to enter it; the seeding

--- a/src/game/index.ts
+++ b/src/game/index.ts
@@ -29,3 +29,4 @@ export * from "./raceDamagePersistence";
 // ambiguity. Direct importers can still reach `raceBonuses` via
 // `@/game/raceBonuses` for the tour-completion / sponsor surfaces.
 export * from "./raceResult";
+export * from "./tourProgress";

--- a/src/game/raceResult.ts
+++ b/src/game/raceResult.ts
@@ -118,6 +118,19 @@ export interface NextRaceCard {
   laps: number;
 }
 
+/** Persisted tour handoff displayed by the results screen. */
+export interface TourResultProgress {
+  tourId: string;
+  /** 0-indexed race that just finished. */
+  raceIndex: number;
+  /** 0-indexed next race, or null when the tour is complete. */
+  nextRaceIndex: number | null;
+  completed: boolean;
+  passed: boolean | null;
+  playerStanding: number | null;
+  unlockedTourId: string | null;
+}
+
 /**
  * Records patch the page component is responsible for merging into the
  * save before calling `saveGame`. The mode (Practice, Time Trial, Quick
@@ -199,6 +212,7 @@ export interface RaceResult {
   damageTaken: DamageDelta;
   fastestLap: FinalRaceState["fastestLap"];
   nextRace: NextRaceCard | null;
+  tourProgress?: TourResultProgress | null;
   recordsUpdated: RecordsUpdatePatch | null;
 }
 
@@ -416,6 +430,18 @@ export function buildRaceResult(input: BuildRaceResultInput): RaceResult {
     currentTrackId: track.id,
     currentTrackIndex,
   });
+  const tourProgress =
+    championship && tourId
+      ? {
+          tourId,
+          raceIndex: currentTrackIndex ?? 0,
+          nextRaceIndex: nextRace ? (currentTrackIndex ?? 0) + 1 : null,
+          completed: nextRace === null,
+          passed: null,
+          playerStanding: null,
+          unlockedTourId: null,
+        }
+      : null;
 
   // 8. Records patch.
   const recordsUpdated = recordPBs
@@ -445,6 +471,7 @@ export function buildRaceResult(input: BuildRaceResultInput): RaceResult {
     damageTaken,
     fastestLap: finalState.fastestLap,
     nextRace,
+    tourProgress,
     recordsUpdated,
   };
 }

--- a/src/game/tourProgress.ts
+++ b/src/game/tourProgress.ts
@@ -1,0 +1,138 @@
+import type { Championship, SaveGame } from "@/data/schemas";
+
+import {
+  recordResult,
+  tourComplete,
+  unlockNextTour,
+  type TourCompletionSummary,
+} from "./championship";
+import type { RaceResult, TourResultProgress } from "./raceResult";
+
+export interface ApplyTourRaceResultResult {
+  readonly save: SaveGame;
+  readonly result: RaceResult;
+  readonly summary: TourCompletionSummary | null;
+}
+
+/**
+ * Persist one race result into `save.progress.activeTour`.
+ *
+ * The results screen owns the inter-race handoff, but this helper keeps
+ * the save mutation pure and deterministic. It advances the active
+ * cursor after races one through three. After the fourth race it clears
+ * the cursor, records the completed tour, and unlocks the next tour when
+ * the aggregate standing passes the tour gate.
+ */
+export function applyTourRaceResult(input: {
+  save: SaveGame;
+  result: RaceResult;
+  championship: Championship;
+  playerCarId?: string;
+}): ApplyTourRaceResultResult {
+  const activeTour = input.save.progress.activeTour;
+  if (!activeTour) {
+    return { save: input.save, result: input.result, summary: null };
+  }
+
+  const tour = input.championship.tours.find((candidate) => {
+    return candidate.id === activeTour.tourId;
+  });
+  if (!tour) {
+    return { save: input.save, result: input.result, summary: null };
+  }
+
+  const plannedTrackId = tour.tracks[activeTour.raceIndex] ?? input.result.trackId;
+  const playerRecord =
+    input.result.finishingOrder.find((record) => {
+      return record.carId === input.result.playerCarId;
+    }) ?? null;
+  const nextTour = recordResult(activeTour, {
+    trackId: plannedTrackId,
+    placement: input.result.playerPlacement ?? 0,
+    dnf: playerRecord?.status !== "finished",
+    cashEarned: input.result.cashEarned,
+  });
+
+  if (nextTour.raceIndex < tour.tracks.length) {
+    const save = {
+      ...input.save,
+      progress: {
+        ...input.save.progress,
+        activeTour: {
+          ...nextTour,
+          results: [...nextTour.results],
+        },
+      },
+    };
+    return {
+      save,
+      result: withTourProgress(input.result, {
+        tourId: nextTour.tourId,
+        raceIndex: activeTour.raceIndex,
+        nextRaceIndex: nextTour.raceIndex,
+        completed: false,
+        passed: null,
+        playerStanding: null,
+        unlockedTourId: null,
+      }),
+      summary: null,
+    };
+  }
+
+  const playerCarId = input.playerCarId ?? input.save.garage.activeCarId;
+  const raceRewards = nextTour.results.map((race) => race.cashEarned ?? 0);
+  const summary = tourComplete(
+    nextTour,
+    input.championship,
+    playerCarId,
+    raceRewards,
+    input.save,
+  );
+  const clearedSave = withoutActiveTour(input.save);
+  const unlockedSave = summary.passed
+    ? unlockNextTour(clearedSave, nextTour.tourId, input.championship)
+    : clearedSave;
+  const unlockedTourId = firstNewTourId(
+    input.save.progress.unlockedTours,
+    unlockedSave.progress.unlockedTours,
+  );
+
+  return {
+    save: unlockedSave,
+    result: withTourProgress(input.result, {
+      tourId: nextTour.tourId,
+      raceIndex: activeTour.raceIndex,
+      nextRaceIndex: null,
+      completed: true,
+      passed: summary.passed,
+      playerStanding: summary.playerStanding,
+      unlockedTourId,
+    }),
+    summary,
+  };
+}
+
+function withTourProgress(
+  result: RaceResult,
+  tourProgress: TourResultProgress,
+): RaceResult {
+  return {
+    ...result,
+    tourProgress,
+  };
+}
+
+function withoutActiveTour(save: SaveGame): SaveGame {
+  const { activeTour: _activeTour, ...progress } = save.progress;
+  return {
+    ...save,
+    progress,
+  };
+}
+
+function firstNewTourId(
+  before: ReadonlyArray<string>,
+  after: ReadonlyArray<string>,
+): string | null {
+  return after.find((tourId) => !before.includes(tourId)) ?? null;
+}


### PR DESCRIPTION
## Summary
- persist `progress.activeTour` when entering a World Tour
- advance tour race state from race results, clear the cursor after race four, and unlock the next tour on pass
- add Continue tour and tour complete results UI
- cover the final Velvet Coast to Iron Borough unlock path

## GDD
- docs/gdd/05-core-gameplay-loop.md
- docs/gdd/08-world-and-progression-design.md
- docs/gdd/20-hud-and-ui-ux.md
- docs/gdd/22-data-schemas.md

## Progress Log
- docs/PROGRESS_LOG.md: F-065 active tour progression

## Test Plan
- npx vitest run src/game/__tests__/tourProgress.test.ts src/game/__tests__/raceResult.test.ts src/components/world/__tests__/worldTourState.test.ts src/data/schemas.test.ts
- npm run typecheck
- npm run lint
- npm run verify
- npm run test:e2e -- e2e/results-screen.spec.ts e2e/world-tour.spec.ts e2e/tour-flow.spec.ts

## Followups
- None