### PR TITLE
feat(render): add weather accessibility settings

### DIFF
--- a/docs/FOLLOWUPS.md
+++ b/docs/FOLLOWUPS.md
@@ -5,7 +5,7 @@ entry has an id (`F-NNN`), a one-line description, the loop that created it,
 and a priority.
 
 Priorities: `blocks-release`, `nice-to-have`, `polish`. Statuses: `open`,
-`in-progress`, `done`, `obsolete`. Do not delete entries — mark them `done`
+`in-progress`, `done`, `obsolete`. Do not delete entries. Mark them `done`
 or `obsolete` so the trail is preserved.
 
 ---
@@ -13,7 +13,7 @@ or `obsolete` so the trail is preserved.
 ## F-067: Add weather particle intensity, glare, and fog readability settings
 **Created:** 2026-04-28
 **Priority:** polish
-**Status:** open
+**Status:** done (2026-04-28)
 **Notes:** The weather render-effects slice draws active rain, snow,
 fog, and dusk or night bloom and wires the existing visual weather
 assist to reduce intensity. §14 also calls for finer accessibility
@@ -23,6 +23,11 @@ bloom. Add these settings to the options surface, persist them in
 `SaveGameSettings.accessibility` or the successor display settings
 bundle, and thread them into `drawRoad` so the renderer can scale or
 disable the relevant effects independently.
+
+Closed by `feat/weather-accessibility-settings`. The Accessibility pane
+now persists weather particle intensity, fog readability floor, reduced
+glare, and flash reduction settings. The live race renderer consumes
+those settings for rain, snow, fog, and dusk or night bloom.
 
 ## F-066: Add pre-race tire selection and persist the active tire channel
 **Created:** 2026-04-28

--- a/docs/GDD_COVERAGE.json
+++ b/docs/GDD_COVERAGE.json
@@ -2,6 +2,31 @@
   "version": 1,
   "requirements": [
     {
+      "id": "GDD-14-WEATHER-ACCESSIBILITY-SETTINGS",
+      "gddSections": [
+        "docs/gdd/14-weather-and-environmental-systems.md",
+        "docs/gdd/16-rendering-and-visual-design.md",
+        "docs/gdd/20-hud-and-ui-ux.md",
+        "docs/gdd/22-data-schemas.md"
+      ],
+      "requirement": "Players can persist weather display controls for particle intensity, fog readability, reduced glare, and flash reduction, and live races apply them to the weather renderer.",
+      "coverage": ["implemented-code", "automated-test"],
+      "implementationRefs": [
+        "src/components/options/AccessibilityPane.tsx",
+        "src/components/options/accessibilityPaneState.ts",
+        "src/data/schemas.ts",
+        "src/render/pseudoRoadCanvas.ts",
+        "src/app/race/page.tsx"
+      ],
+      "testRefs": [
+        "src/components/options/__tests__/accessibilityPaneState.test.ts",
+        "src/data/__tests__/settings-schema.test.ts",
+        "src/render/__tests__/pseudoRoadCanvas.test.ts",
+        "e2e/options-accessibility.spec.ts"
+      ],
+      "followupRefs": []
+    },
+    {
       "id": "GDD-14-WEATHER-RENDER-EFFECTS",
       "gddSections": [
         "docs/gdd/14-weather-and-environmental-systems.md",
@@ -18,7 +43,7 @@
       "testRefs": [
         "src/render/__tests__/pseudoRoadCanvas.test.ts"
       ],
-      "followupRefs": ["F-067"]
+      "followupRefs": []
     },
     {
       "id": "GDD-20-PRE-RACE-TIRE-SELECTION",

--- a/docs/PROGRESS_LOG.md
+++ b/docs/PROGRESS_LOG.md
@@ -6,6 +6,59 @@ Correct them by adding a new entry that references the old one.
 
 ---
 
+## 2026-04-28: Slice: Weather accessibility settings
+
+**GDD sections touched:**
+[§14](gdd/14-weather-and-environmental-systems.md) weather
+accessibility controls,
+[§16](gdd/16-rendering-and-visual-design.md) weather VFX tuning,
+[§20](gdd/20-hud-and-ui-ux.md) settings surface,
+[§22](gdd/22-data-schemas.md) save settings schema.
+**Branch / PR:** `feat/weather-accessibility-settings`, PR pending.
+**Status:** Implemented.
+
+### Done
+- `src/data/schemas.ts` and `src/persistence/migrations/v1ToV2.ts`:
+  added additive weather accessibility settings for particle intensity,
+  reduced glare, fog readability floor, and flash reduction.
+- `src/components/options/AccessibilityPane.tsx`: surfaced the new
+  sliders and toggles in the Accessibility pane and persisted changes
+  to the existing save bundle.
+- `src/render/pseudoRoadCanvas.ts` and `src/app/race/page.tsx`: wired
+  the settings into rain, snow, fog, and dusk or night bloom rendering.
+- `docs/FOLLOWUPS.md`: marked F-067 done.
+- `docs/GDD_COVERAGE.json`: added
+  GDD-14-WEATHER-ACCESSIBILITY-SETTINGS.
+
+### Verified
+- `npx vitest run src/components/options/__tests__/accessibilityPaneState.test.ts src/data/__tests__/settings-schema.test.ts src/persistence/migrations/v1ToV2.test.ts src/render/__tests__/pseudoRoadCanvas.test.ts`
+  green, 96 passed.
+- `npm run typecheck` clean.
+- `npm run content-lint` clean.
+- `npx playwright test e2e/options-accessibility.spec.ts` green, 4
+  passed.
+- `npm run verify` green, 2331 passed.
+- `npm run test:e2e` green, 71 passed.
+
+### Decisions and assumptions
+- New fields are optional in the schema so old v2 and v3 saves with an
+  existing accessibility bundle remain valid.
+- Fresh and migrated saves still include concrete defaults, so the UI
+  persists a complete accessibility object after a change.
+
+### Coverage ledger
+- GDD-14-WEATHER-ACCESSIBILITY-SETTINGS covers the §14 persisted
+  controls and renderer application for weather particles, fog, glare,
+  and flashes.
+- Uncovered adjacent requirements: weather state transitions and heat
+  shimmer remain future slices.
+
+### Followups created
+None.
+
+### GDD edits
+None.
+
 ## 2026-04-28: Slice: Weather render effects
 
 **GDD sections touched:**

--- a/e2e/options-accessibility.spec.ts
+++ b/e2e/options-accessibility.spec.ts
@@ -101,4 +101,52 @@ test.describe("options accessibility pane", () => {
       page.getByTestId("accessibility-toggle-steeringSmoothing"),
     ).toBeChecked();
   });
+
+  test("weather visibility settings persist to localStorage", async ({ page }) => {
+    await page.goto("/options");
+    await page.getByTestId("options-tab-accessibility").click();
+
+    await expect(
+      page.getByTestId("accessibility-weather-settings"),
+    ).toBeVisible();
+    await page
+      .getByTestId("accessibility-weather-particle-intensity")
+      .fill("0.5");
+    await page.getByTestId("accessibility-fog-readability-clamp").fill("0.75");
+    await page.getByTestId("accessibility-toggle-reducedWeatherGlare").check();
+    await page.getByTestId("accessibility-toggle-weatherFlashReduction").check();
+
+    await expect(
+      page.getByTestId("accessibility-weather-particle-intensity-value"),
+    ).toHaveText("50%");
+    await expect(
+      page.getByTestId("accessibility-fog-readability-clamp-value"),
+    ).toHaveText("75%");
+
+    const persisted = await page.evaluate((key) => {
+      const raw = window.localStorage.getItem(key);
+      return raw ? JSON.parse(raw) : null;
+    }, SAVE_KEY);
+    expect(persisted?.settings?.accessibility?.weatherParticleIntensity).toBe(
+      0.5,
+    );
+    expect(persisted?.settings?.accessibility?.fogReadabilityClamp).toBe(0.75);
+    expect(persisted?.settings?.accessibility?.reducedWeatherGlare).toBe(true);
+    expect(persisted?.settings?.accessibility?.weatherFlashReduction).toBe(true);
+
+    await page.reload();
+    await page.getByTestId("options-tab-accessibility").click();
+    await expect(
+      page.getByTestId("accessibility-weather-particle-intensity-value"),
+    ).toHaveText("50%");
+    await expect(
+      page.getByTestId("accessibility-fog-readability-clamp-value"),
+    ).toHaveText("75%");
+    await expect(
+      page.getByTestId("accessibility-toggle-reducedWeatherGlare"),
+    ).toBeChecked();
+    await expect(
+      page.getByTestId("accessibility-toggle-weatherFlashReduction"),
+    ).toBeChecked();
+  });
 });

--- a/src/app/race/page.tsx
+++ b/src/app/race/page.tsx
@@ -939,6 +939,12 @@ function RaceCanvas({
           weatherEffects: {
             weather: activeWeather,
             visualReduction: persistedAssists.weatherVisualReduction,
+            particleIntensity:
+              persistedSettings.accessibility?.weatherParticleIntensity,
+            reducedGlare: persistedSettings.accessibility?.reducedWeatherGlare,
+            fogFloorClamp: persistedSettings.accessibility?.fogReadabilityClamp,
+            flashReduction:
+              persistedSettings.accessibility?.weatherFlashReduction,
           },
           ghostCar: ghostOverlayRef.current
             ? {

--- a/src/components/options/AccessibilityPane.tsx
+++ b/src/components/options/AccessibilityPane.tsx
@@ -23,10 +23,19 @@ import { defaultSave, loadSave, saveSave } from "@/persistence";
 
 import {
   ASSISTS,
+  FOG_READABILITY_CLAMP_LABEL,
   PANE_HEADLINE,
   PANE_SUBTITLE,
+  WEATHER_PARTICLE_INTENSITY_LABEL,
+  WEATHER_SETTINGS_HEADLINE,
+  WEATHER_SETTINGS_SUBTITLE,
+  applyFogReadabilityClamp,
   applyAssistToggle,
+  applyWeatherAccessibilityToggle,
+  applyWeatherParticleIntensity,
   isAssistActive,
+  readWeatherAccessibility,
+  type WeatherAccessibilityToggleKey,
 } from "./accessibilityPaneState";
 
 interface PaneStatus {
@@ -66,6 +75,63 @@ export function AccessibilityPane(): ReactElement {
         setStatus({
           kind: "info",
           message: `${label} ${value ? "enabled" : "disabled"}.`,
+        });
+      } else {
+        setStatus({
+          kind: "error",
+          message: `Save failed (${writeResult.reason}); change kept in memory only.`,
+        });
+      }
+    },
+    [save],
+  );
+
+  const onWeatherToggle = useCallback(
+    (key: WeatherAccessibilityToggleKey, value: boolean) => {
+      if (!save) return;
+      const result = applyWeatherAccessibilityToggle(save, key, value);
+      if (result.kind === "noop") return;
+      setSave(result.save);
+      const writeResult = saveSave(result.save);
+      const label =
+        key === "reducedWeatherGlare" ? "Reduced glare" : "Flash reduction";
+      if (writeResult.kind === "ok") {
+        setStatus({
+          kind: "info",
+          message: `${label} ${value ? "enabled" : "disabled"}.`,
+        });
+      } else {
+        setStatus({
+          kind: "error",
+          message: `Save failed (${writeResult.reason}); change kept in memory only.`,
+        });
+      }
+    },
+    [save],
+  );
+
+  const onWeatherSlider = useCallback(
+    (
+      kind: "weatherParticleIntensity" | "fogReadabilityClamp",
+      rawValue: string,
+    ) => {
+      if (!save) return;
+      const value = Number(rawValue);
+      const result =
+        kind === "weatherParticleIntensity"
+          ? applyWeatherParticleIntensity(save, value)
+          : applyFogReadabilityClamp(save, value);
+      if (result.kind === "noop") return;
+      setSave(result.save);
+      const writeResult = saveSave(result.save);
+      const label =
+        kind === "weatherParticleIntensity"
+          ? WEATHER_PARTICLE_INTENSITY_LABEL
+          : FOG_READABILITY_CLAMP_LABEL;
+      if (writeResult.kind === "ok") {
+        setStatus({
+          kind: "info",
+          message: `${label} set to ${Math.round(value * 100)}%.`,
         });
       } else {
         setStatus({
@@ -133,6 +199,12 @@ export function AccessibilityPane(): ReactElement {
         </ul>
       </fieldset>
 
+      <WeatherSettings
+        save={save}
+        onToggle={onWeatherToggle}
+        onSlider={onWeatherSlider}
+      />
+
       {status.kind !== "idle" ? (
         <p
           data-testid="accessibility-status"
@@ -143,6 +215,124 @@ export function AccessibilityPane(): ReactElement {
       ) : null}
     </div>
   );
+}
+
+interface WeatherSettingsProps {
+  save: SaveGame;
+  onToggle(key: WeatherAccessibilityToggleKey, value: boolean): void;
+  onSlider(
+    key: "weatherParticleIntensity" | "fogReadabilityClamp",
+    value: string,
+  ): void;
+}
+
+function WeatherSettings({
+  save,
+  onToggle,
+  onSlider,
+}: WeatherSettingsProps): ReactElement {
+  const weather = readWeatherAccessibility(save);
+  return (
+    <fieldset
+      style={fieldsetStyle}
+      aria-label="Weather visibility"
+      data-testid="accessibility-weather-settings"
+    >
+      <legend style={legendStyle}>{WEATHER_SETTINGS_HEADLINE}</legend>
+      <p style={weatherSubtitleStyle}>{WEATHER_SETTINGS_SUBTITLE}</p>
+
+      <label style={sliderLabelStyle} htmlFor="weather-particle-intensity">
+        <span style={titleStyle}>{WEATHER_PARTICLE_INTENSITY_LABEL}</span>
+        <input
+          id="weather-particle-intensity"
+          type="range"
+          min="0"
+          max="1"
+          step="0.05"
+          value={weather.weatherParticleIntensity}
+          onChange={(e) =>
+            onSlider("weatherParticleIntensity", e.currentTarget.value)
+          }
+          data-testid="accessibility-weather-particle-intensity"
+        />
+        <span
+          style={sliderValueStyle}
+          data-testid="accessibility-weather-particle-intensity-value"
+        >
+          {formatPercent(weather.weatherParticleIntensity)}
+        </span>
+      </label>
+
+      <label style={sliderLabelStyle} htmlFor="fog-readability-clamp">
+        <span style={titleStyle}>{FOG_READABILITY_CLAMP_LABEL}</span>
+        <input
+          id="fog-readability-clamp"
+          type="range"
+          min="0"
+          max="1"
+          step="0.05"
+          value={weather.fogReadabilityClamp}
+          onChange={(e) => onSlider("fogReadabilityClamp", e.currentTarget.value)}
+          data-testid="accessibility-fog-readability-clamp"
+        />
+        <span
+          style={sliderValueStyle}
+          data-testid="accessibility-fog-readability-clamp-value"
+        >
+          {formatPercent(weather.fogReadabilityClamp)}
+        </span>
+      </label>
+
+      <ul style={listStyle}>
+        <li
+          style={itemStyle(weather.reducedWeatherGlare)}
+          data-testid="accessibility-row-reducedWeatherGlare"
+          data-active={weather.reducedWeatherGlare ? "true" : "false"}
+        >
+          <label htmlFor="accessibility-toggle-reducedWeatherGlare" style={labelStyle}>
+            <input
+              id="accessibility-toggle-reducedWeatherGlare"
+              type="checkbox"
+              checked={weather.reducedWeatherGlare}
+              onChange={(e) =>
+                onToggle("reducedWeatherGlare", e.currentTarget.checked)
+              }
+              data-testid="accessibility-toggle-reducedWeatherGlare"
+            />
+            <span style={textStyle}>
+              <span style={titleStyle}>Reduced glare</span>
+              <span style={descStyle}>Dampen dusk and night weather bloom.</span>
+            </span>
+          </label>
+        </li>
+        <li
+          style={itemStyle(weather.weatherFlashReduction)}
+          data-testid="accessibility-row-weatherFlashReduction"
+          data-active={weather.weatherFlashReduction ? "true" : "false"}
+        >
+          <label htmlFor="accessibility-toggle-weatherFlashReduction" style={labelStyle}>
+            <input
+              id="accessibility-toggle-weatherFlashReduction"
+              type="checkbox"
+              checked={weather.weatherFlashReduction}
+              onChange={(e) =>
+                onToggle("weatherFlashReduction", e.currentTarget.checked)
+              }
+              data-testid="accessibility-toggle-weatherFlashReduction"
+            />
+            <span style={textStyle}>
+              <span style={titleStyle}>Flash reduction</span>
+              <span style={descStyle}>Reduce high-contrast weather flashes.</span>
+            </span>
+          </label>
+        </li>
+      </ul>
+    </fieldset>
+  );
+}
+
+function formatPercent(value: number): string {
+  return `${Math.round(value * 100)}%`;
 }
 
 const paneStyle: CSSProperties = {
@@ -226,6 +416,26 @@ const titleStyle: CSSProperties = {
 const descStyle: CSSProperties = {
   color: "var(--muted, #aaa)",
   fontSize: "0.85rem",
+};
+
+const weatherSubtitleStyle: CSSProperties = {
+  margin: "0 0 0.75rem",
+  color: "var(--muted, #aaa)",
+  fontSize: "0.85rem",
+};
+
+const sliderLabelStyle: CSSProperties = {
+  display: "grid",
+  gridTemplateColumns: "minmax(10rem, 1fr) minmax(9rem, 2fr) 3.5rem",
+  alignItems: "center",
+  gap: "0.75rem",
+  marginBottom: "0.75rem",
+};
+
+const sliderValueStyle: CSSProperties = {
+  color: "var(--fg, #ddd)",
+  fontVariantNumeric: "tabular-nums",
+  textAlign: "right",
 };
 
 function statusStyle(kind: PaneStatus["kind"]): CSSProperties {

--- a/src/components/options/AccessibilityPane.tsx
+++ b/src/components/options/AccessibilityPane.tsx
@@ -63,27 +63,32 @@ export function AccessibilityPane(): ReactElement {
     }
   }, []);
 
+  const persist = useCallback((next: SaveGame, successMessage: string) => {
+    const writeResult = saveSave(next);
+    if (writeResult.kind === "ok") {
+      setSave({
+        ...next,
+        writeCounter: (next.writeCounter ?? 0) + 1,
+      });
+      setStatus({ kind: "info", message: successMessage });
+      return;
+    }
+    setSave(next);
+    setStatus({
+      kind: "error",
+      message: `Save failed (${writeResult.reason}); change kept in memory only.`,
+    });
+  }, []);
+
   const onToggle = useCallback(
     (key: AssistFieldKey, value: boolean) => {
       if (!save) return;
       const result = applyAssistToggle(save, key, value);
       if (result.kind === "noop") return;
-      setSave(result.save);
-      const writeResult = saveSave(result.save);
       const label = ASSISTS.find((a) => a.key === key)?.label ?? key;
-      if (writeResult.kind === "ok") {
-        setStatus({
-          kind: "info",
-          message: `${label} ${value ? "enabled" : "disabled"}.`,
-        });
-      } else {
-        setStatus({
-          kind: "error",
-          message: `Save failed (${writeResult.reason}); change kept in memory only.`,
-        });
-      }
+      persist(result.save, `${label} ${value ? "enabled" : "disabled"}.`);
     },
-    [save],
+    [persist, save],
   );
 
   const onWeatherToggle = useCallback(
@@ -91,23 +96,11 @@ export function AccessibilityPane(): ReactElement {
       if (!save) return;
       const result = applyWeatherAccessibilityToggle(save, key, value);
       if (result.kind === "noop") return;
-      setSave(result.save);
-      const writeResult = saveSave(result.save);
       const label =
         key === "reducedWeatherGlare" ? "Reduced glare" : "Flash reduction";
-      if (writeResult.kind === "ok") {
-        setStatus({
-          kind: "info",
-          message: `${label} ${value ? "enabled" : "disabled"}.`,
-        });
-      } else {
-        setStatus({
-          kind: "error",
-          message: `Save failed (${writeResult.reason}); change kept in memory only.`,
-        });
-      }
+      persist(result.save, `${label} ${value ? "enabled" : "disabled"}.`);
     },
-    [save],
+    [persist, save],
   );
 
   const onWeatherSlider = useCallback(
@@ -122,25 +115,14 @@ export function AccessibilityPane(): ReactElement {
           ? applyWeatherParticleIntensity(save, value)
           : applyFogReadabilityClamp(save, value);
       if (result.kind === "noop") return;
-      setSave(result.save);
-      const writeResult = saveSave(result.save);
       const label =
         kind === "weatherParticleIntensity"
           ? WEATHER_PARTICLE_INTENSITY_LABEL
           : FOG_READABILITY_CLAMP_LABEL;
-      if (writeResult.kind === "ok") {
-        setStatus({
-          kind: "info",
-          message: `${label} set to ${Math.round(value * 100)}%.`,
-        });
-      } else {
-        setStatus({
-          kind: "error",
-          message: `Save failed (${writeResult.reason}); change kept in memory only.`,
-        });
-      }
+      const clamped = readWeatherAccessibility(result.save)[kind];
+      persist(result.save, `${label} set to ${formatPercent(clamped)}.`);
     },
-    [save],
+    [persist, save],
   );
 
   if (!save) {

--- a/src/components/options/__tests__/accessibilityPaneState.test.ts
+++ b/src/components/options/__tests__/accessibilityPaneState.test.ts
@@ -9,9 +9,17 @@ import {
   PANE_HEADLINE,
   PANE_SUBTITLE,
   VISIBLE_ASSIST_KEYS,
+  WEATHER_ACCESSIBILITY_DEFAULTS,
+  WEATHER_PARTICLE_INTENSITY_LABEL,
+  WEATHER_SETTINGS_HEADLINE,
+  WEATHER_SETTINGS_SUBTITLE,
+  applyFogReadabilityClamp,
   applyAssistToggle,
+  applyWeatherAccessibilityToggle,
+  applyWeatherParticleIntensity,
   isAssistActive,
   readAssists,
+  readWeatherAccessibility,
 } from "../accessibilityPaneState";
 
 /**
@@ -42,11 +50,14 @@ describe("ASSISTS catalogue (§19)", () => {
 
   it("never uses an em-dash in any catalogue copy (project rule)", () => {
     for (const assist of ASSISTS) {
-      expect(assist.label).not.toMatch(/[–—]/u);
-      expect(assist.description).not.toMatch(/[–—]/u);
+      expect(assist.label).not.toMatch(/[\u2013\u2014]/u);
+      expect(assist.description).not.toMatch(/[\u2013\u2014]/u);
     }
-    expect(PANE_HEADLINE).not.toMatch(/[–—]/u);
-    expect(PANE_SUBTITLE).not.toMatch(/[–—]/u);
+    expect(PANE_HEADLINE).not.toMatch(/[\u2013\u2014]/u);
+    expect(PANE_SUBTITLE).not.toMatch(/[\u2013\u2014]/u);
+    expect(WEATHER_SETTINGS_HEADLINE).not.toMatch(/[\u2013\u2014]/u);
+    expect(WEATHER_SETTINGS_SUBTITLE).not.toMatch(/[\u2013\u2014]/u);
+    expect(WEATHER_PARTICLE_INTENSITY_LABEL).not.toMatch(/[\u2013\u2014]/u);
   });
 
   it("the visible row keys are the §19 six (legacy schema fields excluded)", () => {
@@ -63,6 +74,96 @@ describe("ASSISTS catalogue (§19)", () => {
   it("the schema's full assist field list still includes the legacy trio", () => {
     expect(ALL_ASSIST_FIELDS).toContain("steeringAssist");
     expect(ALL_ASSIST_FIELDS).toContain("autoNitro");
+  });
+});
+
+describe("readWeatherAccessibility", () => {
+  it("returns weather defaults on a fresh save", () => {
+    expect(readWeatherAccessibility(defaultSave())).toEqual({
+      ...WEATHER_ACCESSIBILITY_DEFAULTS,
+    });
+  });
+
+  it("falls back to defaults when an old save has no accessibility bundle", () => {
+    const save = defaultSave();
+    const stripped: SaveGame = {
+      ...save,
+      settings: {
+        ...save.settings,
+        accessibility: undefined,
+      },
+    };
+    expect(readWeatherAccessibility(stripped)).toEqual({
+      ...WEATHER_ACCESSIBILITY_DEFAULTS,
+    });
+  });
+
+  it("clamps persisted weather slider values when reading", () => {
+    const save = defaultSave();
+    const customised: SaveGame = {
+      ...save,
+      settings: {
+        ...save.settings,
+        accessibility: {
+          ...save.settings.accessibility!,
+          weatherParticleIntensity: 2,
+          fogReadabilityClamp: -1,
+        },
+      },
+    };
+    expect(readWeatherAccessibility(customised).weatherParticleIntensity).toBe(1);
+    expect(readWeatherAccessibility(customised).fogReadabilityClamp).toBe(0);
+  });
+});
+
+describe("weather accessibility mutations", () => {
+  it("applies the weather particle slider without mutating input", () => {
+    const save = defaultSave();
+    const before = JSON.stringify(save);
+    const result = applyWeatherParticleIntensity(save, 0.45);
+    expect(JSON.stringify(save)).toBe(before);
+    expect(result.kind).toBe("applied");
+    if (result.kind === "applied") {
+      expect(
+        result.save.settings.accessibility?.weatherParticleIntensity,
+      ).toBeCloseTo(0.45, 6);
+    }
+  });
+
+  it("clamps the fog readability slider before persisting", () => {
+    const save = defaultSave();
+    const result = applyFogReadabilityClamp(save, 2);
+    expect(result.kind).toBe("applied");
+    if (result.kind === "applied") {
+      expect(result.save.settings.accessibility?.fogReadabilityClamp).toBe(1);
+    }
+  });
+
+  it("returns a same-value noop for unchanged slider values", () => {
+    const save = defaultSave();
+    const result = applyWeatherParticleIntensity(save, 1);
+    expect(result.kind).toBe("noop");
+  });
+
+  it("applies reduced glare and flash reduction independently", () => {
+    let save = defaultSave();
+    const glare = applyWeatherAccessibilityToggle(
+      save,
+      "reducedWeatherGlare",
+      true,
+    );
+    if (glare.kind !== "applied") throw new Error("expected applied");
+    save = glare.save;
+
+    const flash = applyWeatherAccessibilityToggle(
+      save,
+      "weatherFlashReduction",
+      true,
+    );
+    if (flash.kind !== "applied") throw new Error("expected applied");
+
+    expect(flash.save.settings.accessibility?.reducedWeatherGlare).toBe(true);
+    expect(flash.save.settings.accessibility?.weatherFlashReduction).toBe(true);
   });
 });
 

--- a/src/components/options/accessibilityPaneState.ts
+++ b/src/components/options/accessibilityPaneState.ts
@@ -8,7 +8,12 @@
  * `difficultyPaneState.ts`.
  */
 
-import type { AssistFieldKey, AssistSettings, SaveGame } from "@/data/schemas";
+import type {
+  AccessibilitySettings,
+  AssistFieldKey,
+  AssistSettings,
+  SaveGame,
+} from "@/data/schemas";
 import { ASSIST_FIELDS } from "@/data/schemas";
 
 export interface AssistSpec {
@@ -79,6 +84,27 @@ export const PANE_HEADLINE = "Accessibility assists";
 export const PANE_SUBTITLE =
   "Six §19 assists for smoother control. Each toggle persists to your save and applies to every race mode.";
 
+export const WEATHER_SETTINGS_HEADLINE = "Weather visibility";
+export const WEATHER_SETTINGS_SUBTITLE =
+  "§14 weather display controls for rain, snow, fog, glare, and flashes.";
+
+export const WEATHER_PARTICLE_INTENSITY_LABEL = "Weather particle intensity";
+export const FOG_READABILITY_CLAMP_LABEL = "Fog readability floor";
+
+export const WEATHER_ACCESSIBILITY_DEFAULTS = Object.freeze({
+  weatherParticleIntensity: 1,
+  reducedWeatherGlare: false,
+  fogReadabilityClamp: 0,
+  weatherFlashReduction: false,
+});
+
+const BASE_ACCESSIBILITY_DEFAULTS = Object.freeze({
+  colorBlindMode: "off" as const,
+  reducedMotion: false,
+  largeUiText: false,
+  screenShakeScale: 1,
+});
+
 export type AssistReadResult = Required<
   Pick<
     AssistSettings,
@@ -100,6 +126,38 @@ export function readAssists(save: SaveGame): AssistReadResult {
     nitroToggleMode: a.nitroToggleMode === true,
     reducedSimultaneousInput: a.reducedSimultaneousInput === true,
     weatherVisualReduction: a.weatherVisualReduction === true,
+  };
+}
+
+export type WeatherAccessibilityReadResult = Required<
+  Pick<
+    AccessibilitySettings,
+    | "weatherParticleIntensity"
+    | "reducedWeatherGlare"
+    | "fogReadabilityClamp"
+    | "weatherFlashReduction"
+  >
+>;
+
+export function readWeatherAccessibility(
+  save: SaveGame,
+): WeatherAccessibilityReadResult {
+  const accessibility = save.settings.accessibility;
+  return {
+    weatherParticleIntensity: clampUnit(
+      accessibility?.weatherParticleIntensity ??
+        WEATHER_ACCESSIBILITY_DEFAULTS.weatherParticleIntensity,
+    ),
+    reducedWeatherGlare:
+      accessibility?.reducedWeatherGlare ??
+      WEATHER_ACCESSIBILITY_DEFAULTS.reducedWeatherGlare,
+    fogReadabilityClamp: clampUnit(
+      accessibility?.fogReadabilityClamp ??
+        WEATHER_ACCESSIBILITY_DEFAULTS.fogReadabilityClamp,
+    ),
+    weatherFlashReduction:
+      accessibility?.weatherFlashReduction ??
+      WEATHER_ACCESSIBILITY_DEFAULTS.weatherFlashReduction,
   };
 }
 
@@ -134,9 +192,89 @@ export function applyAssistToggle(
   return { kind: "applied", save: next };
 }
 
+export type WeatherAccessibilityToggleKey =
+  | "reducedWeatherGlare"
+  | "weatherFlashReduction";
+
+export type ApplyWeatherAccessibilityResult =
+  | { kind: "applied"; save: SaveGame }
+  | { kind: "noop"; reason: "same-value" };
+
+export function applyWeatherAccessibilityToggle(
+  save: SaveGame,
+  key: WeatherAccessibilityToggleKey,
+  value: boolean,
+): ApplyWeatherAccessibilityResult {
+  const current = readWeatherAccessibility(save)[key];
+  if (current === value) {
+    return { kind: "noop", reason: "same-value" };
+  }
+  return {
+    kind: "applied",
+    save: withAccessibility(save, { [key]: value }),
+  };
+}
+
+export function applyWeatherParticleIntensity(
+  save: SaveGame,
+  value: number,
+): ApplyWeatherAccessibilityResult {
+  return applyWeatherAccessibilityNumber(
+    save,
+    "weatherParticleIntensity",
+    value,
+  );
+}
+
+export function applyFogReadabilityClamp(
+  save: SaveGame,
+  value: number,
+): ApplyWeatherAccessibilityResult {
+  return applyWeatherAccessibilityNumber(save, "fogReadabilityClamp", value);
+}
+
+function applyWeatherAccessibilityNumber(
+  save: SaveGame,
+  key: "weatherParticleIntensity" | "fogReadabilityClamp",
+  value: number,
+): ApplyWeatherAccessibilityResult {
+  const nextValue = clampUnit(value);
+  const current = readWeatherAccessibility(save)[key];
+  if (current === nextValue) {
+    return { kind: "noop", reason: "same-value" };
+  }
+  return {
+    kind: "applied",
+    save: withAccessibility(save, { [key]: nextValue }),
+  };
+}
+
 function readAssistField(save: SaveGame, key: AssistFieldKey): boolean {
   const raw = save.settings.assists[key];
   return raw === true;
+}
+
+function withAccessibility(
+  save: SaveGame,
+  patch: Partial<WeatherAccessibilityReadResult>,
+): SaveGame {
+  return {
+    ...save,
+    settings: {
+      ...save.settings,
+      accessibility: {
+        ...BASE_ACCESSIBILITY_DEFAULTS,
+        ...save.settings.accessibility,
+        ...readWeatherAccessibility(save),
+        ...patch,
+      },
+    },
+  };
+}
+
+function clampUnit(value: number): number {
+  if (!Number.isFinite(value)) return 0;
+  return Math.min(1, Math.max(0, value));
 }
 
 /**

--- a/src/data/__tests__/settings-schema.test.ts
+++ b/src/data/__tests__/settings-schema.test.ts
@@ -63,6 +63,18 @@ describe("AccessibilitySettingsSchema", () => {
     expect(AccessibilitySettingsSchema.safeParse(happy).success).toBe(true);
   });
 
+  it("accepts the §14 weather accessibility defaults", () => {
+    expect(
+      AccessibilitySettingsSchema.safeParse({
+        ...happy,
+        weatherParticleIntensity: 1,
+        reducedWeatherGlare: false,
+        fogReadabilityClamp: 0,
+        weatherFlashReduction: false,
+      }).success,
+    ).toBe(true);
+  });
+
   it("accepts each colourblind mode", () => {
     for (const mode of ["off", "protanopia", "deuteranopia", "tritanopia"]) {
       expect(
@@ -106,6 +118,21 @@ describe("AccessibilitySettingsSchema", () => {
       AccessibilitySettingsSchema.safeParse({
         ...happy,
         reducedMotion: "yes",
+      }).success,
+    ).toBe(false);
+  });
+
+  it("rejects out-of-range weather accessibility sliders", () => {
+    expect(
+      AccessibilitySettingsSchema.safeParse({
+        ...happy,
+        weatherParticleIntensity: 1.5,
+      }).success,
+    ).toBe(false);
+    expect(
+      AccessibilitySettingsSchema.safeParse({
+        ...happy,
+        fogReadabilityClamp: -0.1,
       }).success,
     ).toBe(false);
   });
@@ -182,6 +209,10 @@ describe("SaveGameSettingsSchema (v2 expansion)", () => {
           reducedMotion: false,
           largeUiText: false,
           screenShakeScale: 1,
+          weatherParticleIntensity: 1,
+          reducedWeatherGlare: false,
+          fogReadabilityClamp: 0,
+          weatherFlashReduction: false,
         },
         keyBindings: { accelerate: ["ArrowUp"] },
       }).success,

--- a/src/data/schemas.ts
+++ b/src/data/schemas.ts
@@ -560,12 +560,20 @@ export type AudioSettings = z.infer<typeof AudioSettingsSchema>;
  * - `screenShakeScale`: 0..1 multiplier on the §16 shake intensity. 0
  *   disables shake entirely; consumers must guard against multiplying NaN /
  *   negative input by clamping to this range at parse time.
+ * - `weatherParticleIntensity`: 0..1 multiplier for rain and snow particles.
+ * - `reducedWeatherGlare`: dampens weather bloom in dusk and night races.
+ * - `fogReadabilityClamp`: minimum fog visibility target for readability.
+ * - `weatherFlashReduction`: further reduces high-contrast weather flashes.
  */
 export const AccessibilitySettingsSchema = z.object({
   colorBlindMode: z.enum(["off", "protanopia", "deuteranopia", "tritanopia"]),
   reducedMotion: z.boolean(),
   largeUiText: z.boolean(),
   screenShakeScale: unitInterval,
+  weatherParticleIntensity: unitInterval.optional(),
+  reducedWeatherGlare: z.boolean().optional(),
+  fogReadabilityClamp: unitInterval.optional(),
+  weatherFlashReduction: z.boolean().optional(),
 });
 export type AccessibilitySettings = z.infer<typeof AccessibilitySettingsSchema>;
 

--- a/src/persistence/migrations/v1ToV2.test.ts
+++ b/src/persistence/migrations/v1ToV2.test.ts
@@ -54,6 +54,10 @@ describe("migrateV1ToV2", () => {
       reducedMotion: false,
       largeUiText: false,
       screenShakeScale: 1,
+      weatherParticleIntensity: 1,
+      reducedWeatherGlare: false,
+      fogReadabilityClamp: 0,
+      weatherFlashReduction: false,
     });
     expect(migrated.settings.accessibility).toEqual({
       ...V2_ACCESSIBILITY_DEFAULTS,

--- a/src/persistence/migrations/v1ToV2.ts
+++ b/src/persistence/migrations/v1ToV2.ts
@@ -11,8 +11,10 @@
  * - `audio = { master: 1, music: 0.8, sfx: 0.9 }` per the §20 audio defaults
  *   (`docs/gdd/20-hud-and-ui-ux.md` Settings section).
  * - `accessibility = { colorBlindMode: 'off', reducedMotion: false,
- *   largeUiText: false, screenShakeScale: 1 }` per the §20 accessibility
- *   defaults; `screenShakeScale: 1` keeps the v1 shake intensity unchanged.
+ *   largeUiText: false, screenShakeScale: 1, weatherParticleIntensity: 1,
+ *   reducedWeatherGlare: false, fogReadabilityClamp: 0,
+ *   weatherFlashReduction: false }` per the §20 accessibility defaults;
+ *   `screenShakeScale: 1` keeps the v1 shake intensity unchanged.
  * - `keyBindings = DEFAULT_KEY_BINDINGS` (cloned from `src/game/input.ts`).
  * - `writeCounter = 0` for the §21 cross-tab last-write-wins protocol; the
  *   first `saveSave` after migration ticks it to 1. v1 saves never had a
@@ -42,6 +44,10 @@ export const V2_ACCESSIBILITY_DEFAULTS = Object.freeze({
   reducedMotion: false,
   largeUiText: false,
   screenShakeScale: 1,
+  weatherParticleIntensity: 1,
+  reducedWeatherGlare: false,
+  fogReadabilityClamp: 0,
+  weatherFlashReduction: false,
 });
 
 /**

--- a/src/render/__tests__/pseudoRoadCanvas.test.ts
+++ b/src/render/__tests__/pseudoRoadCanvas.test.ts
@@ -852,6 +852,34 @@ describe("drawRoad weather effects", () => {
     );
   });
 
+  it("applies the particle intensity slider to rain density", () => {
+    const spy = makeCanvasSpy();
+    drawRoad(spy.ctx, EMPTY_STRIPS, VIEWPORT, {
+      weatherEffects: { weather: "heavy_rain", particleIntensity: 0.5 },
+    });
+
+    const streaks = spy.calls.filter(
+      (c): c is FillRectCall =>
+        c.type === "fillRect" && c.fillStyle === "#cfefff",
+    );
+    expect(streaks).toHaveLength(Math.round(92 * 0.5));
+    expect(streaks[0]!.globalAlpha).toBeCloseTo(0.34 * 0.5, 6);
+  });
+
+  it("allows weather particles to be disabled", () => {
+    const spy = makeCanvasSpy();
+    drawRoad(spy.ctx, EMPTY_STRIPS, VIEWPORT, {
+      weatherEffects: { weather: "snow", particleIntensity: 0 },
+    });
+
+    expect(
+      spy.calls.some(
+        (c): c is FillRectCall =>
+          c.type === "fillRect" && c.fillStyle === "#f4fbff",
+      ),
+    ).toBe(false);
+  });
+
   it("paints snow particles with reduced square sizes", () => {
     const spy = makeCanvasSpy();
     drawRoad(spy.ctx, EMPTY_STRIPS, VIEWPORT, {
@@ -900,6 +928,23 @@ describe("drawRoad weather effects", () => {
     ).toBe(false);
   });
 
+  it("uses the fog readability floor to reduce fog overlay alpha", () => {
+    const spy = makeCanvasSpy();
+    drawRoad(spy.ctx, EMPTY_STRIPS, VIEWPORT, {
+      weatherEffects: { weather: "fog", fogFloorClamp: 0.8 },
+    });
+
+    const fogRects = spy.calls.filter(
+      (c): c is FillRectCall =>
+        c.type === "fillRect" && c.fillStyle === "#cbd7e1",
+    );
+    expect(fogRects).toHaveLength(2);
+    expect(fogRects[0]!.globalAlpha).toBeCloseTo(
+      Math.min(0.5, (1 - 0.8) * 0.72),
+      6,
+    );
+  });
+
   it("paints night bloom pools and restores fill state", () => {
     const spy = makeCanvasSpy();
     spy.ctx.fillStyle = "#123456";
@@ -917,6 +962,24 @@ describe("drawRoad weather effects", () => {
     expect(bloom[0]!.globalAlpha).toBeCloseTo(0.34, 6);
     expect(bloom[0]!.w).toBeCloseTo(VIEWPORT.width * 0.12, 6);
     expect(spy.finalAlpha()).toBeCloseTo(0.64, 6);
+  });
+
+  it("reduces night bloom when glare and flash reduction are enabled", () => {
+    const spy = makeCanvasSpy();
+    drawRoad(spy.ctx, EMPTY_STRIPS, VIEWPORT, {
+      weatherEffects: {
+        weather: "night",
+        reducedGlare: true,
+        flashReduction: true,
+      },
+    });
+
+    const bloom = spy.calls.filter(
+      (c): c is FillRectCall =>
+        c.type === "fillRect" && c.fillStyle === "#f4e779",
+    );
+    expect(bloom).toHaveLength(2);
+    expect(bloom[0]!.globalAlpha).toBeCloseTo(0.34 * 0.55 * 0.45, 6);
   });
 
   it("skips weather effects on a zero-area viewport", () => {

--- a/src/render/pseudoRoadCanvas.ts
+++ b/src/render/pseudoRoadCanvas.ts
@@ -136,6 +136,10 @@ export interface DrawRoadOptions {
   weatherEffects?: {
     weather: WeatherOption;
     visualReduction?: boolean;
+    particleIntensity?: number;
+    reducedGlare?: boolean;
+    fogFloorClamp?: number;
+    flashReduction?: boolean;
   };
   /**
    * Optional ghost car overlay per F-022. The §6 Time Trial flow drives
@@ -492,27 +496,51 @@ function drawWeatherEffects(
   effects: NonNullable<DrawRoadOptions["weatherEffects"]>,
 ): void {
   if (viewport.width <= 0 || viewport.height <= 0) return;
-  const intensity = effects.visualReduction === true ? WEATHER_EFFECT_REDUCTION_SCALE : 1;
+  const settings = resolveWeatherEffectSettings(effects);
 
   switch (effects.weather) {
     case "light_rain":
     case "rain":
     case "heavy_rain":
-      drawRainStreaks(ctx, viewport, effects.weather, intensity);
+      drawRainStreaks(ctx, viewport, effects.weather, settings.particleIntensity);
       return;
     case "snow":
-      drawSnowParticles(ctx, viewport, intensity);
+      drawSnowParticles(ctx, viewport, settings.particleIntensity);
       return;
     case "fog":
-      drawFogFade(ctx, viewport, intensity);
+      drawFogFade(ctx, viewport, settings.alphaScale, settings.fogFloorClamp);
       return;
     case "dusk":
     case "night":
-      drawNightBloom(ctx, viewport, effects.weather, intensity);
+      drawNightBloom(ctx, viewport, effects.weather, settings.bloomScale);
       return;
     case "clear":
       return;
   }
+}
+
+interface ResolvedWeatherEffectSettings {
+  particleIntensity: number;
+  alphaScale: number;
+  fogFloorClamp: number;
+  bloomScale: number;
+}
+
+function resolveWeatherEffectSettings(
+  effects: NonNullable<DrawRoadOptions["weatherEffects"]>,
+): ResolvedWeatherEffectSettings {
+  const reductionScale =
+    effects.visualReduction === true ? WEATHER_EFFECT_REDUCTION_SCALE : 1;
+  const particleIntensity = clampUnit(effects.particleIntensity ?? 1) * reductionScale;
+  const alphaScale = reductionScale;
+  const glareScale = effects.reducedGlare === true ? 0.55 : 1;
+  const flashScale = effects.flashReduction === true ? 0.45 : 1;
+  return {
+    particleIntensity,
+    alphaScale,
+    fogFloorClamp: clampUnit(effects.fogFloorClamp ?? 0),
+    bloomScale: reductionScale * glareScale * flashScale,
+  };
 }
 
 function drawRainStreaks(
@@ -522,7 +550,8 @@ function drawRainStreaks(
   intensity: number,
 ): void {
   const baseCount = weather === "heavy_rain" ? 92 : weather === "rain" ? 58 : 32;
-  const count = Math.max(4, Math.round(baseCount * intensity));
+  const count = Math.round(baseCount * intensity);
+  if (count <= 0) return;
   const alpha = (weather === "heavy_rain" ? 0.34 : weather === "rain" ? 0.26 : 0.18) * intensity;
   const prevFill = ctx.fillStyle;
   const prevAlpha = ctx.globalAlpha;
@@ -546,7 +575,8 @@ function drawSnowParticles(
   viewport: Viewport,
   intensity: number,
 ): void {
-  const count = Math.max(5, Math.round(54 * intensity));
+  const count = Math.round(54 * intensity);
+  if (count <= 0) return;
   const prevFill = ctx.fillStyle;
   const prevAlpha = ctx.globalAlpha;
   try {
@@ -568,8 +598,9 @@ function drawFogFade(
   ctx: CanvasRenderingContext2D,
   viewport: Viewport,
   intensity: number,
+  fogFloorClamp: number,
 ): void {
-  const visibility = visibilityForWeather("fog");
+  const visibility = Math.max(visibilityForWeather("fog"), fogFloorClamp);
   const prevFill = ctx.fillStyle;
   const prevAlpha = ctx.globalAlpha;
   try {
@@ -604,6 +635,11 @@ function drawNightBloom(
     ctx.fillStyle = prevFill;
     ctx.globalAlpha = prevAlpha;
   }
+}
+
+function clampUnit(value: number): number {
+  if (!Number.isFinite(value)) return 0;
+  return Math.min(1, Math.max(0, value));
 }
 
 /**


### PR DESCRIPTION
## Summary
- add persisted §14 weather accessibility settings for particle intensity, fog readability floor, reduced glare, and flash reduction
- surface the new controls in the Accessibility options pane
- thread the settings into live race weather rendering for rain, snow, fog, and dusk or night bloom

## GDD
- docs/gdd/14-weather-and-environmental-systems.md
- docs/gdd/16-rendering-and-visual-design.md
- docs/gdd/20-hud-and-ui-ux.md
- docs/gdd/22-data-schemas.md

## Progress Log
- docs/PROGRESS_LOG.md: Weather accessibility settings

## Test Plan
- npx vitest run src/components/options/__tests__/accessibilityPaneState.test.ts src/data/__tests__/settings-schema.test.ts src/persistence/migrations/v1ToV2.test.ts src/render/__tests__/pseudoRoadCanvas.test.ts
- npm run typecheck
- npm run content-lint
- npx playwright test e2e/options-accessibility.spec.ts
- npm run verify
- npm run test:e2e

## Followups
- closes F-067
