### PR TITLE
feat(game): add pre-race tire selection

### DIFF
--- a/docs/FOLLOWUPS.md
+++ b/docs/FOLLOWUPS.md
@@ -13,13 +13,19 @@ or `obsolete` so the trail is preserved.
 ## F-066: Add pre-race tire selection and persist the active tire channel
 **Created:** 2026-04-28
 **Priority:** blocks-release
-**Status:** open
+**Status:** done (2026-04-28)
 **Notes:** The weather grip runtime slice applies §23 weather modifiers
 through the existing dry handling path because no active tire-selection
 state exists yet. Add the §14/§20 pre-race tire choice, persist the
 active tire channel for the race, and pass `"wet"` into
 `weatherGripScalar` when the player actually chooses wet tires. The AI
 path can keep dry default until AI setup selection lands.
+
+Closed by `feat/pre-race-tire-selection`. `/world` now routes tour
+entry through `/race/prep`, the pre-race card shows the §20 race fields
+and §14 forecast cells, the player can choose dry or wet tires, and
+`/race` consumes the `tire` query as `RaceSessionConfig.playerTire`.
+AI cars keep the dry default until AI setup selection lands.
 
 ## F-065: Persist active tour race progression through the four-race World Tour loop
 **Created:** 2026-04-28

--- a/docs/GDD_COVERAGE.json
+++ b/docs/GDD_COVERAGE.json
@@ -2,6 +2,32 @@
   "version": 1,
   "requirements": [
     {
+      "id": "GDD-20-PRE-RACE-TIRE-SELECTION",
+      "gddSections": [
+        "docs/gdd/05-core-gameplay-loop.md",
+        "docs/gdd/14-weather-and-environmental-systems.md",
+        "docs/gdd/20-hud-and-ui-ux.md",
+        "docs/gdd/23-balancing-tables.md"
+      ],
+      "requirement": "World Tour entry passes through a pre-race card that shows track, tour, weather forecast, laps, difficulty, tire recommendation, standings, cash, repair estimate, car summary, and carries the selected tire into race physics.",
+      "coverage": ["implemented-code", "automated-test"],
+      "implementationRefs": [
+        "src/game/preRaceCard.ts",
+        "src/app/race/prep/page.tsx",
+        "src/app/world/page.tsx",
+        "src/app/race/page.tsx",
+        "src/game/raceSession.ts"
+      ],
+      "testRefs": [
+        "src/game/__tests__/preRaceCard.test.ts",
+        "src/game/__tests__/raceSession.test.ts",
+        "e2e/pre-race.spec.ts",
+        "e2e/world-tour.spec.ts",
+        "e2e/tour-flow.spec.ts"
+      ],
+      "followupRefs": []
+    },
+    {
       "id": "GDD-14-WEATHER-GRIP-RUNTIME",
       "gddSections": [
         "docs/gdd/14-weather-and-environmental-systems.md",
@@ -20,7 +46,7 @@
         "src/game/__tests__/physics.test.ts",
         "src/game/__tests__/raceSession.test.ts"
       ],
-      "followupRefs": ["F-066"]
+      "followupRefs": []
     },
     {
       "id": "GDD-21-RNG-CONSUMERS",

--- a/docs/PROGRESS_LOG.md
+++ b/docs/PROGRESS_LOG.md
@@ -6,6 +6,67 @@ Correct them by adding a new entry that references the old one.
 
 ---
 
+## 2026-04-28: Slice: Pre-race tire selection
+
+**GDD sections touched:**
+[§5](gdd/05-core-gameplay-loop.md) race preparation,
+[§14](gdd/14-weather-and-environmental-systems.md) pre-race forecast,
+[§20](gdd/20-hud-and-ui-ux.md) pre-race screen,
+[§23](gdd/23-balancing-tables.md) weather modifiers.
+**Branch / PR:** `feat/pre-race-tire-selection`, PR pending.
+**Status:** Implemented.
+
+### Done
+- `src/game/preRaceCard.ts`: added a pure pre-race card builder with
+  track, tour, weather, laps, difficulty, recommended tires, standings,
+  cash, repair estimate, car summary, setup summary, grip rating, and
+  visibility rating.
+- `src/app/race/prep/page.tsx`: added the pre-race surface with weather
+  selection, dry/wet tire choice, tire mismatch warning, and Start CTA.
+- `src/app/world/page.tsx`: routes World Tour entry through the
+  pre-race screen instead of jumping directly into the race.
+- `src/app/race/page.tsx` and `src/game/raceSession.ts`: read the
+  selected `weather` and `tire` query values and apply the player tire
+  channel to runtime weather grip.
+- `docs/FOLLOWUPS.md`: marked F-066 done.
+- `docs/GDD_COVERAGE.json`: added GDD-20-PRE-RACE-TIRE-SELECTION and
+  removed F-066 from the weather-runtime coverage followup list.
+
+### Verified
+- `npx vitest run src/game/__tests__/preRaceCard.test.ts src/game/__tests__/raceSession.test.ts`
+  green, 124 passed.
+- `npm run typecheck` clean.
+- `npm run content-lint` clean.
+- `npx playwright test e2e/pre-race.spec.ts e2e/world-tour.spec.ts`
+  green, 2 passed.
+- `npx playwright test e2e/tour-flow.spec.ts` green, 2 passed.
+- `npm run verify` green, 2312 passed.
+- `npm run test:e2e` green, 70 passed.
+- `grep -rn $'\u2014\|\u2013' ...` clean on changed files.
+- `git diff --check` clean.
+
+### Decisions and assumptions
+- The active tire channel is persisted for the race through the route
+  query (`tire=dry|wet`) and held on `RaceSessionConfig.playerTire`.
+  This avoids a save-schema change for a per-race setup choice.
+- AI cars keep dry tires until an AI setup-selection slice lands, matching
+  F-066.
+- Direct `/race` links still default to dry tires and the first track
+  weather option.
+
+### Coverage ledger
+- GDD-20-PRE-RACE-TIRE-SELECTION covers the first pre-race card surface
+  and active player tire handoff into race physics.
+- Uncovered adjacent requirements: optional setup bias, nitro loadout
+  confirmation, practice-mode weather swap UI, and AI tire selection
+  remain future slices.
+
+### Followups created
+None.
+
+### GDD edits
+None.
+
 ## 2026-04-28: Slice: Weather AI allocation hotfix
 
 **GDD sections touched:**

--- a/e2e/pre-race.spec.ts
+++ b/e2e/pre-race.spec.ts
@@ -1,0 +1,90 @@
+import { expect, test } from "@playwright/test";
+
+const SAVE_KEY = "vibegear2:save:v3";
+
+test.describe("pre-race tire selection", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto("/");
+    const hasStorage = await page.evaluate(
+      () => typeof window.localStorage !== "undefined",
+    );
+    test.skip(!hasStorage, "localStorage unavailable in this browser context");
+    await page.evaluate(
+      ({ key, save }) => window.localStorage.setItem(key, JSON.stringify(save)),
+      { key: SAVE_KEY, save: buildSave() },
+    );
+  });
+
+  test("shows forecast fields and carries wet tires into race start", async ({
+    page,
+  }) => {
+    await page.goto(
+      "/race/prep?track=velvet-coast%2Fharbor-run&tour=velvet-coast&raceIndex=0&weather=rain",
+    );
+
+    await expect(page.getByTestId("pre-race-page")).toBeVisible();
+    await expect(page.getByTestId("pre-race-track")).toHaveText("Harbor Run");
+    await expect(page.getByTestId("pre-race-weather")).toHaveText("Rain");
+    await expect(page.getByTestId("pre-race-recommended-tire")).toContainText(
+      "wet",
+    );
+    await expect(page.getByTestId("pre-race-car")).toHaveText("Sparrow GT");
+    await page.getByTestId("pre-race-tire-dry").click();
+    await expect(page.getByTestId("pre-race-tire-warning")).toContainText(
+      "wet tires",
+    );
+    await page.getByTestId("pre-race-tire-wet").click();
+    await page.getByTestId("pre-race-start-link").click();
+    await expect(page).toHaveURL(
+      /\/race\?track=velvet-coast%2Fharbor-run&weather=rain&tire=wet&tour=velvet-coast&raceIndex=0$/,
+    );
+    await expect(page.getByTestId("race-canvas")).toBeVisible();
+  });
+});
+
+function buildSave() {
+  return {
+    version: 3,
+    profileName: "PreRaceTester",
+    settings: {
+      displaySpeedUnit: "kph",
+      assists: {
+        steeringAssist: false,
+        autoNitro: false,
+        weatherVisualReduction: false,
+      },
+      difficultyPreset: "normal",
+      transmissionMode: "auto",
+      audio: { master: 1, music: 1, sfx: 1 },
+      accessibility: {
+        colorBlindMode: "off",
+        reducedMotion: false,
+        largeUiText: false,
+        screenShakeScale: 1,
+      },
+    },
+    garage: {
+      credits: 5000,
+      ownedCars: ["sparrow-gt"],
+      activeCarId: "sparrow-gt",
+      installedUpgrades: {
+        "sparrow-gt": {
+          engine: 0,
+          gearbox: 0,
+          dryTires: 0,
+          wetTires: 0,
+          nitro: 0,
+          armor: 0,
+          cooling: 0,
+          aero: 0,
+        },
+      },
+      pendingDamage: {},
+      lastRaceCashEarned: 0,
+    },
+    progress: { unlockedTours: ["velvet-coast"], completedTours: [] },
+    records: {},
+    ghosts: {},
+    writeCounter: 0,
+  };
+}

--- a/e2e/pre-race.spec.ts
+++ b/e2e/pre-race.spec.ts
@@ -28,8 +28,16 @@ test.describe("pre-race tire selection", () => {
     await expect(page.getByTestId("pre-race-recommended-tire")).toContainText(
       "wet",
     );
+    await expect(page.getByTestId("pre-race-tire-wet")).toHaveAttribute(
+      "aria-pressed",
+      "true",
+    );
     await expect(page.getByTestId("pre-race-car")).toHaveText("Sparrow GT");
     await page.getByTestId("pre-race-tire-dry").click();
+    await expect(page.getByTestId("pre-race-tire-dry")).toHaveAttribute(
+      "aria-pressed",
+      "true",
+    );
     await expect(page.getByTestId("pre-race-tire-warning")).toContainText(
       "wet tires",
     );

--- a/e2e/tour-flow.spec.ts
+++ b/e2e/tour-flow.spec.ts
@@ -94,7 +94,11 @@ async function runFullTourFromWorld(page: Page): Promise<FullTourResult> {
   await page.goto("/world");
   await page.getByTestId("world-tour-enter-velvet-coast").click();
   await expect(page).toHaveURL(
-    /\/race\?track=velvet-coast%2Fharbor-run&tour=velvet-coast&raceIndex=0$/,
+    /\/race\/prep\?track=velvet-coast%2Fharbor-run&tour=velvet-coast&raceIndex=0$/,
+  );
+  await page.getByTestId("pre-race-start-link").click();
+  await expect(page).toHaveURL(
+    /\/race\?track=velvet-coast%2Fharbor-run&weather=clear&tire=dry&tour=velvet-coast&raceIndex=0$/,
   );
 
   const completedTracks: string[] = [];

--- a/e2e/world-tour.spec.ts
+++ b/e2e/world-tour.spec.ts
@@ -75,7 +75,11 @@ test.describe("world tour hub", () => {
 
     await page.getByTestId("world-tour-enter-velvet-coast").click();
     await expect(page).toHaveURL(
-      /\/race\?track=velvet-coast%2Fharbor-run&tour=velvet-coast&raceIndex=0$/,
+      /\/race\/prep\?track=velvet-coast%2Fharbor-run&tour=velvet-coast&raceIndex=0$/,
+    );
+    await expect(page.getByTestId("pre-race-track")).toHaveText("Harbor Run");
+    await expect(page.getByTestId("pre-race-recommended-tire")).toContainText(
+      "dry",
     );
 
     const persisted = await page.evaluate((key) => {

--- a/src/app/race/page.tsx
+++ b/src/app/race/page.tsx
@@ -85,6 +85,7 @@ import {
 import { DEFAULT_TOUCH_LAYOUT, type TouchLayout } from "@/game/inputTouch";
 import { FIXED_STEP_SECONDS } from "@/game/loop";
 import type { AIDriver, CarBaseStats } from "@/data/schemas";
+import { WeatherOptionSchema } from "@/data/schemas";
 import {
   CAMERA_DEPTH,
   CAMERA_HEIGHT,
@@ -110,6 +111,7 @@ import { awardCredits, baseRewardForTrackDifficulty } from "@/game/economy";
 import type { SaveGame } from "@/data/schemas";
 import type { RaceResult } from "@/game/raceResult";
 import { PRISTINE_DAMAGE_STATE, type DamageState } from "@/game/damage";
+import type { TireKind } from "@/game/weather";
 
 const VIEWPORT_WIDTH = 800;
 const VIEWPORT_HEIGHT = 480;
@@ -308,6 +310,19 @@ function resolveRaceMode(raw: string | null): RaceMode {
   return raw === "timeTrial" ? "timeTrial" : "race";
 }
 
+function resolveRaceWeather(
+  raw: string | null,
+  track: ResolvedTrack,
+): RaceSessionConfig["weather"] {
+  const parsed = WeatherOptionSchema.safeParse(raw);
+  if (!parsed.success) return undefined;
+  return track.compiled.weatherOptions.includes(parsed.data) ? parsed.data : undefined;
+}
+
+function resolvePlayerTire(raw: string | null): TireKind | undefined {
+  return raw === "wet" || raw === "dry" ? raw : undefined;
+}
+
 /**
  * Parse the optional `?laps=N` URL override. Used by the F-029 e2e to
  * coerce a multi-lap run on the bundled single-lap test tracks without
@@ -472,6 +487,8 @@ function RaceShell(): ReactElement {
   const requestedId = search?.get("track") ?? null;
   const lapsRaw = search?.get("laps") ?? null;
   const modeRaw = search?.get("mode") ?? null;
+  const weatherRaw = search?.get("weather") ?? null;
+  const tireRaw = search?.get("tire") ?? null;
   const tourId = search?.get("tour") ?? null;
   const raceIndexRaw = search?.get("raceIndex") ?? null;
   const tourContext = useMemo(
@@ -484,12 +501,19 @@ function RaceShell(): ReactElement {
   );
   const lapsOverride = useMemo(() => resolveLapsOverride(lapsRaw), [lapsRaw]);
   const mode = useMemo(() => resolveRaceMode(modeRaw), [modeRaw]);
+  const weather = useMemo(
+    () => resolveRaceWeather(weatherRaw, track),
+    [track, weatherRaw],
+  );
+  const playerTire = useMemo(() => resolvePlayerTire(tireRaw), [tireRaw]);
   return (
     <RaceCanvas
       track={track}
       lapsOverride={lapsOverride}
       mode={mode}
       tourContext={tourContext}
+      weather={weather}
+      playerTire={playerTire}
     />
   );
 }
@@ -499,6 +523,8 @@ interface RaceCanvasProps {
   lapsOverride: number | null;
   mode: RaceMode;
   tourContext: TourRaceContext | null;
+  weather: RaceSessionConfig["weather"];
+  playerTire: TireKind | undefined;
 }
 
 function RaceCanvas({
@@ -506,6 +532,8 @@ function RaceCanvas({
   lapsOverride,
   mode,
   tourContext,
+  weather,
+  playerTire,
 }: RaceCanvasProps): ReactElement {
   const router = useRouter();
   const canvasRef = useRef<HTMLCanvasElement | null>(null);
@@ -643,6 +671,8 @@ function RaceCanvas({
       ai: spawnedAi,
       hazardsById: HAZARDS_BY_ID,
       seed: raceSeed,
+      ...(weather ? { weather } : {}),
+      ...(playerTire ? { playerTire } : {}),
       ...(lapsOverride !== null ? { totalLaps: lapsOverride } : {}),
     };
     setFieldSize(1 + config.ai.length);
@@ -1093,7 +1123,17 @@ function RaceCanvas({
       sessionRef.current = null;
       inputManager.dispose();
     };
-  }, [track, router, lapsOverride, initialTotalLaps, mode, tourContext, openPauseMenu]);
+  }, [
+    track,
+    router,
+    lapsOverride,
+    initialTotalLaps,
+    mode,
+    tourContext,
+    openPauseMenu,
+    weather,
+    playerTire,
+  ]);
 
   return (
     <main

--- a/src/app/race/page.tsx
+++ b/src/app/race/page.tsx
@@ -84,8 +84,11 @@ import {
 } from "@/game";
 import { DEFAULT_TOUCH_LAYOUT, type TouchLayout } from "@/game/inputTouch";
 import { FIXED_STEP_SECONDS } from "@/game/loop";
-import type { AIDriver, CarBaseStats } from "@/data/schemas";
-import { WeatherOptionSchema } from "@/data/schemas";
+import {
+  WeatherOptionSchema,
+  type AIDriver,
+  type CarBaseStats,
+} from "@/data/schemas";
 import {
   CAMERA_DEPTH,
   CAMERA_HEIGHT,

--- a/src/app/race/prep/page.tsx
+++ b/src/app/race/prep/page.tsx
@@ -110,7 +110,11 @@ function RacePrepShell(): ReactElement {
     );
   }
 
-  if (!trackId || !track || !save || !card) {
+  if (!save) {
+    return <RacePrepLoading />;
+  }
+
+  if (!trackId || !track || !card) {
     return (
       <main style={pageStyle} data-testid="pre-race-page">
         <h1>Pre-race</h1>
@@ -219,6 +223,7 @@ function RacePrepShell(): ReactElement {
                 key={tire}
                 type="button"
                 style={selectedTire === tire ? activeSegmentStyle : segmentStyle}
+                aria-pressed={selectedTire === tire}
                 onClick={() => setSelectedTire(tire)}
                 data-testid={`pre-race-tire-${tire}`}
               >

--- a/src/app/race/prep/page.tsx
+++ b/src/app/race/prep/page.tsx
@@ -1,0 +1,468 @@
+"use client";
+
+import Link from "next/link";
+import { useRouter, useSearchParams } from "next/navigation";
+import {
+  Suspense,
+  useEffect,
+  useMemo,
+  useState,
+  type CSSProperties,
+  type ReactElement,
+} from "react";
+
+import { TRACK_IDS, TRACK_RAW, getChampionship } from "@/data";
+import {
+  TrackSchema,
+  WeatherOptionSchema,
+  type SaveGame,
+  type WeatherOption,
+} from "@/data/schemas";
+import {
+  buildPreRaceCard,
+  recommendTire,
+  resolveWeatherSelection,
+  type PreRaceCard,
+} from "@/game/preRaceCard";
+import type { TireKind } from "@/game/weather";
+import { loadSave } from "@/persistence/save";
+
+const CHAMPIONSHIP_ID = "world-tour-standard";
+
+export default function RacePrepPage(): ReactElement {
+  return (
+    <Suspense fallback={<RacePrepLoading />}>
+      <RacePrepShell />
+    </Suspense>
+  );
+}
+
+function RacePrepLoading(): ReactElement {
+  return (
+    <main style={pageStyle} data-testid="pre-race-page">
+      <h1>Pre-race</h1>
+      <p data-testid="pre-race-loading">Loading pre-race card</p>
+    </main>
+  );
+}
+
+function RacePrepShell(): ReactElement {
+  const router = useRouter();
+  const search = useSearchParams();
+  const trackId = search?.get("track") ?? null;
+  const tourId = search?.get("tour") ?? null;
+  const raceIndexRaw = search?.get("raceIndex") ?? null;
+  const requestedWeather = parseWeather(search?.get("weather") ?? null);
+  const requestedTire = parseTire(search?.get("tire") ?? null);
+  const [save, setSave] = useState<SaveGame | null>(null);
+  const [redirecting, setRedirecting] = useState(false);
+
+  useEffect(() => {
+    const outcome = loadSave();
+    if (outcome.kind === "loaded") {
+      setSave(outcome.save);
+      return;
+    }
+    setRedirecting(true);
+    router.replace("/");
+  }, [router]);
+
+  const track = useMemo(() => {
+    if (!trackId || !TRACK_IDS.includes(trackId)) return null;
+    return TrackSchema.parse(TRACK_RAW[trackId]);
+  }, [trackId]);
+
+  const championship = useMemo(() => getChampionship(CHAMPIONSHIP_ID), []);
+  const raceIndex = parseRaceIndex(raceIndexRaw);
+  const initialWeather = useMemo(
+    () => (track ? resolveWeatherSelection(track, requestedWeather) : "clear"),
+    [requestedWeather, track],
+  );
+  const [weather, setWeather] = useState<WeatherOption>(initialWeather);
+  const [selectedTire, setSelectedTire] = useState<TireKind>(
+    requestedTire ?? recommendTire(initialWeather),
+  );
+
+  useEffect(() => {
+    setWeather(initialWeather);
+    setSelectedTire(requestedTire ?? recommendTire(initialWeather));
+  }, [initialWeather, requestedTire]);
+
+  const card: PreRaceCard | null = useMemo(() => {
+    if (!save || !track) return null;
+    return buildPreRaceCard({
+      track,
+      save,
+      championship,
+      tourId,
+      raceIndex,
+      weatherSelection: weather,
+      selectedTire,
+    });
+  }, [championship, raceIndex, save, selectedTire, tourId, track, weather]);
+
+  if (redirecting) {
+    return (
+      <main style={pageStyle} data-testid="pre-race-page">
+        <h1>Pre-race</h1>
+        <p data-testid="pre-race-redirect">Create or load a profile first.</p>
+      </main>
+    );
+  }
+
+  if (!trackId || !track || !save || !card) {
+    return (
+      <main style={pageStyle} data-testid="pre-race-page">
+        <h1>Pre-race</h1>
+        <p data-testid="pre-race-error">Race setup is unavailable.</p>
+        <Link href="/world" style={linkStyle}>
+          Back to world tour
+        </Link>
+      </main>
+    );
+  }
+
+  const startHref = raceHref({
+    trackId,
+    weather,
+    tire: selectedTire,
+    tourId,
+    raceIndex,
+  });
+
+  return (
+    <main style={pageStyle} data-testid="pre-race-page">
+      <header style={headerStyle}>
+        <div>
+          <p style={eyebrowStyle} data-testid="pre-race-tour">
+            {card.tourName}
+          </p>
+          <h1 style={titleStyle} data-testid="pre-race-track">
+            {card.trackName}
+          </h1>
+        </div>
+        <nav style={navStyle} aria-label="Pre-race actions">
+          <Link href="/garage" style={linkStyle}>
+            Garage
+          </Link>
+          <Link href="/world" style={linkStyle}>
+            World
+          </Link>
+        </nav>
+      </header>
+
+      <section style={gridStyle} aria-label="Race briefing">
+        <article style={panelStyle}>
+          <h2 style={sectionTitleStyle}>Track card</h2>
+          <dl style={summaryGridStyle}>
+            <Field label="Laps" testId="pre-race-laps" value={card.laps} />
+            <Field
+              label="Difficulty"
+              testId="pre-race-difficulty"
+              value={`${card.difficulty.value} (${card.difficulty.label})`}
+            />
+            <Field label="Base reward" testId="pre-race-base-reward" value={card.baseReward} />
+            <Field label="Standings" testId="pre-race-standings" value={card.standings} />
+          </dl>
+        </article>
+
+        <article style={panelStyle}>
+          <h2 style={sectionTitleStyle}>Forecast</h2>
+          <label style={fieldLabelStyle} htmlFor="weather-select">
+            Weather
+          </label>
+          <select
+            id="weather-select"
+            value={weather}
+            onChange={(event) => {
+              const next = parseWeather(event.target.value) ?? card.weather;
+              setWeather(next);
+              setSelectedTire(recommendTire(next));
+            }}
+            style={selectStyle}
+            data-testid="pre-race-weather-select"
+          >
+            {card.allowedWeather.map((option) => (
+              <option key={option} value={option}>
+                {optionLabel(option)}
+              </option>
+            ))}
+          </select>
+          <dl style={summaryGridStyle}>
+            <Field
+              label="Condition"
+              testId="pre-race-weather"
+              value={card.forecast.condition}
+            />
+            <Field
+              label="Surface temp"
+              testId="pre-race-surface-temp"
+              value={card.forecast.surfaceTemperatureBand}
+            />
+            <Field label="Grip" testId="pre-race-grip" value={card.forecast.gripRating} />
+            <Field
+              label="Visibility"
+              testId="pre-race-visibility"
+              value={card.forecast.visibilityRating}
+            />
+          </dl>
+        </article>
+
+        <article style={panelStyle}>
+          <h2 style={sectionTitleStyle}>Tires</h2>
+          <p style={recommendationStyle} data-testid="pre-race-recommended-tire">
+            Recommended: {card.recommendedTire}
+          </p>
+          <div style={segmentedStyle} role="group" aria-label="Tire choice">
+            {(["dry", "wet"] as const).map((tire) => (
+              <button
+                key={tire}
+                type="button"
+                style={selectedTire === tire ? activeSegmentStyle : segmentStyle}
+                onClick={() => setSelectedTire(tire)}
+                data-testid={`pre-race-tire-${tire}`}
+              >
+                {tire}
+              </button>
+            ))}
+          </div>
+          <p
+            style={{
+              ...mutedTextStyle,
+              color: card.selectedTireWarning ? "#ffd166" : "#aab0bd",
+            }}
+            data-testid="pre-race-tire-warning"
+          >
+            {card.selectedTireWarning || "Tire choice matches the forecast."}
+          </p>
+        </article>
+
+        <article style={panelStyle}>
+          <h2 style={sectionTitleStyle}>Car and economy</h2>
+          <dl style={summaryGridStyle}>
+            <Field
+              label="Selected car"
+              testId="pre-race-car"
+              value={card.carSummary.name}
+            />
+            <Field
+              label="Class"
+              testId="pre-race-car-class"
+              value={card.carSummary.className}
+            />
+            <Field label="Setup" testId="pre-race-setup" value={card.setupSummary} />
+            <Field label="Cash" testId="pre-race-cash" value={card.cashOnHand} />
+            <Field
+              label="Repair estimate"
+              testId="pre-race-repair-estimate"
+              value={card.repairEstimate}
+            />
+          </dl>
+        </article>
+      </section>
+
+      <footer style={footerStyle}>
+        <Link href={startHref} style={primaryLinkStyle} data-testid="pre-race-start-link">
+          Start race
+        </Link>
+      </footer>
+    </main>
+  );
+}
+
+function Field({
+  label,
+  value,
+  testId,
+}: {
+  readonly label: string;
+  readonly value: string | number;
+  readonly testId: string;
+}): ReactElement {
+  return (
+    <div style={summaryRowStyle}>
+      <dt>{label}</dt>
+      <dd data-testid={testId}>{value}</dd>
+    </div>
+  );
+}
+
+function parseWeather(raw: string | null): WeatherOption | null {
+  const parsed = WeatherOptionSchema.safeParse(raw);
+  return parsed.success ? parsed.data : null;
+}
+
+function parseTire(raw: string | null): TireKind | null {
+  return raw === "dry" || raw === "wet" ? raw : null;
+}
+
+function parseRaceIndex(raw: string | null): number | null {
+  if (raw === null) return null;
+  const parsed = Number.parseInt(raw, 10);
+  return Number.isInteger(parsed) && parsed >= 0 ? parsed : null;
+}
+
+function raceHref(input: {
+  readonly trackId: string;
+  readonly weather: WeatherOption;
+  readonly tire: TireKind;
+  readonly tourId: string | null;
+  readonly raceIndex: number | null;
+}): string {
+  const params = new URLSearchParams({
+    track: input.trackId,
+    weather: input.weather,
+    tire: input.tire,
+  });
+  if (input.tourId) params.set("tour", input.tourId);
+  if (input.raceIndex !== null) params.set("raceIndex", String(input.raceIndex));
+  return `/race?${params.toString()}`;
+}
+
+function optionLabel(weather: WeatherOption): string {
+  return weather
+    .split("_")
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+    .join(" ");
+}
+
+const pageStyle: CSSProperties = {
+  minHeight: "100vh",
+  padding: "2rem",
+  color: "var(--fg, #ddd)",
+  background: "var(--bg, #111)",
+  fontFamily: "system-ui, sans-serif",
+};
+
+const headerStyle: CSSProperties = {
+  display: "flex",
+  justifyContent: "space-between",
+  alignItems: "flex-start",
+  gap: "1rem",
+  marginBottom: "1.5rem",
+  flexWrap: "wrap",
+};
+
+const eyebrowStyle: CSSProperties = {
+  margin: 0,
+  color: "#9bd2ff",
+  fontWeight: 700,
+};
+
+const titleStyle: CSSProperties = {
+  margin: "0.25rem 0 0",
+  fontSize: "2rem",
+};
+
+const navStyle: CSSProperties = {
+  display: "flex",
+  gap: "0.75rem",
+  flexWrap: "wrap",
+};
+
+const linkStyle: CSSProperties = {
+  color: "#dfe8ff",
+  border: "1px solid #4f5f7a",
+  borderRadius: "0.5rem",
+  padding: "0.6rem 0.85rem",
+  textDecoration: "none",
+};
+
+const primaryLinkStyle: CSSProperties = {
+  ...linkStyle,
+  display: "inline-flex",
+  justifyContent: "center",
+  minWidth: "10rem",
+  color: "#081018",
+  background: "#ffd166",
+  borderColor: "#ffd166",
+  fontWeight: 800,
+};
+
+const gridStyle: CSSProperties = {
+  display: "grid",
+  gridTemplateColumns: "repeat(auto-fit, minmax(16rem, 1fr))",
+  gap: "1rem",
+};
+
+const panelStyle: CSSProperties = {
+  border: "1px solid #2e3c55",
+  borderRadius: "0.5rem",
+  padding: "1rem",
+  background: "#141b28",
+};
+
+const sectionTitleStyle: CSSProperties = {
+  margin: "0 0 1rem",
+  fontSize: "1.1rem",
+};
+
+const summaryGridStyle: CSSProperties = {
+  display: "grid",
+  gap: "0.6rem",
+  margin: 0,
+};
+
+const summaryRowStyle: CSSProperties = {
+  display: "flex",
+  justifyContent: "space-between",
+  gap: "1rem",
+  alignItems: "baseline",
+};
+
+const fieldLabelStyle: CSSProperties = {
+  display: "block",
+  marginBottom: "0.35rem",
+  color: "#aab0bd",
+};
+
+const selectStyle: CSSProperties = {
+  width: "100%",
+  marginBottom: "1rem",
+  padding: "0.6rem",
+  color: "#e8edf8",
+  background: "#0d1320",
+  border: "1px solid #40506b",
+  borderRadius: "0.35rem",
+};
+
+const recommendationStyle: CSSProperties = {
+  margin: "0 0 1rem",
+  fontSize: "1.2rem",
+  fontWeight: 800,
+};
+
+const segmentedStyle: CSSProperties = {
+  display: "grid",
+  gridTemplateColumns: "1fr 1fr",
+  gap: "0.5rem",
+  marginBottom: "0.8rem",
+};
+
+const segmentStyle: CSSProperties = {
+  padding: "0.65rem",
+  color: "#dfe8ff",
+  background: "#0d1320",
+  border: "1px solid #40506b",
+  borderRadius: "0.35rem",
+  textTransform: "uppercase",
+  fontWeight: 800,
+};
+
+const activeSegmentStyle: CSSProperties = {
+  ...segmentStyle,
+  color: "#081018",
+  background: "#9bd2ff",
+  borderColor: "#9bd2ff",
+};
+
+const mutedTextStyle: CSSProperties = {
+  margin: 0,
+  color: "#aab0bd",
+};
+
+const footerStyle: CSSProperties = {
+  display: "flex",
+  justifyContent: "flex-end",
+  marginTop: "1.5rem",
+};

--- a/src/app/world/page.tsx
+++ b/src/app/world/page.tsx
@@ -81,7 +81,7 @@ export default function WorldPage() {
       }
 
       router.push(
-        `/race?track=${encodeURIComponent(result.firstTrackId)}&tour=${encodeURIComponent(tourId)}&raceIndex=0`,
+        `/race/prep?track=${encodeURIComponent(result.firstTrackId)}&tour=${encodeURIComponent(tourId)}&raceIndex=0`,
       );
     },
     [championship, router, save],

--- a/src/game/__tests__/preRaceCard.test.ts
+++ b/src/game/__tests__/preRaceCard.test.ts
@@ -1,0 +1,114 @@
+import { describe, expect, it } from "vitest";
+
+import { getChampionship } from "@/data/championships";
+import { TRACK_RAW } from "@/data/tracks";
+import { TrackSchema, type SaveGame, type WeatherOption } from "@/data/schemas";
+import { defaultSave } from "@/persistence/save";
+
+import {
+  buildPreRaceCard,
+  difficultyLabel,
+  recommendTire,
+  resolveWeatherSelection,
+} from "../preRaceCard";
+
+describe("pre-race card", () => {
+  const track = TrackSchema.parse(TRACK_RAW["velvet-coast/harbor-run"]);
+  const championship = getChampionship("world-tour-standard");
+
+  it("populates the required §20 and §14 fields", () => {
+    const save: SaveGame = {
+      ...defaultSave(),
+      garage: {
+        ...defaultSave().garage,
+        credits: 1250,
+        pendingDamage: {
+          "sparrow-gt": {
+            zones: { engine: 0.1, tires: 0.2, body: 0.05 },
+            total: 0.115,
+            offRoadAccumSeconds: 0,
+          },
+        },
+      },
+      progress: {
+        ...defaultSave().progress,
+        activeTour: {
+          tourId: "velvet-coast",
+          raceIndex: 1,
+          results: [{ trackId: "velvet-coast/harbor-run", placement: 2, dnf: false }],
+        },
+      },
+    };
+
+    const card = buildPreRaceCard({
+      track,
+      save,
+      championship,
+      tourId: "velvet-coast",
+      raceIndex: 1,
+      weatherSelection: "rain",
+      selectedTire: "wet",
+    });
+
+    expect(card.trackName).toBe("Harbor Run");
+    expect(card.tourName).toBe("Velvet Coast");
+    expect(card.weather).toBe("rain");
+    expect(card.laps).toBe(1);
+    expect(card.difficulty).toEqual({ value: 1, label: "Easy" });
+    expect(card.recommendedTire).toBe("wet");
+    expect(card.forecast.condition).toBe("Rain");
+    expect(card.forecast.surfaceTemperatureBand).toBe("Wet");
+    expect(card.forecast.visibilityRating).toBe("Medium");
+    expect(card.standings).toBe("Race 2 of 4, 1 complete");
+    expect(card.cashOnHand).toBe(1250);
+    expect(card.repairEstimate).toBeGreaterThan(0);
+    expect(card.baseReward).toBe(1000);
+    expect(card.carSummary.name).toBe("Sparrow GT");
+    expect(card.setupSummary).toBe("Stock setup");
+  });
+
+  it.each([
+    ["clear", "dry"],
+    ["light_rain", "wet"],
+    ["rain", "wet"],
+    ["heavy_rain", "wet"],
+    ["fog", "dry"],
+    ["snow", "wet"],
+    ["dusk", "dry"],
+    ["night", "dry"],
+  ] satisfies ReadonlyArray<readonly [WeatherOption, "dry" | "wet"]>)(
+    "recommends %s tires for %s",
+    (weather, expected) => {
+      expect(recommendTire(weather)).toBe(expected);
+    },
+  );
+
+  it("falls back to the track default when the requested weather is not allowed", () => {
+    expect(resolveWeatherSelection(track, "snow")).toBe("clear");
+    expect(resolveWeatherSelection(track, "fog")).toBe("fog");
+  });
+
+  it("warns when the selected tire does not match the forecast", () => {
+    const card = buildPreRaceCard({
+      track,
+      save: defaultSave(),
+      championship,
+      tourId: "velvet-coast",
+      weatherSelection: "rain",
+      selectedTire: "dry",
+    });
+
+    expect(card.recommendedTire).toBe("wet");
+    expect(card.selectedTireWarning).toContain("wet tires");
+  });
+
+  it.each([
+    [1, "Easy"],
+    [2, "Moderate"],
+    [3, "Hard"],
+    [4, "Expert"],
+    [5, "Master"],
+  ])("labels difficulty %i as %s", (value, expected) => {
+    expect(difficultyLabel(value)).toBe(expected);
+  });
+});

--- a/src/game/__tests__/raceSession.test.ts
+++ b/src/game/__tests__/raceSession.test.ts
@@ -243,6 +243,37 @@ describe("stepRaceSession (racing)", () => {
     );
   });
 
+  it("applies the selected player tire channel to weather grip", () => {
+    const steer = { ...NEUTRAL_INPUT, steer: 1 };
+    const dryConfig = buildConfig({
+      countdownSec: 0,
+      weather: "rain",
+      playerTire: "dry",
+      player: { stats: STARTER_STATS, initial: { speed: 30 } },
+    });
+    const wetConfig = buildConfig({
+      countdownSec: 0,
+      weather: "rain",
+      playerTire: "wet",
+      player: { stats: STARTER_STATS, initial: { speed: 30 } },
+    });
+    const dry = stepRaceSession(
+      createRaceSession(dryConfig),
+      steer,
+      dryConfig,
+      DT,
+    );
+    const wet = stepRaceSession(
+      createRaceSession(wetConfig),
+      steer,
+      wetConfig,
+      DT,
+    );
+    expect(Math.abs(wet.player.car.x)).toBeGreaterThan(
+      Math.abs(dry.player.car.x),
+    );
+  });
+
   it("maps active weather through AI weather skill", () => {
     const wetSpecialist = {
       ...TEST_DRIVER,

--- a/src/game/index.ts
+++ b/src/game/index.ts
@@ -24,6 +24,7 @@ export * from "./timeTrial";
 export * from "./assists";
 export * from "./difficultyPresets";
 export * from "./raceDamagePersistence";
+export * from "./preRaceCard";
 // `raceBonuses` is the owner of the §5 bonus pipeline; `raceResult` is
 // the §20 results-screen builder that consumes it. The two re-export the
 // same `RaceBonus` / `RaceBonusKind` and the four bonus constants, so

--- a/src/game/preRaceCard.ts
+++ b/src/game/preRaceCard.ts
@@ -1,0 +1,292 @@
+import { getCar } from "@/data/cars";
+import type {
+  Car,
+  Championship,
+  ChampionshipTour,
+  SaveGame,
+  Track,
+  WeatherOption,
+} from "@/data/schemas";
+
+import { applyRepairCost, baseRewardForTrackDifficulty } from "./economy";
+import { createDamageState, type DamageState } from "./damage";
+import {
+  visibilityForWeather,
+  weatherGripScalar,
+  type TireKind,
+} from "./weather";
+
+const REPAIR_ZONES = ["engine", "tires", "body"] as const;
+
+type PendingGarageDamage = NonNullable<SaveGame["garage"]["pendingDamage"]>[string];
+
+export interface PreRaceCard {
+  readonly trackName: string;
+  readonly tourName: string;
+  readonly weather: WeatherOption;
+  readonly allowedWeather: readonly WeatherOption[];
+  readonly laps: number;
+  readonly difficulty: {
+    readonly value: number;
+    readonly label: string;
+  };
+  readonly recommendedTire: TireKind;
+  readonly selectedTire: TireKind;
+  readonly selectedTireWarning: string;
+  readonly forecast: {
+    readonly condition: string;
+    readonly surfaceTemperatureBand: string;
+    readonly gripRating: string;
+    readonly visibilityRating: string;
+  };
+  readonly standings: string;
+  readonly cashOnHand: number;
+  readonly repairEstimate: number;
+  readonly baseReward: number;
+  readonly carSummary: {
+    readonly id: string;
+    readonly name: string;
+    readonly className: string;
+    readonly topSpeed: number;
+    readonly gripDry: number;
+    readonly gripWet: number;
+  };
+  readonly setupSummary: string;
+}
+
+export interface BuildPreRaceCardInput {
+  readonly track: Track;
+  readonly save: SaveGame;
+  readonly championship?: Championship | null;
+  readonly tourId?: string | null;
+  readonly raceIndex?: number | null;
+  readonly weatherSelection?: WeatherOption | null;
+  readonly selectedTire?: TireKind | null;
+}
+
+export function buildPreRaceCard(input: BuildPreRaceCardInput): PreRaceCard {
+  const {
+    track,
+    save,
+    championship = null,
+    tourId = track.tourId,
+    raceIndex = null,
+  } = input;
+  const weather = resolveWeatherSelection(track, input.weatherSelection);
+  const car = getCar(save.garage.activeCarId);
+  const selectedTire = input.selectedTire ?? recommendTire(weather);
+  const recommendedTire = recommendTire(weather);
+  const activeTour = championship
+    ? championship.tours.find((tour) => tour.id === tourId) ?? null
+    : null;
+
+  return {
+    trackName: track.name,
+    tourName: activeTour ? displayTourName(activeTour.id) : "Quick Race",
+    weather,
+    allowedWeather: track.weatherOptions,
+    laps: track.laps,
+    difficulty: {
+      value: track.difficulty,
+      label: difficultyLabel(track.difficulty),
+    },
+    recommendedTire,
+    selectedTire,
+    selectedTireWarning: tireWarning(selectedTire, recommendedTire, weather),
+    forecast: {
+      condition: weatherLabel(weather),
+      surfaceTemperatureBand: surfaceTemperatureBand(weather),
+      gripRating: gripRating(car, weather, selectedTire),
+      visibilityRating: visibilityRating(weather),
+    },
+    standings: standingsSummary(save, activeTour, raceIndex),
+    cashOnHand: save.garage.credits,
+    repairEstimate: repairEstimate(save),
+    baseReward: baseRewardForTrackDifficulty(track.difficulty),
+    carSummary: carSummary(save.garage.activeCarId, car),
+    setupSummary: setupSummary(save.garage.activeCarId, save),
+  };
+}
+
+export function resolveWeatherSelection(
+  track: Track,
+  requested: WeatherOption | null | undefined,
+): WeatherOption {
+  if (requested && track.weatherOptions.includes(requested)) return requested;
+  return track.weatherOptions[0] ?? "clear";
+}
+
+export function recommendTire(weather: WeatherOption): TireKind {
+  switch (weather) {
+    case "light_rain":
+    case "rain":
+    case "heavy_rain":
+    case "snow":
+      return "wet";
+    case "clear":
+    case "fog":
+    case "dusk":
+    case "night":
+      return "dry";
+  }
+}
+
+export function difficultyLabel(difficulty: number): string {
+  if (difficulty <= 1) return "Easy";
+  if (difficulty === 2) return "Moderate";
+  if (difficulty === 3) return "Hard";
+  if (difficulty === 4) return "Expert";
+  return "Master";
+}
+
+export function weatherLabel(weather: WeatherOption): string {
+  switch (weather) {
+    case "clear":
+      return "Clear";
+    case "light_rain":
+      return "Light rain";
+    case "rain":
+      return "Rain";
+    case "heavy_rain":
+      return "Heavy rain";
+    case "fog":
+      return "Fog";
+    case "snow":
+      return "Snow";
+    case "dusk":
+      return "Dusk";
+    case "night":
+      return "Night";
+  }
+}
+
+function tireWarning(
+  selected: TireKind,
+  recommended: TireKind,
+  weather: WeatherOption,
+): string {
+  if (selected === recommended) return "";
+  return `Forecast favors ${recommended} tires for ${weatherLabel(weather).toLowerCase()}.`;
+}
+
+function surfaceTemperatureBand(weather: WeatherOption): string {
+  switch (weather) {
+    case "snow":
+      return "Cold";
+    case "night":
+    case "dusk":
+    case "fog":
+      return "Cool";
+    case "clear":
+      return "Warm";
+    case "light_rain":
+    case "rain":
+    case "heavy_rain":
+      return "Wet";
+  }
+}
+
+function visibilityRating(weather: WeatherOption): string {
+  const scalar = visibilityForWeather(weather);
+  if (scalar >= 0.9) return "High";
+  if (scalar >= 0.75) return "Medium";
+  if (scalar >= 0.6) return "Low";
+  return "Very low";
+}
+
+function gripRating(
+  car: Car | undefined,
+  weather: WeatherOption,
+  tire: TireKind,
+): string {
+  if (!car) return "Unknown";
+  const scalar = weatherGripScalar(car.baseStats, weather, tire);
+  if (scalar >= 1.05) return "Excellent";
+  if (scalar >= 0.95) return "Good";
+  if (scalar >= 0.85) return "Reduced";
+  return "Poor";
+}
+
+function standingsSummary(
+  save: SaveGame,
+  tour: ChampionshipTour | null,
+  raceIndex: number | null,
+): string {
+  const activeTour = save.progress.activeTour;
+  if (!tour || !activeTour || activeTour.tourId !== tour.id) return "No tour standings yet";
+  const completed = activeTour.results.length;
+  const total = tour.tracks.length;
+  const next = raceIndex === null ? activeTour.raceIndex : raceIndex;
+  return `Race ${Math.min(total, next + 1)} of ${total}, ${completed} complete`;
+}
+
+function repairEstimate(save: SaveGame): number {
+  const carId = save.garage.activeCarId;
+  const pending = save.garage.pendingDamage?.[carId];
+  const damage = damageFromPending(pending);
+  const quoteSave: SaveGame = {
+    ...save,
+    garage: {
+      ...save.garage,
+      credits: Number.MAX_SAFE_INTEGER,
+    },
+  };
+  const result = applyRepairCost(quoteSave, {
+    carId,
+    damage,
+    tourTier: 1,
+    zones: REPAIR_ZONES,
+    repairKind: "full",
+    lastRaceCashEarned: save.garage.lastRaceCashEarned ?? 0,
+  });
+  return result.ok ? result.cashSpent ?? 0 : 0;
+}
+
+function damageFromPending(
+  pending: PendingGarageDamage | undefined,
+): DamageState {
+  if (!pending) return createDamageState({});
+  return {
+    ...createDamageState({
+      engine: pending.zones.engine,
+      tires: pending.zones.tires,
+      body: pending.zones.body,
+    }),
+    offRoadAccumSeconds: pending.offRoadAccumSeconds,
+  };
+}
+
+function carSummary(activeCarId: string, car: Car | undefined): PreRaceCard["carSummary"] {
+  if (!car) {
+    return {
+      id: activeCarId,
+      name: activeCarId,
+      className: "Unknown",
+      topSpeed: 0,
+      gripDry: 0,
+      gripWet: 0,
+    };
+  }
+  return {
+    id: car.id,
+    name: car.name,
+    className: car.class,
+    topSpeed: car.baseStats.topSpeed,
+    gripDry: car.baseStats.gripDry,
+    gripWet: car.baseStats.gripWet,
+  };
+}
+
+function setupSummary(activeCarId: string, save: SaveGame): string {
+  const upgrades = save.garage.installedUpgrades?.[activeCarId];
+  if (!upgrades) return "Stock setup";
+  const totalTiers = Object.values(upgrades).reduce((sum, tier) => sum + tier, 0);
+  return totalTiers === 0 ? "Stock setup" : `${totalTiers} upgrade tiers installed`;
+}
+
+function displayTourName(tourId: string): string {
+  return tourId
+    .split("-")
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+    .join(" ");
+}

--- a/src/game/raceSession.ts
+++ b/src/game/raceSession.ts
@@ -100,7 +100,7 @@ import {
   tickTransmission,
   type TransmissionState,
 } from "./transmission";
-import { weatherGripScalar, weatherSkillFor } from "./weather";
+import { weatherGripScalar, weatherSkillFor, type TireKind } from "./weather";
 import {
   DEFAULT_TRACK_CONTEXT,
   INITIAL_CAR_STATE,
@@ -239,6 +239,12 @@ export interface RaceSessionConfig {
    * builds.
    */
   weather?: WeatherOption;
+  /**
+   * Active player tire channel chosen in the pre-race surface. Defaults
+   * to dry so existing direct race links preserve their old behavior.
+   * AI cars keep dry tires until an AI setup-selection slice lands.
+   */
+  playerTire?: TireKind;
 }
 
 /**
@@ -919,7 +925,11 @@ export function stepRaceSession(
   const assistSettings = config.player.assists ?? {};
   const trackWeather =
     config.weather ?? config.track.weatherOptions[0] ?? "clear";
-  const playerWeatherGripScalar = weatherGripScalar(playerStats, trackWeather);
+  const playerWeatherGripScalar = weatherGripScalar(
+    playerStats,
+    trackWeather,
+    config.playerTire ?? "dry",
+  );
   const assistResult = playerIsRacing
     ? applyAssists(
         playerInput,


### PR DESCRIPTION
## Summary
- add a pure pre-race card builder for track, tour, forecast, tire recommendation, cash, repair estimate, car, and setup fields
- route World Tour entry through /race/prep and carry selected weather plus dry or wet tires into /race
- apply RaceSessionConfig.playerTire to player weather grip and close F-066

## GDD
- §5 race preparation
- §14 weather forecasting
- §20 pre-race screen
- §23 weather modifiers

## Progress log
- docs/PROGRESS_LOG.md: 2026-04-28 Slice: Pre-race tire selection

## Test plan
- npx vitest run src/game/__tests__/preRaceCard.test.ts src/game/__tests__/raceSession.test.ts
- npm run typecheck
- npm run content-lint
- npx playwright test e2e/pre-race.spec.ts e2e/world-tour.spec.ts
- npx playwright test e2e/tour-flow.spec.ts
- npm run verify
- npm run test:e2e
- grep -rn $'\u2014\|\u2013' src/game/preRaceCard.ts src/app/race/prep/page.tsx src/app/race/page.tsx src/app/world/page.tsx src/game/raceSession.ts src/game/__tests__/preRaceCard.test.ts src/game/__tests__/raceSession.test.ts e2e/pre-race.spec.ts e2e/world-tour.spec.ts e2e/tour-flow.spec.ts docs/FOLLOWUPS.md docs/GDD_COVERAGE.json docs/PROGRESS_LOG.md || true
- git diff --check