### PR TITLE
feat(weather): add state transitions

### DIFF
--- a/docs/GDD_COVERAGE.json
+++ b/docs/GDD_COVERAGE.json
@@ -118,6 +118,28 @@
       "followupRefs": []
     },
     {
+      "id": "GDD-14-WEATHER-STATE-MACHINE",
+      "gddSections": [
+        "docs/gdd/14-weather-and-environmental-systems.md",
+        "docs/gdd/21-technical-design-for-web-implementation.md",
+        "docs/gdd/22-data-schemas.md"
+      ],
+      "requirement": "Race sessions carry deterministic weather state constrained to the track's authored weather options, with smooth opt-in transitions between allowed states.",
+      "coverage": ["implemented-code", "automated-test"],
+      "implementationRefs": [
+        "src/game/weather.ts",
+        "src/game/raceSession.ts",
+        "src/game/raceSessionActions.ts",
+        "src/app/race/page.tsx"
+      ],
+      "testRefs": [
+        "src/game/__tests__/weather.test.ts",
+        "src/game/__tests__/raceSession.test.ts",
+        "src/game/__tests__/raceSessionActions.test.ts"
+      ],
+      "followupRefs": []
+    },
+    {
       "id": "GDD-21-RNG-CONSUMERS",
       "gddSections": [
         "docs/gdd/15-cpu-opponents-and-ai.md",

--- a/docs/PROGRESS_LOG.md
+++ b/docs/PROGRESS_LOG.md
@@ -6,6 +6,57 @@ Correct them by adding a new entry that references the old one.
 
 ---
 
+## 2026-04-28: Slice: Weather state transitions
+
+**GDD sections touched:**
+[§14](gdd/14-weather-and-environmental-systems.md) weather types and
+track-specific weather,
+[§21](gdd/21-technical-design-for-web-implementation.md) deterministic
+runtime state,
+[§22](gdd/22-data-schemas.md) track weather options.
+**Branch / PR:** `feat/weather-state-transitions`, PR pending.
+**Status:** Implemented.
+
+### Done
+- `src/game/weather.ts`: added `WeatherState`, deterministic transition
+  stepping, active-weather selection, and interpolated grip and
+  visibility helpers.
+- `src/game/raceSession.ts`: initialized per-session weather state from
+  the selected race weather, reserved a seeded weather RNG stream, and
+  applied weather-state grip to player and AI physics.
+- `src/game/raceSessionActions.ts`: preserved the weather state through
+  retire-session cloning.
+- `src/app/race/page.tsx`: renders weather effects and car trails from
+  the live session weather state.
+- `docs/GDD_COVERAGE.json`: added GDD-14-WEATHER-STATE-MACHINE.
+
+### Verified
+- `npx vitest run src/game/__tests__/weather.test.ts src/game/__tests__/raceSession.test.ts src/game/__tests__/raceSessionActions.test.ts`
+  green, 197 passed.
+- `npm run typecheck` clean.
+- `npm run verify` green, 2353 passed.
+- `npm run test:e2e` green, 71 passed.
+
+### Decisions and assumptions
+- Runtime transitions are opt-in with `changeChancePerSecond`. The
+  default is 0 so existing races keep the forecast chosen in pre-race
+  setup while future modes can enable deterministic mid-race changes.
+- The state machine rejects a weather option not listed by the active
+  track, matching §14's authored 1 to 3 weather-set constraint.
+
+### Coverage ledger
+- GDD-14-WEATHER-STATE-MACHINE covers deterministic state storage,
+  track-constrained transitions, and smooth grip or visibility
+  interpolation.
+- Uncovered adjacent requirements: heat shimmer and tunnel adaptation
+  remain future slices.
+
+### Followups created
+None.
+
+### GDD edits
+None.
+
 ## 2026-04-28: Slice: High-contrast roadside signs
 
 **GDD sections touched:**

--- a/src/app/race/page.tsx
+++ b/src/app/race/page.tsx
@@ -114,7 +114,7 @@ import { awardCredits, baseRewardForTrackDifficulty } from "@/game/economy";
 import type { SaveGame } from "@/data/schemas";
 import type { RaceResult } from "@/game/raceResult";
 import { PRISTINE_DAMAGE_STATE, type DamageState } from "@/game/damage";
-import type { TireKind } from "@/game/weather";
+import { activeWeatherForState, type TireKind } from "@/game/weather";
 
 const VIEWPORT_WIDTH = 800;
 const VIEWPORT_HEIGHT = 480;
@@ -679,7 +679,6 @@ function RaceCanvas({
       ...(lapsOverride !== null ? { totalLaps: lapsOverride } : {}),
     };
     setFieldSize(1 + config.ai.length);
-    const activeWeather = config.weather ?? track.compiled.weatherOptions[0] ?? "clear";
 
     const resetTimeTrialRuntime = (): void => {
       ghostOverlayRef.current = null;
@@ -910,6 +909,7 @@ function RaceCanvas({
         if (!session) return;
         camera.z = session.player.car.z;
         camera.x = session.player.car.x;
+        const renderWeather = activeWeatherForState(session.weather);
 
         const strips = project(track.compiled.segments, camera, viewport);
         const playerFrameIndex = playerCarFrameIndex(
@@ -937,7 +937,7 @@ function RaceCanvas({
         drawRoad(ctx, strips, viewport, {
           parallax: { layers: parallaxLayers, camera },
           weatherEffects: {
-            weather: activeWeather,
+            weather: renderWeather,
             visualReduction: persistedAssists.weatherVisualReduction,
             particleIntensity:
               persistedSettings.accessibility?.weatherParticleIntensity,
@@ -958,7 +958,7 @@ function RaceCanvas({
           playerCar: {
             atlas: carAtlasRef.current,
             frameIndex: playerFrameIndex,
-            weather: activeWeather,
+            weather: renderWeather,
           },
         });
 

--- a/src/game/__tests__/raceSession.test.ts
+++ b/src/game/__tests__/raceSession.test.ts
@@ -52,7 +52,7 @@ import {
   DNF_NO_PROGRESS_TIMEOUT_SEC,
   DNF_OFF_TRACK_TIMEOUT_SEC,
 } from "@/game/raceRules";
-import type { AIDriver, CarBaseStats } from "@/data/schemas";
+import type { AIDriver, CarBaseStats, WeatherOption } from "@/data/schemas";
 
 const STARTER_STATS: CarBaseStats = Object.freeze({
   topSpeed: 61.0,
@@ -91,6 +91,12 @@ function buildConfig(overrides: Partial<RaceSessionConfig> = {}): RaceSessionCon
     seed: 42,
     ...overrides,
   };
+}
+
+function trackWithWeather(
+  weatherOptions: ReadonlyArray<WeatherOption>,
+): RaceSessionConfig["track"] {
+  return { ...loadTrack("test/curve"), weatherOptions };
 }
 
 function rollForward(
@@ -219,11 +225,13 @@ describe("stepRaceSession (racing)", () => {
     const clearConfig = buildConfig({
       countdownSec: 0,
       weather: "clear",
+      track: trackWithWeather(["clear", "rain"]),
       player: { stats: STARTER_STATS, initial: { speed: 30 } },
     });
     const rainConfig = buildConfig({
       countdownSec: 0,
       weather: "rain",
+      track: trackWithWeather(["clear", "rain"]),
       player: { stats: STARTER_STATS, initial: { speed: 30 } },
     });
     const clear = stepRaceSession(
@@ -243,17 +251,79 @@ describe("stepRaceSession (racing)", () => {
     );
   });
 
+  it("initializes weather state from the active race weather", () => {
+    const track = loadTrack("velvet-coast/harbor-run");
+    const config = buildConfig({
+      track,
+      weather: "rain",
+      countdownSec: 0,
+    });
+    const session = createRaceSession(config);
+    expect(session.weather).toEqual({ current: "rain", transitioning: null });
+    expect(Number.isInteger(session.weatherRngState)).toBe(true);
+  });
+
+  it("rejects a session weather outside the track weather options", () => {
+    expect(() =>
+      createRaceSession(
+        buildConfig({
+          track: loadTrack("test/curve"),
+          weather: "rain",
+        }),
+      ),
+    ).toThrow(RangeError);
+  });
+
+  it("keeps weather fixed when transitions are not configured", () => {
+    const track = loadTrack("velvet-coast/harbor-run");
+    const config = buildConfig({
+      track,
+      weather: "clear",
+      countdownSec: 0,
+    });
+    const first = createRaceSession(config);
+    const next = stepRaceSession(first, NEUTRAL_INPUT, config, DT);
+    expect(next.weather).toEqual(first.weather);
+    expect(next.weatherRngState).toBe(first.weatherRngState);
+  });
+
+  it("advances weather transitions when the caller opts in", () => {
+    const track = loadTrack("velvet-coast/harbor-run");
+    const config = buildConfig({
+      track,
+      weather: "clear",
+      countdownSec: 0,
+      weatherTransitions: {
+        changeChancePerSecond: 1,
+        transitionSeconds: DT,
+      },
+    });
+    const first = stepRaceSession(
+      createRaceSession(config),
+      NEUTRAL_INPUT,
+      config,
+      DT,
+    );
+    expect(first.weather.transitioning?.from).toBe("clear");
+    expect(["rain", "fog"]).toContain(first.weather.transitioning?.to);
+    const target = first.weather.transitioning?.to;
+    const second = stepRaceSession(first, NEUTRAL_INPUT, config, DT);
+    expect(second.weather).toEqual({ current: target, transitioning: null });
+  });
+
   it("applies the selected player tire channel to weather grip", () => {
     const steer = { ...NEUTRAL_INPUT, steer: 1 };
     const dryConfig = buildConfig({
       countdownSec: 0,
       weather: "rain",
+      track: trackWithWeather(["clear", "rain"]),
       playerTire: "dry",
       player: { stats: STARTER_STATS, initial: { speed: 30 } },
     });
     const wetConfig = buildConfig({
       countdownSec: 0,
       weather: "rain",
+      track: trackWithWeather(["clear", "rain"]),
       playerTire: "wet",
       player: { stats: STARTER_STATS, initial: { speed: 30 } },
     });
@@ -282,11 +352,13 @@ describe("stepRaceSession (racing)", () => {
     const rainConfig = buildConfig({
       countdownSec: 0,
       weather: "heavy_rain",
+      track: trackWithWeather(["clear", "heavy_rain"]),
       ai: [{ driver: wetSpecialist, stats: STARTER_STATS }],
     });
     const clearConfig = buildConfig({
       countdownSec: 0,
       weather: "clear",
+      track: trackWithWeather(["clear", "heavy_rain"]),
       ai: [{ driver: wetSpecialist, stats: STARTER_STATS }],
     });
     const rain = stepRaceSession(

--- a/src/game/__tests__/weather.test.ts
+++ b/src/game/__tests__/weather.test.ts
@@ -17,20 +17,28 @@
 import { describe, expect, it } from "vitest";
 
 import type { WeatherOption } from "@/data/schemas";
+import { createRng, serializeRng } from "@/game/rng";
 
 import {
+  activeWeatherForState,
+  createWeatherState,
   effectiveWeatherGrip,
   getWeatherTireModifier,
   getResolvedWeatherTireModifier,
   isWeatherTireModifierKey,
   resolveWeatherTireModifierKey,
+  stepWeatherState,
   visibilityForWeather,
+  visibilityForWeatherState,
   weatherGripScalar,
+  weatherGripScalarForState,
   weatherSkillFor,
+  WEATHER_TRANSITION_SECONDS,
   WEATHER_TIRE_MODIFIER_ALIASES,
   WEATHER_TIRE_MODIFIER_KEYS,
   WEATHER_TIRE_MODIFIERS,
   WEATHER_VISIBILITY,
+  type WeatherState,
   type WeatherTireModifier,
   type WeatherTireModifierKey,
 } from "../weather";
@@ -282,6 +290,96 @@ describe("weatherSkillFor", () => {
       expect(weatherSkillFor(DRIVER, weather)).toBeCloseTo(expected, 9);
     },
   );
+});
+
+describe("WeatherState transitions", () => {
+  it("creates a stable fixed-weather state from a track option", () => {
+    expect(createWeatherState("rain", ["clear", "rain"])).toEqual<WeatherState>({
+      current: "rain",
+      transitioning: null,
+    });
+  });
+
+  it("rejects empty allowed states and weather outside the track set", () => {
+    expect(() => createWeatherState("clear", [])).toThrow(RangeError);
+    expect(() => createWeatherState("snow", ["clear", "rain"])).toThrow(
+      RangeError,
+    );
+  });
+
+  it("does not consume RNG when transition chance is disabled", () => {
+    const rng = createRng(7);
+    const before = serializeRng(rng);
+    const next = stepWeatherState(
+      createWeatherState("clear", ["clear", "rain"]),
+      1,
+      rng,
+      { allowedStates: ["clear", "rain"] },
+    );
+    expect(next).toEqual({ current: "clear", transitioning: null });
+    expect(serializeRng(rng)).toBe(before);
+  });
+
+  it("never leaves a single-weather track", () => {
+    const rng = createRng(11);
+    const next = stepWeatherState(createWeatherState("clear", ["clear"]), 5, rng, {
+      allowedStates: ["clear"],
+      changeChancePerSecond: 1,
+    });
+    expect(next).toEqual({ current: "clear", transitioning: null });
+  });
+
+  it("starts a deterministic transition to another allowed state", () => {
+    const a = stepWeatherState(
+      createWeatherState("clear", ["clear", "rain", "snow"]),
+      1,
+      createRng(42),
+      { allowedStates: ["clear", "rain", "snow"], changeChancePerSecond: 1 },
+    );
+    const b = stepWeatherState(
+      createWeatherState("clear", ["clear", "rain", "snow"]),
+      1,
+      createRng(42),
+      { allowedStates: ["clear", "rain", "snow"], changeChancePerSecond: 1 },
+    );
+    expect(a).toEqual(b);
+    expect(a.transitioning?.from).toBe("clear");
+    expect(["rain", "snow"]).toContain(a.transitioning?.to);
+    expect(a.transitioning?.progress).toBe(0);
+  });
+
+  it("advances transition progress over the default two-second window", () => {
+    const initial: WeatherState = {
+      current: "clear",
+      transitioning: { from: "clear", to: "rain", progress: 0 },
+    };
+    const half = stepWeatherState(initial, WEATHER_TRANSITION_SECONDS / 2, createRng(1), {
+      allowedStates: ["clear", "rain"],
+    });
+    expect(half.transitioning?.progress).toBeCloseTo(0.5, 9);
+    const done = stepWeatherState(half, WEATHER_TRANSITION_SECONDS / 2, createRng(1), {
+      allowedStates: ["clear", "rain"],
+    });
+    expect(done).toEqual({ current: "rain", transitioning: null });
+  });
+
+  it("interpolates grip and visibility during a transition", () => {
+    const mid: WeatherState = {
+      current: "clear",
+      transitioning: { from: "clear", to: "rain", progress: 0.5 },
+    };
+    const clearGrip = weatherGripScalar(STATS, "clear", "dry");
+    const rainGrip = weatherGripScalar(STATS, "rain", "dry");
+    expect(weatherGripScalarForState(STATS, mid, "dry")).toBeCloseTo(
+      (clearGrip + rainGrip) / 2,
+      9,
+    );
+    expect(visibilityForWeatherState(mid)).toBeCloseTo(
+      (visibilityForWeather("clear") + visibilityForWeather("rain")) / 2,
+      9,
+    );
+    expect(activeWeatherForState(mid)).toBe("rain");
+  });
 });
 
 describe("§23 table monotonicity (sanity)", () => {

--- a/src/game/raceSession.ts
+++ b/src/game/raceSession.ts
@@ -92,7 +92,7 @@ import {
   tickNitro,
   type NitroState,
 } from "./nitro";
-import { createRng, serializeRng, splitRng } from "./rng";
+import { createRng, deserializeRng, serializeRng, splitRng } from "./rng";
 import {
   createTransmissionForCar,
   gearAccelMultiplier,
@@ -100,7 +100,15 @@ import {
   tickTransmission,
   type TransmissionState,
 } from "./transmission";
-import { weatherGripScalar, weatherSkillFor, type TireKind } from "./weather";
+import {
+  activeWeatherForState,
+  createWeatherState,
+  stepWeatherState,
+  weatherGripScalarForState,
+  weatherSkillFor,
+  type TireKind,
+  type WeatherState,
+} from "./weather";
 import {
   DEFAULT_TRACK_CONTEXT,
   INITIAL_CAR_STATE,
@@ -230,15 +238,21 @@ export interface RaceSessionConfig {
    */
   seed?: number;
   /**
-   * Active weather option for the session, read by the §19 accessibility
+   * Initial weather option for the session, read by the §19 accessibility
    * assist pipeline (`AssistContext.weather`) so visual-only-weather
    * mode can flag the runtime. Defaults to the first entry in
-   * `track.weatherOptions` when the host does not pin one. Held on
-   * config (rather than a per-tick parameter) because weather is
-   * decided at race-start time and never flips mid-race in current
-   * builds.
+   * `track.weatherOptions` when the host does not pin one.
    */
   weather?: WeatherOption;
+  /**
+   * Optional §14 weather-state-machine knobs. The default change chance
+   * is 0 so existing races keep a fixed forecast unless a caller opts
+   * into mid-race transitions.
+   */
+  weatherTransitions?: {
+    readonly changeChancePerSecond?: number;
+    readonly transitionSeconds?: number;
+  };
   /**
    * Active player tire channel chosen in the pre-race surface. Defaults
    * to dry so existing direct race links preserve their old behavior.
@@ -502,6 +516,10 @@ export interface RaceSessionState {
   draftWindows: Readonly<Record<string, DraftWindowState>>;
   /** Breakable track hazards consumed during this race, keyed by segment and id. */
   brokenHazards: ReadonlyArray<string>;
+  /** §14 weather runtime state, constrained to this track's authored options. */
+  weather: WeatherState;
+  /** Serialized deterministic PRNG state reserved for weather transitions. */
+  weatherRngState: number;
 }
 
 /**
@@ -674,6 +692,9 @@ export function createRaceSession(config: RaceSessionConfig): RaceSessionState {
   };
 
   const sectorTimer = createSectorState(config.track.checkpoints);
+  const initialWeather = config.weather ?? config.track.weatherOptions[0] ?? "clear";
+  const weather = createWeatherState(initialWeather, config.track.weatherOptions);
+  const weatherRng = splitRng(createRng(raceSeed), "weather");
 
   return {
     race,
@@ -684,6 +705,8 @@ export function createRaceSession(config: RaceSessionConfig): RaceSessionState {
     baselineSplitsMs: null,
     draftWindows: {},
     brokenHazards: [],
+    weather,
+    weatherRngState: serializeRng(weatherRng),
   };
 }
 
@@ -846,6 +869,8 @@ export function stepRaceSession(
         baselineSplitsMs: state.baselineSplitsMs,
         draftWindows: state.draftWindows,
         brokenHazards: state.brokenHazards,
+        weather: cloneWeatherState(state.weather),
+        weatherRngState: state.weatherRngState,
       };
     }
     // Lights out. Flip to racing, zero the tick clock, reset the sector
@@ -871,6 +896,8 @@ export function stepRaceSession(
       baselineSplitsMs: state.baselineSplitsMs,
       draftWindows: state.draftWindows,
       brokenHazards: state.brokenHazards,
+      weather: cloneWeatherState(state.weather),
+      weatherRngState: state.weatherRngState,
     };
     return stepRaceSession(promoted, playerInput, config, dt);
   }
@@ -923,11 +950,18 @@ export function stepRaceSession(
   // forced to neutral so any downstream reducer that still reads it
   // sees zero throttle / brake / nitro.
   const assistSettings = config.player.assists ?? {};
-  const trackWeather =
-    config.weather ?? config.track.weatherOptions[0] ?? "clear";
-  const playerWeatherGripScalar = weatherGripScalar(
+  const weatherRng = deserializeRng(state.weatherRngState);
+  const nextWeather = stepWeatherState(state.weather, dt, weatherRng, {
+    allowedStates: config.track.weatherOptions,
+    changeChancePerSecond:
+      config.weatherTransitions?.changeChancePerSecond ?? 0,
+    transitionSeconds: config.weatherTransitions?.transitionSeconds,
+  });
+  const nextWeatherRngState = serializeRng(weatherRng);
+  const trackWeather = activeWeatherForState(nextWeather);
+  const playerWeatherGripScalar = weatherGripScalarForState(
     playerStats,
-    trackWeather,
+    nextWeather,
     config.playerTire ?? "dry",
   );
   const assistResult = playerIsRacing
@@ -1260,7 +1294,10 @@ export function stepRaceSession(
       getDamageScalars(entry.damage.total * 100),
       aiHazards.gripMultiplier,
     );
-    const aiWeatherGripScalar = weatherGripScalar(aiConfig.stats, trackWeather);
+    const aiWeatherGripScalar = weatherGripScalarForState(
+      aiConfig.stats,
+      nextWeather,
+    );
     const nextCar = step(
       entry.car,
       tick.input,
@@ -1639,6 +1676,8 @@ export function stepRaceSession(
       nextBrokenHazards === initialBrokenHazards
         ? state.brokenHazards
         : Array.from(nextBrokenHazards),
+    weather: nextWeather,
+    weatherRngState: nextWeatherRngState,
   };
 }
 
@@ -1680,6 +1719,8 @@ function cloneSessionState(state: Readonly<RaceSessionState>): RaceSessionState 
     baselineSplitsMs: state.baselineSplitsMs,
     draftWindows: state.draftWindows,
     brokenHazards: state.brokenHazards.slice(),
+    weather: cloneWeatherState(state.weather),
+    weatherRngState: state.weatherRngState,
   };
 }
 
@@ -1717,6 +1758,19 @@ function withHazardGrip(
 
 function seedForAiIndex(raceSeed: number, index: number): number {
   return serializeRng(splitRng(createRng(raceSeed), `ai:${index}`));
+}
+
+function cloneWeatherState(state: Readonly<WeatherState>): WeatherState {
+  return {
+    current: state.current,
+    transitioning: state.transitioning
+      ? {
+          from: state.transitioning.from,
+          to: state.transitioning.to,
+          progress: state.transitioning.progress,
+        }
+      : null,
+  };
 }
 
 function clonePlayerCar(

--- a/src/game/raceSessionActions.ts
+++ b/src/game/raceSessionActions.ts
@@ -108,6 +108,8 @@ export function retireRaceSession(
     baselineSplitsMs: state.baselineSplitsMs,
     draftWindows: state.draftWindows,
     brokenHazards: state.brokenHazards.slice(),
+    weather: cloneWeatherPure(state.weather),
+    weatherRngState: state.weatherRngState,
   };
 }
 
@@ -155,6 +157,23 @@ function clonePure(state: Readonly<RaceSessionState>): RaceSessionState {
     baselineSplitsMs: state.baselineSplitsMs,
     draftWindows: state.draftWindows,
     brokenHazards: state.brokenHazards.slice(),
+    weather: cloneWeatherPure(state.weather),
+    weatherRngState: state.weatherRngState,
+  };
+}
+
+function cloneWeatherPure(
+  weather: Readonly<RaceSessionState["weather"]>,
+): RaceSessionState["weather"] {
+  return {
+    current: weather.current,
+    transitioning: weather.transitioning
+      ? {
+          from: weather.transitioning.from,
+          to: weather.transitioning.to,
+          progress: weather.transitioning.progress,
+        }
+      : null,
   };
 }
 

--- a/src/game/weather.ts
+++ b/src/game/weather.ts
@@ -41,12 +41,12 @@
  * `getWeatherTireModifier(weather)` returns the same frozen object
  * reference every call so callers can lean on identity comparison.
  *
- * Scope. This slice deliberately does **not** add active tire selection
- * or a weather state machine. Per
- * `docs/AGENTS.md` RULE 9 (scope discipline) the table itself is the
- * smallest shippable cell: future work adds tire-selection UI and the
- * state-machine on top of this binding. Adding a new §23 weather row,
- * renaming a column, or moving a number
+ * Scope. The module owns tire modifiers and the pure weather state
+ * machine. Runtime callers opt into mid-race transitions explicitly;
+ * a missing transition config keeps the race weather fixed. Per
+ * `docs/AGENTS.md` RULE 9 (scope discipline) the state machine still
+ * avoids picking live transition odds for production races. Adding a
+ * new §23 weather row, renaming a column, or moving a number
  * requires updating both the table here and the unit pin in
  * `src/game/__tests__/weather.test.ts` (and the §23 cross-check in
  * `src/data/__tests__/balancing.test.ts`).
@@ -64,6 +64,7 @@
  */
 
 import type { AIDriver, CarBaseStats, WeatherOption } from "@/data/schemas";
+import type { Rng } from "./rng";
 
 /**
  * §23 rows that pin a tire-modifier cell. Five entries, exactly the
@@ -99,6 +100,23 @@ export interface WeatherTireModifier {
 }
 
 export type TireKind = "dry" | "wet";
+
+export const WEATHER_TRANSITION_SECONDS = 2;
+
+export interface WeatherState {
+  readonly current: WeatherOption;
+  readonly transitioning: {
+    readonly from: WeatherOption;
+    readonly to: WeatherOption;
+    readonly progress: number;
+  } | null;
+}
+
+export interface WeatherTransitionOptions {
+  readonly allowedStates: ReadonlyArray<WeatherOption>;
+  readonly transitionSeconds?: number;
+  readonly changeChancePerSecond?: number;
+}
 
 /**
  * Frozen scalar table, copied verbatim from §23 "Weather modifiers"
@@ -265,6 +283,91 @@ export function visibilityForWeather(weather: WeatherOption): number {
   return WEATHER_VISIBILITY[weather];
 }
 
+export function createWeatherState(
+  initial: WeatherOption,
+  allowedStates: ReadonlyArray<WeatherOption>,
+): WeatherState {
+  const allowed = normalizeAllowedStates(allowedStates);
+  ensureWeatherAllowed(initial, allowed);
+  return { current: initial, transitioning: null };
+}
+
+export function activeWeatherForState(state: Readonly<WeatherState>): WeatherOption {
+  return state.transitioning?.to ?? state.current;
+}
+
+export function stepWeatherState(
+  state: Readonly<WeatherState>,
+  dt: number,
+  rng: Rng,
+  options: Readonly<WeatherTransitionOptions>,
+): WeatherState {
+  if (!Number.isFinite(dt) || dt <= 0) {
+    return cloneWeatherState(state);
+  }
+
+  const allowed = normalizeAllowedStates(options.allowedStates);
+  ensureWeatherAllowed(state.current, allowed);
+  if (state.transitioning) {
+    ensureWeatherAllowed(state.transitioning.from, allowed);
+    ensureWeatherAllowed(state.transitioning.to, allowed);
+    const transitionSeconds = Math.max(
+      Number.EPSILON,
+      options.transitionSeconds ?? WEATHER_TRANSITION_SECONDS,
+    );
+    const progress = clamp(
+      state.transitioning.progress + dt / transitionSeconds,
+      0,
+      1,
+    );
+    if (progress >= 1) {
+      return { current: state.transitioning.to, transitioning: null };
+    }
+    return {
+      current: state.current,
+      transitioning: {
+        from: state.transitioning.from,
+        to: state.transitioning.to,
+        progress,
+      },
+    };
+  }
+
+  if (allowed.length < 2) return cloneWeatherState(state);
+  const chancePerSecond = clamp(options.changeChancePerSecond ?? 0, 0, 1);
+  if (chancePerSecond <= 0) return cloneWeatherState(state);
+
+  const probability = 1 - Math.pow(1 - chancePerSecond, dt);
+  if (!rng.nextBool(probability)) return cloneWeatherState(state);
+
+  const candidates = allowed.filter((weather) => weather !== state.current);
+  const next = candidates[rng.nextInt(0, candidates.length)]!;
+  return {
+    current: state.current,
+    transitioning: { from: state.current, to: next, progress: 0 },
+  };
+}
+
+export function visibilityForWeatherState(
+  state: Readonly<WeatherState>,
+): number {
+  if (!state.transitioning) return visibilityForWeather(state.current);
+  const from = visibilityForWeather(state.transitioning.from);
+  const to = visibilityForWeather(state.transitioning.to);
+  return lerp(from, to, state.transitioning.progress);
+}
+
+export function weatherGripScalarForState(
+  stats: Readonly<CarBaseStats>,
+  state: Readonly<WeatherState>,
+  tire: TireKind = "dry",
+): number {
+  if (!state.transitioning) return weatherGripScalar(stats, state.current, tire);
+  const from = weatherGripScalar(stats, state.transitioning.from, tire);
+  const to = weatherGripScalar(stats, state.transitioning.to, tire);
+  return lerp(from, to, state.transitioning.progress);
+}
+
 /**
  * Map the full weather enum onto the four-key AI weather-skill schema.
  * The AI data stays compact while runtime callers can remain exhaustive.
@@ -295,4 +398,45 @@ function clamp(value: number, min: number, max: number): number {
   if (value < min) return min;
   if (value > max) return max;
   return value;
+}
+
+function normalizeAllowedStates(
+  allowedStates: ReadonlyArray<WeatherOption>,
+): ReadonlyArray<WeatherOption> {
+  const unique: WeatherOption[] = [];
+  for (const weather of allowedStates) {
+    if (!unique.includes(weather)) unique.push(weather);
+  }
+  if (unique.length === 0) {
+    throw new RangeError("Weather transition allowedStates must not be empty");
+  }
+  return unique;
+}
+
+function ensureWeatherAllowed(
+  weather: WeatherOption,
+  allowedStates: ReadonlyArray<WeatherOption>,
+): void {
+  if (!allowedStates.includes(weather)) {
+    throw new RangeError(
+      `Weather state ${weather} is not allowed by this track`,
+    );
+  }
+}
+
+function cloneWeatherState(state: Readonly<WeatherState>): WeatherState {
+  return {
+    current: state.current,
+    transitioning: state.transitioning
+      ? {
+          from: state.transitioning.from,
+          to: state.transitioning.to,
+          progress: state.transitioning.progress,
+        }
+      : null,
+  };
+}
+
+function lerp(from: number, to: number, progress: number): number {
+  return from + (to - from) * clamp(progress, 0, 1);
 }


### PR DESCRIPTION
## GDD sections
- §14 Weather and environmental systems
- §21 Technical design for web implementation
- §22 Data schemas

## Requirement inventory
- Adds deterministic `WeatherState` runtime state with `current` plus optional transition metadata.
- Constrains weather state and transitions to each track's authored `weatherOptions`.
- Adds smooth grip and visibility interpolation for in-progress weather transitions.
- Threads the live session weather state into race physics, renderer weather effects, and player car weather trails.
- Preserves the existing fixed-forecast behavior by default. Runtime transitions require explicit `weatherTransitions.changeChancePerSecond` config.

Nearby §14 work still outside this PR: heat shimmer and tunnel adaptation.

## Progress log
- `docs/PROGRESS_LOG.md`: 2026-04-28: Slice: Weather state transitions

## Test plan
- [x] `npx vitest run src/game/__tests__/weather.test.ts src/game/__tests__/raceSession.test.ts src/game/__tests__/raceSessionActions.test.ts`
- [x] `npm run typecheck`
- [x] `npm run lint`
- [x] `npm run content-lint`
- [x] `git diff --check`
- [x] changed-file dash scan
- [x] `npm run verify`
- [x] `npm run test:e2e`

## Followups
None.
