### PR TITLE
feat(game): wire deterministic rng consumers

### DIFF
--- a/docs/FOLLOWUPS.md
+++ b/docs/FOLLOWUPS.md
@@ -1114,7 +1114,7 @@ will read it from there when it lands.
 ## F-024: Migrate `src/game/` randomness to `createRng` / `splitRng`
 **Created:** 2026-04-26
 **Priority:** nice-to-have
-**Status:** open
+**Status:** done (2026-04-28)
 **Notes:** The PRNG slice (`feat(game): seeded deterministic PRNG
 module`, `2fcc7be`) ships `src/game/rng.ts` with `createRng`,
 `splitRng`, `serialiseRng`, `deserialiseRng`, and bans `Math.random`
@@ -1138,6 +1138,17 @@ seed advances reproducibly. Until those slices wire up there is no
 code that exercises `splitRng` end-to-end; the unit tests cover the
 algorithm but not the integration. Track this so the PRNG does not
 sit unused indefinitely.
+
+Closed by `feat/f-024-rng-consumers`. Current production consumers now
+use the owned PRNG surface: `src/game/aiGrid.ts` splits roster shuffle
+and per-slot seed derivation from labelled streams, `src/game/ai.ts`
+resumes the AI mistake stream with `deserializeRng`, and
+`src/game/raceSession.ts` derives default per-AI streams from the
+race-level seed unless a grid entry supplies an explicit seed. Hazards
+and weather remain deterministic without random draws today; any future
+debris scatter, splash variation, wind gust schedule, or damage
+magnitude roll must add its own labelled `splitRng` consumer in that
+feature slice.
 
 ## F-023: Time Trial UI wiring for the ghost recorder
 **Created:** 2026-04-26

--- a/docs/GDD_COVERAGE.json
+++ b/docs/GDD_COVERAGE.json
@@ -2,6 +2,29 @@
   "version": 1,
   "requirements": [
     {
+      "id": "GDD-21-RNG-CONSUMERS",
+      "gddSections": [
+        "docs/gdd/15-cpu-opponents-and-ai.md",
+        "docs/gdd/21-technical-design-for-web-implementation.md",
+        "docs/gdd/27-risks-and-mitigations.md"
+      ],
+      "requirement": "Game-runtime randomness consumers use the owned deterministic PRNG surface so replay-relevant AI seeding and mistake rolls are reproducible from stable seeds.",
+      "coverage": ["implemented-code", "automated-test"],
+      "implementationRefs": [
+        "src/game/rng.ts",
+        "src/game/aiGrid.ts",
+        "src/game/ai.ts",
+        "src/game/raceSession.ts"
+      ],
+      "testRefs": [
+        "src/game/__tests__/rng.test.ts",
+        "src/game/__tests__/no-math-random.test.ts",
+        "src/game/__tests__/aiGrid.test.ts",
+        "src/game/__tests__/ai.test.ts",
+        "src/game/__tests__/raceSession.test.ts"
+      ]
+    },
+    {
       "id": "GDD-09-HAZARDS-RUNTIME",
       "gddSections": [
         "docs/gdd/09-track-design.md",

--- a/docs/PROGRESS_LOG.md
+++ b/docs/PROGRESS_LOG.md
@@ -6,6 +6,56 @@ Correct them by adding a new entry that references the old one.
 
 ---
 
+## 2026-04-28: Slice: F-024 RNG consumers
+
+**GDD sections touched:**
+[§15](gdd/15-cpu-opponents-and-ai.md) deterministic AI contract,
+[§21](gdd/21-technical-design-for-web-implementation.md) deterministic replay tests,
+[§27](gdd/27-risks-and-mitigations.md) physics feel and replay risk mitigation.
+**Branch / PR:** `feat/f-024-rng-consumers`, PR pending.
+**Status:** Implemented.
+
+### Done
+- `src/game/aiGrid.ts`: switched roster shuffling and per-slot AI seed
+  derivation to labelled `splitRng` streams from the grid seed.
+- `src/game/ai.ts`: resumes the persisted AI mistake stream with
+  `deserializeRng` instead of treating the saved state as a fresh seed.
+- `src/game/raceSession.ts`: derives default per-AI seeds from the
+  race-level seed through labelled streams while preserving explicit
+  grid-provided seeds.
+- `src/game/__tests__/aiGrid.test.ts` and `src/game/__tests__/raceSession.test.ts`:
+  added coverage for stable, distinct PRNG-derived AI seeds.
+- `docs/FOLLOWUPS.md`: marked F-024 done for the consumers that exist
+  today.
+- `docs/GDD_COVERAGE.json`: added GDD-21-RNG-CONSUMERS.
+
+### Verified
+- `npx vitest run src/game/__tests__/aiGrid.test.ts src/game/__tests__/ai.test.ts src/game/__tests__/raceSession.test.ts src/game/__tests__/rng.test.ts src/game/__tests__/no-math-random.test.ts`
+  green, 172 passed.
+- `npm run typecheck` clean.
+- `npm run verify` green, 2261 passed.
+- `npm run test:e2e` green, 69 passed.
+
+### Decisions and assumptions
+- Hazards and weather do not draw random values in production today, so
+  this slice does not add placeholder RNG state to them. Future splash,
+  scatter, gust, or hit-magnitude variation must add a labelled stream
+  in the owning feature slice.
+- Explicit AI seeds from `spawnGrid` remain authoritative over the
+  race-level fallback seed so campaign grids keep their per-slot streams.
+
+### Coverage ledger
+- GDD-21-RNG-CONSUMERS covers current runtime PRNG consumers and the
+  static `Math.random` guard.
+- Uncovered adjacent requirements: seeded damage magnitude variation,
+  hazard VFX variation, and weather gust schedules remain future slices.
+
+### Followups created
+None.
+
+### GDD edits
+None.
+
 ## 2026-04-28: Slice: Hazards runtime
 
 **GDD sections touched:**

--- a/src/game/__tests__/aiGrid.test.ts
+++ b/src/game/__tests__/aiGrid.test.ts
@@ -73,6 +73,22 @@ describe("spawnGrid", () => {
     expect(new Set(b).size).toBe(b.length);
   });
 
+  it("derives stable per-slot AI seeds from the grid seed", () => {
+    const input = {
+      trackSpawn: { gridSlots: 6 },
+      laneCount: 3,
+      aiDrivers: roster(5),
+      seed: 9,
+    };
+    const first = spawnGrid(input).map((entry) => entry.seed);
+    const repeat = spawnGrid(input).map((entry) => entry.seed);
+    const different = spawnGrid({ ...input, seed: 10 }).map((entry) => entry.seed);
+
+    expect(first).toEqual(repeat);
+    expect(new Set(first).size).toBe(first.length);
+    expect(first).not.toEqual(different);
+  });
+
   it("spreads lanes within each row and preserves unique slots", () => {
     const grid = spawnGrid({
       trackSpawn: { gridSlots: 12 },

--- a/src/game/__tests__/raceSession.test.ts
+++ b/src/game/__tests__/raceSession.test.ts
@@ -135,6 +135,26 @@ describe("createRaceSession", () => {
     expect(() => createRaceSession(buildConfig({ totalLaps: 2.5 }))).toThrow(RangeError);
     expect(() => createRaceSession(buildConfig({ countdownSec: -1 }))).toThrow(RangeError);
   });
+
+  it("derives default AI seeds from the race seed", () => {
+    const first = createRaceSession(buildConfig({ seed: 7 }));
+    const repeat = createRaceSession(buildConfig({ seed: 7 }));
+    const different = createRaceSession(buildConfig({ seed: 8 }));
+
+    expect(first.ai[0]?.state.seed).toBe(repeat.ai[0]?.state.seed);
+    expect(first.ai[0]?.state.seed).not.toBe(different.ai[0]?.state.seed);
+  });
+
+  it("preserves explicit AI seeds over race-level seed derivation", () => {
+    const session = createRaceSession(
+      buildConfig({
+        seed: 7,
+        ai: [{ driver: TEST_DRIVER, stats: STARTER_STATS, seed: 1234 }],
+      }),
+    );
+
+    expect(session.ai[0]?.state.seed).toBe(1234);
+  });
 });
 
 describe("stepRaceSession (countdown)", () => {

--- a/src/game/ai.ts
+++ b/src/game/ai.ts
@@ -59,7 +59,7 @@ import {
 import { NEUTRAL_INPUT, type Input } from "./input";
 import type { CarState } from "./physics";
 import type { RaceState } from "./raceState";
-import { createRng } from "./rng";
+import { deserializeRng } from "./rng";
 
 /**
  * Identity §23 CPU modifiers row used as the default when a caller does
@@ -266,7 +266,7 @@ export function tickAI(
   let nextSeed = aiState.seed;
   let mistakeOffset = 0;
   if (race.phase === "racing" && effectiveMistakeRate > 0) {
-    const mistakeRng = createRng(aiState.seed);
+    const mistakeRng = deserializeRng(aiState.seed);
     const mistakeActive = mistakeRng.nextBool(effectiveMistakeRate);
     const mistakeDirection = mistakeRng.next() < 0.5 ? -1 : 1;
     mistakeOffset = mistakeActive

--- a/src/game/aiGrid.ts
+++ b/src/game/aiGrid.ts
@@ -2,7 +2,7 @@ import type { AIDriver, CarBaseStats, TrackSpawn } from "@/data/schemas";
 import { ROAD_WIDTH } from "@/road/constants";
 
 import type { CarUpgradeTiers, RaceSessionAI } from "./raceSession";
-import { createRng } from "./rng";
+import { createRng, serializeRng, splitRng } from "./rng";
 
 export interface AIGridDriver {
   readonly driver: Readonly<AIDriver>;
@@ -62,7 +62,7 @@ function shuffleDrivers(
   seed: number,
 ): AIGridDriver[] {
   const next = drivers.slice();
-  const rng = createRng(seed);
+  const rng = splitRng(createRng(seed), "ai-grid-roster");
   for (let i = next.length - 1; i > 0; i -= 1) {
     const j = rng.nextInt(0, i + 1);
     const tmp = next[i]!;
@@ -88,5 +88,5 @@ function xForLane(lane: number, laneCount: number): number {
 }
 
 function seedForGridSlot(seed: number, gridSlot: number): number {
-  return (Math.imul(seed >>> 0, 1664525) + Math.imul(gridSlot, 1013904223)) >>> 0;
+  return serializeRng(splitRng(createRng(seed), `ai-grid-slot:${gridSlot}`));
 }

--- a/src/game/raceSession.ts
+++ b/src/game/raceSession.ts
@@ -92,6 +92,7 @@ import {
   tickNitro,
   type NitroState,
 } from "./nitro";
+import { createRng, serializeRng, splitRng } from "./rng";
 import {
   createTransmissionForCar,
   gearAccelMultiplier,
@@ -545,6 +546,8 @@ export const COLLISION_REFERENCE_TOP_SPEED_M_PER_S = 60;
 export const COLLISION_CAR_HIT_BASE_MAGNITUDE =
   (HIT_MAGNITUDE_RANGES.carHit.min + HIT_MAGNITUDE_RANGES.carHit.max) / 2;
 
+const DEFAULT_RACE_SESSION_SEED = 1;
+
 /**
  * True iff the two car snapshots are within the §13 contact box
  * (`|dz| < CAR_LENGTH_M && |dx| < CAR_WIDTH_M`). Pure: no allocation,
@@ -621,8 +624,9 @@ export function createRaceSession(config: RaceSessionConfig): RaceSessionState {
     damage: config.player.initialDamage ?? PRISTINE_DAMAGE_STATE,
   };
 
+  const raceSeed = config.seed ?? DEFAULT_RACE_SESSION_SEED;
   const ai: RaceSessionAICar[] = config.ai.map((entry, index) => {
-    const seed = entry.seed ?? INITIAL_AI_STATE.seed + index + 1;
+    const seed = entry.seed ?? seedForAiIndex(raceSeed, index);
     const initialZ =
       -(AI_GRID_OFFSET_BEHIND_PLAYER_M + index * AI_GRID_SPACING_M);
     return {
@@ -1693,6 +1697,10 @@ function withHazardGrip(
     ...scalars,
     gripScalar: scalars.gripScalar * Math.max(0, gripMultiplier),
   };
+}
+
+function seedForAiIndex(raceSeed: number, index: number): number {
+  return serializeRng(splitRng(createRng(raceSeed), `ai:${index}`));
 }
 
 function clonePlayerCar(


### PR DESCRIPTION
## Summary
- route AI grid roster shuffling and per-slot seed derivation through labelled splitRng streams
- resume AI mistake streams with deserializeRng instead of treating saved state as a fresh seed
- derive default race-session AI seeds from the race-level seed while preserving explicit grid-provided seeds

## GDD
- docs/gdd/15-cpu-opponents-and-ai.md
- docs/gdd/21-technical-design-for-web-implementation.md
- docs/gdd/27-risks-and-mitigations.md
- docs/PROGRESS_LOG.md entry: 2026-04-28 Slice: F-024 RNG consumers
- docs/GDD_COVERAGE.json: GDD-21-RNG-CONSUMERS
- docs/FOLLOWUPS.md: closes F-024

## Test plan
- npx vitest run src/game/__tests__/aiGrid.test.ts src/game/__tests__/ai.test.ts src/game/__tests__/raceSession.test.ts src/game/__tests__/rng.test.ts src/game/__tests__/no-math-random.test.ts
- npm run typecheck
- npm run verify
- npm run test:e2e

## Notes
- Hazards and weather do not draw random values in production today. Future splash, scatter, gust, or hit-magnitude variation must add a labelled stream in the owning feature slice.