### PR TITLE
docs(contributing): tighten contributor guidance

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -100,12 +100,15 @@ contributor consent.
 ## 9. Asset Manifest Rules
 
 Every art contribution must update [`public/art.manifest.json`](../public/art.manifest.json)
-with author, source, licence, and originality statement metadata. Audio,
-track, championship, balancing, and mod-data contributions must include the
-same metadata in the matching manifest once that content loader exists. Until
-then, include the metadata beside the data change in the PR description and
-ask for `legal-review` if the source is not fully original. A PR that ships
-binary assets or third-party data without manifest metadata will not merge.
+with the required manifest fields: `id`, `path`, `kind`, `license`,
+`source`, `originality`, and `date`. Follow
+[`LEGAL_SAFETY.md`](LEGAL_SAFETY.md) section 6 for the canonical field
+requirements. Audio, track, championship, balancing, and mod-data
+contributions must include the corresponding required manifest metadata in
+the matching manifest once that content loader exists. Until then, include
+the metadata beside the data change in the PR description and ask for
+`legal-review` if the source is not fully original. A PR that ships binary
+assets or third-party data without manifest metadata will not merge.
 
 ## 10. Schema and Lint Expectations
 

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -6,7 +6,8 @@ VibeGear2 is an original open-source arcade road racer for the web. Start
 with [`README.md`](../README.md), [`GDD.md`](../GDD.md), and the Markdown GDD
 tree under [`docs/gdd/`](gdd/). The project is built to accept community code,
 data, art, audio, and modding work, provided each contribution follows the
-workflow and originality rules below.
+workflow and originality rules below. For mod-specific rules, read
+[`MODDING.md`](MODDING.md) before changing any mod data or loader behavior.
 
 ## 2. Code of Conduct
 
@@ -98,11 +99,13 @@ contributor consent.
 
 ## 9. Asset Manifest Rules
 
-Every art, audio, track, championship, balancing, and mod-data contribution
-must include manifest metadata for author, source, licence, and originality
-statement. The exact manifest paths are owned by the asset and mod-loader
-slices as those systems land. A PR that ships binary assets or third-party
-data without manifest metadata will not merge.
+Every art contribution must update [`public/art.manifest.json`](../public/art.manifest.json)
+with author, source, licence, and originality statement metadata. Audio,
+track, championship, balancing, and mod-data contributions must include the
+same metadata in the matching manifest once that content loader exists. Until
+then, include the metadata beside the data change in the PR description and
+ask for `legal-review` if the source is not fully original. A PR that ships
+binary assets or third-party data without manifest metadata will not merge.
 
 ## 10. Schema and Lint Expectations
 

--- a/docs/PROGRESS_LOG.md
+++ b/docs/PROGRESS_LOG.md
@@ -6,6 +6,47 @@ Correct them by adding a new entry that references the old one.
 
 ---
 
+## 2026-04-28: Slice: CONTRIBUTING.md guidance
+
+**GDD sections touched:**
+[§26](gdd/26-open-source-project-guidance.md) contribution guidelines,
+licensing, issue labels, and modding rules.
+**Branch / PR:** `docs/contributing-guidance`, PR pending.
+**Status:** Implemented.
+
+### Done
+- `docs/CONTRIBUTING.md`: confirmed the contributor workflow covers branch
+  and PR rules, commit style, verification, originality, licensing, asset
+  manifest expectations, issue labels, first-time contributor setup,
+  maintainer expectations, and question routing.
+- `docs/CONTRIBUTING.md`: linked `MODDING.md` from the scope section and
+  replaced the generic manifest language with the current
+  `public/art.manifest.json` path.
+- Confirmed the README contributing one-liner is already present.
+
+### Verified
+- `grep -rn $'\u2014\|\u2013' docs/CONTRIBUTING.md docs/PROGRESS_LOG.md` clean.
+- `npm run verify` green: lint, typecheck, unit tests, and content-lint
+  passed; 2,220 unit tests passed.
+
+### Decisions and assumptions
+- Audio, track, balancing, and mod-data manifest loaders are not all present
+  yet, so the contributor guide names the current art manifest path and tells
+  contributors to carry equivalent provenance metadata in the PR until the
+  matching loader exists.
+
+### Coverage ledger
+- GDD-26-CONTRIBUTING-GUIDE covers the contributor guide.
+- Uncovered adjacent requirements: full code of conduct file, PR template
+  reuse of the checklist, expanded audio and mod asset manifest loaders,
+  expanded `MODDING.md`, and GitHub Discussions setup remain future slices.
+
+### Followups created
+None.
+
+### GDD edits
+None.
+
 ## 2026-04-28: Slice: Full World Tour flow coverage
 
 **GDD sections touched:**


### PR DESCRIPTION
## GDD sections
- docs/gdd/26-open-source-project-guidance.md

## Requirement inventory
- Documents branch and PR workflow, commit style, verification, PR confirmations, originality, licensing, manifest rules, schema expectations, issue labels, onboarding, maintainer expectations, and question routing for external contributors.
- Links current project references: LICENSE, ASSETS-LICENSE, DATA-LICENSE, docs/LEGAL_SAFETY.md, docs/MODDING.md, docs/WORKING_AGREEMENT.md, and GDD.md.
- Names the current art manifest path public/art.manifest.json.

Uncovered adjacent requirements: full code of conduct file, PR template reuse of the checklist, expanded audio and mod asset manifest loaders, expanded MODDING.md, and GitHub Discussions setup remain future slices.

## Progress log
- docs/PROGRESS_LOG.md entry: 2026-04-28 Slice: CONTRIBUTING.md guidance

## Test plan
- [x] grep -rn $'\u2014\|\u2013' docs/CONTRIBUTING.md docs/PROGRESS_LOG.md
- [x] npm run verify

## Followups
- None.

## Review process
- I will inspect Copilot and threaded review comments before merge and respond to any actionable feedback.