### PR TITLE
feat(render): add weather race effects

### DIFF
--- a/docs/FOLLOWUPS.md
+++ b/docs/FOLLOWUPS.md
@@ -10,6 +10,20 @@ or `obsolete` so the trail is preserved.
 
 ---
 
+## F-067: Add weather particle intensity, glare, and fog readability settings
+**Created:** 2026-04-28
+**Priority:** polish
+**Status:** open
+**Notes:** The weather render-effects slice draws active rain, snow,
+fog, and dusk or night bloom and wires the existing visual weather
+assist to reduce intensity. §14 also calls for finer accessibility
+controls: a weather particles intensity slider, reduced glare mode, fog
+floor clamp for readability, and flash reduction for lightning or night
+bloom. Add these settings to the options surface, persist them in
+`SaveGameSettings.accessibility` or the successor display settings
+bundle, and thread them into `drawRoad` so the renderer can scale or
+disable the relevant effects independently.
+
 ## F-066: Add pre-race tire selection and persist the active tire channel
 **Created:** 2026-04-28
 **Priority:** blocks-release

--- a/docs/GDD_COVERAGE.json
+++ b/docs/GDD_COVERAGE.json
@@ -2,6 +2,25 @@
   "version": 1,
   "requirements": [
     {
+      "id": "GDD-14-WEATHER-RENDER-EFFECTS",
+      "gddSections": [
+        "docs/gdd/14-weather-and-environmental-systems.md",
+        "docs/gdd/16-rendering-and-visual-design.md",
+        "docs/gdd/20-hud-and-ui-ux.md",
+        "docs/gdd/21-technical-design-for-web-implementation.md"
+      ],
+      "requirement": "Live races render active weather as rain streaks, snow particles, fog read-distance fade, and dusk or night bloom, with the visual weather assist reducing effect intensity.",
+      "coverage": ["implemented-code", "automated-test"],
+      "implementationRefs": [
+        "src/render/pseudoRoadCanvas.ts",
+        "src/app/race/page.tsx"
+      ],
+      "testRefs": [
+        "src/render/__tests__/pseudoRoadCanvas.test.ts"
+      ],
+      "followupRefs": ["F-067"]
+    },
+    {
       "id": "GDD-20-PRE-RACE-TIRE-SELECTION",
       "gddSections": [
         "docs/gdd/05-core-gameplay-loop.md",

--- a/docs/PROGRESS_LOG.md
+++ b/docs/PROGRESS_LOG.md
@@ -6,6 +6,63 @@ Correct them by adding a new entry that references the old one.
 
 ---
 
+## 2026-04-28: Slice: Weather render effects
+
+**GDD sections touched:**
+[§14](gdd/14-weather-and-environmental-systems.md) visual effects and
+accessibility,
+[§16](gdd/16-rendering-and-visual-design.md) weather VFX and renderer
+pipeline,
+[§20](gdd/20-hud-and-ui-ux.md) weather communication,
+[§21](gdd/21-technical-design-for-web-implementation.md) Canvas2D
+renderer ownership.
+**Branch / PR:** `feat/weather-render-effects`, PR pending.
+**Status:** Implemented.
+
+### Done
+- `src/render/pseudoRoadCanvas.ts`: added deterministic screen-space
+  weather effects for rain streaks, snow particles, fog read-distance
+  fade, and dusk or night bloom pools.
+- `src/app/race/page.tsx`: passes the active race weather into the
+  renderer and uses the existing visual weather assist to reduce
+  particle density and overlay alpha.
+- `docs/GDD_COVERAGE.json`: added GDD-14-WEATHER-RENDER-EFFECTS.
+- `docs/FOLLOWUPS.md`: added F-067 for the remaining weather
+  accessibility settings.
+
+### Verified
+- `npx vitest run src/render/__tests__/pseudoRoadCanvas.test.ts`
+  green, 33 passed.
+- `npm run typecheck` clean.
+- `npm run content-lint` clean.
+- `npm run verify` green, 2318 passed.
+- `npm run test:e2e` green, 70 passed.
+- `grep -rn $'\u2014\|\u2013' ...` clean on changed files.
+- `git diff --check` clean.
+
+### Decisions and assumptions
+- Weather effects are deterministic screen-space patterns for this
+  slice so renderer tests can assert structure without brittle
+  screenshots.
+- The existing visual weather assist is the first reduction control.
+  F-067 owns finer §14 settings for particle intensity, glare, fog floor,
+  and flash reduction.
+
+### Coverage ledger
+- GDD-14-WEATHER-RENDER-EFFECTS covers static active-weather rendering
+  and the visual weather assist intensity reduction.
+- Uncovered adjacent requirements: weather state transitions, weather
+  particle intensity slider, reduced glare mode, fog floor clamp,
+  lightning or night flash reduction, and heat shimmer remain future
+  slices.
+
+### Followups created
+- F-067: Add weather particle intensity, glare, and fog readability
+  settings.
+
+### GDD edits
+None.
+
 ## 2026-04-28: Slice: Pre-race tire selection
 
 **GDD sections touched:**

--- a/src/app/race/page.tsx
+++ b/src/app/race/page.tsx
@@ -936,6 +936,10 @@ function RaceCanvas({
         }
         drawRoad(ctx, strips, viewport, {
           parallax: { layers: parallaxLayers, camera },
+          weatherEffects: {
+            weather: activeWeather,
+            visualReduction: persistedAssists.weatherVisualReduction,
+          },
           ghostCar: ghostOverlayRef.current
             ? {
                 ...ghostOverlayRef.current,

--- a/src/render/__tests__/pseudoRoadCanvas.test.ts
+++ b/src/render/__tests__/pseudoRoadCanvas.test.ts
@@ -33,6 +33,7 @@ import {
   PLAYER_CAR_DEFAULT_WINDSHIELD,
   PLAYER_CAR_HEIGHT_FRACTION,
   PLAYER_CAR_WIDTH_TO_HEIGHT,
+  WEATHER_EFFECT_REDUCTION_SCALE,
   drawRoad,
   type DrawRoadOptions,
 } from "../pseudoRoadCanvas";
@@ -812,5 +813,119 @@ describe("drawRoad player car overlay", () => {
     const nulled = makeCanvasSpy();
     drawRoad(nulled.ctx, EMPTY_STRIPS, VIEWPORT, { playerCar: null });
     expect(nulled.calls.filter((c) => c.type === "fill")).toHaveLength(0);
+  });
+});
+
+describe("drawRoad weather effects", () => {
+  it("paints deterministic heavy-rain streaks over the road layer", () => {
+    const spy = makeCanvasSpy();
+    drawRoad(spy.ctx, EMPTY_STRIPS, VIEWPORT, {
+      weatherEffects: { weather: "heavy_rain" },
+    });
+
+    const streaks = spy.calls.filter(
+      (c): c is FillRectCall =>
+        c.type === "fillRect" && c.fillStyle === "#cfefff",
+    );
+    expect(streaks).toHaveLength(92);
+    expect(streaks[0]!.globalAlpha).toBeCloseTo(0.34, 6);
+    expect(streaks[0]!.w).toBe(2);
+    expect(streaks[0]!.h).toBe(18);
+    expect(spy.finalAlpha()).toBeCloseTo(1, 6);
+  });
+
+  it("reduces rain density when visual weather reduction is enabled", () => {
+    const spy = makeCanvasSpy();
+    drawRoad(spy.ctx, EMPTY_STRIPS, VIEWPORT, {
+      weatherEffects: { weather: "heavy_rain", visualReduction: true },
+    });
+
+    const streaks = spy.calls.filter(
+      (c): c is FillRectCall =>
+        c.type === "fillRect" && c.fillStyle === "#cfefff",
+    );
+    expect(streaks).toHaveLength(Math.round(92 * WEATHER_EFFECT_REDUCTION_SCALE));
+    expect(streaks[0]!.globalAlpha).toBeCloseTo(
+      0.34 * WEATHER_EFFECT_REDUCTION_SCALE,
+      6,
+    );
+  });
+
+  it("paints snow particles with reduced square sizes", () => {
+    const spy = makeCanvasSpy();
+    drawRoad(spy.ctx, EMPTY_STRIPS, VIEWPORT, {
+      weatherEffects: { weather: "snow" },
+    });
+
+    const flakes = spy.calls.filter(
+      (c): c is FillRectCall =>
+        c.type === "fillRect" && c.fillStyle === "#f4fbff",
+    );
+    expect(flakes).toHaveLength(54);
+    expect(flakes[0]!.w).toBe(3);
+    expect(flakes[1]!.w).toBe(2);
+    expect(flakes[0]!.globalAlpha).toBeCloseTo(0.72, 6);
+  });
+
+  it("paints fog as a draw-distance fade without changing clear weather", () => {
+    const fog = makeCanvasSpy();
+    drawRoad(fog.ctx, EMPTY_STRIPS, VIEWPORT, {
+      weatherEffects: { weather: "fog" },
+    });
+
+    const fogRects = fog.calls.filter(
+      (c): c is FillRectCall =>
+        c.type === "fillRect" && c.fillStyle === "#cbd7e1",
+    );
+    expect(fogRects).toHaveLength(2);
+    expect(fogRects[0]!.x).toBe(0);
+    expect(fogRects[0]!.y).toBe(0);
+    expect(fogRects[0]!.w).toBe(VIEWPORT.width);
+    expect(fogRects[0]!.h).toBeCloseTo(VIEWPORT.height * 0.72, 6);
+    expect(fogRects[0]!.globalAlpha).toBeCloseTo(0.36, 6);
+
+    const clear = makeCanvasSpy();
+    drawRoad(clear.ctx, EMPTY_STRIPS, VIEWPORT, {
+      weatherEffects: { weather: "clear" },
+    });
+    expect(
+      clear.calls.some(
+        (c): c is FillRectCall =>
+          c.type === "fillRect" && c.fillStyle === "#cbd7e1",
+      ),
+    ).toBe(false);
+  });
+
+  it("paints night bloom pools and restores fill state", () => {
+    const spy = makeCanvasSpy();
+    spy.ctx.fillStyle = "#123456";
+    spy.ctx.globalAlpha = 0.64;
+
+    drawRoad(spy.ctx, EMPTY_STRIPS, VIEWPORT, {
+      weatherEffects: { weather: "night" },
+    });
+
+    const bloom = spy.calls.filter(
+      (c): c is FillRectCall =>
+        c.type === "fillRect" && c.fillStyle === "#f4e779",
+    );
+    expect(bloom).toHaveLength(2);
+    expect(bloom[0]!.globalAlpha).toBeCloseTo(0.34, 6);
+    expect(bloom[0]!.w).toBeCloseTo(VIEWPORT.width * 0.12, 6);
+    expect(spy.finalAlpha()).toBeCloseTo(0.64, 6);
+  });
+
+  it("skips weather effects on a zero-area viewport", () => {
+    const spy = makeCanvasSpy();
+    drawRoad(spy.ctx, EMPTY_STRIPS, { width: 0, height: 480 }, {
+      weatherEffects: { weather: "heavy_rain" },
+    });
+
+    expect(
+      spy.calls.some(
+        (c): c is FillRectCall =>
+          c.type === "fillRect" && c.fillStyle === "#cfefff",
+      ),
+    ).toBe(false);
   });
 });

--- a/src/render/__tests__/pseudoRoadCanvas.test.ts
+++ b/src/render/__tests__/pseudoRoadCanvas.test.ts
@@ -19,6 +19,7 @@
 
 import { describe, expect, it } from "vitest";
 
+import { visibilityForWeather } from "@/game/weather";
 import type { Strip, Viewport } from "@/road/types";
 import type { LoadedAtlas } from "../spriteAtlas";
 
@@ -882,7 +883,10 @@ describe("drawRoad weather effects", () => {
     expect(fogRects[0]!.y).toBe(0);
     expect(fogRects[0]!.w).toBe(VIEWPORT.width);
     expect(fogRects[0]!.h).toBeCloseTo(VIEWPORT.height * 0.72, 6);
-    expect(fogRects[0]!.globalAlpha).toBeCloseTo(0.36, 6);
+    expect(fogRects[0]!.globalAlpha).toBeCloseTo(
+      Math.min(0.5, (1 - visibilityForWeather("fog")) * 0.72),
+      6,
+    );
 
     const clear = makeCanvasSpy();
     drawRoad(clear.ctx, EMPTY_STRIPS, VIEWPORT, {

--- a/src/render/pseudoRoadCanvas.ts
+++ b/src/render/pseudoRoadCanvas.ts
@@ -27,6 +27,7 @@ import {
 } from "@/road/constants";
 import type { Camera, Strip, Viewport } from "@/road/types";
 import type { WeatherOption } from "@/data/schemas";
+import { visibilityForWeather } from "@/game/weather";
 
 import { drawDust, type DustState } from "./dust";
 import { drawParallax, type ParallaxLayer } from "./parallax";
@@ -74,6 +75,7 @@ export const PLAYER_CAR_WIDTH_TO_HEIGHT = 1.15;
 export const PLAYER_CAR_DEFAULT_SPRITE_ID = "sparrow_clean";
 export const ROADSIDE_DRAW_PERIOD = 10;
 export const ROADSIDE_MAX_HEIGHT_FRACTION = 0.22;
+export const WEATHER_EFFECT_REDUCTION_SCALE = 0.35;
 const LANE_DASH_CYCLE_METERS = LANE_STRIPE_LEN * SEGMENT_LENGTH;
 const LANE_DASH_VISIBLE_METERS = SEGMENT_LENGTH * 2;
 
@@ -125,6 +127,16 @@ export interface DrawRoadOptions {
    * pass it in here; the drawer never advances the pool itself.
    */
   dust?: DustState;
+  /**
+   * Optional screen-space weather effects for §14 / §16. These are
+   * visual only: physics weather is handled by `src/game/raceSession.ts`.
+   * The accessibility flag reduces particle density and overlay alpha
+   * while preserving enough feedback to show the selected weather.
+   */
+  weatherEffects?: {
+    weather: WeatherOption;
+    visualReduction?: boolean;
+  };
   /**
    * Optional ghost car overlay per F-022. The §6 Time Trial flow drives
    * a second physics step from the recorded `Player.readNext` inputs to
@@ -304,6 +316,10 @@ export function drawRoad(
     drawDust(ctx, options.dust, viewport);
   }
 
+  if (options.weatherEffects) {
+    drawWeatherEffects(ctx, viewport, options.weatherEffects);
+  }
+
   if (options.playerCar) {
     drawPlayerCar(ctx, options.playerCar, viewport);
   }
@@ -468,6 +484,126 @@ function drawPoleSprite(
   ctx.fillRect(baseX - width * 0.22, baseY - height, width * 0.44, height);
   ctx.fillStyle = "#f1e36a";
   ctx.fillRect(baseX - width * 1.4, baseY - height, width * 2.8, height * 0.09);
+}
+
+function drawWeatherEffects(
+  ctx: CanvasRenderingContext2D,
+  viewport: Viewport,
+  effects: NonNullable<DrawRoadOptions["weatherEffects"]>,
+): void {
+  if (viewport.width <= 0 || viewport.height <= 0) return;
+  const intensity = effects.visualReduction === true ? WEATHER_EFFECT_REDUCTION_SCALE : 1;
+
+  switch (effects.weather) {
+    case "light_rain":
+    case "rain":
+    case "heavy_rain":
+      drawRainStreaks(ctx, viewport, effects.weather, intensity);
+      return;
+    case "snow":
+      drawSnowParticles(ctx, viewport, intensity);
+      return;
+    case "fog":
+      drawFogFade(ctx, viewport, intensity);
+      return;
+    case "dusk":
+    case "night":
+      drawNightBloom(ctx, viewport, effects.weather, intensity);
+      return;
+    case "clear":
+      return;
+  }
+}
+
+function drawRainStreaks(
+  ctx: CanvasRenderingContext2D,
+  viewport: Viewport,
+  weather: Extract<WeatherOption, "light_rain" | "rain" | "heavy_rain">,
+  intensity: number,
+): void {
+  const baseCount = weather === "heavy_rain" ? 92 : weather === "rain" ? 58 : 32;
+  const count = Math.max(4, Math.round(baseCount * intensity));
+  const alpha = (weather === "heavy_rain" ? 0.34 : weather === "rain" ? 0.26 : 0.18) * intensity;
+  const prevFill = ctx.fillStyle;
+  const prevAlpha = ctx.globalAlpha;
+  try {
+    ctx.globalAlpha = alpha;
+    ctx.fillStyle = "#cfefff";
+    for (let i = 0; i < count; i++) {
+      const x = ((i * 73) % Math.max(1, viewport.width + 80)) - 40;
+      const y = (i * 47) % Math.max(1, viewport.height);
+      const h = weather === "heavy_rain" ? 18 : 13;
+      ctx.fillRect(x, y, 2, h);
+    }
+  } finally {
+    ctx.fillStyle = prevFill;
+    ctx.globalAlpha = prevAlpha;
+  }
+}
+
+function drawSnowParticles(
+  ctx: CanvasRenderingContext2D,
+  viewport: Viewport,
+  intensity: number,
+): void {
+  const count = Math.max(5, Math.round(54 * intensity));
+  const prevFill = ctx.fillStyle;
+  const prevAlpha = ctx.globalAlpha;
+  try {
+    ctx.globalAlpha = 0.72 * intensity;
+    ctx.fillStyle = "#f4fbff";
+    for (let i = 0; i < count; i++) {
+      const size = i % 5 === 0 ? 3 : 2;
+      const x = (i * 89) % Math.max(1, viewport.width);
+      const y = (i * 53) % Math.max(1, viewport.height);
+      ctx.fillRect(x, y, size, size);
+    }
+  } finally {
+    ctx.fillStyle = prevFill;
+    ctx.globalAlpha = prevAlpha;
+  }
+}
+
+function drawFogFade(
+  ctx: CanvasRenderingContext2D,
+  viewport: Viewport,
+  intensity: number,
+): void {
+  const visibility = visibilityForWeather("fog");
+  const prevFill = ctx.fillStyle;
+  const prevAlpha = ctx.globalAlpha;
+  try {
+    ctx.globalAlpha = Math.min(0.5, (1 - visibility) * 0.72 * intensity);
+    ctx.fillStyle = "#cbd7e1";
+    ctx.fillRect(0, 0, viewport.width, viewport.height * 0.72);
+    ctx.globalAlpha = Math.min(0.28, (1 - visibility) * 0.4 * intensity);
+    ctx.fillRect(0, viewport.height * 0.48, viewport.width, viewport.height * 0.34);
+  } finally {
+    ctx.fillStyle = prevFill;
+    ctx.globalAlpha = prevAlpha;
+  }
+}
+
+function drawNightBloom(
+  ctx: CanvasRenderingContext2D,
+  viewport: Viewport,
+  weather: Extract<WeatherOption, "dusk" | "night">,
+  intensity: number,
+): void {
+  const prevFill = ctx.fillStyle;
+  const prevAlpha = ctx.globalAlpha;
+  try {
+    ctx.globalAlpha = (weather === "night" ? 0.34 : 0.22) * intensity;
+    ctx.fillStyle = "#f4e779";
+    const y = viewport.height * 0.22;
+    const w = viewport.width * 0.12;
+    const h = viewport.height * 0.035;
+    ctx.fillRect(viewport.width * 0.28 - w / 2, y, w, h);
+    ctx.fillRect(viewport.width * 0.72 - w / 2, y, w, h);
+  } finally {
+    ctx.fillStyle = prevFill;
+    ctx.globalAlpha = prevAlpha;
+  }
 }
 
 /**


### PR DESCRIPTION
## Summary
- render active race weather as rain streaks, snow particles, fog fade, and dusk or night bloom in the Canvas2D road layer
- wire the race route to pass active weather and the existing visual weather assist into drawRoad
- add GDD coverage plus F-067 for the remaining weather accessibility settings

## GDD
- docs/gdd/14-weather-and-environmental-systems.md
- docs/gdd/16-rendering-and-visual-design.md
- docs/gdd/20-hud-and-ui-ux.md
- docs/gdd/21-technical-design-for-web-implementation.md

## Requirement inventory
- Handles static active-weather rendering for rain, snow, fog, dusk, and night during live races.
- Handles visual weather assist reduction for particle density and overlay alpha.
- Leaves weather state transitions, particle intensity slider, reduced glare, fog floor clamp, lightning or night flash reduction, and heat shimmer to future slices.

## Progress log
- docs/PROGRESS_LOG.md: Weather render effects

## Followups
- F-067: Add weather particle intensity, glare, and fog readability settings

## Test plan
- [x] npx vitest run src/render/__tests__/pseudoRoadCanvas.test.ts
- [x] npm run typecheck
- [x] npm run content-lint
- [x] npm run verify
- [x] npm run test:e2e
- [x] git diff --check
- [x] grep changed files for U+2014 and U+2013