### PR TITLE
feat(game): evaluate track hazards

### DIFF
--- a/docs/FOLLOWUPS.md
+++ b/docs/FOLLOWUPS.md
@@ -1361,7 +1361,7 @@ asserts zero hits.
 ## F-019: Race session integration of the §13 damage model
 **Created:** 2026-04-26
 **Priority:** nice-to-have
-**Status:** in-progress
+**Status:** done (2026-04-28)
 **Notes:** The `feat/damage-model` slice ships `src/game/damage.ts` as a
 pure module: `applyHit`, `applyOffRoadDamage`, `performanceMultiplier`,
 `isWrecked`, `repairCostFor`, `totalRepairCost` and the constants
@@ -1392,13 +1392,12 @@ tick reads the new band). PRISTINE damage collapses the multipliers
 to identity, so an undamaged car's behaviour is bit-for-bit
 identical to the pre-binding pipeline.
 
-The remaining open consumer is the hazard-runtime damage emitter
-(per-tick puddle / cone / debris hits feeding `applyHit` with the
-matching `HitKind`) owned by the hazards-runtime dot
-(`VibeGear2-implement-hazards-runtime-6085799c`); F-047 did not
-bundle it because the hazards module does not yet exist.
-
-Close F-019 once the hazards-runtime path lands.
+Closed by `feat/hazards-runtime`. The hazards runtime now resolves
+authored track hazard ids through `src/data/hazards.json`, evaluates
+overlap per compiled segment, applies grip multipliers to the physics
+step, forwards hazard damage through `applyHit`, and records breakable
+hazards in race state so a cone or sign damages only once per race.
+Tunnel entries remain registry metadata for the dedicated tunnel slice.
 
 ## F-018: Playwright e2e spec for the loading screen / preload gate
 **Created:** 2026-04-26

--- a/docs/GDD_COVERAGE.json
+++ b/docs/GDD_COVERAGE.json
@@ -2,6 +2,29 @@
   "version": 1,
   "requirements": [
     {
+      "id": "GDD-09-HAZARDS-RUNTIME",
+      "gddSections": [
+        "docs/gdd/09-track-design.md",
+        "docs/gdd/13-damage-repairs-and-risk.md",
+        "docs/gdd/22-data-schemas.md",
+        "docs/gdd/23-balancing-tables.md"
+      ],
+      "requirement": "Authored track hazard ids resolve through a typed registry, and live races evaluate physical hazards for grip, breakable objects, and damage events.",
+      "coverage": ["implemented-code", "automated-test"],
+      "implementationRefs": [
+        "src/data/hazards.json",
+        "src/data/hazards.ts",
+        "src/game/hazards.ts",
+        "src/game/raceSession.ts",
+        "src/app/race/page.tsx"
+      ],
+      "testRefs": [
+        "src/data/__tests__/hazards-content.test.ts",
+        "src/game/__tests__/hazards.test.ts",
+        "src/game/__tests__/raceSession.test.ts"
+      ]
+    },
+    {
       "id": "GDD-15-AI-GRID-SPAWNER",
       "gddSections": [
         "docs/gdd/15-cpu-opponents-and-ai.md",

--- a/docs/PROGRESS_LOG.md
+++ b/docs/PROGRESS_LOG.md
@@ -6,6 +6,67 @@ Correct them by adding a new entry that references the old one.
 
 ---
 
+## 2026-04-28: Slice: Hazards runtime
+
+**GDD sections touched:**
+[§9](gdd/09-track-design.md) authored track hazards,
+[§13](gdd/13-damage-repairs-and-risk.md) off-road object damage,
+[§22](gdd/22-data-schemas.md) hazard registry schema,
+[§23](gdd/23-balancing-tables.md) damage formula targets.
+**Branch / PR:** `feat/hazards-runtime`, PR pending.
+**Status:** Implemented.
+
+### Done
+- `src/data/hazards.json` and `src/data/hazards.ts`: added a typed hazard
+  registry for puddles, slick paint, cones, signs, gravel bands, snow
+  buildup, and tunnel metadata.
+- `src/game/hazards.ts`: added a pure evaluator that maps a car position
+  and compiled segment to hazard events, grip multipliers, damage hits,
+  and breakable hazard state.
+- `src/game/raceSession.ts`: threads active hazard grip into the physics
+  step, forwards physical hazard hits through `applyHit`, and persists
+  breakable hazard keys in race state.
+- `src/app/race/page.tsx`: passes the bundled hazard registry into live
+  race sessions.
+- `src/data/__tests__/hazards-content.test.ts`, `src/game/__tests__/hazards.test.ts`,
+  and `src/game/__tests__/raceSession.test.ts`: pin registry validity,
+  hazard overlap behavior, tunnel no-op behavior, and one-shot breakable
+  cone damage.
+- `docs/FOLLOWUPS.md`: marked F-019 done now that the hazard damage emitter
+  exists.
+- `docs/GDD_COVERAGE.json`: added GDD-09-HAZARDS-RUNTIME.
+
+### Verified
+- `npx vitest run src/game/__tests__/hazards.test.ts src/data/__tests__/hazards-content.test.ts src/game/__tests__/raceSession.test.ts src/game/__tests__/raceSessionActions.test.ts`
+  green, 118 passed.
+- `npm run typecheck` clean.
+- `npm run verify` green, 2256 passed.
+- `npm run test:e2e` green, 69 passed.
+
+### Decisions and assumptions
+- Segment-authored hazards occupy the compiled segment where they are
+  referenced and use registry default widths and lengths until the track
+  schema grows per-instance hazard placement.
+- Tunnel hazards are registered and validated now, but tunnel light and
+  audio effects stay out of this PR because the tunnel segment slice owns
+  that behavior.
+- Breakable hazards are tracked per compiled segment and id for the current
+  race only. Nothing persists into the save file.
+
+### Coverage ledger
+- GDD-09-HAZARDS-RUNTIME covers physical hazard registry validation and live
+  race-session grip and damage effects.
+- Uncovered adjacent requirements: rendered hazard sprites, puddle splash
+  VFX, snow buildup visuals, tunnel light adaptation, and seeded magnitude
+  rolls remain future slices.
+
+### Followups created
+None.
+
+### GDD edits
+- `docs/gdd/22-data-schemas.md`: added the hazard registry JSON example and
+  clarified `Track.segments[].hazards` references.
+
 ## 2026-04-28: Slice: AI grid spawner
 
 **GDD sections touched:**

--- a/docs/gdd/22-data-schemas.md
+++ b/docs/gdd/22-data-schemas.md
@@ -146,6 +146,27 @@
 }
 ```
 
+## Hazard registry JSON schema
+
+```
+{
+  "id": "traffic_cone",
+  "kind": "traffic_cone",
+  "displayName": "Traffic Cone",
+  "defaultWidth": 1.8,
+  "defaultLength": 8,
+  "laneOffset": 0,
+  "gripMultiplier": 1.0,
+  "damageKind": "offRoadObject",
+  "damageMagnitude": 6,
+  "breakable": true
+}
+```
+
+`Track.segments[].hazards` entries reference these hazard ids. Tunnel
+entries are valid registry metadata but their light and audio transition
+effects are owned by the tunnel segment slice.
+
 ## Save-game JSON schema
 
 Current schema major: **v3**. v1 saves migrate forward additively via

--- a/src/app/race/page.tsx
+++ b/src/app/race/page.tsx
@@ -44,6 +44,7 @@ import { usePauseToggle } from "@/components/pause/usePauseToggle";
 import { saveRaceResult } from "@/components/results/raceResultStorage";
 import {
   AI_DRIVERS,
+  HAZARDS_BY_ID,
   TRACK_IDS,
   TRACK_RAW,
   getAIDriver,
@@ -640,6 +641,7 @@ function RaceCanvas({
         initialDamage: initialPlayerDamage,
       },
       ai: spawnedAi,
+      hazardsById: HAZARDS_BY_ID,
       seed: raceSeed,
       ...(lapsOverride !== null ? { totalLaps: lapsOverride } : {}),
     };

--- a/src/data/__tests__/hazards-content.test.ts
+++ b/src/data/__tests__/hazards-content.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vitest";
+
+import { HAZARDS, HAZARDS_BY_ID, TRACK_RAW } from "@/data";
+import { HazardRegistryEntrySchema, TrackSchema } from "@/data/schemas";
+
+describe("hazard registry", () => {
+  it("validates every bundled hazard entry", () => {
+    for (const hazard of HAZARDS) {
+      expect(HazardRegistryEntrySchema.safeParse(hazard).success).toBe(true);
+    }
+  });
+
+  it("indexes hazard ids uniquely", () => {
+    expect(HAZARDS_BY_ID.size).toBe(HAZARDS.length);
+  });
+
+  it("resolves every hazard id referenced by bundled tracks", () => {
+    const missing: string[] = [];
+    for (const [trackId, raw] of Object.entries(TRACK_RAW)) {
+      const track = TrackSchema.parse(raw);
+      for (const [segmentIndex, segment] of track.segments.entries()) {
+        for (const hazardId of segment.hazards) {
+          if (!HAZARDS_BY_ID.has(hazardId)) {
+            missing.push(`${trackId}:${segmentIndex}:${hazardId}`);
+          }
+        }
+      }
+    }
+    expect(missing).toEqual([]);
+  });
+});

--- a/src/data/hazards.json
+++ b/src/data/hazards.json
@@ -1,0 +1,86 @@
+[
+  {
+    "id": "puddle",
+    "kind": "puddle",
+    "displayName": "Puddle",
+    "defaultWidth": 14,
+    "defaultLength": 24,
+    "laneOffset": 0,
+    "gripMultiplier": 0.65,
+    "damageKind": null,
+    "damageMagnitude": null,
+    "breakable": false
+  },
+  {
+    "id": "slick_paint",
+    "kind": "slick_paint",
+    "displayName": "Slick Paint",
+    "defaultWidth": 10,
+    "defaultLength": 18,
+    "laneOffset": 0,
+    "gripMultiplier": 0.8,
+    "damageKind": null,
+    "damageMagnitude": null,
+    "breakable": false
+  },
+  {
+    "id": "traffic_cone",
+    "kind": "traffic_cone",
+    "displayName": "Traffic Cone",
+    "defaultWidth": 1.8,
+    "defaultLength": 8,
+    "laneOffset": 0,
+    "gripMultiplier": 1,
+    "damageKind": "offRoadObject",
+    "damageMagnitude": 6,
+    "breakable": true
+  },
+  {
+    "id": "sign_marker",
+    "kind": "sign",
+    "displayName": "Sign Marker",
+    "defaultWidth": 2.2,
+    "defaultLength": 8,
+    "laneOffset": 0,
+    "gripMultiplier": 1,
+    "damageKind": "offRoadObject",
+    "damageMagnitude": 13,
+    "breakable": true
+  },
+  {
+    "id": "gravel_band",
+    "kind": "gravel_band",
+    "displayName": "Gravel Band",
+    "defaultWidth": 14,
+    "defaultLength": 30,
+    "laneOffset": 0,
+    "gripMultiplier": 0.55,
+    "damageKind": "rub",
+    "damageMagnitude": 3,
+    "breakable": false
+  },
+  {
+    "id": "snow_buildup",
+    "kind": "snow_buildup",
+    "displayName": "Snow Buildup",
+    "defaultWidth": 14,
+    "defaultLength": 30,
+    "laneOffset": 0,
+    "gripMultiplier": 0.45,
+    "damageKind": null,
+    "damageMagnitude": null,
+    "breakable": false
+  },
+  {
+    "id": "tunnel",
+    "kind": "tunnel",
+    "displayName": "Tunnel",
+    "defaultWidth": 14,
+    "defaultLength": 48,
+    "laneOffset": 0,
+    "gripMultiplier": 1,
+    "damageKind": null,
+    "damageMagnitude": null,
+    "breakable": false
+  }
+]

--- a/src/data/hazards.ts
+++ b/src/data/hazards.ts
@@ -1,0 +1,15 @@
+import rawHazards from "./hazards.json";
+import { HazardRegistryEntrySchema, type HazardRegistryEntry } from "./schemas";
+
+export const HAZARDS: readonly HazardRegistryEntry[] = Object.freeze(
+  rawHazards.map((entry) =>
+    Object.freeze(HazardRegistryEntrySchema.parse(entry)),
+  ),
+);
+
+export const HAZARDS_BY_ID: ReadonlyMap<string, HazardRegistryEntry> =
+  Object.freeze(new Map(HAZARDS.map((entry) => [entry.id, entry])));
+
+export function getHazard(id: string): HazardRegistryEntry | undefined {
+  return HAZARDS_BY_ID.get(id);
+}

--- a/src/data/index.ts
+++ b/src/data/index.ts
@@ -26,6 +26,11 @@ export {
   SPONSOR_OBJECTIVES_BY_ID,
   getSponsorObjective,
 } from "./sponsors";
+export {
+  HAZARDS,
+  HAZARDS_BY_ID,
+  getHazard,
+} from "./hazards";
 
 import { compileTrack } from "@/road/trackCompiler";
 import type { CompiledTrack } from "@/road/types";

--- a/src/data/schemas.ts
+++ b/src/data/schemas.ts
@@ -47,13 +47,38 @@ export const WeatherOptionSchema = z.enum([
 ]);
 export type WeatherOption = z.infer<typeof WeatherOptionSchema>;
 
+export const HazardKindSchema = z.enum([
+  "puddle",
+  "slick_paint",
+  "traffic_cone",
+  "sign",
+  "gravel_band",
+  "snow_buildup",
+  "tunnel",
+]);
+export type HazardKind = z.infer<typeof HazardKindSchema>;
+
+export const HazardRegistryEntrySchema = z.object({
+  id: slug,
+  kind: HazardKindSchema,
+  displayName: z.string().min(1),
+  defaultWidth: positiveNumber,
+  defaultLength: positiveNumber,
+  laneOffset: z.number().optional(),
+  gripMultiplier: positiveNumber.optional(),
+  damageKind: z.enum(["rub", "offRoadObject"]).nullable().optional(),
+  damageMagnitude: positiveNumber.nullable().optional(),
+  breakable: z.boolean(),
+});
+export type HazardRegistryEntry = z.infer<typeof HazardRegistryEntrySchema>;
+
 export const TrackSegmentSchema = z.object({
   len: positiveNumber,
   curve: z.number().min(-1).max(1),
   grade: z.number().min(-0.3).max(0.3),
   roadsideLeft: z.string().min(1),
   roadsideRight: z.string().min(1),
-  hazards: z.array(z.string().min(1)),
+  hazards: z.array(slug),
 });
 export type TrackSegment = z.infer<typeof TrackSegmentSchema>;
 

--- a/src/game/__tests__/hazards.test.ts
+++ b/src/game/__tests__/hazards.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from "vitest";
+
+import { HAZARDS_BY_ID } from "@/data";
+import { loadTrack } from "@/data";
+import { evaluateHazards } from "@/game/hazards";
+import type { CarState } from "@/game/physics";
+
+const TRACK = loadTrack("iron-borough/freightline-ring");
+
+function car(overrides: Partial<CarState> = {}): CarState {
+  return {
+    x: 0,
+    z: 245,
+    speed: 30,
+    surface: "road",
+    ...overrides,
+  };
+}
+
+describe("evaluateHazards", () => {
+  it("emits a traffic cone hit on a matching compiled segment", () => {
+    const effect = evaluateHazards({
+      car: car(),
+      track: TRACK,
+      hazardsById: HAZARDS_BY_ID,
+    });
+    expect(effect.events).toHaveLength(1);
+    expect(effect.events[0]?.hazard.id).toBe("traffic_cone");
+    expect(effect.events[0]?.hit?.kind).toBe("offRoadObject");
+    expect(effect.brokenHazards.has("40:traffic_cone")).toBe(true);
+  });
+
+  it("skips a broken breakable hazard on the next pass", () => {
+    const first = evaluateHazards({
+      car: car(),
+      track: TRACK,
+      hazardsById: HAZARDS_BY_ID,
+    });
+    const second = evaluateHazards({
+      car: car(),
+      track: TRACK,
+      hazardsById: HAZARDS_BY_ID,
+      brokenHazards: first.brokenHazards,
+    });
+    expect(second.events).toEqual([]);
+  });
+
+  it("applies puddle grip without damage", () => {
+    const track = loadTrack("velvet-coast/harbor-run");
+    const effect = evaluateHazards({
+      car: car({ z: 660 }),
+      track,
+      hazardsById: HAZARDS_BY_ID,
+    });
+    expect(effect.events[0]?.hazard.id).toBe("puddle");
+    expect(effect.gripMultiplier).toBeCloseTo(0.65, 6);
+    expect(effect.events[0]?.hit).toBeNull();
+  });
+
+  it("ignores tunnel metadata until the tunnel slice consumes it", () => {
+    const track = loadTrack("iron-borough/rivet-tunnel");
+    const effect = evaluateHazards({
+      car: car({ z: 505 }),
+      track,
+      hazardsById: HAZARDS_BY_ID,
+    });
+    expect(effect.events).toEqual([]);
+    expect(effect.gripMultiplier).toBe(1);
+  });
+});

--- a/src/game/__tests__/raceSession.test.ts
+++ b/src/game/__tests__/raceSession.test.ts
@@ -14,7 +14,7 @@
 
 import { describe, expect, it } from "vitest";
 
-import { loadTrack } from "@/data";
+import { HAZARDS_BY_ID, loadTrack } from "@/data";
 import {
   AI_GRID_OFFSET_BEHIND_PLAYER_M,
   CAR_LENGTH_M,
@@ -192,6 +192,27 @@ describe("stepRaceSession (racing)", () => {
     expect(second).not.toBe(first);
     expect(second.player).not.toBe(first.player);
     expect(second.player.car).not.toBe(first.player.car);
+  });
+
+  it("applies breakable track hazard damage once", () => {
+    const track = loadTrack("iron-borough/freightline-ring");
+    const config = buildConfig({
+      track,
+      player: {
+        stats: STARTER_STATS,
+        initial: { z: 245, speed: 30 },
+      },
+      ai: [],
+      countdownSec: 0,
+      hazardsById: HAZARDS_BY_ID,
+    });
+    const first = stepRaceSession(createRaceSession(config), NEUTRAL_INPUT, config, DT);
+    const afterFirstHit = first.player.damage.total;
+    expect(afterFirstHit).toBeGreaterThan(0);
+    expect(first.brokenHazards).toContain("40:traffic_cone");
+
+    const second = stepRaceSession(first, NEUTRAL_INPUT, config, DT);
+    expect(second.player.damage.total).toBe(afterFirstHit);
   });
 });
 

--- a/src/game/hazards.ts
+++ b/src/game/hazards.ts
@@ -1,0 +1,122 @@
+import type { HazardRegistryEntry } from "@/data/schemas";
+import { SEGMENT_LENGTH } from "@/road/constants";
+import type { CompiledTrack } from "@/road/types";
+
+import type { HitEvent, HitKind } from "./damage";
+import type { CarState } from "./physics";
+
+export interface HazardEvent {
+  readonly key: string;
+  readonly hazard: Readonly<HazardRegistryEntry>;
+  readonly segmentIndex: number;
+  readonly gripMultiplier: number;
+  readonly hit: HitEvent | null;
+  readonly breakable: boolean;
+}
+
+export interface EvaluateHazardsInput {
+  readonly car: Readonly<CarState>;
+  readonly track: Readonly<CompiledTrack>;
+  readonly hazardsById: ReadonlyMap<string, Readonly<HazardRegistryEntry>>;
+  readonly brokenHazards?: ReadonlySet<string>;
+}
+
+export interface HazardTickEffect {
+  readonly events: readonly HazardEvent[];
+  readonly gripMultiplier: number;
+  readonly brokenHazards: ReadonlySet<string>;
+}
+
+export function evaluateHazards(input: EvaluateHazardsInput): HazardTickEffect {
+  const segment = segmentAt(input.track, input.car.z);
+  if (segment === null || segment.hazardIds.length === 0) {
+    return noHazardEffect(input.brokenHazards);
+  }
+
+  const priorBroken = input.brokenHazards ?? new Set<string>();
+  const nextBroken = new Set(priorBroken);
+  const events: HazardEvent[] = [];
+  let gripMultiplier = 1;
+
+  for (const hazardId of segment.hazardIds) {
+    const hazard = input.hazardsById.get(hazardId);
+    if (hazard === undefined) continue;
+    if (hazard.kind === "tunnel") continue;
+    const key = `${segment.index}:${hazard.id}`;
+    if (priorBroken.has(key)) continue;
+    if (!overlapsLateral(input.car.x, hazard)) continue;
+    const event = buildHazardEvent(key, hazard, segment.index, input.car.speed);
+    events.push(event);
+    gripMultiplier *= event.gripMultiplier;
+    if (event.breakable) nextBroken.add(key);
+  }
+
+  return {
+    events,
+    gripMultiplier,
+    brokenHazards: nextBroken,
+  };
+}
+
+export function segmentAt(
+  track: Readonly<CompiledTrack>,
+  z: number,
+) {
+  if (track.segments.length === 0) return null;
+  const wrappedZ =
+    track.totalLengthMeters > 0
+      ? ((z % track.totalLengthMeters) + track.totalLengthMeters) %
+        track.totalLengthMeters
+      : z;
+  const index = Math.floor(wrappedZ / SEGMENT_LENGTH) % track.segments.length;
+  return track.segments[index] ?? null;
+}
+
+function buildHazardEvent(
+  key: string,
+  hazard: Readonly<HazardRegistryEntry>,
+  segmentIndex: number,
+  speed: number,
+): HazardEvent {
+  return {
+    key,
+    hazard,
+    segmentIndex,
+    gripMultiplier: hazard.gripMultiplier ?? 1,
+    hit: buildHit(hazard, speed),
+    breakable: hazard.breakable,
+  };
+}
+
+function buildHit(
+  hazard: Readonly<HazardRegistryEntry>,
+  speed: number,
+): HitEvent | null {
+  if (hazard.damageKind === null || hazard.damageKind === undefined) return null;
+  if (hazard.damageMagnitude === null || hazard.damageMagnitude === undefined) {
+    return null;
+  }
+  return {
+    kind: hazard.damageKind satisfies HitKind,
+    baseMagnitude: hazard.damageMagnitude,
+    speedFactor: Math.max(0, Math.min(1, speed / 60)),
+  };
+}
+
+function overlapsLateral(
+  carX: number,
+  hazard: Readonly<HazardRegistryEntry>,
+): boolean {
+  const center = hazard.laneOffset ?? 0;
+  return Math.abs(carX - center) <= hazard.defaultWidth / 2;
+}
+
+function noHazardEffect(
+  brokenHazards: ReadonlySet<string> | undefined,
+): HazardTickEffect {
+  return {
+    events: [],
+    gripMultiplier: 1,
+    brokenHazards: brokenHazards ?? new Set<string>(),
+  };
+}

--- a/src/game/index.ts
+++ b/src/game/index.ts
@@ -12,6 +12,7 @@ export * from "./physics";
 export * from "./hudState";
 export * from "./ai";
 export * from "./aiGrid";
+export * from "./hazards";
 export * from "./damageBands";
 export * from "./transmission";
 export * from "./nitro";

--- a/src/game/raceSession.ts
+++ b/src/game/raceSession.ts
@@ -32,6 +32,7 @@
 import type {
   AIDriver,
   CarBaseStats,
+  HazardRegistryEntry,
   PlayerDifficultyPreset,
   TransmissionModePersisted,
   UpgradeCategory,
@@ -71,6 +72,7 @@ import {
   type HitKind,
 } from "./damage";
 import { getDamageBand, getDamageScalars } from "./damageBands";
+import type { DamageScalars } from "./damageBands";
 import {
   resolvePresetScalars,
   type AssistScalars,
@@ -82,6 +84,7 @@ import {
   type DraftCarSnapshot,
   type DraftWindowState,
 } from "./drafting";
+import { evaluateHazards } from "./hazards";
 import { NEUTRAL_INPUT, type Input } from "./input";
 import {
   createNitroForCar,
@@ -206,6 +209,8 @@ export interface RaceSessionConfig {
   aiContext?: AITrackContext;
   player: RaceSessionPlayer;
   ai: ReadonlyArray<RaceSessionAI>;
+  /** Optional hazard registry keyed by `TrackSegment.hazards` ids. */
+  hazardsById?: ReadonlyMap<string, Readonly<HazardRegistryEntry>>;
   /**
    * Total laps. Defaults to `track.laps` so the data file owns the lap count
    * unless the run mode (e.g. quick-race) overrides it.
@@ -487,6 +492,8 @@ export interface RaceSessionState {
    * other car), which is small even for a full 12-car grid.
    */
   draftWindows: Readonly<Record<string, DraftWindowState>>;
+  /** Breakable track hazards consumed during this race, keyed by segment and id. */
+  brokenHazards: ReadonlyArray<string>;
 }
 
 /**
@@ -665,6 +672,7 @@ export function createRaceSession(config: RaceSessionConfig): RaceSessionState {
     sectorTimer,
     baselineSplitsMs: null,
     draftWindows: {},
+    brokenHazards: [],
   };
 }
 
@@ -826,6 +834,7 @@ export function stepRaceSession(
         sectorTimer: state.sectorTimer,
         baselineSplitsMs: state.baselineSplitsMs,
         draftWindows: state.draftWindows,
+        brokenHazards: state.brokenHazards,
       };
     }
     // Lights out. Flip to racing, zero the tick clock, reset the sector
@@ -850,6 +859,7 @@ export function stepRaceSession(
       sectorTimer: createSectorState(config.track.checkpoints),
       baselineSplitsMs: state.baselineSplitsMs,
       draftWindows: state.draftWindows,
+      brokenHazards: state.brokenHazards,
     };
     return stepRaceSession(promoted, playerInput, config, dt);
   }
@@ -1101,6 +1111,22 @@ export function stepRaceSession(
   }
 
   const playerDraftBonus = draftMultipliers.get(PLAYER_CAR_ID) ?? 1;
+  const hazardsById = config.hazardsById ?? EMPTY_HAZARD_REGISTRY;
+  let nextBrokenHazards = new Set(state.brokenHazards);
+  const hazardHitsByCarId = new Map<string, HitEvent[]>();
+  const playerHazards = playerIsRacing
+    ? evaluateHazards({
+        car: state.player.car,
+        track: config.track,
+        hazardsById,
+        brokenHazards: nextBrokenHazards,
+      })
+    : EMPTY_HAZARD_EFFECT;
+  nextBrokenHazards = new Set(playerHazards.brokenHazards);
+  const playerHazardHits = hitsFromHazards(playerHazards.events);
+  if (playerHazardHits.length > 0) {
+    hazardHitsByCarId.set(PLAYER_CAR_ID, playerHazardHits);
+  }
   // §13 / F-019: derive the player's per-tick damage scalars from the
   // pre-step damage band. The §10 narrative wants engine damage to clip
   // top speed and tire damage to scrub grip; the band table in
@@ -1111,7 +1137,10 @@ export function stepRaceSession(
   // bite the next physics integration. PRISTINE_SCALARS at zero damage
   // collapses the multipliers to identity, preserving pre-binding
   // behaviour for an undamaged car.
-  const playerDamageScalars = getDamageScalars(state.player.damage.total * 100);
+  const playerDamageScalars = withHazardGrip(
+    getDamageScalars(state.player.damage.total * 100),
+    playerHazards.gripMultiplier,
+  );
   // Skip physics integration entirely for non-racing players (DNF or
   // post-finish). Freezing the snapshot is what makes a retired player
   // sit in place across the rest of the race rather than continuing to
@@ -1192,7 +1221,21 @@ export function stepRaceSession(
     // agnostic, so every AI car reads its own pre-step damage band
     // through the same band table. Identity scalars at zero damage keep
     // the unscaled behaviour for an undamaged AI.
-    const aiDamageScalars = getDamageScalars(entry.damage.total * 100);
+    const aiHazards = evaluateHazards({
+      car: entry.car,
+      track: config.track,
+      hazardsById,
+      brokenHazards: nextBrokenHazards,
+    });
+    nextBrokenHazards = new Set(aiHazards.brokenHazards);
+    const aiHazardHits = hitsFromHazards(aiHazards.events);
+    if (aiHazardHits.length > 0) {
+      hazardHitsByCarId.set(aiCarId(index), aiHazardHits);
+    }
+    const aiDamageScalars = withHazardGrip(
+      getDamageScalars(entry.damage.total * 100),
+      aiHazards.gripMultiplier,
+    );
     const nextCar = step(
       entry.car,
       tick.input,
@@ -1268,7 +1311,7 @@ export function stepRaceSession(
   // Per-id list of `carHit` events to apply this tick. The pair scan
   // populates both sides of every contact pair so the §13 carHit
   // distribution applies symmetrically.
-  const hitsByCarId = new Map<string, HitEvent[]>();
+  const hitsByCarId = new Map(hazardHitsByCarId);
   for (let i = 0; i < damageEntries.length; i += 1) {
     const a = damageEntries[i]!;
     if (!a.racing) continue;
@@ -1566,6 +1609,7 @@ export function stepRaceSession(
     sectorTimer: nextSectorTimer,
     baselineSplitsMs: nextBaseline,
     draftWindows: nextDraftWindows,
+    brokenHazards: Array.from(nextBrokenHazards),
   };
 }
 
@@ -1606,6 +1650,35 @@ function cloneSessionState(state: Readonly<RaceSessionState>): RaceSessionState 
     sectorTimer: state.sectorTimer,
     baselineSplitsMs: state.baselineSplitsMs,
     draftWindows: state.draftWindows,
+    brokenHazards: state.brokenHazards.slice(),
+  };
+}
+
+const EMPTY_HAZARD_REGISTRY: ReadonlyMap<string, Readonly<HazardRegistryEntry>> =
+  Object.freeze(new Map());
+
+const EMPTY_HAZARD_EFFECT = Object.freeze({
+  events: Object.freeze([]),
+  gripMultiplier: 1,
+  brokenHazards: Object.freeze(new Set<string>()),
+});
+
+function hitsFromHazards(
+  events: readonly { readonly hit: HitEvent | null }[],
+): HitEvent[] {
+  return events.flatMap((event) => (event.hit === null ? [] : [event.hit]));
+}
+
+function withHazardGrip(
+  scalars: Readonly<DamageScalars>,
+  gripMultiplier: number,
+): DamageScalars {
+  if (!Number.isFinite(gripMultiplier) || gripMultiplier === 1) {
+    return scalars;
+  }
+  return {
+    ...scalars,
+    gripScalar: scalars.gripScalar * Math.max(0, gripMultiplier),
   };
 }
 

--- a/src/game/raceSessionActions.ts
+++ b/src/game/raceSessionActions.ts
@@ -107,6 +107,7 @@ export function retireRaceSession(
     sectorTimer: state.sectorTimer,
     baselineSplitsMs: state.baselineSplitsMs,
     draftWindows: state.draftWindows,
+    brokenHazards: state.brokenHazards.slice(),
   };
 }
 
@@ -153,6 +154,7 @@ function clonePure(state: Readonly<RaceSessionState>): RaceSessionState {
     sectorTimer: state.sectorTimer,
     baselineSplitsMs: state.baselineSplitsMs,
     draftWindows: state.draftWindows,
+    brokenHazards: state.brokenHazards.slice(),
   };
 }
 


### PR DESCRIPTION
## Summary
- add a typed hazard registry and content validation for bundled track hazard ids
- add a pure race hazard evaluator for grip, damage hits, and breakable one-shot hazards
- wire live race sessions to apply hazard grip and damage effects, while leaving tunnel light and audio effects for the tunnel slice

## GDD
- docs/gdd/09-track-design.md
- docs/gdd/13-damage-repairs-and-risk.md
- docs/gdd/22-data-schemas.md
- docs/gdd/23-balancing-tables.md
- docs/PROGRESS_LOG.md entry: 2026-04-28 Slice: Hazards runtime
- docs/GDD_COVERAGE.json: GDD-09-HAZARDS-RUNTIME
- docs/FOLLOWUPS.md: closes F-019

## Test plan
- npx vitest run src/game/__tests__/hazards.test.ts src/data/__tests__/hazards-content.test.ts src/game/__tests__/raceSession.test.ts src/game/__tests__/raceSessionActions.test.ts
- npm run typecheck
- npm run verify
- npm run test:e2e

## Notes
- Tunnel hazards are registry-valid metadata only in this slice.
- Rendered hazard sprites, splash VFX, and seeded damage magnitude rolls remain future slices.