### PR TITLE
feat(game): apply weather grip at runtime

### DIFF
--- a/docs/FOLLOWUPS.md
+++ b/docs/FOLLOWUPS.md
@@ -10,6 +10,17 @@ or `obsolete` so the trail is preserved.
 
 ---
 
+## F-066: Add pre-race tire selection and persist the active tire channel
+**Created:** 2026-04-28
+**Priority:** blocks-release
+**Status:** open
+**Notes:** The weather grip runtime slice applies §23 weather modifiers
+through the existing dry handling path because no active tire-selection
+state exists yet. Add the §14/§20 pre-race tire choice, persist the
+active tire channel for the race, and pass `"wet"` into
+`weatherGripScalar` when the player actually chooses wet tires. The AI
+path can keep dry default until AI setup selection lands.
+
 ## F-065: Persist active tour race progression through the four-race World Tour loop
 **Created:** 2026-04-28
 **Priority:** blocks-release

--- a/docs/GDD_COVERAGE.json
+++ b/docs/GDD_COVERAGE.json
@@ -2,6 +2,27 @@
   "version": 1,
   "requirements": [
     {
+      "id": "GDD-14-WEATHER-GRIP-RUNTIME",
+      "gddSections": [
+        "docs/gdd/14-weather-and-environmental-systems.md",
+        "docs/gdd/15-cpu-opponents-and-ai.md",
+        "docs/gdd/23-balancing-tables.md"
+      ],
+      "requirement": "Live race sessions apply active weather to player and AI grip, expose read-distance scalars, and map full weather options onto compact AI weather-skill rows.",
+      "coverage": ["implemented-code", "automated-test"],
+      "implementationRefs": [
+        "src/game/weather.ts",
+        "src/game/physics.ts",
+        "src/game/raceSession.ts"
+      ],
+      "testRefs": [
+        "src/game/__tests__/weather.test.ts",
+        "src/game/__tests__/physics.test.ts",
+        "src/game/__tests__/raceSession.test.ts"
+      ],
+      "followupRefs": ["F-066"]
+    },
+    {
       "id": "GDD-21-RNG-CONSUMERS",
       "gddSections": [
         "docs/gdd/15-cpu-opponents-and-ai.md",

--- a/docs/OPEN_QUESTIONS.md
+++ b/docs/OPEN_QUESTIONS.md
@@ -128,8 +128,9 @@ this resolution only confirms no upgrade is required. Resolved.
 **GDD reference:** [§23](gdd/23-balancing-tables.md) "Weather modifiers",
 [§14](gdd/14-weather-and-environmental-systems.md) "Weather types",
 [§22](gdd/22-data-schemas.md) "Weather option enum"
-**Status:** open
+**Status:** answered
 **Asked in loop:** 2026-04-26
+**Answered in loop:** 2026-04-28
 
 **Question.** `WeatherOption` (the `TrackSchema`-validated enum in
 `src/data/schemas.ts`) declares eight values: `clear`, `light_rain`,
@@ -166,6 +167,15 @@ without blocking on a GDD edit.
 the §23-row subset; no runtime consumer reads the lookup yet. The
 parent weather dot picks a resolution before its physics integration
 lands.
+
+**Resolution.** Adopted option (b) for the first runtime consumer:
+`light_rain` aliases to Rain, `dusk` aliases to Clear, and `night`
+aliases to Clear for tire-grip math. The weather grip runtime slice
+documents the alias map in §23 and pins it in
+`WEATHER_TIRE_MODIFIER_ALIASES`. Dusk and night still reduce read
+distance through `WEATHER_VISIBILITY`, so they are not fully neutral;
+they are grip-neutral. Full per-weather balancing rows remain optional
+future tuning, but no runtime caller receives `undefined`.
 
 ---
 

--- a/docs/PROGRESS_LOG.md
+++ b/docs/PROGRESS_LOG.md
@@ -6,6 +6,62 @@ Correct them by adding a new entry that references the old one.
 
 ---
 
+## 2026-04-28: Slice: Weather grip runtime
+
+**GDD sections touched:**
+[§14](gdd/14-weather-and-environmental-systems.md) weather physics and
+visibility effects,
+[§15](gdd/15-cpu-opponents-and-ai.md) AI weather skill,
+[§23](gdd/23-balancing-tables.md) weather modifiers.
+**Branch / PR:** `feat/weather-grip-runtime`, PR pending.
+**Status:** Implemented.
+
+### Done
+- `src/game/weather.ts`: added runtime aliases for weather options that
+  §23 does not give a separate tire row, weather visibility scalars,
+  effective grip helpers, and exhaustive AI weather-skill mapping.
+- `src/game/physics.ts`: added an optional weather grip scalar to the
+  lateral grip calculation while preserving identity behavior for
+  callers that omit it.
+- `src/game/raceSession.ts`: threads active race weather into player
+  and AI physics, and applies AI weather skill to the AI pace scalar.
+- `docs/OPEN_QUESTIONS.md`: answered Q-008 with the runtime alias map.
+- `docs/FOLLOWUPS.md`: added F-066 for the missing pre-race tire
+  selection and active tire-channel persistence.
+- `docs/GDD_COVERAGE.json`: added GDD-14-WEATHER-GRIP-RUNTIME.
+
+### Verified
+- `npx vitest run src/game/__tests__/weather.test.ts src/game/__tests__/physics.test.ts src/game/__tests__/raceSession.test.ts src/data/__tests__/balancing.test.ts`
+  green, 287 passed.
+- `npm run typecheck` clean.
+- `npm run verify` green, 2295 passed.
+- `npm run test:e2e` green, 69 passed.
+
+### Decisions and assumptions
+- Q-008 resolved to aliases rather than new balancing numbers:
+  `light_rain` uses Rain, `dusk` uses Clear, and `night` uses Clear for
+  tire grip. Dusk and night still reduce visibility through
+  `WEATHER_VISIBILITY`.
+- Race sessions still use the dry tire channel because no active
+  tire-selection state exists yet. F-066 owns the §14/§20 tire choice
+  surface and the `"wet"` channel handoff.
+- Weather changes remain race-start static. Mid-race weather
+  transitions stay out of this PR.
+
+### Coverage ledger
+- GDD-14-WEATHER-GRIP-RUNTIME covers active weather grip, visibility
+  scalars, and AI weather-skill mapping.
+- Uncovered adjacent requirements: tire selection, weather VFX
+  particles, fog draw-distance rendering, weather intensity settings,
+  and mid-race weather transitions remain future slices.
+
+### Followups created
+- F-066: Add pre-race tire selection and persist the active tire channel.
+
+### GDD edits
+- `docs/gdd/23-balancing-tables.md`: documented runtime aliases for
+  §14 weather options without separate §23 tire rows.
+
 ## 2026-04-28: Slice: F-024 RNG consumers
 
 **GDD sections touched:**

--- a/docs/gdd/23-balancing-tables.md
+++ b/docs/gdd/23-balancing-tables.md
@@ -122,6 +122,11 @@ nitroWhileSeverelyDamagedBonus = +15%
 | Snow | -0.18 | +0.14 |
 | Fog | 0.00 | 0.00 |
 
+Runtime weather aliases for §14 weather types without a separate row:
+`light_rain` uses Rain, `dusk` uses Clear, and `night` uses Clear for
+grip. Dusk and night still reduce visibility through §14 read-distance
+scalars rather than tire grip.
+
 ## CPU difficulty modifiers
 
 | Difficulty | Pace scalar | Recovery scalar | Mistake scalar |

--- a/src/game/__tests__/physics.test.ts
+++ b/src/game/__tests__/physics.test.ts
@@ -202,6 +202,28 @@ describe("step (steering)", () => {
   });
 });
 
+describe("step (weather grip scalar)", () => {
+  it("lower weather grip reduces lateral authority", () => {
+    const start = freshState({ speed: 30 });
+    const clear = step(start, withInput({ steer: 1 }), STARTER_STATS, ROAD, DT, {
+      weatherGripScalar: 1.08,
+    });
+    const rain = step(start, withInput({ steer: 1 }), STARTER_STATS, ROAD, DT, {
+      weatherGripScalar: 0.88,
+    });
+    expect(Math.abs(rain.x)).toBeLessThan(Math.abs(clear.x));
+  });
+
+  it("omitting weatherGripScalar preserves prior output", () => {
+    const start = freshState({ speed: 30 });
+    const a = step(start, withInput({ steer: 0.4 }), STARTER_STATS, ROAD, DT);
+    const b = step(start, withInput({ steer: 0.4 }), STARTER_STATS, ROAD, DT, {
+      weatherGripScalar: 1,
+    });
+    expect(b).toEqual(a);
+  });
+});
+
 describe("step (off-road)", () => {
   it("isOffRoad detects positions outside road half-width", () => {
     expect(isOffRoad(0, ROAD.roadHalfWidth)).toBe(false);

--- a/src/game/__tests__/raceSession.test.ts
+++ b/src/game/__tests__/raceSession.test.ts
@@ -214,6 +214,67 @@ describe("stepRaceSession (racing)", () => {
     expect(second.player.car).not.toBe(first.player.car);
   });
 
+  it("applies active weather grip to player steering", () => {
+    const steer = { ...NEUTRAL_INPUT, steer: 1 };
+    const clearConfig = buildConfig({
+      countdownSec: 0,
+      weather: "clear",
+      player: { stats: STARTER_STATS, initial: { speed: 30 } },
+    });
+    const rainConfig = buildConfig({
+      countdownSec: 0,
+      weather: "rain",
+      player: { stats: STARTER_STATS, initial: { speed: 30 } },
+    });
+    const clear = stepRaceSession(
+      createRaceSession(clearConfig),
+      steer,
+      clearConfig,
+      DT,
+    );
+    const rain = stepRaceSession(
+      createRaceSession(rainConfig),
+      steer,
+      rainConfig,
+      DT,
+    );
+    expect(Math.abs(rain.player.car.x)).toBeLessThan(
+      Math.abs(clear.player.car.x),
+    );
+  });
+
+  it("maps active weather through AI weather skill", () => {
+    const wetSpecialist = {
+      ...TEST_DRIVER,
+      weatherSkill: { clear: 1, rain: 0.8, fog: 1, snow: 1 },
+    };
+    const rainConfig = buildConfig({
+      countdownSec: 0,
+      weather: "heavy_rain",
+      ai: [{ driver: wetSpecialist, stats: STARTER_STATS }],
+    });
+    const clearConfig = buildConfig({
+      countdownSec: 0,
+      weather: "clear",
+      ai: [{ driver: wetSpecialist, stats: STARTER_STATS }],
+    });
+    const rain = stepRaceSession(
+      createRaceSession(rainConfig),
+      NEUTRAL_INPUT,
+      rainConfig,
+      DT,
+    );
+    const clear = stepRaceSession(
+      createRaceSession(clearConfig),
+      NEUTRAL_INPUT,
+      clearConfig,
+      DT,
+    );
+    expect(rain.ai[0]?.state.targetSpeed).toBeLessThan(
+      clear.ai[0]?.state.targetSpeed ?? 0,
+    );
+  });
+
   it("applies breakable track hazard damage once", () => {
     const track = loadTrack("iron-borough/freightline-ring");
     const config = buildConfig({

--- a/src/game/__tests__/weather.test.ts
+++ b/src/game/__tests__/weather.test.ts
@@ -19,13 +19,43 @@ import { describe, expect, it } from "vitest";
 import type { WeatherOption } from "@/data/schemas";
 
 import {
+  effectiveWeatherGrip,
   getWeatherTireModifier,
+  getResolvedWeatherTireModifier,
   isWeatherTireModifierKey,
+  resolveWeatherTireModifierKey,
+  visibilityForWeather,
+  weatherGripScalar,
+  weatherSkillFor,
+  WEATHER_TIRE_MODIFIER_ALIASES,
   WEATHER_TIRE_MODIFIER_KEYS,
   WEATHER_TIRE_MODIFIERS,
+  WEATHER_VISIBILITY,
   type WeatherTireModifier,
   type WeatherTireModifierKey,
 } from "../weather";
+
+const STATS = Object.freeze({
+  topSpeed: 61,
+  accel: 16,
+  brake: 28,
+  gripDry: 1,
+  gripWet: 0.82,
+  stability: 1,
+  durability: 0.95,
+  nitroEfficiency: 1,
+});
+
+const DRIVER = Object.freeze({
+  id: "ai_weather",
+  displayName: "AI Weather",
+  archetype: "clean_line" as const,
+  paceScalar: 1,
+  mistakeRate: 0,
+  aggression: 0,
+  weatherSkill: { clear: 1, rain: 1.04, fog: 0.98, snow: 1.06 },
+  nitroUsage: { launchBias: 0.5, straightBias: 0.5, panicBias: 0.1 },
+});
 
 describe("WEATHER_TIRE_MODIFIER_KEYS", () => {
   it("lists the §23 rows in §23 order (Clear, Rain, Heavy rain, Snow, Fog)", () => {
@@ -152,6 +182,96 @@ describe("getWeatherTireModifier", () => {
     expect(first).toBe(second);
     expect(first && Object.isFrozen(first)).toBe(true);
   });
+});
+
+describe("runtime weather aliases", () => {
+  it("is frozen so runtime alias policy cannot drift by mutation", () => {
+    expect(Object.isFrozen(WEATHER_TIRE_MODIFIER_ALIASES)).toBe(true);
+  });
+
+  it.each([
+    ["clear", "clear"],
+    ["light_rain", "rain"],
+    ["rain", "rain"],
+    ["heavy_rain", "heavy_rain"],
+    ["fog", "fog"],
+    ["snow", "snow"],
+    ["dusk", "clear"],
+    ["night", "clear"],
+  ] as ReadonlyArray<readonly [WeatherOption, WeatherTireModifierKey]>)(
+    "maps %s to the %s §23 row",
+    (weather, expected) => {
+      expect(resolveWeatherTireModifierKey(weather)).toBe(expected);
+      expect(getResolvedWeatherTireModifier(weather)).toBe(
+        WEATHER_TIRE_MODIFIERS[expected],
+      );
+    },
+  );
+});
+
+describe("effectiveWeatherGrip", () => {
+  it("applies dry-tire §23 offsets to the dry grip baseline", () => {
+    expect(effectiveWeatherGrip(STATS, "clear", "dry")).toBeCloseTo(1.08, 9);
+    expect(effectiveWeatherGrip(STATS, "rain", "dry")).toBeCloseTo(0.88, 9);
+    expect(effectiveWeatherGrip(STATS, "heavy_rain", "dry")).toBeCloseTo(0.8, 9);
+  });
+
+  it("can resolve the wet tire channel once tire selection exists", () => {
+    expect(effectiveWeatherGrip(STATS, "rain", "wet")).toBeCloseTo(0.92, 9);
+    expect(effectiveWeatherGrip(STATS, "snow", "wet")).toBeCloseTo(0.96, 9);
+  });
+
+  it("converts effective grip into a scalar relative to dry baseline", () => {
+    expect(weatherGripScalar(STATS, "clear", "dry")).toBeCloseTo(1.08, 9);
+    expect(weatherGripScalar(STATS, "rain", "dry")).toBeCloseTo(0.88, 9);
+  });
+
+  it("uses the runtime alias for light rain instead of returning identity", () => {
+    expect(effectiveWeatherGrip(STATS, "light_rain", "dry")).toBeCloseTo(
+      effectiveWeatherGrip(STATS, "rain", "dry"),
+      9,
+    );
+  });
+});
+
+describe("visibilityForWeather", () => {
+  it("is frozen so forecast/read-distance scalars cannot drift by mutation", () => {
+    expect(Object.isFrozen(WEATHER_VISIBILITY)).toBe(true);
+  });
+
+  it.each([
+    ["clear", 1],
+    ["light_rain", 0.9],
+    ["rain", 0.8],
+    ["heavy_rain", 0.7],
+    ["fog", 0.5],
+    ["snow", 0.6],
+    ["dusk", 0.85],
+    ["night", 0.65],
+  ] as ReadonlyArray<readonly [WeatherOption, number]>)(
+    "returns %s visibility",
+    (weather, expected) => {
+      expect(visibilityForWeather(weather)).toBeCloseTo(expected, 9);
+    },
+  );
+});
+
+describe("weatherSkillFor", () => {
+  it.each([
+    ["clear", 1],
+    ["dusk", 1],
+    ["night", 1],
+    ["light_rain", 1.04],
+    ["rain", 1.04],
+    ["heavy_rain", 1.04],
+    ["fog", 0.98],
+    ["snow", 1.06],
+  ] as ReadonlyArray<readonly [WeatherOption, number]>)(
+    "maps %s to the compact AI weather skill row",
+    (weather, expected) => {
+      expect(weatherSkillFor(DRIVER, weather)).toBeCloseTo(expected, 9);
+    },
+  );
 });
 
 describe("§23 table monotonicity (sanity)", () => {

--- a/src/game/physics.ts
+++ b/src/game/physics.ts
@@ -268,6 +268,12 @@ export interface StepOptions {
    * no per-tick allocation cost.
    */
   assistScalars?: Readonly<AssistScalars>;
+  /**
+   * Per-tick weather grip scalar, composed by the race session from
+   * `weatherGripScalar` in `weather.ts`. Defaults to `1` so callers
+   * that have not wired weather preserve their old dry-grip output.
+   */
+  weatherGripScalar?: number;
 }
 
 /** Conservative upper bound on the draft bonus inside the step. */
@@ -382,7 +388,9 @@ export function step(
   // The damage band's `gripScalar` derates grip in the moderate band
   // and above per §10 "reduced grip".
   const damageGripScalar = clamp(damageScalars.gripScalar, 0, 1);
-  const baseGrip = clamp(stats.gripDry, 0, 2) * damageGripScalar;
+  const weatherGripScalar = clamp(options.weatherGripScalar ?? 1, 0, 2);
+  const baseGrip =
+    clamp(stats.gripDry, 0, 2) * damageGripScalar * weatherGripScalar;
   const tractionScalar = offRoad ? baseGrip * 0.5 : baseGrip;
   const steerInput = clamp(input.steer, -1, 1);
   const steerRate = steerRateForSpeed(nextSpeed, stats.topSpeed);

--- a/src/game/raceSession.ts
+++ b/src/game/raceSession.ts
@@ -100,6 +100,7 @@ import {
   tickTransmission,
   type TransmissionState,
 } from "./transmission";
+import { weatherGripScalar, weatherSkillFor } from "./weather";
 import {
   DEFAULT_TRACK_CONTEXT,
   INITIAL_CAR_STATE,
@@ -918,6 +919,7 @@ export function stepRaceSession(
   const assistSettings = config.player.assists ?? {};
   const trackWeather =
     config.weather ?? config.track.weatherOptions[0] ?? "clear";
+  const playerWeatherGripScalar = weatherGripScalar(playerStats, trackWeather);
   const assistResult = playerIsRacing
     ? applyAssists(
         playerInput,
@@ -1019,6 +1021,14 @@ export function stepRaceSession(
   const aiTickResults = state.ai.map((entry, index) => {
     const aiConfig = config.ai[index];
     if (!aiConfig) return null;
+    const aiWeatherSkill = weatherSkillFor(aiConfig.driver, trackWeather);
+    const aiCpuModifiers =
+      aiWeatherSkill === 1
+        ? cpuModifiers
+        : {
+            ...cpuModifiers,
+            paceScalar: cpuModifiers.paceScalar * aiWeatherSkill,
+          };
     return tickAI(
       aiConfig.driver,
       entry.state,
@@ -1029,7 +1039,7 @@ export function stepRaceSession(
       aiConfig.stats,
       aiContext,
       dt,
-      cpuModifiers,
+      aiCpuModifiers,
     );
   });
 
@@ -1167,6 +1177,7 @@ export function stepRaceSession(
           draftBonus: playerDraftBonus,
           assistScalars: playerAssistScalars,
           damageScalars: playerDamageScalars,
+          weatherGripScalar: playerWeatherGripScalar,
         },
       )
     : { ...state.player.car };
@@ -1246,6 +1257,7 @@ export function stepRaceSession(
       getDamageScalars(entry.damage.total * 100),
       aiHazards.gripMultiplier,
     );
+    const aiWeatherGripScalar = weatherGripScalar(aiConfig.stats, trackWeather);
     const nextCar = step(
       entry.car,
       tick.input,
@@ -1256,6 +1268,7 @@ export function stepRaceSession(
         accelMultiplier: aiAccelMultiplier,
         draftBonus: aiDraftBonus,
         damageScalars: aiDamageScalars,
+        weatherGripScalar: aiWeatherGripScalar,
       },
     );
     return {

--- a/src/game/weather.ts
+++ b/src/game/weather.ts
@@ -25,25 +25,28 @@
  * (§14 calls out fog as a visibility hazard, not a grip hazard); the
  * row exists in §23 only as a documentation anchor.
  *
- * The runtime consumers of these modifiers (per the parent dot
- * `VibeGear2-implement-weather-38d61fc2`) have not landed yet:
+ * Runtime consumers now read these modifiers through
+ * `weatherGripScalar`:
  *
- *   - `src/game/physics.ts` will read the resolved grip in its lateral
- *     friction term so a heavy-rain track on dry tires demonstrably
- *     under-steers compared to clear.
+ *   - `src/game/physics.ts` reads the resolved scalar in its lateral
+ *     friction term so a heavy-rain track under-steers compared to
+ *     clear under identical input.
+ *   - `src/game/raceSession.ts` forwards the active race weather to
+ *     the player and AI physics paths, and maps it through compact AI
+ *     weather-skill rows for AI pace.
  *   - The pre-race UI (§14) will surface "current condition / grip
- *     rating" using these numbers as the input to the rating pill.
+ *     rating" using these numbers as a future input to the rating pill.
  *
  * Determinism: no `Math.random`, no `Date.now`, no globals.
  * `getWeatherTireModifier(weather)` returns the same frozen object
  * reference every call so callers can lean on identity comparison.
  *
- * Scope. This slice deliberately does **not** add a tire-type concept,
- * a weather state machine, or a physics integration. Per
+ * Scope. This slice deliberately does **not** add active tire selection
+ * or a weather state machine. Per
  * `docs/AGENTS.md` RULE 9 (scope discipline) the table itself is the
- * smallest shippable cell: future work in the parent dot wires the
- * consumers and adds the state-machine on top of this binding. Adding
- * a new §23 weather row, renaming a column, or moving a number
+ * smallest shippable cell: future work adds tire-selection UI and the
+ * state-machine on top of this binding. Adding a new §23 weather row,
+ * renaming a column, or moving a number
  * requires updating both the table here and the unit pin in
  * `src/game/__tests__/weather.test.ts` (and the §23 cross-check in
  * `src/data/__tests__/balancing.test.ts`).
@@ -54,15 +57,13 @@
  * `night`. §23 only specifies five of them. The lookup here is
  * intentionally typed as a `Partial<Record<WeatherOption, ...>>` so a
  * caller asking for `light_rain`, `dusk`, or `night` gets a typed
- * `undefined` rather than a fabricated row. The convention matches
- * `AIWeatherSkillSchema`, which also collapses light / medium rain
- * into a single `rain` key. Filed as `Q-008` to track whether the
- * three uncovered weathers should pin to identity, alias to the §23
- * row that fits, or block the parent weather slice; no decision is
- * needed until a runtime consumer lands.
+ * `undefined` rather than a fabricated row. Runtime consumers use
+ * `WEATHER_TIRE_MODIFIER_ALIASES` to map the full enum onto §23 rows:
+ * light rain maps to Rain, dusk maps to Clear, and night maps to Clear.
+ * Q-008 records that decision.
  */
 
-import type { WeatherOption } from "@/data/schemas";
+import type { AIDriver, CarBaseStats, WeatherOption } from "@/data/schemas";
 
 /**
  * §23 rows that pin a tire-modifier cell. Five entries, exactly the
@@ -96,6 +97,8 @@ export interface WeatherTireModifier {
    */
   readonly wetTireMod: number;
 }
+
+export type TireKind = "dry" | "wet";
 
 /**
  * Frozen scalar table, copied verbatim from §23 "Weather modifiers"
@@ -134,6 +137,42 @@ export const WEATHER_TIRE_MODIFIER_KEYS: ReadonlyArray<WeatherTireModifierKey> =
   Object.freeze(["clear", "rain", "heavy_rain", "snow", "fog"]);
 
 /**
+ * Runtime aliases for weather options that §14 exposes but §23 has not
+ * given separate tire rows. This avoids fabricating new balancing
+ * numbers while still letting runtime consumers handle every
+ * `WeatherOption` exhaustively.
+ */
+export const WEATHER_TIRE_MODIFIER_ALIASES: Readonly<
+  Record<WeatherOption, WeatherTireModifierKey>
+> = Object.freeze({
+  clear: "clear",
+  light_rain: "rain",
+  rain: "rain",
+  heavy_rain: "heavy_rain",
+  fog: "fog",
+  snow: "snow",
+  dusk: "clear",
+  night: "clear",
+});
+
+/**
+ * §14 visibility scalar. `1` means full read distance. Lower values
+ * mean the renderer, AI, or pre-race forecast can communicate reduced
+ * read distance without changing grip.
+ */
+export const WEATHER_VISIBILITY: Readonly<Record<WeatherOption, number>> =
+  Object.freeze({
+    clear: 1,
+    light_rain: 0.9,
+    rain: 0.8,
+    heavy_rain: 0.7,
+    fog: 0.5,
+    snow: 0.6,
+    dusk: 0.85,
+    night: 0.65,
+  });
+
+/**
  * Type guard for the §23-row subset of `WeatherOption`. Useful at
  * call sites that have a generic `WeatherOption` and need to branch
  * on whether the §23 lookup applies.
@@ -164,4 +203,93 @@ export function getWeatherTireModifier(
 ): WeatherTireModifier | undefined {
   if (!isWeatherTireModifierKey(weather)) return undefined;
   return WEATHER_TIRE_MODIFIERS[weather];
+}
+
+/** Resolve any `WeatherOption` to the §23 tire row it uses at runtime. */
+export function resolveWeatherTireModifierKey(
+  weather: WeatherOption,
+): WeatherTireModifierKey {
+  return WEATHER_TIRE_MODIFIER_ALIASES[weather];
+}
+
+/**
+ * Runtime tire modifier lookup for every weather. Unlike
+ * `getWeatherTireModifier`, this always returns a row by applying the
+ * alias table above.
+ */
+export function getResolvedWeatherTireModifier(
+  weather: WeatherOption,
+): WeatherTireModifier {
+  return WEATHER_TIRE_MODIFIERS[resolveWeatherTireModifierKey(weather)];
+}
+
+/**
+ * Effective grip for a car under a weather condition and tire channel.
+ * Current race sessions do not expose tire selection yet, so callers use
+ * `"dry"` to preserve the existing default handling path. The pre-race
+ * tire-choice slice can pass `"wet"` once the player can actually pick it.
+ */
+export function effectiveWeatherGrip(
+  stats: Readonly<CarBaseStats>,
+  weather: WeatherOption,
+  tire: TireKind = "dry",
+): number {
+  const modifier = getResolvedWeatherTireModifier(weather);
+  const base =
+    tire === "wet"
+      ? clamp(stats.gripWet, 0, 2)
+      : clamp(stats.gripDry, 0, 2);
+  const offset =
+    tire === "wet" ? modifier.wetTireMod : modifier.dryTireMod;
+  return Math.max(0.05, base + offset);
+}
+
+/**
+ * Convert weather grip into a scalar the physics step can compose with
+ * damage and hazard grip multipliers. The scalar is relative to the dry
+ * baseline because the current physics step was dry-grip-only before
+ * this slice.
+ */
+export function weatherGripScalar(
+  stats: Readonly<CarBaseStats>,
+  weather: WeatherOption,
+  tire: TireKind = "dry",
+): number {
+  const dryBaseline = clamp(stats.gripDry, 0.05, 2);
+  return effectiveWeatherGrip(stats, weather, tire) / dryBaseline;
+}
+
+export function visibilityForWeather(weather: WeatherOption): number {
+  return WEATHER_VISIBILITY[weather];
+}
+
+/**
+ * Map the full weather enum onto the four-key AI weather-skill schema.
+ * The AI data stays compact while runtime callers can remain exhaustive.
+ */
+export function weatherSkillFor(
+  driver: Readonly<AIDriver>,
+  weather: WeatherOption,
+): number {
+  switch (weather) {
+    case "clear":
+    case "dusk":
+    case "night":
+      return driver.weatherSkill.clear;
+    case "light_rain":
+    case "rain":
+    case "heavy_rain":
+      return driver.weatherSkill.rain;
+    case "fog":
+      return driver.weatherSkill.fog;
+    case "snow":
+      return driver.weatherSkill.snow;
+  }
+}
+
+function clamp(value: number, min: number, max: number): number {
+  if (!Number.isFinite(value)) return min;
+  if (value < min) return min;
+  if (value > max) return max;
+  return value;
 }


### PR DESCRIPTION
## GDD sections
- docs/gdd/14-weather-and-environmental-systems.md: weather physics and visibility effects
- docs/gdd/15-cpu-opponents-and-ai.md: AI weather skill
- docs/gdd/23-balancing-tables.md: weather modifiers

## Requirement inventory
- Applies active race weather to player and AI physics via a deterministic grip scalar.
- Maps light_rain, dusk, and night onto existing §23 tire rows so runtime callers never receive undefined.
- Exposes visibility scalars for all WeatherOption values.
- Maps full weather options onto the compact AI weatherSkill rows.
- Leaves active tire selection to F-066 because no race config field persists that choice yet.
- Leaves VFX particles, fog draw distance, intensity settings, and mid-race transitions to later weather slices.

## Progress log
- docs/PROGRESS_LOG.md entry: 2026-04-28, Slice: Weather grip runtime

## Followups
- F-066: Add pre-race tire selection and persist the active tire channel.

## Test plan
- [x] npx vitest run src/game/__tests__/weather.test.ts src/game/__tests__/physics.test.ts src/game/__tests__/raceSession.test.ts src/data/__tests__/balancing.test.ts
- [x] npm run typecheck
- [x] npm run verify
- [x] npm run test:e2e
- [x] grep dash scan on touched files
- [x] git diff --check