### PR TITLE
feat(ai): spawn tour race grids

### DIFF
--- a/docs/GDD_COVERAGE.json
+++ b/docs/GDD_COVERAGE.json
@@ -2,6 +2,29 @@
   "version": 1,
   "requirements": [
     {
+      "id": "GDD-15-AI-GRID-SPAWNER",
+      "gddSections": [
+        "docs/gdd/15-cpu-opponents-and-ai.md",
+        "docs/gdd/20-hud-and-ui-ux.md",
+        "docs/gdd/22-data-schemas.md",
+        "docs/gdd/25-development-roadmap.md"
+      ],
+      "requirement": "World Tour races can spawn a deterministic campaign-size AI field from per-tour driver rosters while preserving time-trial and prototype route behavior.",
+      "coverage": ["implemented-code", "automated-test"],
+      "implementationRefs": [
+        "src/game/aiGrid.ts",
+        "src/app/race/page.tsx",
+        "src/data/championships/world-tour-standard.json",
+        "src/data/schemas.ts"
+      ],
+      "testRefs": [
+        "src/game/__tests__/aiGrid.test.ts",
+        "src/data/__tests__/championship-content.test.ts",
+        "e2e/twelve-car-field.spec.ts",
+        "e2e/race-demo.spec.ts"
+      ]
+    },
+    {
       "id": "GDD-24-MVP-TRACK-SET",
       "gddSections": [
         "docs/gdd/09-track-design.md",

--- a/docs/PROGRESS_LOG.md
+++ b/docs/PROGRESS_LOG.md
@@ -6,6 +6,60 @@ Correct them by adding a new entry that references the old one.
 
 ---
 
+## 2026-04-28: Slice: AI grid spawner
+
+**GDD sections touched:**
+[§15](gdd/15-cpu-opponents-and-ai.md) CPU opponent rosters,
+[§20](gdd/20-hud-and-ui-ux.md) race route diagnostics,
+[§22](gdd/22-data-schemas.md) championship tour schema,
+[§25](gdd/25-development-roadmap.md) MVP race field progression.
+**Branch / PR:** `feat/ai-grid-spawner`, PR pending.
+**Status:** Implemented.
+
+### Done
+- `src/game/aiGrid.ts`: added a pure deterministic grid spawner that
+  reserves the player slot, shuffles AI rosters by seed, assigns slots,
+  lanes, start positions, and per-car seeds for `RaceSession`.
+- `src/data/championships/world-tour-standard.json`: added 11-driver AI
+  rosters for the first two authored World Tour regions.
+- `src/data/schemas.ts` and `docs/gdd/22-data-schemas.md`: documented the
+  optional per-tour `aiDrivers` list keyed by `AIDriver.id`.
+- `src/app/race/page.tsx`: wired tour races to spawn an 11-opponent field on
+  12-slot tracks while keeping the plain `/race` prototype route on its
+  single-AI fallback.
+- `e2e/twelve-car-field.spec.ts`: added browser coverage that confirms the
+  Velvet Coast tour route starts with a 12-car field.
+
+### Verified
+- `npx vitest run src/game/__tests__/aiGrid.test.ts src/data/__tests__/championship-content.test.ts`
+  green, 24 passed.
+- `npm run typecheck` clean.
+- `npm run test:e2e -- e2e/twelve-car-field.spec.ts e2e/race-demo.spec.ts`
+  green, 4 passed.
+- `npm run verify` green, 2248 passed.
+- `npm run test:e2e` green, 69 passed.
+
+### Decisions and assumptions
+- The player occupies the first grid slot; AI cars use the remaining
+  `track.spawn.gridSlots - 1` slots.
+- Non-tour `/race` remains a one-opponent prototype smoke route so the new
+  campaign-size field does not hide regressions behind early demo DNFs.
+- Time trial still spawns no live AI opponents.
+
+### Coverage ledger
+- GDD-15-AI-GRID-SPAWNER covers the initial grid-spawn portion of §15 for authored
+  World Tour race fields.
+- Uncovered adjacent requirements: richer AI tactical behavior, collision
+  avoidance, per-class roster balancing, and full 32-track roster tuning
+  remain future slices.
+
+### Followups created
+None.
+
+### GDD edits
+- `docs/gdd/22-data-schemas.md`: added `aiDrivers` to the championship
+  tour JSON example.
+
 ## 2026-04-28: Slice: MVP track set
 
 **GDD sections touched:**

--- a/docs/gdd/22-data-schemas.md
+++ b/docs/gdd/22-data-schemas.md
@@ -110,6 +110,12 @@
         "velvet-coast/sunpier-loop",
         "velvet-coast/cliffline-arc",
         "velvet-coast/lighthouse-fall"
+      ],
+      "sponsors": ["velvet-coast-co-op", "cleanline-insurance"],
+      "aiDrivers": [
+        "ai_rocket_01",
+        "ai_cleanline_01",
+        "ai_bully_01"
       ]
     }
   ]

--- a/e2e/twelve-car-field.spec.ts
+++ b/e2e/twelve-car-field.spec.ts
@@ -1,0 +1,11 @@
+import { expect, test } from "@playwright/test";
+
+test("World Tour race starts with a 12-car field on a 12-slot track", async ({
+  page,
+}) => {
+  await page.goto("/race?tour=velvet-coast&raceIndex=0");
+  await expect(page.getByTestId("race-phase")).toHaveText(/countdown|racing/, {
+    timeout: 10_000,
+  });
+  await expect(page.getByTestId("race-field-size")).toHaveText("12");
+});

--- a/src/app/race/page.tsx
+++ b/src/app/race/page.tsx
@@ -42,7 +42,14 @@ import { readKeyBindings } from "@/components/options/controlsPaneState";
 import { usePauseActions } from "@/components/pause/usePauseActions";
 import { usePauseToggle } from "@/components/pause/usePauseToggle";
 import { saveRaceResult } from "@/components/results/raceResultStorage";
-import { TRACK_IDS, TRACK_RAW, getChampionship, loadTrack } from "@/data";
+import {
+  AI_DRIVERS,
+  TRACK_IDS,
+  TRACK_RAW,
+  getAIDriver,
+  getChampionship,
+  loadTrack,
+} from "@/data";
 import carsAtlasFixture from "@/data/atlas/cars.json";
 import { AtlasMetaSchema, TrackSchema, type Track } from "@/data/schemas";
 import {
@@ -62,6 +69,7 @@ import {
   applyRaceResultRecords,
   applyTourRaceResult,
   retireRaceSession,
+  spawnGrid,
   startLoop,
   stepRaceSession,
   totalProgress,
@@ -239,21 +247,6 @@ const STARTER_STATS: CarBaseStats = Object.freeze({
   nitroEfficiency: 1.0,
 });
 
-/**
- * Demo AI driver. Single clean_line opponent per the dot stress-test §4.
- * Full grid spawning is owned by `implement-ai-grid-02d7e311`.
- */
-const DEMO_DRIVER: AIDriver = Object.freeze({
-  id: "ai_cleanline_demo",
-  displayName: "K. Vale",
-  archetype: "clean_line",
-  paceScalar: 1.0,
-  mistakeRate: 0,
-  aggression: 0.3,
-  weatherSkill: { clear: 1, rain: 1, fog: 1, snow: 1 },
-  nitroUsage: { launchBias: 0.5, straightBias: 0.5, panicBias: 0.1 },
-});
-
 interface ResolvedTrack {
   id: string;
   runtimeId: string;
@@ -266,6 +259,7 @@ interface TourRaceContext {
   tourId: string;
   raceIndex: number;
   plannedTrackId: string;
+  aiDriverIds: readonly string[];
 }
 
 function resolveTourRaceContext(
@@ -281,7 +275,13 @@ function resolveTourRaceContext(
   if (!Number.isInteger(raceIndex) || raceIndex < 0) return null;
   const plannedTrackId = tour.tracks[raceIndex];
   if (!plannedTrackId) return null;
-  return { championship, tourId, raceIndex, plannedTrackId };
+  return {
+    championship,
+    tourId,
+    raceIndex,
+    plannedTrackId,
+    aiDriverIds: tour.aiDrivers ?? [],
+  };
 }
 
 function resolveTrack(
@@ -321,6 +321,17 @@ function resolveLapsOverride(raw: string | null): number | null {
   const parsed = Number.parseInt(raw, 10);
   if (!Number.isInteger(parsed) || parsed < 1 || parsed > 50) return null;
   return parsed;
+}
+
+function resolveRaceAIDrivers(
+  tourContext: TourRaceContext | null,
+): readonly AIDriver[] {
+  if (tourContext === null) return AI_DRIVERS.slice(0, 1);
+  const tourRoster =
+    tourContext.aiDriverIds
+      .map((driverId) => getAIDriver(driverId))
+      .filter((driver): driver is AIDriver => driver !== undefined);
+  return tourRoster.length > 0 ? tourRoster : AI_DRIVERS.slice(0, 11);
 }
 
 /**
@@ -536,6 +547,7 @@ function RaceCanvas({
     steer: number;
     touchActive: boolean;
   }>(() => ({ steer: 0, touchActive: false }));
+  const [fieldSize, setFieldSize] = useState<number>(1);
   const [touchLayout, setTouchLayout] = useState<TouchLayout>(() =>
     touchLayoutFor({ width: VIEWPORT_WIDTH, height: VIEWPORT_HEIGHT }),
   );
@@ -607,6 +619,17 @@ function RaceCanvas({
       : pendingDamageForActiveCar(sessionSave);
     const raceSeed = 1;
     let timeTrialSaveSnapshot = sessionSave;
+    const spawnedAi = timeTrialEnabled
+      ? []
+      : spawnGrid({
+          trackSpawn: track.compiled.spawn,
+          laneCount: track.compiled.laneCount,
+          aiDrivers: resolveRaceAIDrivers(tourContext).map((driver) => ({
+            driver,
+            stats: STARTER_STATS,
+          })),
+          seed: raceSeed,
+        });
 
     const config: RaceSessionConfig = {
       track: track.compiled,
@@ -616,10 +639,11 @@ function RaceCanvas({
         difficultyPreset: persistedDifficulty,
         initialDamage: initialPlayerDamage,
       },
-      ai: [{ driver: DEMO_DRIVER, stats: STARTER_STATS }],
+      ai: spawnedAi,
       seed: raceSeed,
       ...(lapsOverride !== null ? { totalLaps: lapsOverride } : {}),
     };
+    setFieldSize(1 + config.ai.length);
     const activeWeather = config.weather ?? track.compiled.weatherOptions[0] ?? "clear";
 
     const resetTimeTrialRuntime = (): void => {
@@ -1106,6 +1130,8 @@ function RaceCanvas({
         </dd>
         <dt>Position:</dt>
         <dd data-testid="hud-position">{hudSnapshot.position}</dd>
+        <dt>Field size:</dt>
+        <dd data-testid="race-field-size">{fieldSize}</dd>
         <dt>Touch active:</dt>
         <dd data-testid="race-touch-active">
           {inputSnapshot.touchActive ? "yes" : "no"}

--- a/src/data/__tests__/championship-content.test.ts
+++ b/src/data/__tests__/championship-content.test.ts
@@ -27,6 +27,7 @@ import {
   CHAMPIONSHIPS_BY_ID,
   getChampionship,
 } from "@/data/championships";
+import { AI_DRIVERS_BY_ID } from "@/data/ai";
 import { ChampionshipSchema } from "@/data/schemas";
 import { SPONSOR_OBJECTIVES_BY_ID } from "@/data/sponsors";
 import { TRACK_RAW } from "@/data/tracks";
@@ -172,6 +173,24 @@ describe("world-tour-standard sponsor roster cross-references", () => {
       for (const sponsorId of tour.sponsors ?? []) {
         expect(SPONSOR_OBJECTIVES_BY_ID.has(sponsorId)).toBe(true);
       }
+    }
+  });
+});
+
+describe("world-tour-standard AI roster cross-references", () => {
+  const wt = getChampionship(WORLD_TOUR_ID);
+
+  it("resolves every referenced AI driver id", () => {
+    for (const tour of wt.tours) {
+      for (const driverId of tour.aiDrivers ?? []) {
+        expect(AI_DRIVERS_BY_ID.has(driverId)).toBe(true);
+      }
+    }
+  });
+
+  it("declares 11 AI drivers for each authored MVP tour", () => {
+    for (const tour of wt.tours.slice(0, 2)) {
+      expect(tour.aiDrivers ?? []).toHaveLength(11);
     }
   });
 });

--- a/src/data/championships/world-tour-standard.json
+++ b/src/data/championships/world-tour-standard.json
@@ -15,6 +15,19 @@
       "sponsors": [
         "velvet-coast-co-op",
         "cleanline-insurance"
+      ],
+      "aiDrivers": [
+        "ai_rocket_01",
+        "ai_cleanline_01",
+        "ai_bully_01",
+        "ai_cautious_01",
+        "ai_chaotic_01",
+        "ai_enduro_01",
+        "ai_rocket_02",
+        "ai_cleanline_02",
+        "ai_bully_02",
+        "ai_cautious_02",
+        "ai_chaotic_02"
       ]
     },
     {
@@ -29,6 +42,19 @@
       "sponsors": [
         "iron-borough-fabricators",
         "cleanline-insurance"
+      ],
+      "aiDrivers": [
+        "ai_rocket_03",
+        "ai_cleanline_03",
+        "ai_bully_03",
+        "ai_cautious_03",
+        "ai_chaotic_03",
+        "ai_enduro_02",
+        "ai_rocket_04",
+        "ai_cleanline_04",
+        "ai_enduro_03",
+        "ai_rocket_01",
+        "ai_cleanline_01"
       ]
     },
     {

--- a/src/data/schemas.ts
+++ b/src/data/schemas.ts
@@ -243,6 +243,13 @@ export const ChampionshipTourSchema = z.object({
    * so a content rename does not crash the race-finish flow.
    */
   sponsors: z.array(slug).optional(),
+  /**
+   * Optional per-tour AI roster keyed by `AIDriver.id`. When present,
+   * `/race?tour=...` builds the runtime grid from these drivers up to
+   * `track.spawn.gridSlots - 1` opponents. Optional so future tours can
+   * keep placeholder structure before their driver lineups are tuned.
+   */
+  aiDrivers: z.array(slug).optional(),
 });
 export type ChampionshipTour = z.infer<typeof ChampionshipTourSchema>;
 

--- a/src/game/__tests__/aiGrid.test.ts
+++ b/src/game/__tests__/aiGrid.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, it } from "vitest";
+
+import type { AIDriver, CarBaseStats } from "@/data/schemas";
+
+import { spawnGrid, type AIGridDriver } from "../aiGrid";
+
+const STATS: CarBaseStats = Object.freeze({
+  topSpeed: 61,
+  accel: 16,
+  brake: 28,
+  gripDry: 1,
+  gripWet: 0.82,
+  stability: 1,
+  durability: 0.95,
+  nitroEfficiency: 1,
+});
+
+function driver(id: string): AIDriver {
+  return {
+    id,
+    displayName: id,
+    archetype: "clean_line",
+    paceScalar: 1,
+    mistakeRate: 0,
+    aggression: 0.3,
+    weatherSkill: { clear: 1, rain: 1, fog: 1, snow: 1 },
+    nitroUsage: { launchBias: 0.5, straightBias: 0.5, panicBias: 0.1 },
+  };
+}
+
+function roster(count: number): readonly AIGridDriver[] {
+  return Array.from({ length: count }, (_, index) => ({
+    driver: driver(`ai_${String(index + 1).padStart(2, "0")}`),
+    stats: STATS,
+  }));
+}
+
+describe("spawnGrid", () => {
+  it("packs available AI drivers into player-reserved grid slots", () => {
+    const grid = spawnGrid({
+      trackSpawn: { gridSlots: 12 },
+      laneCount: 3,
+      aiDrivers: roster(20),
+      seed: 42,
+    });
+    expect(grid).toHaveLength(11);
+    expect(grid.map((entry) => entry.gridSlot)).toEqual([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]);
+  });
+
+  it("is pure and deterministic for repeated calls", () => {
+    const input = {
+      trackSpawn: { gridSlots: 12 },
+      laneCount: 3,
+      aiDrivers: roster(11),
+      seed: 7,
+    };
+    const first = spawnGrid(input);
+    for (let i = 0; i < 1000; i += 1) {
+      expect(spawnGrid(input)).toEqual(first);
+    }
+  });
+
+  it("permutes drivers by seed without duplicating ids", () => {
+    const input = {
+      trackSpawn: { gridSlots: 8 },
+      laneCount: 3,
+      aiDrivers: roster(8),
+    };
+    const a = spawnGrid({ ...input, seed: 1 }).map((entry) => entry.driver.id);
+    const b = spawnGrid({ ...input, seed: 2 }).map((entry) => entry.driver.id);
+    expect(a).not.toEqual(b);
+    expect(new Set(a).size).toBe(a.length);
+    expect(new Set(b).size).toBe(b.length);
+  });
+
+  it("spreads lanes within each row and preserves unique slots", () => {
+    const grid = spawnGrid({
+      trackSpawn: { gridSlots: 12 },
+      laneCount: 3,
+      aiDrivers: roster(11),
+      seed: 3,
+    });
+    expect(grid.slice(0, 3).map((entry) => entry.lane)).toEqual([1, 0, 2]);
+    const slotLanePairs = new Set(
+      grid.map((entry) => `${entry.gridSlot}:${entry.lane}`),
+    );
+    expect(slotLanePairs.size).toBe(grid.length);
+  });
+
+  it("leaves trailing slots empty when the roster is short", () => {
+    const grid = spawnGrid({
+      trackSpawn: { gridSlots: 12 },
+      laneCount: 3,
+      aiDrivers: roster(2),
+      seed: 4,
+    });
+    expect(grid).toHaveLength(2);
+  });
+
+  it("returns no AI cars when only the player slot exists", () => {
+    const grid = spawnGrid({
+      trackSpawn: { gridSlots: 1 },
+      laneCount: 3,
+      aiDrivers: roster(3),
+      seed: 5,
+    });
+    expect(grid).toEqual([]);
+  });
+});

--- a/src/game/aiGrid.ts
+++ b/src/game/aiGrid.ts
@@ -1,0 +1,92 @@
+import type { AIDriver, CarBaseStats, TrackSpawn } from "@/data/schemas";
+import { ROAD_WIDTH } from "@/road/constants";
+
+import type { CarUpgradeTiers, RaceSessionAI } from "./raceSession";
+import { createRng } from "./rng";
+
+export interface AIGridDriver {
+  readonly driver: Readonly<AIDriver>;
+  readonly stats: Readonly<CarBaseStats>;
+  readonly upgrades?: Readonly<CarUpgradeTiers> | null;
+}
+
+export interface SpawnGridInput {
+  readonly trackSpawn: Readonly<TrackSpawn>;
+  readonly laneCount: number;
+  readonly aiDrivers: ReadonlyArray<AIGridDriver>;
+  readonly seed?: number;
+  readonly rowSpacingMeters?: number;
+}
+
+export interface SpawnedGridCar extends RaceSessionAI {
+  readonly gridSlot: number;
+  readonly lane: number;
+  readonly startX: number;
+  readonly startZ: number;
+}
+
+const DEFAULT_GRID_SEED = 1;
+const DEFAULT_ROW_SPACING_METERS = 5;
+
+export function spawnGrid(input: SpawnGridInput): readonly SpawnedGridCar[] {
+  const slotCount = Math.max(0, Math.floor(input.trackSpawn.gridSlots) - 1);
+  const laneCount = Math.max(1, Math.floor(input.laneCount));
+  const rowSpacingMeters =
+    input.rowSpacingMeters === undefined
+      ? DEFAULT_ROW_SPACING_METERS
+      : Math.max(1, input.rowSpacingMeters);
+  const shuffled = shuffleDrivers(input.aiDrivers, input.seed ?? DEFAULT_GRID_SEED);
+
+  return shuffled.slice(0, slotCount).map((entry, index) => {
+    const gridSlot = index + 1;
+    const lane = laneForGridIndex(index, laneCount);
+    const row = Math.floor(index / laneCount) + 1;
+    const startX = xForLane(lane, laneCount);
+    const startZ = -row * rowSpacingMeters;
+    return {
+      driver: entry.driver,
+      stats: entry.stats,
+      upgrades: entry.upgrades ?? null,
+      gridSlot,
+      lane,
+      startX,
+      startZ,
+      seed: seedForGridSlot(input.seed ?? DEFAULT_GRID_SEED, gridSlot),
+      initial: { x: startX, z: startZ },
+    };
+  });
+}
+
+function shuffleDrivers(
+  drivers: ReadonlyArray<AIGridDriver>,
+  seed: number,
+): AIGridDriver[] {
+  const next = drivers.slice();
+  const rng = createRng(seed);
+  for (let i = next.length - 1; i > 0; i -= 1) {
+    const j = rng.nextInt(0, i + 1);
+    const tmp = next[i]!;
+    next[i] = next[j]!;
+    next[j] = tmp;
+  }
+  return next;
+}
+
+function laneForGridIndex(index: number, laneCount: number): number {
+  const rowIndex = index % laneCount;
+  const center = Math.floor(laneCount / 2);
+  if (rowIndex === 0) return center;
+  const offset = Math.ceil(rowIndex / 2);
+  return rowIndex % 2 === 1
+    ? Math.max(0, center - offset)
+    : Math.min(laneCount - 1, center + offset);
+}
+
+function xForLane(lane: number, laneCount: number): number {
+  const laneWidth = (ROAD_WIDTH * 2) / laneCount;
+  return -ROAD_WIDTH + laneWidth * (lane + 0.5);
+}
+
+function seedForGridSlot(seed: number, gridSlot: number): number {
+  return (Math.imul(seed >>> 0, 1664525) + Math.imul(gridSlot, 1013904223)) >>> 0;
+}

--- a/src/game/index.ts
+++ b/src/game/index.ts
@@ -11,6 +11,7 @@ export * from "./input";
 export * from "./physics";
 export * from "./hudState";
 export * from "./ai";
+export * from "./aiGrid";
 export * from "./damageBands";
 export * from "./transmission";
 export * from "./nitro";


### PR DESCRIPTION
## Summary
- add a deterministic AI grid spawner that reserves the player slot and fills remaining track grid slots
- add per-tour AI rosters for the first two World Tour regions and document the optional aiDrivers schema field
- wire World Tour race routes to launch 12-car fields while preserving the plain /race prototype fallback

## GDD
- docs/gdd/15-cpu-opponents-and-ai.md
- docs/gdd/20-hud-and-ui-ux.md
- docs/gdd/22-data-schemas.md
- docs/gdd/25-development-roadmap.md
- docs/PROGRESS_LOG.md entry: 2026-04-28 Slice: AI grid spawner
- docs/GDD_COVERAGE.json: GDD-15-AI-GRID-SPAWNER

## Test plan
- npx vitest run src/game/__tests__/aiGrid.test.ts src/data/__tests__/championship-content.test.ts
- npm run typecheck
- npm run test:e2e -- e2e/twelve-car-field.spec.ts e2e/race-demo.spec.ts
- npm run verify
- npm run test:e2e

## Notes
- Time trial still spawns no live AI opponents.
- The non-tour /race smoke route remains on one AI opponent so the campaign-size grid does not mask prototype-route regressions.