### PR TITLE
feat(game): add overcast weather option

### DIFF
--- a/docs/GDD_COVERAGE.json
+++ b/docs/GDD_COVERAGE.json
@@ -2,6 +2,31 @@
   "version": 1,
   "requirements": [
     {
+      "id": "GDD-14-OVERCAST-WEATHER-OPTION",
+      "gddSections": [
+        "docs/gdd/14-weather-and-environmental-systems.md",
+        "docs/gdd/22-data-schemas.md",
+        "docs/gdd/23-balancing-tables.md"
+      ],
+      "requirement": "Overcast is a valid authored weather option and resolves as a clear-adjacent, grip-neutral condition with a mild visibility reduction.",
+      "coverage": ["implemented-code", "automated-test"],
+      "implementationRefs": [
+        "src/data/schemas.ts",
+        "src/game/weather.ts",
+        "src/game/preRaceCard.ts",
+        "src/game/nitro.ts",
+        "src/render/pseudoRoadCanvas.ts"
+      ],
+      "testRefs": [
+        "src/data/schemas.test.ts",
+        "src/game/__tests__/weather.test.ts",
+        "src/game/__tests__/preRaceCard.test.ts",
+        "src/game/__tests__/nitro.test.ts",
+        "src/render/__tests__/pseudoRoadCanvas.test.ts"
+      ],
+      "followupRefs": []
+    },
+    {
       "id": "GDD-14-WEATHER-ACCESSIBILITY-SETTINGS",
       "gddSections": [
         "docs/gdd/14-weather-and-environmental-systems.md",

--- a/docs/PROGRESS_LOG.md
+++ b/docs/PROGRESS_LOG.md
@@ -6,6 +6,54 @@ Correct them by adding a new entry that references the old one.
 
 ---
 
+## 2026-04-28: Slice: Overcast weather option
+
+**GDD sections touched:**
+[§14](gdd/14-weather-and-environmental-systems.md) weather types,
+[§22](gdd/22-data-schemas.md) track weather enum,
+[§23](gdd/23-balancing-tables.md) weather modifier mapping.
+**Branch / PR:** `feat/overcast-weather-option`, PR pending.
+**Status:** Implemented.
+
+### Done
+- `src/data/schemas.ts`: added `overcast` to the runtime weather enum
+  so tracks can author the §14 condition.
+- `src/game/weather.ts`: mapped overcast to the clear §23 grip row and
+  a mild 0.95 visibility scalar.
+- `src/game/preRaceCard.ts`, `src/game/nitro.ts`, and
+  `src/render/pseudoRoadCanvas.ts`: treated overcast as a dry-tire,
+  low-risk, visual-neutral weather condition.
+- `docs/gdd/22-data-schemas.md`: documented the weather option ids.
+- `docs/GDD_COVERAGE.json`: added GDD-14-OVERCAST-WEATHER-OPTION.
+
+### Verified
+- `npx vitest run src/data/schemas.test.ts src/game/__tests__/weather.test.ts src/game/__tests__/preRaceCard.test.ts src/game/__tests__/nitro.test.ts src/render/__tests__/pseudoRoadCanvas.test.ts src/data/__tests__/balancing.test.ts`
+  green, 300 passed.
+- `npm run typecheck` clean.
+- `npm run content-lint` clean.
+- `npm run verify` green, 2340 passed.
+- `npm run test:e2e` green, 71 passed.
+
+### Decisions and assumptions
+- Overcast is clear-adjacent for grip and nitro risk because §23 has no
+  dedicated Overcast modifier row.
+- Overcast uses a 0.95 visibility scalar, matching the parent weather
+  dot's planned treatment and keeping it distinct from clear without
+  adding particles or bloom.
+
+### Coverage ledger
+- GDD-14-OVERCAST-WEATHER-OPTION covers schema authoring and runtime
+  handling for overcast weather.
+- Uncovered adjacent requirements: weather state transitions, high
+  contrast roadside signs, heat shimmer, and tunnel adaptation remain
+  future slices.
+
+### Followups created
+None.
+
+### GDD edits
+- `docs/gdd/22-data-schemas.md`: listed the canonical weather ids.
+
 ## 2026-04-28: Slice: Weather accessibility settings
 
 **GDD sections touched:**

--- a/docs/gdd/22-data-schemas.md
+++ b/docs/gdd/22-data-schemas.md
@@ -42,6 +42,10 @@
 }
 ```
 
+`weatherOptions` entries are the §14 weather ids:
+`clear`, `overcast`, `light_rain`, `rain`, `heavy_rain`, `fog`, `snow`,
+`night`, and `dusk`.
+
 ## Car JSON schema
 
 ```

--- a/docs/gdd/22-data-schemas.md
+++ b/docs/gdd/22-data-schemas.md
@@ -44,7 +44,7 @@
 
 `weatherOptions` entries are the §14 weather ids:
 `clear`, `overcast`, `light_rain`, `rain`, `heavy_rain`, `fog`, `snow`,
-`night`, and `dusk`.
+`dusk`, and `night`.
 
 ## Car JSON schema
 

--- a/src/data/__tests__/balancing.test.ts
+++ b/src/data/__tests__/balancing.test.ts
@@ -460,8 +460,8 @@ describe("§23 Damage formula targets", () => {
  *
  * The §23 row labels ("Clear", "Rain", "Heavy rain", "Snow", "Fog")
  * map onto the `WeatherOption` schema enum values (`clear`, `rain`,
- * `heavy_rain`, `snow`, `fog`). The other three `WeatherOption`
- * values (`light_rain`, `dusk`, `night`) are not part of §23 and are
+ * `heavy_rain`, `snow`, `fog`). The other four `WeatherOption`
+ * values (`overcast`, `light_rain`, `dusk`, `night`) are not part of §23 and are
  * deliberately not pinned here. See Q-008.
  */
 const WEATHER_MODIFIER_TARGETS: Readonly<

--- a/src/data/schemas.test.ts
+++ b/src/data/schemas.test.ts
@@ -45,6 +45,11 @@ describe("TrackSchema", () => {
     expect(TrackSchema.safeParse(broken).success).toBe(false);
   });
 
+  it("accepts overcast as a §14 weather option", () => {
+    const ok = { ...trackExample, weatherOptions: ["clear", "overcast"] };
+    expect(TrackSchema.safeParse(ok).success).toBe(true);
+  });
+
   it("accepts an authored minimapPoints override of length 2 or more", () => {
     const ok = {
       ...trackExample,

--- a/src/data/schemas.ts
+++ b/src/data/schemas.ts
@@ -37,6 +37,7 @@ const unitInterval = z.number().min(0).max(1);
 
 export const WeatherOptionSchema = z.enum([
   "clear",
+  "overcast",
   "light_rain",
   "rain",
   "heavy_rain",

--- a/src/game/__tests__/nitro.test.ts
+++ b/src/game/__tests__/nitro.test.ts
@@ -457,6 +457,7 @@ describe("getInstabilityMultiplier", () => {
   const SURFACES: ReadonlyArray<Surface> = ["road", "rumble", "grass"];
   const WEATHERS: ReadonlyArray<WeatherOption> = [
     "clear",
+    "overcast",
     "light_rain",
     "rain",
     "heavy_rain",
@@ -534,7 +535,8 @@ describe("getInstabilityMultiplier", () => {
     expect(moderate).toBeGreaterThan(light);
   });
 
-  it("dusk and night both map to the §10 Low risk tier", () => {
+  it("overcast, dusk, and night map to the §10 Low risk tier", () => {
+    expect(NITRO_WEATHER_RISK.overcast).toBe("low");
     expect(NITRO_WEATHER_RISK.dusk).toBe("low");
     expect(NITRO_WEATHER_RISK.night).toBe("low");
   });

--- a/src/game/__tests__/preRaceCard.test.ts
+++ b/src/game/__tests__/preRaceCard.test.ts
@@ -69,6 +69,7 @@ describe("pre-race card", () => {
 
   it.each([
     ["clear", "dry"],
+    ["overcast", "dry"],
     ["light_rain", "wet"],
     ["rain", "wet"],
     ["heavy_rain", "wet"],
@@ -100,6 +101,25 @@ describe("pre-race card", () => {
 
     expect(card.recommendedTire).toBe("wet");
     expect(card.selectedTireWarning).toContain("wet tires");
+  });
+
+  it("surfaces overcast as a clear-adjacent forecast", () => {
+    const rawTrack = TRACK_RAW["velvet-coast/harbor-run"];
+    if (!rawTrack) throw new Error("expected Harbor Run fixture");
+    const overcastTrack = TrackSchema.parse({
+      ...rawTrack,
+      weatherOptions: ["clear", "overcast"],
+    });
+    const card = buildPreRaceCard({
+      track: overcastTrack,
+      save: defaultSave(),
+      weatherSelection: "overcast",
+    });
+
+    expect(card.forecast.condition).toBe("Overcast");
+    expect(card.forecast.surfaceTemperatureBand).toBe("Warm");
+    expect(card.forecast.visibilityRating).toBe("High");
+    expect(card.recommendedTire).toBe("dry");
   });
 
   it.each([

--- a/src/game/__tests__/weather.test.ts
+++ b/src/game/__tests__/weather.test.ts
@@ -135,7 +135,7 @@ describe("isWeatherTireModifierKey", () => {
     },
   );
 
-  it.each(["light_rain", "dusk", "night"] as const)(
+  it.each(["overcast", "light_rain", "dusk", "night"] as const)(
     "returns false for the WeatherOption %s that §23 leaves uncovered",
     (key) => {
       expect(isWeatherTireModifierKey(key)).toBe(false);
@@ -169,7 +169,7 @@ describe("getWeatherTireModifier", () => {
     },
   );
 
-  it.each(["light_rain", "dusk", "night"] as ReadonlyArray<WeatherOption>)(
+  it.each(["overcast", "light_rain", "dusk", "night"] as ReadonlyArray<WeatherOption>)(
     "returns undefined for the §23-uncovered WeatherOption %s (Q-008)",
     (key) => {
       expect(getWeatherTireModifier(key)).toBeUndefined();
@@ -191,6 +191,7 @@ describe("runtime weather aliases", () => {
 
   it.each([
     ["clear", "clear"],
+    ["overcast", "clear"],
     ["light_rain", "rain"],
     ["rain", "rain"],
     ["heavy_rain", "heavy_rain"],
@@ -232,6 +233,13 @@ describe("effectiveWeatherGrip", () => {
       9,
     );
   });
+
+  it("uses the runtime alias for overcast as a clear-adjacent grip row", () => {
+    expect(effectiveWeatherGrip(STATS, "overcast", "dry")).toBeCloseTo(
+      effectiveWeatherGrip(STATS, "clear", "dry"),
+      9,
+    );
+  });
 });
 
 describe("visibilityForWeather", () => {
@@ -241,6 +249,7 @@ describe("visibilityForWeather", () => {
 
   it.each([
     ["clear", 1],
+    ["overcast", 0.95],
     ["light_rain", 0.9],
     ["rain", 0.8],
     ["heavy_rain", 0.7],
@@ -259,6 +268,7 @@ describe("visibilityForWeather", () => {
 describe("weatherSkillFor", () => {
   it.each([
     ["clear", 1],
+    ["overcast", 1],
     ["dusk", 1],
     ["night", 1],
     ["light_rain", 1.04],

--- a/src/game/nitro.ts
+++ b/src/game/nitro.ts
@@ -513,7 +513,7 @@ export type NitroWeatherRisk = "low" | "medium" | "high";
 
 /**
  * §10 weather to risk-tier mapping. The §22 schema's weather values
- * are mapped onto the §10 narrative's 6 buckets here; `rain` maps to
+ * are mapped onto the §10 narrative's 9 buckets here; `rain` maps to
  * `medium`, while overcast, dusk, and night map to the `low` tier.
  */
 export const NITRO_WEATHER_RISK: Readonly<Record<WeatherOption, NitroWeatherRisk>> =

--- a/src/game/nitro.ts
+++ b/src/game/nitro.ts
@@ -512,13 +512,14 @@ export const NITRO_ACCEL_MULTIPLIER_MAX = 2;
 export type NitroWeatherRisk = "low" | "medium" | "high";
 
 /**
- * §10 weather to risk-tier mapping. The §22 schema's 8 weather values
+ * §10 weather to risk-tier mapping. The §22 schema's weather values
  * are mapped onto the §10 narrative's 6 buckets here; `rain` maps to
- * `medium`, `dusk` and `night` both map to the `low` tier.
+ * `medium`, while overcast, dusk, and night map to the `low` tier.
  */
 export const NITRO_WEATHER_RISK: Readonly<Record<WeatherOption, NitroWeatherRisk>> =
   Object.freeze({
     clear: "low",
+    overcast: "low",
     light_rain: "medium",
     rain: "medium",
     heavy_rain: "high",

--- a/src/game/preRaceCard.ts
+++ b/src/game/preRaceCard.ts
@@ -124,6 +124,7 @@ export function recommendTire(weather: WeatherOption): TireKind {
     case "snow":
       return "wet";
     case "clear":
+    case "overcast":
     case "fog":
     case "dusk":
     case "night":
@@ -143,6 +144,8 @@ export function weatherLabel(weather: WeatherOption): string {
   switch (weather) {
     case "clear":
       return "Clear";
+    case "overcast":
+      return "Overcast";
     case "light_rain":
       return "Light rain";
     case "rain":
@@ -178,6 +181,7 @@ function surfaceTemperatureBand(weather: WeatherOption): string {
     case "fog":
       return "Cool";
     case "clear":
+    case "overcast":
       return "Warm";
     case "light_rain":
     case "rain":

--- a/src/game/weather.ts
+++ b/src/game/weather.ts
@@ -52,15 +52,15 @@
  * `src/data/__tests__/balancing.test.ts`).
  *
  * Schema coverage. `WeatherOption` (the `TrackSchema`-validated enum
- * authored in `src/data/schemas.ts`) declares eight weather values:
- * `clear`, `light_rain`, `rain`, `heavy_rain`, `fog`, `snow`, `dusk`,
- * `night`. §23 only specifies five of them. The lookup here is
+ * authored in `src/data/schemas.ts`) declares nine weather values:
+ * `clear`, `overcast`, `light_rain`, `rain`, `heavy_rain`, `fog`,
+ * `snow`, `dusk`, `night`. §23 only specifies five of them. The lookup here is
  * intentionally typed as a `Partial<Record<WeatherOption, ...>>` so a
- * caller asking for `light_rain`, `dusk`, or `night` gets a typed
- * `undefined` rather than a fabricated row. Runtime consumers use
+ * caller asking for `overcast`, `light_rain`, `dusk`, or `night` gets
+ * a typed `undefined` rather than a fabricated row. Runtime consumers use
  * `WEATHER_TIRE_MODIFIER_ALIASES` to map the full enum onto §23 rows:
- * light rain maps to Rain, dusk maps to Clear, and night maps to Clear.
- * Q-008 records that decision.
+ * overcast, dusk, and night map to Clear, and light rain maps to Rain.
+ * Q-008 records the original uncovered-weather decision.
  */
 
 import type { AIDriver, CarBaseStats, WeatherOption } from "@/data/schemas";
@@ -68,7 +68,7 @@ import type { AIDriver, CarBaseStats, WeatherOption } from "@/data/schemas";
 /**
  * §23 rows that pin a tire-modifier cell. Five entries, exactly the
  * five rows in `docs/gdd/23-balancing-tables.md` "Weather modifiers".
- * Subset of `WeatherOption` (the schema enum has eight entries; §23
+ * Subset of `WeatherOption` (the schema enum has nine entries; §23
  * specifies five). Exported so callers can constrain to the §23 set
  * at their site.
  */
@@ -146,6 +146,7 @@ export const WEATHER_TIRE_MODIFIER_ALIASES: Readonly<
   Record<WeatherOption, WeatherTireModifierKey>
 > = Object.freeze({
   clear: "clear",
+  overcast: "clear",
   light_rain: "rain",
   rain: "rain",
   heavy_rain: "heavy_rain",
@@ -163,6 +164,7 @@ export const WEATHER_TIRE_MODIFIER_ALIASES: Readonly<
 export const WEATHER_VISIBILITY: Readonly<Record<WeatherOption, number>> =
   Object.freeze({
     clear: 1,
+    overcast: 0.95,
     light_rain: 0.9,
     rain: 0.8,
     heavy_rain: 0.7,
@@ -194,7 +196,7 @@ export function isWeatherTireModifierKey(
  * frozen object reference every call so callers can lean on identity
  * comparison without a deep-clone allocation per tick. Returns
  * `undefined` for any `WeatherOption` value that §23 does not pin
- * (currently `light_rain`, `dusk`, `night`); see Q-008. Callers must
+ * (currently `overcast`, `light_rain`, `dusk`, `night`); see Q-008. Callers must
  * decide their fallback at the call site rather than have this module
  * fabricate a row that drifts from §23.
  */
@@ -273,6 +275,7 @@ export function weatherSkillFor(
 ): number {
   switch (weather) {
     case "clear":
+    case "overcast":
     case "dusk":
     case "night":
       return driver.weatherSkill.clear;

--- a/src/render/__tests__/pseudoRoadCanvas.test.ts
+++ b/src/render/__tests__/pseudoRoadCanvas.test.ts
@@ -926,6 +926,17 @@ describe("drawRoad weather effects", () => {
           c.type === "fillRect" && c.fillStyle === "#cbd7e1",
       ),
     ).toBe(false);
+
+    const overcast = makeCanvasSpy();
+    drawRoad(overcast.ctx, EMPTY_STRIPS, VIEWPORT, {
+      weatherEffects: { weather: "overcast" },
+    });
+    expect(
+      overcast.calls.some(
+        (c): c is FillRectCall =>
+          c.type === "fillRect" && c.fillStyle === "#cbd7e1",
+      ),
+    ).toBe(false);
   });
 
   it("uses the fog readability floor to reduce fog overlay alpha", () => {

--- a/src/render/pseudoRoadCanvas.ts
+++ b/src/render/pseudoRoadCanvas.ts
@@ -515,6 +515,7 @@ function drawWeatherEffects(
       drawNightBloom(ctx, viewport, effects.weather, settings.bloomScale);
       return;
     case "clear":
+    case "overcast":
       return;
   }
 }
@@ -815,7 +816,13 @@ function drawCarWeatherTrail(
   height: number,
   weather: WeatherOption | undefined,
 ): void {
-  if (!weather || weather === "clear" || weather === "dusk" || weather === "night") {
+  if (
+    !weather ||
+    weather === "clear" ||
+    weather === "overcast" ||
+    weather === "dusk" ||
+    weather === "night"
+  ) {
     return;
   }
 


### PR DESCRIPTION
## Summary
- add `overcast` to the §14 weather option enum
- map overcast to clear-adjacent grip, low nitro risk, dry tire recommendation, and 0.95 visibility
- document weather ids in §22 and add coverage ledger entry

## GDD
- docs/gdd/14-weather-and-environmental-systems.md
- docs/gdd/22-data-schemas.md
- docs/gdd/23-balancing-tables.md

## Progress Log
- docs/PROGRESS_LOG.md: Overcast weather option

## Test Plan
- npx vitest run src/data/schemas.test.ts src/game/__tests__/weather.test.ts src/game/__tests__/preRaceCard.test.ts src/game/__tests__/nitro.test.ts src/render/__tests__/pseudoRoadCanvas.test.ts src/data/__tests__/balancing.test.ts
- npm run typecheck
- npm run content-lint
- npm run verify
- npm run test:e2e

## Followups
- none
