### PR TITLE
fix(game): avoid weather AI allocation

### DIFF
--- a/docs/PROGRESS_LOG.md
+++ b/docs/PROGRESS_LOG.md
@@ -6,6 +6,48 @@ Correct them by adding a new entry that references the old one.
 
 ---
 
+## 2026-04-28: Slice: Weather AI allocation hotfix
+
+**GDD sections touched:**
+[§15](gdd/15-cpu-opponents-and-ai.md) AI weather skill,
+[§21](gdd/21-technical-design-for-web-implementation.md) runtime performance.
+**Branch / PR:** `fix/weather-ai-allocation`, PR pending.
+**Status:** Implemented.
+
+### Done
+- `src/game/ai.ts`: accepts the active weather-skill scalar directly in
+  `tickAI`, composes it into the AI pace scalar, and documents why this
+  stays numeric in the 60 Hz loop.
+- `src/game/raceSession.ts`: reuses the existing `cpuModifiers` reference
+  for AI ticks and passes each driver's resolved weather skill as a scalar
+  instead of allocating adjusted modifier objects per AI per tick.
+- Copilot PR #44 review thread was answered and resolved, but PR #44 had
+  already merged before the fix commit landed on `main`; this hotfix
+  carries that verified fix forward.
+
+### Verified
+- `npx vitest run src/game/__tests__/ai.test.ts src/game/__tests__/weather.test.ts src/game/__tests__/raceSession.test.ts`
+  green, 197 passed.
+- `npm run typecheck` clean.
+- `npm run verify` green, 2295 passed.
+- `grep -rn $'\u2014\|\u2013' src/game/ai.ts src/game/raceSession.ts || true`
+  clean.
+- `git diff --check` clean.
+
+### Decisions and assumptions
+- The weather-skill value remains race-session static for this slice,
+  matching PR #44. Mid-race weather transitions remain future work.
+
+### Coverage ledger
+- No new GDD coverage ID. This hotfix preserves the runtime performance
+  contract for the existing GDD-14-WEATHER-GRIP-RUNTIME coverage.
+
+### Followups created
+None.
+
+### GDD edits
+None.
+
 ## 2026-04-28: Slice: Weather grip runtime
 
 **GDD sections touched:**

--- a/docs/PROGRESS_LOG.md
+++ b/docs/PROGRESS_LOG.md
@@ -41,6 +41,9 @@ Correct them by adding a new entry that references the old one.
 ### Coverage ledger
 - No new GDD coverage ID. This hotfix preserves the runtime performance
   contract for the existing GDD-14-WEATHER-GRIP-RUNTIME coverage.
+- Uncovered adjacent requirements: tire selection, weather VFX particles,
+  fog draw-distance rendering, weather intensity settings, and mid-race
+  weather transitions remain future slices.
 
 ### Followups created
 None.

--- a/src/game/ai.ts
+++ b/src/game/ai.ts
@@ -36,6 +36,11 @@
  * identity (`getCpuModifiers("normal")`) so existing callers keep
  * Normal behavior unchanged.
  *
+ * Weather skill wiring: callers may pass `weatherSkillScalar` as the
+ * compact §15 weather-skill row resolved for the active weather. It is
+ * a number rather than an adjusted modifiers object so the 60 Hz race
+ * loop does not allocate one object per AI per tick.
+ *
  * Out of scope for this slice (deferred to follow-up AI dots):
  * - Overtake / lane-shift behaviour. §15 lists it; the clean_line single
  *   AI may collide with the player. Collision avoidance lands with the
@@ -44,7 +49,6 @@
  * - Archetype-specific mistake shapes (miss apex, brake too early in
  *   fog, etc.). This slice ships the shared deterministic lane-target
  *   mistake hook.
- * - Weather skill modulation of `paceScalar`.
  * - Full rubber-banding policy. This slice ships the light catch-up
  *   pace hook so the §23 `recoveryScalar` row is consumed.
  */
@@ -235,6 +239,7 @@ export function tickAI(
   context: Readonly<AITrackContext> = DEFAULT_AI_TRACK_CONTEXT,
   _dt: number = 0,
   cpuModifiers: Readonly<CpuDifficultyModifiers> = IDENTITY_CPU_MODIFIERS,
+  weatherSkillScalar: number = 1,
 ): AITickResult {
   const segment = currentSegment(track, aiCar.z);
   // `segment.curve` is the per-compiled-segment dx contribution, already
@@ -298,11 +303,16 @@ export function tickAI(
   // at Hard targets ~5% above the same driver at Normal, while at Easy
   // the same driver targets ~8% below. Identity modifiers (the default
   // when a caller has not threaded the resolved tier) preserve
-  // pre-binding behaviour bit-for-bit. The composed target is then
-  // re-clamped at `stats.topSpeed` so a Master-tier driver with an
-  // authored `paceScalar > 1` still cannot exceed the chassis ceiling.
+  // pre-binding behaviour bit-for-bit. `weatherSkillScalar` stacks the
+  // compact §15 weather-skill row without allocating adjusted modifier
+  // objects per AI tick. The composed target is then re-clamped at
+  // `stats.topSpeed` so a Master-tier driver with an authored
+  // `paceScalar > 1` still cannot exceed the chassis ceiling.
   const curvePenalty = 1 - AI_TUNING.CLEAN_LINE_CURVE_DECEL * Math.abs(authoredCurve);
-  const composedPaceScalar = driver.paceScalar * cpuModifiers.paceScalar;
+  const composedPaceScalar =
+    driver.paceScalar *
+    cpuModifiers.paceScalar *
+    clamp(weatherSkillScalar, 0, 2);
   const rawTarget =
     stats.topSpeed *
     Math.max(0, curvePenalty) *

--- a/src/game/raceSession.ts
+++ b/src/game/raceSession.ts
@@ -1021,14 +1021,6 @@ export function stepRaceSession(
   const aiTickResults = state.ai.map((entry, index) => {
     const aiConfig = config.ai[index];
     if (!aiConfig) return null;
-    const aiWeatherSkill = weatherSkillFor(aiConfig.driver, trackWeather);
-    const aiCpuModifiers =
-      aiWeatherSkill === 1
-        ? cpuModifiers
-        : {
-            ...cpuModifiers,
-            paceScalar: cpuModifiers.paceScalar * aiWeatherSkill,
-          };
     return tickAI(
       aiConfig.driver,
       entry.state,
@@ -1039,7 +1031,8 @@ export function stepRaceSession(
       aiConfig.stats,
       aiContext,
       dt,
-      aiCpuModifiers,
+      cpuModifiers,
+      weatherSkillFor(aiConfig.driver, trackWeather),
     );
   });
 


### PR DESCRIPTION
## Summary
- carry the resolved PR #44 Copilot review fix onto main
- pass AI weather skill as a scalar into tickAI instead of allocating adjusted modifier objects per AI tick
- log the hotfix slice and remaining adjacent weather followups

## GDD
- §15 CPU opponents and AI
- §21 technical design for runtime performance

## Progress log
- docs/PROGRESS_LOG.md: 2026-04-28 Slice: Weather AI allocation hotfix

## Test plan
- npx vitest run src/game/__tests__/ai.test.ts src/game/__tests__/weather.test.ts src/game/__tests__/raceSession.test.ts
- npm run typecheck
- npm run verify
- grep -rn $'\u2014\|\u2013' src/game/ai.ts src/game/raceSession.ts docs/PROGRESS_LOG.md || true
- git diff --check