### PR TITLE
test(world): cover full tour flow

### DIFF
--- a/docs/PROGRESS_LOG.md
+++ b/docs/PROGRESS_LOG.md
@@ -6,6 +6,46 @@ Correct them by adding a new entry that references the old one.
 
 ---
 
+## 2026-04-28: Slice: Full World Tour flow coverage
+
+**GDD sections touched:**
+[§5](gdd/05-core-gameplay-loop.md) race to results loop,
+[§8](gdd/08-world-and-progression-design.md) tour progression,
+[§20](gdd/20-hud-and-ui-ux.md) results next-race flow.
+**Branch / PR:** `test/full-world-tour-flow`, PR pending.
+**Status:** Implemented.
+
+### Done
+- `e2e/tour-flow.spec.ts`: added a start-from-`/world` Velvet Coast
+  flow that finishes all four queued tour races through the Continue
+  tour CTA and asserts Iron Borough unlocks.
+- The same seeded four-race flow runs twice in one test and compares the
+  completed track sequence and tour-complete text, covering the parent
+  dot determinism requirement.
+
+### Verified
+- `npm run typecheck` clean.
+- `npm run verify` green: lint, typecheck, unit tests, and
+  content-lint all passed; 2,220 unit tests passed.
+- `npm run test:e2e -- e2e/tour-flow.spec.ts` green, 2 passed.
+
+### Decisions and assumptions
+- The full flow intentionally reuses the temporary unresolved-tour-track
+  placeholder from F-065. This validates tour progression behavior while
+  the authored World Tour track JSON remains future content work.
+
+### Coverage ledger
+- GDD-08-TOUR-PROGRESSION now has start-from-world four-race Playwright
+  coverage in addition to the final-race unlock coverage.
+- Uncovered adjacent requirements: full authored World Tour track JSON
+  and richer tour standings UI remain future slices.
+
+### Followups created
+None.
+
+### GDD edits
+None.
+
 ## 2026-04-28: Slice: F-065 active tour progression
 
 **GDD sections touched:**

--- a/e2e/tour-flow.spec.ts
+++ b/e2e/tour-flow.spec.ts
@@ -1,8 +1,25 @@
-import { expect, test } from "@playwright/test";
+import { expect, test, type Page } from "@playwright/test";
 
 const SAVE_KEY = "vibegear2:save:v3";
 
 test.describe("World Tour race progression", () => {
+  test("entering Velvet Coast from the world hub completes all four races", async ({
+    page,
+  }) => {
+    test.setTimeout(420_000);
+
+    const first = await runFullTourFromWorld(page);
+    const second = await runFullTourFromWorld(page);
+
+    expect(first.completedTracks).toEqual([
+      "velvet-coast/harbor-run",
+      "velvet-coast/sunpier-loop",
+      "velvet-coast/cliffline-arc",
+      "velvet-coast/lighthouse-fall",
+    ]);
+    expect(second).toEqual(first);
+  });
+
   test("final Velvet Coast race unlocks Iron Borough", async ({ page }) => {
     test.setTimeout(70_000);
 
@@ -61,6 +78,75 @@ test.describe("World Tour race progression", () => {
     );
   });
 });
+
+interface FullTourResult {
+  completedTracks: string[];
+  completionText: string;
+}
+
+async function runFullTourFromWorld(page: Page): Promise<FullTourResult> {
+  await page.goto("/");
+  await page.evaluate(
+    ({ key, save }) => window.localStorage.setItem(key, JSON.stringify(save)),
+    { key: SAVE_KEY, save: buildFreshTourSave() },
+  );
+
+  await page.goto("/world");
+  await page.getByTestId("world-tour-enter-velvet-coast").click();
+  await expect(page).toHaveURL(
+    /\/race\?track=velvet-coast%2Fharbor-run&tour=velvet-coast&raceIndex=0$/,
+  );
+
+  const completedTracks: string[] = [];
+  for (let raceIndex = 0; raceIndex < 4; raceIndex += 1) {
+    completedTracks.push(await finishCurrentRace(page));
+    if (raceIndex < 3) {
+      await expect(page.getByTestId("results-cta-continue-tour")).toBeVisible();
+      await page.getByTestId("results-cta-continue-tour").click();
+      await expect(page).toHaveURL(new RegExp(`raceIndex=${raceIndex + 1}$`));
+    }
+  }
+
+  const completion = page.getByTestId("results-tour-complete");
+  await expect(completion).toContainText("Tour complete");
+  await expect(completion).toContainText("Iron Borough");
+  const completionText = (await completion.textContent()) ?? "";
+
+  await page.goto("/world");
+  await expect(page.getByTestId("world-tour-status-iron-borough")).toHaveText(
+    "Available",
+  );
+
+  return { completedTracks, completionText };
+}
+
+async function finishCurrentRace(page: Page): Promise<string> {
+  const canvas = page.getByTestId("race-canvas-element");
+  await expect(canvas).toBeVisible();
+  await expect(page.getByTestId("race-phase")).toHaveText("racing", {
+    timeout: 10_000,
+  });
+
+  await canvas.focus();
+  await page.keyboard.down("ArrowUp");
+  await expect(page).toHaveURL(/\/race\/results/, { timeout: 45_000 });
+  await page.keyboard.up("ArrowUp");
+  const root = page.getByTestId("race-results");
+  await expect(root).toBeVisible();
+  const track = await root.getAttribute("data-track");
+  expect(track).not.toBeNull();
+  return track ?? "";
+}
+
+function buildFreshTourSave() {
+  return {
+    ...buildFinalRaceSave(),
+    progress: {
+      unlockedTours: [],
+      completedTours: [],
+    },
+  };
+}
 
 function buildFinalRaceSave() {
   return {


### PR DESCRIPTION
## Summary
- add a start-from-world four-race Velvet Coast Playwright flow
- run the same seeded flow twice and compare the completed track sequence and final tour-complete text
- keep the existing final-race unlock smoke test

## GDD
- docs/gdd/05-core-gameplay-loop.md
- docs/gdd/08-world-and-progression-design.md
- docs/gdd/20-hud-and-ui-ux.md

## Progress Log
- docs/PROGRESS_LOG.md: Full World Tour flow coverage

## Test Plan
- npm run typecheck
- npm run verify
- npm run test:e2e -- e2e/tour-flow.spec.ts

## Followups
- None