### PR TITLE
feat(tracks): add mvp world tour track set

### DIFF
--- a/docs/GDD_COVERAGE.json
+++ b/docs/GDD_COVERAGE.json
@@ -2,6 +2,35 @@
   "version": 1,
   "requirements": [
     {
+      "id": "GDD-24-MVP-TRACK-SET",
+      "gddSections": [
+        "docs/gdd/09-track-design.md",
+        "docs/gdd/22-data-schemas.md",
+        "docs/gdd/24-content-plan.md"
+      ],
+      "requirement": "The MVP content set includes the first two World Tour regions with eight registered, schema-valid, compiler-valid bundled track JSON files that cover clear, rain, fog, curves, and elevation.",
+      "coverage": ["implemented-code", "automated-test"],
+      "implementationRefs": [
+        "src/data/tracks/index.ts",
+        "src/data/tracks/velvet-coast-harbor-run.json",
+        "src/data/tracks/velvet-coast-sunpier-loop.json",
+        "src/data/tracks/velvet-coast-cliffline-arc.json",
+        "src/data/tracks/velvet-coast-lighthouse-fall.json",
+        "src/data/tracks/iron-borough-freightline-ring.json",
+        "src/data/tracks/iron-borough-rivet-tunnel.json",
+        "src/data/tracks/iron-borough-foundry-mile.json",
+        "src/data/tracks/iron-borough-outer-exchange.json"
+      ],
+      "testRefs": [
+        "src/data/__tests__/tracks-content.test.ts",
+        "src/data/__tests__/championship-content.test.ts",
+        "src/road/__tests__/trackCompiler.test.ts",
+        "src/road/__tests__/trackCompiler.golden.test.ts",
+        "e2e/tour-flow.spec.ts",
+        "e2e/world-tour.spec.ts"
+      ]
+    },
+    {
       "id": "GDD-19-MOBILE-RACE-INPUT",
       "gddSections": [
         "docs/gdd/19-controls-and-input.md",

--- a/docs/PROGRESS_LOG.md
+++ b/docs/PROGRESS_LOG.md
@@ -6,6 +6,58 @@ Correct them by adding a new entry that references the old one.
 
 ---
 
+## 2026-04-28: Slice: MVP track set
+
+**GDD sections touched:**
+[§9](gdd/09-track-design.md) track anatomy, curve and elevation mix,
+[§22](gdd/22-data-schemas.md) track JSON schema,
+[§24](gdd/24-content-plan.md) MVP two-tour track content.
+**Branch / PR:** `feat/mvp-track-set`, PR pending.
+**Status:** Implemented.
+
+### Done
+- `src/data/tracks/`: added eight bundled MVP track JSON files for
+  Velvet Coast and Iron Borough.
+- `src/data/tracks/index.ts`: registered the first two World Tour regions
+  in `TRACK_RAW` so the live `/race?track=...` route loads real content
+  instead of the temporary unresolved-track fallback.
+- `src/data/__tests__/tracks-content.test.ts`: expanded the expected
+  catalogue and pinned the MVP set's weather, lane, curve, and elevation
+  coverage.
+- `src/data/__tests__/championship-content.test.ts`: now requires every
+  first-two-tour championship track id to resolve while preserving the
+  temporary permissive guard for later tours.
+- `docs/GDD_COVERAGE.json`: added GDD-24-MVP-TRACK-SET.
+
+### Verified
+- `npx vitest run src/data/__tests__/tracks-content.test.ts src/data/__tests__/championship-content.test.ts src/road/__tests__/trackCompiler.test.ts src/road/__tests__/trackCompiler.golden.test.ts`
+  green, 88 passed.
+- `npm run typecheck` clean.
+- `npm run test:e2e -- e2e/tour-flow.spec.ts e2e/world-tour.spec.ts`
+  green, 3 passed.
+- `npm run verify` green, 2240 passed.
+- `npm run test:e2e` green, 68 passed in 5.0m.
+
+### Decisions and assumptions
+- The first two regions ship as the §24 MVP track set. The remaining
+  six World Tour regions stay under the existing permissive championship
+  placeholder guard until their content slices land.
+- MVP track lengths are intentionally short enough to keep current
+  tour-flow e2e stable while still exercising curves, elevation, rain,
+  fog, and authored hazards.
+
+### Coverage ledger
+- GDD-24-MVP-TRACK-SET covers the first two World Tour regions.
+- Uncovered adjacent requirements: the remaining six tours, full 32-track
+  v1.0 content, richer region-specific art themes, and track-editor
+  authoring workflows remain future slices.
+
+### Followups created
+None.
+
+### GDD edits
+None.
+
 ## 2026-04-28: Slice: Mobile race playability
 
 **GDD sections touched:**

--- a/src/data/__tests__/championship-content.test.ts
+++ b/src/data/__tests__/championship-content.test.ts
@@ -133,7 +133,9 @@ describe("world-tour-standard track id cross-references", () => {
   const wt = getChampionship(WORLD_TOUR_ID);
   const allTrackIds = wt.tours.flatMap((t) => t.tracks);
   const mvpTrackIds = wt.tours.slice(0, 2).flatMap((t) => t.tracks);
-  const unresolved = allTrackIds.filter((id) => !(id in TRACK_RAW));
+  const hasBundledTrack = (id: string) =>
+    Object.prototype.hasOwnProperty.call(TRACK_RAW, id);
+  const unresolved = allTrackIds.filter((id) => !hasBundledTrack(id));
 
   if (STRICT_TRACK_RESOLUTION) {
     it("resolves every referenced track id in TRACK_RAW (strict mode)", () => {
@@ -141,7 +143,7 @@ describe("world-tour-standard track id cross-references", () => {
     });
   } else {
     it("resolves every §24 MVP track id for the first two tours", () => {
-      expect(mvpTrackIds.filter((id) => !(id in TRACK_RAW))).toEqual([]);
+      expect(mvpTrackIds.filter((id) => !hasBundledTrack(id))).toEqual([]);
     });
 
     it("permits unresolved track ids during the MVP content window", () => {

--- a/src/data/__tests__/championship-content.test.ts
+++ b/src/data/__tests__/championship-content.test.ts
@@ -132,6 +132,7 @@ describe("world-tour-standard structure", () => {
 describe("world-tour-standard track id cross-references", () => {
   const wt = getChampionship(WORLD_TOUR_ID);
   const allTrackIds = wt.tours.flatMap((t) => t.tracks);
+  const mvpTrackIds = wt.tours.slice(0, 2).flatMap((t) => t.tracks);
   const unresolved = allTrackIds.filter((id) => !(id in TRACK_RAW));
 
   if (STRICT_TRACK_RESOLUTION) {
@@ -139,12 +140,16 @@ describe("world-tour-standard track id cross-references", () => {
       expect(unresolved).toEqual([]);
     });
   } else {
+    it("resolves every §24 MVP track id for the first two tours", () => {
+      expect(mvpTrackIds.filter((id) => !(id in TRACK_RAW))).toEqual([]);
+    });
+
     it("permits unresolved track ids during the MVP content window", () => {
       // Phase guard: full 32-track set is authored in sibling slices.
       // The presence of unresolved ids is expected; this assertion still
       // runs to catch regressions that drop already-authored tracks.
       const resolvedCount = allTrackIds.length - unresolved.length;
-      expect(resolvedCount).toBeGreaterThanOrEqual(0);
+      expect(resolvedCount).toBeGreaterThanOrEqual(mvpTrackIds.length);
       expect(allTrackIds.length).toBe(32);
     });
   }

--- a/src/data/__tests__/tracks-content.test.ts
+++ b/src/data/__tests__/tracks-content.test.ts
@@ -16,11 +16,40 @@ import { describe, expect, it } from "vitest";
 import { TRACK_IDS, TRACK_RAW, loadTrack } from "@/data";
 import { TrackSchema } from "@/data/schemas";
 
-const EXPECTED_IDS = ["test/curve", "test/elevation", "test/straight"];
+const EXPECTED_MVP_TRACK_IDS = [
+  "velvet-coast/harbor-run",
+  "velvet-coast/sunpier-loop",
+  "velvet-coast/cliffline-arc",
+  "velvet-coast/lighthouse-fall",
+  "iron-borough/freightline-ring",
+  "iron-borough/rivet-tunnel",
+  "iron-borough/foundry-mile",
+  "iron-borough/outer-exchange",
+];
+
+const EXPECTED_IDS = [
+  "iron-borough/foundry-mile",
+  "iron-borough/freightline-ring",
+  "iron-borough/outer-exchange",
+  "iron-borough/rivet-tunnel",
+  "test/curve",
+  "test/elevation",
+  "test/straight",
+  "velvet-coast/cliffline-arc",
+  "velvet-coast/harbor-run",
+  "velvet-coast/lighthouse-fall",
+  "velvet-coast/sunpier-loop",
+];
 
 describe("track catalogue", () => {
   it("registers every expected MVP track id", () => {
     expect([...TRACK_IDS].sort()).toEqual(EXPECTED_IDS);
+  });
+
+  it("registers the two-tour §24 MVP track set", () => {
+    for (const id of EXPECTED_MVP_TRACK_IDS) {
+      expect(TRACK_IDS).toContain(id);
+    }
   });
 });
 
@@ -57,5 +86,37 @@ describe("test/elevation track", () => {
   it("compiles grade-bearing segments into the renderer segment buffer", () => {
     const compiled = loadTrack("test/elevation");
     expect(compiled.segments.some((segment) => segment.grade !== 0)).toBe(true);
+  });
+});
+
+describe("§24 MVP track set", () => {
+  it("covers the first two World Tour regions with clear, rain, and fog support", () => {
+    const weather = new Set<string>();
+    for (const id of EXPECTED_MVP_TRACK_IDS) {
+      const parsed = TrackSchema.parse(TRACK_RAW[id]);
+      expect(parsed.tourId).toBe(id.split("/")[0]);
+      expect(parsed.laps).toBe(1);
+      expect(parsed.laneCount).toBe(3);
+      for (const option of parsed.weatherOptions) weather.add(option);
+    }
+    expect(weather.has("clear")).toBe(true);
+    expect(weather.has("rain")).toBe(true);
+    expect(weather.has("fog")).toBe(true);
+  });
+
+  it("includes authored curves and elevation across the bundled MVP tracks", () => {
+    const tracks = EXPECTED_MVP_TRACK_IDS.map((id) =>
+      TrackSchema.parse(TRACK_RAW[id]),
+    );
+    expect(
+      tracks.some((track) =>
+        track.segments.some((segment) => segment.curve !== 0),
+      ),
+    ).toBe(true);
+    expect(
+      tracks.some((track) =>
+        track.segments.some((segment) => segment.grade !== 0),
+      ),
+    ).toBe(true);
   });
 });

--- a/src/data/__tests__/tracks-content.test.ts
+++ b/src/data/__tests__/tracks-content.test.ts
@@ -42,7 +42,7 @@ const EXPECTED_IDS = [
 ];
 
 describe("track catalogue", () => {
-  it("registers every expected MVP track id", () => {
+  it("registers every expected bundled track id", () => {
     expect([...TRACK_IDS].sort()).toEqual(EXPECTED_IDS);
   });
 

--- a/src/data/tracks/index.ts
+++ b/src/data/tracks/index.ts
@@ -14,11 +14,27 @@
 import testCurve from "./test-curve.json";
 import testElevation from "./test-elevation.json";
 import testStraight from "./test-straight.json";
+import ironBoroughFoundryMile from "./iron-borough-foundry-mile.json";
+import ironBoroughFreightlineRing from "./iron-borough-freightline-ring.json";
+import ironBoroughOuterExchange from "./iron-borough-outer-exchange.json";
+import ironBoroughRivetTunnel from "./iron-borough-rivet-tunnel.json";
+import velvetCoastClifflineArc from "./velvet-coast-cliffline-arc.json";
+import velvetCoastHarborRun from "./velvet-coast-harbor-run.json";
+import velvetCoastLighthouseFall from "./velvet-coast-lighthouse-fall.json";
+import velvetCoastSunpierLoop from "./velvet-coast-sunpier-loop.json";
 
 export const TRACK_RAW: Readonly<Record<string, unknown>> = Object.freeze({
   "test/straight": testStraight,
   "test/curve": testCurve,
   "test/elevation": testElevation,
+  "velvet-coast/harbor-run": velvetCoastHarborRun,
+  "velvet-coast/sunpier-loop": velvetCoastSunpierLoop,
+  "velvet-coast/cliffline-arc": velvetCoastClifflineArc,
+  "velvet-coast/lighthouse-fall": velvetCoastLighthouseFall,
+  "iron-borough/freightline-ring": ironBoroughFreightlineRing,
+  "iron-borough/rivet-tunnel": ironBoroughRivetTunnel,
+  "iron-borough/foundry-mile": ironBoroughFoundryMile,
+  "iron-borough/outer-exchange": ironBoroughOuterExchange,
 });
 
 /** Sorted list of available track slugs for menu builders. */

--- a/src/data/tracks/iron-borough-foundry-mile.json
+++ b/src/data/tracks/iron-borough-foundry-mile.json
@@ -1,0 +1,26 @@
+{
+  "id": "iron-borough/foundry-mile",
+  "name": "Foundry Mile",
+  "tourId": "iron-borough",
+  "author": "core",
+  "version": 1,
+  "lengthMeters": 1644,
+  "laps": 1,
+  "laneCount": 3,
+  "weatherOptions": ["clear", "rain"],
+  "difficulty": 3,
+  "segments": [
+    { "len": 240, "curve": 0, "grade": 0.01, "roadsideLeft": "sign_marker", "roadsideRight": "light_pole", "hazards": [] },
+    { "len": 240, "curve": 0.14, "grade": 0, "roadsideLeft": "fence_post", "roadsideRight": "rock_boulder", "hazards": ["traffic_cone"] },
+    { "len": 240, "curve": -0.08, "grade": 0.04, "roadsideLeft": "rock_boulder", "roadsideRight": "light_pole", "hazards": [] },
+    { "len": 240, "curve": -0.12, "grade": -0.03, "roadsideLeft": "light_pole", "roadsideRight": "fence_post", "hazards": ["puddle"] },
+    { "len": 324, "curve": 0.06, "grade": 0, "roadsideLeft": "sign_marker", "roadsideRight": "rock_boulder", "hazards": [] },
+    { "len": 360, "curve": 0, "grade": 0, "roadsideLeft": "fence_post", "roadsideRight": "sign_marker", "hazards": [] }
+  ],
+  "checkpoints": [
+    { "segmentIndex": 0, "label": "start" },
+    { "segmentIndex": 2, "label": "foundry" },
+    { "segmentIndex": 4, "label": "milepost" }
+  ],
+  "spawn": { "gridSlots": 12 }
+}

--- a/src/data/tracks/iron-borough-freightline-ring.json
+++ b/src/data/tracks/iron-borough-freightline-ring.json
@@ -1,0 +1,26 @@
+{
+  "id": "iron-borough/freightline-ring",
+  "name": "Freightline Ring",
+  "tourId": "iron-borough",
+  "author": "core",
+  "version": 1,
+  "lengthMeters": 1608,
+  "laps": 1,
+  "laneCount": 3,
+  "weatherOptions": ["clear", "rain", "fog"],
+  "difficulty": 2,
+  "segments": [
+    { "len": 240, "curve": 0, "grade": 0, "roadsideLeft": "light_pole", "roadsideRight": "sign_marker", "hazards": [] },
+    { "len": 240, "curve": 0.1, "grade": 0, "roadsideLeft": "fence_post", "roadsideRight": "light_pole", "hazards": ["traffic_cone"] },
+    { "len": 240, "curve": 0, "grade": 0.03, "roadsideLeft": "rock_boulder", "roadsideRight": "fence_post", "hazards": [] },
+    { "len": 240, "curve": -0.12, "grade": -0.02, "roadsideLeft": "sign_marker", "roadsideRight": "rock_boulder", "hazards": [] },
+    { "len": 288, "curve": 0.06, "grade": 0, "roadsideLeft": "light_pole", "roadsideRight": "fence_post", "hazards": [] },
+    { "len": 360, "curve": 0, "grade": 0, "roadsideLeft": "fence_post", "roadsideRight": "light_pole", "hazards": [] }
+  ],
+  "checkpoints": [
+    { "segmentIndex": 0, "label": "start" },
+    { "segmentIndex": 2, "label": "freight-yard" },
+    { "segmentIndex": 4, "label": "exchange" }
+  ],
+  "spawn": { "gridSlots": 12 }
+}

--- a/src/data/tracks/iron-borough-outer-exchange.json
+++ b/src/data/tracks/iron-borough-outer-exchange.json
@@ -1,0 +1,26 @@
+{
+  "id": "iron-borough/outer-exchange",
+  "name": "Outer Exchange",
+  "tourId": "iron-borough",
+  "author": "core",
+  "version": 1,
+  "lengthMeters": 1668,
+  "laps": 1,
+  "laneCount": 3,
+  "weatherOptions": ["clear", "rain", "fog"],
+  "difficulty": 3,
+  "segments": [
+    { "len": 240, "curve": 0, "grade": 0, "roadsideLeft": "light_pole", "roadsideRight": "sign_marker", "hazards": [] },
+    { "len": 240, "curve": -0.12, "grade": 0.03, "roadsideLeft": "fence_post", "roadsideRight": "rock_boulder", "hazards": [] },
+    { "len": 240, "curve": 0.12, "grade": -0.02, "roadsideLeft": "sign_marker", "roadsideRight": "light_pole", "hazards": ["traffic_cone"] },
+    { "len": 288, "curve": 0.08, "grade": 0, "roadsideLeft": "rock_boulder", "roadsideRight": "fence_post", "hazards": [] },
+    { "len": 300, "curve": -0.06, "grade": 0.03, "roadsideLeft": "light_pole", "roadsideRight": "sign_marker", "hazards": ["puddle"] },
+    { "len": 360, "curve": 0, "grade": -0.01, "roadsideLeft": "fence_post", "roadsideRight": "light_pole", "hazards": [] }
+  ],
+  "checkpoints": [
+    { "segmentIndex": 0, "label": "start" },
+    { "segmentIndex": 2, "label": "overpass" },
+    { "segmentIndex": 4, "label": "exchange" }
+  ],
+  "spawn": { "gridSlots": 12 }
+}

--- a/src/data/tracks/iron-borough-rivet-tunnel.json
+++ b/src/data/tracks/iron-borough-rivet-tunnel.json
@@ -1,0 +1,26 @@
+{
+  "id": "iron-borough/rivet-tunnel",
+  "name": "Rivet Tunnel",
+  "tourId": "iron-borough",
+  "author": "core",
+  "version": 1,
+  "lengthMeters": 1620,
+  "laps": 1,
+  "laneCount": 3,
+  "weatherOptions": ["clear", "fog"],
+  "difficulty": 2,
+  "segments": [
+    { "len": 240, "curve": 0, "grade": 0, "roadsideLeft": "light_pole", "roadsideRight": "light_pole", "hazards": [] },
+    { "len": 240, "curve": -0.1, "grade": 0.02, "roadsideLeft": "fence_post", "roadsideRight": "rock_boulder", "hazards": [] },
+    { "len": 240, "curve": 0, "grade": -0.02, "roadsideLeft": "rock_boulder", "roadsideRight": "rock_boulder", "hazards": ["tunnel"] },
+    { "len": 240, "curve": 0.12, "grade": 0, "roadsideLeft": "sign_marker", "roadsideRight": "fence_post", "hazards": [] },
+    { "len": 300, "curve": -0.04, "grade": 0.02, "roadsideLeft": "light_pole", "roadsideRight": "sign_marker", "hazards": ["traffic_cone"] },
+    { "len": 360, "curve": 0, "grade": 0, "roadsideLeft": "fence_post", "roadsideRight": "light_pole", "hazards": [] }
+  ],
+  "checkpoints": [
+    { "segmentIndex": 0, "label": "start" },
+    { "segmentIndex": 2, "label": "tunnel" },
+    { "segmentIndex": 4, "label": "rivet-row" }
+  ],
+  "spawn": { "gridSlots": 12 }
+}

--- a/src/data/tracks/velvet-coast-cliffline-arc.json
+++ b/src/data/tracks/velvet-coast-cliffline-arc.json
@@ -1,0 +1,26 @@
+{
+  "id": "velvet-coast/cliffline-arc",
+  "name": "Cliffline Arc",
+  "tourId": "velvet-coast",
+  "author": "core",
+  "version": 1,
+  "lengthMeters": 1560,
+  "laps": 1,
+  "laneCount": 3,
+  "weatherOptions": ["clear", "fog"],
+  "difficulty": 2,
+  "segments": [
+    { "len": 240, "curve": 0, "grade": 0.01, "roadsideLeft": "rock_boulder", "roadsideRight": "sign_marker", "hazards": [] },
+    { "len": 240, "curve": 0.14, "grade": 0.04, "roadsideLeft": "rock_boulder", "roadsideRight": "fence_post", "hazards": [] },
+    { "len": 180, "curve": 0.06, "grade": -0.03, "roadsideLeft": "tree_pine", "roadsideRight": "rock_boulder", "hazards": [] },
+    { "len": 240, "curve": -0.14, "grade": 0, "roadsideLeft": "sign_marker", "roadsideRight": "light_pole", "hazards": ["gravel_band"] },
+    { "len": 300, "curve": -0.04, "grade": -0.02, "roadsideLeft": "fence_post", "roadsideRight": "rock_boulder", "hazards": [] },
+    { "len": 360, "curve": 0, "grade": 0, "roadsideLeft": "light_pole", "roadsideRight": "sign_marker", "hazards": [] }
+  ],
+  "checkpoints": [
+    { "segmentIndex": 0, "label": "start" },
+    { "segmentIndex": 2, "label": "cliff" },
+    { "segmentIndex": 4, "label": "descent" }
+  ],
+  "spawn": { "gridSlots": 12 }
+}

--- a/src/data/tracks/velvet-coast-harbor-run.json
+++ b/src/data/tracks/velvet-coast-harbor-run.json
@@ -1,0 +1,26 @@
+{
+  "id": "velvet-coast/harbor-run",
+  "name": "Harbor Run",
+  "tourId": "velvet-coast",
+  "author": "core",
+  "version": 1,
+  "lengthMeters": 1500,
+  "laps": 1,
+  "laneCount": 3,
+  "weatherOptions": ["clear", "rain", "fog"],
+  "difficulty": 1,
+  "segments": [
+    { "len": 240, "curve": 0, "grade": 0, "roadsideLeft": "sign_marker", "roadsideRight": "light_pole", "hazards": [] },
+    { "len": 180, "curve": 0.08, "grade": 0, "roadsideLeft": "fence_post", "roadsideRight": "sign_marker", "hazards": [] },
+    { "len": 240, "curve": 0, "grade": 0.02, "roadsideLeft": "light_pole", "roadsideRight": "fence_post", "hazards": [] },
+    { "len": 180, "curve": -0.08, "grade": -0.01, "roadsideLeft": "tree_pine", "roadsideRight": "light_pole", "hazards": ["puddle"] },
+    { "len": 300, "curve": 0.04, "grade": 0, "roadsideLeft": "sign_marker", "roadsideRight": "rock_boulder", "hazards": [] },
+    { "len": 360, "curve": 0, "grade": 0, "roadsideLeft": "fence_post", "roadsideRight": "sign_marker", "hazards": [] }
+  ],
+  "checkpoints": [
+    { "segmentIndex": 0, "label": "start" },
+    { "segmentIndex": 2, "label": "marina" },
+    { "segmentIndex": 4, "label": "warehouse" }
+  ],
+  "spawn": { "gridSlots": 12 }
+}

--- a/src/data/tracks/velvet-coast-lighthouse-fall.json
+++ b/src/data/tracks/velvet-coast-lighthouse-fall.json
@@ -1,0 +1,26 @@
+{
+  "id": "velvet-coast/lighthouse-fall",
+  "name": "Lighthouse Fall",
+  "tourId": "velvet-coast",
+  "author": "core",
+  "version": 1,
+  "lengthMeters": 1584,
+  "laps": 1,
+  "laneCount": 3,
+  "weatherOptions": ["clear", "rain", "fog"],
+  "difficulty": 2,
+  "segments": [
+    { "len": 240, "curve": 0, "grade": 0, "roadsideLeft": "sign_marker", "roadsideRight": "light_pole", "hazards": [] },
+    { "len": 180, "curve": -0.1, "grade": 0.05, "roadsideLeft": "rock_boulder", "roadsideRight": "fence_post", "hazards": [] },
+    { "len": 240, "curve": -0.08, "grade": -0.06, "roadsideLeft": "tree_pine", "roadsideRight": "rock_boulder", "hazards": ["puddle"] },
+    { "len": 240, "curve": 0.12, "grade": 0, "roadsideLeft": "light_pole", "roadsideRight": "sign_marker", "hazards": [] },
+    { "len": 324, "curve": 0.06, "grade": 0.03, "roadsideLeft": "fence_post", "roadsideRight": "tree_pine", "hazards": [] },
+    { "len": 360, "curve": 0, "grade": -0.01, "roadsideLeft": "sign_marker", "roadsideRight": "light_pole", "hazards": [] }
+  ],
+  "checkpoints": [
+    { "segmentIndex": 0, "label": "start" },
+    { "segmentIndex": 2, "label": "lighthouse" },
+    { "segmentIndex": 4, "label": "fall" }
+  ],
+  "spawn": { "gridSlots": 12 }
+}

--- a/src/data/tracks/velvet-coast-sunpier-loop.json
+++ b/src/data/tracks/velvet-coast-sunpier-loop.json
@@ -1,0 +1,26 @@
+{
+  "id": "velvet-coast/sunpier-loop",
+  "name": "Sunpier Loop",
+  "tourId": "velvet-coast",
+  "author": "core",
+  "version": 1,
+  "lengthMeters": 1536,
+  "laps": 1,
+  "laneCount": 3,
+  "weatherOptions": ["clear", "rain"],
+  "difficulty": 1,
+  "segments": [
+    { "len": 216, "curve": 0, "grade": 0, "roadsideLeft": "light_pole", "roadsideRight": "sign_marker", "hazards": [] },
+    { "len": 240, "curve": 0.12, "grade": 0, "roadsideLeft": "fence_post", "roadsideRight": "light_pole", "hazards": [] },
+    { "len": 180, "curve": 0.08, "grade": 0.03, "roadsideLeft": "tree_pine", "roadsideRight": "fence_post", "hazards": ["puddle"] },
+    { "len": 240, "curve": -0.1, "grade": -0.02, "roadsideLeft": "sign_marker", "roadsideRight": "rock_boulder", "hazards": [] },
+    { "len": 300, "curve": -0.04, "grade": 0, "roadsideLeft": "light_pole", "roadsideRight": "fence_post", "hazards": [] },
+    { "len": 360, "curve": 0, "grade": 0, "roadsideLeft": "sign_marker", "roadsideRight": "light_pole", "hazards": [] }
+  ],
+  "checkpoints": [
+    { "segmentIndex": 0, "label": "start" },
+    { "segmentIndex": 2, "label": "pier" },
+    { "segmentIndex": 4, "label": "boardwalk" }
+  ],
+  "spawn": { "gridSlots": 12 }
+}


### PR DESCRIPTION
## Summary
- Add the eight bundled MVP tracks for Velvet Coast and Iron Borough.
- Register the first two World Tour regions in `TRACK_RAW` so `/race?track=...` uses real content.
- Pin section 24 coverage in content tests, championship cross refs, and the GDD coverage ledger.

## GDD Links
- `docs/gdd/09-track-design.md`
- `docs/gdd/22-data-schemas.md`
- `docs/gdd/24-content-plan.md`

## Progress Log
- `docs/PROGRESS_LOG.md` entry: `2026-04-28: Slice: MVP track set`

## Coverage Ledger
- Adds `GDD-24-MVP-TRACK-SET` in `docs/GDD_COVERAGE.json`.

## Test Plan
- `npx vitest run src/data/__tests__/tracks-content.test.ts src/data/__tests__/championship-content.test.ts src/road/__tests__/trackCompiler.test.ts src/road/__tests__/trackCompiler.golden.test.ts`
- `npm run typecheck`
- `npm run test:e2e -- e2e/tour-flow.spec.ts e2e/world-tour.spec.ts`
- `npm run verify`
- `npm run test:e2e`

## Review Process
- I will inspect Copilot and threaded PR review comments, respond inline where needed, and push fixes before merge.