### PR TITLE
fix(race): fill mobile viewport and mount touch controls

### DIFF
--- a/docs/GDD_COVERAGE.json
+++ b/docs/GDD_COVERAGE.json
@@ -2,6 +2,27 @@
   "version": 1,
   "requirements": [
     {
+      "id": "GDD-19-MOBILE-RACE-INPUT",
+      "gddSections": [
+        "docs/gdd/19-controls-and-input.md",
+        "docs/gdd/20-hud-and-ui-ux.md",
+        "docs/gdd/21-technical-design-for-web-implementation.md"
+      ],
+      "requirement": "The live race route fills mobile viewports without page scroll and mounts touch controls that feed steering, throttle, brake, nitro, and pause into the race input pipeline.",
+      "coverage": ["implemented-code", "automated-test"],
+      "implementationRefs": [
+        "src/app/race/page.tsx",
+        "src/components/touch/TouchControls.tsx",
+        "src/game/inputTouch.ts",
+        "src/game/input.ts"
+      ],
+      "testRefs": [
+        "src/game/inputTouch.test.ts",
+        "e2e/touch-input.spec.ts",
+        "e2e/race-mobile.spec.ts"
+      ]
+    },
+    {
       "id": "GDD-26-CONTRIBUTING-GUIDE",
       "gddSections": [
         "docs/gdd/26-open-source-project-guidance.md"

--- a/docs/PROGRESS_LOG.md
+++ b/docs/PROGRESS_LOG.md
@@ -6,6 +6,67 @@ Correct them by adding a new entry that references the old one.
 
 ---
 
+## 2026-04-28: Slice: Mobile race playability
+
+**GDD sections touched:**
+[§19](gdd/19-controls-and-input.md) touch controls,
+[§20](gdd/20-hud-and-ui-ux.md) live race HUD surface,
+[§21](gdd/21-technical-design-for-web-implementation.md) browser e2e.
+**Branch / PR:** `fix/mobile-race-playability`, PR pending.
+**Status:** Implemented.
+
+### Done
+- `src/app/race/page.tsx`: changed `/race` to a fixed, full-viewport
+  surface with no page scroll and a canvas backing store that resizes from
+  the rendered CSS size with a DPR clamp.
+- `src/app/race/page.tsx`: mounted the existing `TouchControls` overlay on
+  the live race route and wired the canvas into `createInputManager` as the
+  touch target.
+- `src/app/race/page.tsx`: keeps the touch overlay layout synchronized with
+  the live canvas size so visual zones and input zones match on mobile
+  viewports.
+- `e2e/race-mobile.spec.ts`: added iPhone 13 coverage for full-viewport
+  canvas sizing, no document scroll, live touch steering, and touch pause.
+- `playwright.config.ts`: includes the mobile race spec in the
+  `mobile-chromium` project and excludes it from desktop runs.
+- `e2e/touch-input.spec.ts`: keeps the existing touch pointer-hold smoke
+  tests serial inside the mobile project so they model one device session
+  without parallel pointer-event flake.
+- `docs/GDD_COVERAGE.json`: added GDD-19-MOBILE-RACE-INPUT.
+
+### Verified
+- `npm run lint && npm run typecheck` clean.
+- `npm run test:e2e -- --project=mobile-chromium e2e/race-mobile.spec.ts`
+  green, 2 passed.
+- `npm run test:e2e -- --project=chromium e2e/race-demo.spec.ts e2e/pause-actions.spec.ts e2e/pause-overlay.spec.ts`
+  green, 10 passed.
+- `npm run test:e2e -- --project=mobile-chromium e2e/touch-input.spec.ts e2e/race-mobile.spec.ts`
+  green, 6 passed.
+- `npm run verify` green: lint, typecheck, unit tests, and content-lint
+  all passed; 2,220 unit tests passed.
+
+### Decisions and assumptions
+- The full-screen race surface intentionally uses `position: fixed`,
+  `inset: 0`, `overflow: hidden`, and canvas `width: 100%` /
+  `height: 100%` rather than viewport-height CSS units so mobile browser
+  chrome changes do not leave black page gaps.
+- The overlay remains cosmetic. Pointer events feed the canvas-owned touch
+  input source; the overlay receives the same live layout so it stays
+  visually aligned with that source.
+
+### Coverage ledger
+- GDD-19-MOBILE-RACE-INPUT covers the live mobile viewport and touch-input
+  wiring.
+- Uncovered adjacent requirements: touch handbrake and manual-shift zones,
+  full key-remap UI, haptic feedback, and device-lab Safari / Android
+  manual verification remain future slices.
+
+### Followups created
+None.
+
+### GDD edits
+None.
+
 ## 2026-04-28: Slice: CONTRIBUTING.md guidance
 
 **GDD sections touched:**

--- a/e2e/race-mobile.spec.ts
+++ b/e2e/race-mobile.spec.ts
@@ -1,0 +1,141 @@
+import { expect, test, type Page } from "@playwright/test";
+
+test.describe("mobile race playability", () => {
+  test("race canvas fills the viewport without page scroll", async ({ page }) => {
+    await page.goto("/race");
+
+    const canvas = page.getByTestId("race-canvas-element");
+    await expect(canvas).toBeVisible();
+
+    const box = await canvas.boundingBox();
+    expect(box).not.toBeNull();
+    if (!box) return;
+    const viewport = page.viewportSize();
+    expect(viewport).not.toBeNull();
+    if (!viewport) return;
+
+    expect(box.width).toBeGreaterThanOrEqual(viewport.width - 1);
+    expect(box.height).toBeGreaterThanOrEqual(viewport.height - 1);
+
+    const scrollState = await page.evaluate(() => ({
+      bodyScrollHeight: document.body.scrollHeight,
+      docScrollHeight: document.documentElement.scrollHeight,
+      innerHeight: window.innerHeight,
+      bodyOverflow: getComputedStyle(document.body).overflowY,
+    }));
+    expect(scrollState.bodyScrollHeight).toBeLessThanOrEqual(scrollState.innerHeight + 1);
+    expect(scrollState.docScrollHeight).toBeLessThanOrEqual(scrollState.innerHeight + 1);
+  });
+
+  test("touch overlay drives steering and pause on the live race route", async ({ page }) => {
+    await page.goto("/race");
+
+    await expect(page.getByTestId("touch-controls")).toBeVisible();
+    const surface = page.getByTestId("race-canvas-element");
+    const surfaceBox = await surface.boundingBox();
+    expect(surfaceBox).not.toBeNull();
+    if (!surfaceBox) return;
+
+    const startX = surfaceBox.x + surfaceBox.width * 0.18;
+    const startY = surfaceBox.y + surfaceBox.height * 0.7;
+    const endX = startX + Math.min(180, surfaceBox.width * 0.35);
+
+    await pressPointer(page, startX, startY, 1);
+    try {
+      await movePointer(page, endX, startY, 1);
+      await expect(page.getByTestId("race-touch-active")).toHaveText("yes");
+      await expect.poll(async () => Number(await page.getByTestId("race-last-steer").innerText()))
+        .toBeGreaterThan(0.25);
+    } finally {
+      await releasePointer(page, endX, startY, 1);
+    }
+
+    const pauseBox = await page.getByTestId("touch-pause").boundingBox();
+    expect(pauseBox).not.toBeNull();
+    if (!pauseBox) return;
+    const pauseX = pauseBox.x + pauseBox.width / 2;
+    const pauseY = pauseBox.y + pauseBox.height / 2;
+
+    await pressPointer(page, pauseX, pauseY, 2);
+    try {
+      await expect(page.getByTestId("pause-overlay")).toBeVisible();
+    } finally {
+      await releasePointer(page, pauseX, pauseY, 2);
+    }
+  });
+});
+
+async function pressPointer(
+  page: Page,
+  x: number,
+  y: number,
+  pointerId: number,
+): Promise<void> {
+  await page.evaluate(
+    ({ x: px, y: py, pointerId: id }) => {
+      const target = document.querySelector("[data-testid='race-canvas-element']");
+      if (!target) return;
+      target.dispatchEvent(
+        new PointerEvent("pointerdown", {
+          bubbles: true,
+          cancelable: true,
+          pointerId: id,
+          pointerType: "touch",
+          clientX: px,
+          clientY: py,
+        }),
+      );
+    },
+    { x, y, pointerId },
+  );
+}
+
+async function movePointer(
+  page: Page,
+  toX: number,
+  toY: number,
+  pointerId: number,
+): Promise<void> {
+  await page.evaluate(
+    ({ toX: bx, toY: by, pointerId: id }) => {
+      const target = document.querySelector("[data-testid='race-canvas-element']");
+      if (!target) return;
+      target.dispatchEvent(
+        new PointerEvent("pointermove", {
+          bubbles: true,
+          cancelable: true,
+          pointerId: id,
+          pointerType: "touch",
+          clientX: bx,
+          clientY: by,
+        }),
+      );
+    },
+    { toX, toY, pointerId },
+  );
+}
+
+async function releasePointer(
+  page: Page,
+  x: number,
+  y: number,
+  pointerId: number,
+): Promise<void> {
+  await page.evaluate(
+    ({ x: px, y: py, pointerId: id }) => {
+      const target = document.querySelector("[data-testid='race-canvas-element']");
+      if (!target) return;
+      target.dispatchEvent(
+        new PointerEvent("pointerup", {
+          bubbles: true,
+          cancelable: true,
+          pointerId: id,
+          pointerType: "touch",
+          clientX: px,
+          clientY: py,
+        }),
+      );
+    },
+    { x, y, pointerId },
+  );
+}

--- a/e2e/touch-input.spec.ts
+++ b/e2e/touch-input.spec.ts
@@ -15,6 +15,8 @@ import { expect, test } from "@playwright/test";
  */
 
 test.describe("touch input", () => {
+  test.describe.configure({ mode: "serial" });
+
   test("holding the accelerator zone drives throttle to 1", async ({ page }) => {
     await page.goto("/dev/touch");
 

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -33,7 +33,7 @@ export default defineConfig({
       // The mobile-chromium project owns the touch-input spec; exclude
       // it from desktop runs so a desktop pointer profile does not try
       // to drive the on-screen overlay.
-      testIgnore: /touch-input\.spec\.ts/,
+      testIgnore: /(touch-input|race-mobile)\.spec\.ts/,
     },
     {
       // Mobile profile for the touch-input spec (closes F-017). Reports
@@ -43,7 +43,7 @@ export default defineConfig({
       // Chromium browsers for the e2e job.
       name: "mobile-chromium",
       use: { ...devices["iPhone 13"], browserName: "chromium" },
-      testMatch: /touch-input\.spec\.ts/,
+      testMatch: /(touch-input|race-mobile)\.spec\.ts/,
     },
   ],
   webServer: {

--- a/src/app/race/page.tsx
+++ b/src/app/race/page.tsx
@@ -504,6 +504,7 @@ function RaceCanvas({
   const ghostOverlayTickRef = useRef<number | null>(null);
   const timeTrialRecorderRef = useRef<TimeTrialRecorder | null>(null);
   const lastSteerRef = useRef<number>(0);
+  const pauseInputHeldRef = useRef<boolean>(false);
   const carAtlasRef = useRef<LoadedAtlas | null>(null);
   // Imperative pause-menu effects, populated inside the loop effect
   // below so the hook layer can stay decoupled from the loop / session
@@ -832,9 +833,10 @@ function RaceCanvas({
         const session = sessionRef.current;
         if (!session) return;
         const input = inputManager.sample();
-        if (input.pause) {
+        if (input.pause && !pauseInputHeldRef.current) {
           openPauseMenu();
         }
+        pauseInputHeldRef.current = input.pause;
         lastSteerRef.current = input.steer;
         const next = stepRaceSession(session, input, config, dt);
         sessionRef.current = next;

--- a/src/app/race/page.tsx
+++ b/src/app/race/page.tsx
@@ -37,6 +37,7 @@ import { useRouter, useSearchParams } from "next/navigation";
 
 import { ErrorBoundary } from "@/components/error/ErrorBoundary";
 import { PauseOverlay } from "@/components/pause/PauseOverlay";
+import { TouchControls } from "@/components/touch/TouchControls";
 import { readKeyBindings } from "@/components/options/controlsPaneState";
 import { usePauseActions } from "@/components/pause/usePauseActions";
 import { usePauseToggle } from "@/components/pause/usePauseToggle";
@@ -72,6 +73,7 @@ import {
   type GhostOverlay,
   type TimeTrialRecorder,
 } from "@/game";
+import { DEFAULT_TOUCH_LAYOUT, type TouchLayout } from "@/game/inputTouch";
 import { FIXED_STEP_SECONDS } from "@/game/loop";
 import type { AIDriver, CarBaseStats } from "@/data/schemas";
 import {
@@ -115,12 +117,40 @@ const CARS_ATLAS_META = AtlasMetaSchema.parse(carsAtlasFixture);
  */
 const MINIMAP_PADDING = 16;
 const MINIMAP_SIZE = 120;
-const MINIMAP_BOX = Object.freeze({
-  x: MINIMAP_PADDING,
-  y: VIEWPORT_HEIGHT - MINIMAP_PADDING - MINIMAP_SIZE,
-  w: MINIMAP_SIZE,
-  h: MINIMAP_SIZE,
-});
+
+function minimapBoxFor(viewport: Viewport): { x: number; y: number; w: number; h: number } {
+  return {
+    x: MINIMAP_PADDING,
+    y: Math.max(MINIMAP_PADDING, viewport.height - MINIMAP_PADDING - MINIMAP_SIZE),
+    w: MINIMAP_SIZE,
+    h: MINIMAP_SIZE,
+  };
+}
+
+function resizeCanvasBackingStore(
+  canvas: HTMLCanvasElement,
+  ctx: CanvasRenderingContext2D,
+): Viewport {
+  const rect = canvas.getBoundingClientRect();
+  const width = Math.max(1, Math.round(rect.width || VIEWPORT_WIDTH));
+  const height = Math.max(1, Math.round(rect.height || VIEWPORT_HEIGHT));
+  const dpr = Math.min(window.devicePixelRatio || 1, 2);
+  const backingWidth = Math.max(1, Math.round(width * dpr));
+  const backingHeight = Math.max(1, Math.round(height * dpr));
+  if (canvas.width !== backingWidth) canvas.width = backingWidth;
+  if (canvas.height !== backingHeight) canvas.height = backingHeight;
+  ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
+  ctx.imageSmoothingEnabled = false;
+  return { width, height };
+}
+
+function touchLayoutFor(viewport: Viewport): TouchLayout {
+  return {
+    ...DEFAULT_TOUCH_LAYOUT,
+    width: viewport.width,
+    height: viewport.height,
+  };
+}
 
 function createLayerCanvas(
   width: number,
@@ -501,6 +531,13 @@ function RaceCanvas({
     totalLaps: number;
     position: number;
   }>(() => ({ speed: 0, lap: 1, totalLaps: initialTotalLaps, position: 1 }));
+  const [inputSnapshot, setInputSnapshot] = useState<{
+    steer: number;
+    touchActive: boolean;
+  }>(() => ({ steer: 0, touchActive: false }));
+  const [touchLayout, setTouchLayout] = useState<TouchLayout>(() =>
+    touchLayoutFor({ width: VIEWPORT_WIDTH, height: VIEWPORT_HEIGHT }),
+  );
   const [resultMs, setResultMs] = useState<number | null>(null);
 
   useEffect(() => {
@@ -514,6 +551,7 @@ function RaceCanvas({
   }, []);
 
   const pause = usePauseToggle({ loop: () => handleRef.current });
+  const { openMenu: openPauseMenu } = pause;
 
   // §20 pause-menu actions. Each impl is a thin wrapper around the
   // matching ref so the hook always sees stable callbacks; the refs
@@ -636,21 +674,37 @@ function RaceCanvas({
       z: 0,
       depth: CAMERA_DEPTH,
     };
-    const viewport: Viewport = { width: VIEWPORT_WIDTH, height: VIEWPORT_HEIGHT };
-    const parallaxLayers = createTemperateParallaxLayers(viewport);
+    let viewport = resizeCanvasBackingStore(canvas, ctx);
+    setTouchLayout(touchLayoutFor(viewport));
+    let parallaxLayers = createTemperateParallaxLayers(viewport);
 
     // Refit the unit-square minimap polyline into the §20 layout box once
     // per track so the per-frame draw loop only pays for `projectCar`. The
     // compiled polyline is frozen and never changes during a session.
-    const minimapPoints: readonly MinimapPoint[] = fitToBox(
+    let minimapBox = minimapBoxFor(viewport);
+    let minimapPoints: readonly MinimapPoint[] = fitToBox(
       track.compiled.minimapPoints,
-      MINIMAP_BOX,
+      minimapBox,
     ) as readonly MinimapPoint[];
     const totalSegments = track.compiled.totalCompiledSegments;
     const totalLength = track.compiled.totalLengthMeters;
 
+    const resize = (): void => {
+      viewport = resizeCanvasBackingStore(canvas, ctx);
+      setTouchLayout(touchLayoutFor(viewport));
+      parallaxLayers = createTemperateParallaxLayers(viewport);
+      minimapBox = minimapBoxFor(viewport);
+      minimapPoints = fitToBox(
+        track.compiled.minimapPoints,
+        minimapBox,
+      ) as readonly MinimapPoint[];
+    };
+    window.addEventListener("resize", resize);
+    window.visualViewport?.addEventListener("resize", resize);
+
     const inputManager = createInputManager({
       bindings: persistedKeyBindings,
+      touchTarget: canvas,
     });
 
     // Wire the §20 pause-menu imperative actions. Each callback closes
@@ -778,6 +832,9 @@ function RaceCanvas({
         const session = sessionRef.current;
         if (!session) return;
         const input = inputManager.sample();
+        if (input.pause) {
+          openPauseMenu();
+        }
         lastSteerRef.current = input.steer;
         const next = stepRaceSession(session, input, config, dt);
         sessionRef.current = next;
@@ -885,7 +942,7 @@ function RaceCanvas({
             );
           }
         }
-        drawMinimap(ctx, minimapPoints, minimapCars, { box: MINIMAP_BOX });
+        drawMinimap(ctx, minimapPoints, minimapCars, { box: minimapBox });
 
         // §20 splits / ghost-delta widget. Lap-timer derives from `elapsed`
         // (seconds since the green light), so the widget reads the same
@@ -993,16 +1050,22 @@ function RaceCanvas({
           totalLaps: hud.totalLaps,
           position: hud.position,
         });
+        setInputSnapshot({
+          steer: lastSteerRef.current,
+          touchActive: inputManager.hasTouch(),
+        });
       },
     });
 
     return () => {
+      window.removeEventListener("resize", resize);
+      window.visualViewport?.removeEventListener("resize", resize);
       handleRef.current?.stop();
       handleRef.current = null;
       sessionRef.current = null;
       inputManager.dispose();
     };
-  }, [track, router, lapsOverride, initialTotalLaps, mode, tourContext]);
+  }, [track, router, lapsOverride, initialTotalLaps, mode, tourContext, openPauseMenu]);
 
   return (
     <main
@@ -1017,16 +1080,9 @@ function RaceCanvas({
         height={VIEWPORT_HEIGHT}
         data-testid="race-canvas-element"
         tabIndex={0}
-        style={{
-          display: "block",
-          width: "min(100%, 1280px, calc((100vh - 3rem) * 1.6667))",
-          height: "auto",
-          aspectRatio: `${VIEWPORT_WIDTH} / ${VIEWPORT_HEIGHT}`,
-          maxWidth: "100%",
-          background: "#000",
-          imageRendering: "pixelated",
-        }}
+        style={canvasStyle}
       />
+      <TouchControls layout={touchLayout} />
       <dl
         style={metricsStyle}
         data-testid="race-metrics"
@@ -1048,6 +1104,12 @@ function RaceCanvas({
         </dd>
         <dt>Position:</dt>
         <dd data-testid="hud-position">{hudSnapshot.position}</dd>
+        <dt>Touch active:</dt>
+        <dd data-testid="race-touch-active">
+          {inputSnapshot.touchActive ? "yes" : "no"}
+        </dd>
+        <dt>Steer:</dt>
+        <dd data-testid="race-last-steer">{inputSnapshot.steer.toFixed(3)}</dd>
       </dl>
       {phase === "finished" && resultMs !== null ? (
         <div data-testid="race-finished" style={resultStyle}>
@@ -1060,14 +1122,24 @@ function RaceCanvas({
 }
 
 const shellStyle: CSSProperties = {
-  padding: "1.5rem",
+  position: "fixed",
+  inset: 0,
+  overflow: "hidden",
+  padding: 0,
   fontFamily: "system-ui, sans-serif",
   color: "var(--fg, #ddd)",
   background: "var(--bg, #111)",
-  minHeight: "100vh",
-  display: "flex",
-  flexDirection: "column",
-  alignItems: "center",
+  touchAction: "none",
+  userSelect: "none",
+};
+
+const canvasStyle: CSSProperties = {
+  display: "block",
+  width: "100%",
+  height: "100%",
+  background: "#000",
+  imageRendering: "pixelated",
+  touchAction: "none",
 };
 
 const metricsStyle: CSSProperties = {


### PR DESCRIPTION
## Summary
- Make /race a fixed full-viewport race surface with a CSS-sized canvas backing store and DPR clamp.
- Mount the existing TouchControls overlay on the live race route and feed pointer input through createInputManager via the canvas target.
- Add mobile Playwright coverage for viewport sizing, no document scroll, live touch steering, and touch pause.

## GDD sections
- docs/gdd/19-controls-and-input.md: touch controls reach the live race input pipeline.
- docs/gdd/20-hud-and-ui-ux.md: live race HUD surface remains usable on mobile while the route fills the viewport.
- docs/gdd/21-technical-design-for-web-implementation.md: browser e2e coverage pins the runtime behavior.

## Requirement inventory
- Handled: /race fills mobile viewports without page scroll.
- Handled: touch steering, throttle, brake, nitro, and pause are wired through the same input manager as keyboard and gamepad.
- Handled: touch overlay visual layout stays synchronized with the live canvas size.
- Left for future slices: touch handbrake, manual shift zones, haptics, full key-remap UI, and device-lab Safari / Android manual verification.

## Progress log
- docs/PROGRESS_LOG.md entry: 2026-04-28, Slice: Mobile race playability.
- docs/GDD_COVERAGE.json entry: GDD-19-MOBILE-RACE-INPUT.

## Test plan
- [x] npm run lint && npm run typecheck
- [x] npm run verify
- [x] npm run test:e2e -- --project=mobile-chromium e2e/race-mobile.spec.ts
- [x] npm run test:e2e -- --project=mobile-chromium e2e/touch-input.spec.ts e2e/race-mobile.spec.ts
- [x] npm run test:e2e -- --project=chromium e2e/race-demo.spec.ts e2e/pause-actions.spec.ts e2e/pause-overlay.spec.ts

## Review process
- I will inspect Copilot and threaded PR review comments, respond inline where appropriate, and push follow-up fixes before merge.
