### PR TITLE
feat(render): add tunnel light adaptation

### DIFF
--- a/docs/GDD_COVERAGE.json
+++ b/docs/GDD_COVERAGE.json
@@ -140,6 +140,27 @@
       "followupRefs": []
     },
     {
+      "id": "GDD-14-TUNNEL-LIGHT-ADAPTATION",
+      "gddSections": [
+        "docs/gdd/09-track-design.md",
+        "docs/gdd/14-weather-and-environmental-systems.md",
+        "docs/gdd/16-rendering-and-visual-design.md",
+        "docs/gdd/22-data-schemas.md"
+      ],
+      "requirement": "Projected tunnel hazard metadata drives a visual light-adaptation shift in the live road renderer without making tunnel hazards collide with the car.",
+      "coverage": ["implemented-code", "automated-test"],
+      "implementationRefs": [
+        "src/render/pseudoRoadCanvas.ts"
+      ],
+      "testRefs": [
+        "src/render/__tests__/pseudoRoadCanvas.test.ts",
+        "src/game/__tests__/hazards.test.ts"
+      ],
+      "followupRefs": [
+        "VibeGear2-implement-sound-music-1611f9dd"
+      ]
+    },
+    {
       "id": "GDD-21-RNG-CONSUMERS",
       "gddSections": [
         "docs/gdd/15-cpu-opponents-and-ai.md",

--- a/docs/PROGRESS_LOG.md
+++ b/docs/PROGRESS_LOG.md
@@ -6,6 +6,58 @@ Correct them by adding a new entry that references the old one.
 
 ---
 
+## 2026-04-28: Slice: Tunnel light adaptation
+
+**GDD sections touched:**
+[§9](gdd/09-track-design.md) tunnel light adaptation and tunnel
+segments,
+[§14](gdd/14-weather-and-environmental-systems.md) tunnel adaptation
+shifts,
+[§16](gdd/16-rendering-and-visual-design.md) environmental visual
+feedback,
+[§22](gdd/22-data-schemas.md) authored hazard metadata.
+**Branch / PR:** `feat/tunnel-light-adaptation`, PR pending.
+**Status:** Implemented.
+
+### Done
+- `src/render/pseudoRoadCanvas.ts`: added a data-driven tunnel
+  light-adaptation pass that reads visible strip `hazardIds` and darkens
+  the world view when tunnel metadata is projected.
+- `src/render/__tests__/pseudoRoadCanvas.test.ts`: covered visible
+  tunnel activation, non-tunnel skip behavior, and debug disable
+  behavior.
+- `docs/GDD_COVERAGE.json`: added
+  GDD-14-TUNNEL-LIGHT-ADAPTATION and linked the remaining audio portion
+  to the sound backlog.
+
+### Verified
+- `npx vitest run src/render/__tests__/pseudoRoadCanvas.test.ts` green,
+  41 passed.
+- `npm run typecheck` clean.
+- `npm run lint` clean.
+- `npm run content-lint` clean.
+- `npm run verify` green, 2356 passed.
+- `npm run test:e2e` green, 71 passed.
+
+### Decisions and assumptions
+- Tunnel hazards remain non-colliding game metadata. Gameplay hazard
+  evaluation still ignores `kind: "tunnel"` while the renderer consumes
+  the compiled strip metadata for the visual adaptation.
+- Tunnel audio shift is left to the §18 sound parent because this slice
+  is limited to the §14 visual adaptation requirement.
+
+### Coverage ledger
+- GDD-14-TUNNEL-LIGHT-ADAPTATION covers projected visual adaptation from
+  authored tunnel hazard metadata.
+- Uncovered adjacent requirements: heat shimmer remains a future weather
+  slice, and tunnel audio remains under the sound backlog.
+
+### Followups created
+None.
+
+### GDD edits
+None.
+
 ## 2026-04-28: Slice: Weather state transitions
 
 **GDD sections touched:**

--- a/src/render/__tests__/pseudoRoadCanvas.test.ts
+++ b/src/render/__tests__/pseudoRoadCanvas.test.ts
@@ -34,6 +34,10 @@ import {
   PLAYER_CAR_DEFAULT_WINDSHIELD,
   PLAYER_CAR_HEIGHT_FRACTION,
   PLAYER_CAR_WIDTH_TO_HEIGHT,
+  TUNNEL_ADAPTATION_HIGHLIGHT_FILL,
+  TUNNEL_ADAPTATION_HIGHLIGHT_MAX_ALPHA,
+  TUNNEL_ADAPTATION_MAX_ALPHA,
+  TUNNEL_ADAPTATION_OVERLAY_FILL,
   WEATHER_EFFECT_REDUCTION_SCALE,
   drawRoad,
   type DrawRoadOptions,
@@ -711,6 +715,117 @@ describe("drawRoad roadside sprites", () => {
     const fills = spy.calls.filter((c): c is FillCall => c.type === "fill");
     expect(fills.some((call) => call.fillStyle === "#245c2f")).toBe(false);
     expect(fills.some((call) => call.fillStyle === "#2f7a3a")).toBe(false);
+  });
+});
+
+describe("drawRoad tunnel adaptation", () => {
+  it("darkens the world view when projected strips include a visible tunnel hazard", () => {
+    const spy = makeCanvasSpy();
+    const strips: readonly Strip[] = [
+      strip({
+        screenY: 430,
+        screenW: 220,
+        segment: { ...strip({}).segment, index: 0, hazardIds: ["tunnel"] },
+      }),
+      strip({
+        screenY: 330,
+        screenW: 120,
+        segment: { ...strip({}).segment, index: 1, hazardIds: ["tunnel"] },
+      }),
+      strip({
+        screenY: 250,
+        screenW: 70,
+        segment: { ...strip({}).segment, index: 2, hazardIds: [] },
+      }),
+    ];
+
+    drawRoad(spy.ctx, strips, VIEWPORT, {});
+
+    const overlay = spy.calls.find(
+      (call): call is FillRectCall =>
+        call.type === "fillRect" &&
+        call.fillStyle === TUNNEL_ADAPTATION_OVERLAY_FILL,
+    );
+    expect(overlay).toBeDefined();
+    expect(overlay!.x).toBe(0);
+    expect(overlay!.y).toBe(0);
+    expect(overlay!.w).toBe(VIEWPORT.width);
+    expect(overlay!.h).toBe(VIEWPORT.height);
+    expect(overlay!.globalAlpha).toBeCloseTo(TUNNEL_ADAPTATION_MAX_ALPHA, 6);
+
+    const highlight = spy.calls.find(
+      (call): call is FillRectCall =>
+        call.type === "fillRect" &&
+        call.fillStyle === TUNNEL_ADAPTATION_HIGHLIGHT_FILL,
+    );
+    expect(highlight).toBeDefined();
+    expect(highlight!.globalAlpha).toBeCloseTo(
+      TUNNEL_ADAPTATION_HIGHLIGHT_MAX_ALPHA,
+      6,
+    );
+    expect(spy.finalAlpha()).toBeCloseTo(1, 6);
+  });
+
+  it("skips tunnel adaptation when no visible tunnel strip is projected", () => {
+    const spy = makeCanvasSpy();
+    const strips: readonly Strip[] = [
+      strip({
+        screenY: 430,
+        screenW: 220,
+        segment: { ...strip({}).segment, index: 0, hazardIds: ["tunnel"] },
+        visible: false,
+      }),
+      strip({
+        screenY: 330,
+        screenW: 120,
+        segment: { ...strip({}).segment, index: 1, hazardIds: [] },
+      }),
+    ];
+
+    drawRoad(spy.ctx, strips, VIEWPORT, {});
+
+    expect(
+      spy.calls.some(
+        (call) =>
+          call.type === "fillRect" &&
+          call.fillStyle === TUNNEL_ADAPTATION_OVERLAY_FILL,
+      ),
+    ).toBe(false);
+    expect(
+      spy.calls.some(
+        (call) =>
+          call.type === "fillRect" &&
+          call.fillStyle === TUNNEL_ADAPTATION_HIGHLIGHT_FILL,
+      ),
+    ).toBe(false);
+  });
+
+  it("can be disabled by the caller for debug captures", () => {
+    const spy = makeCanvasSpy();
+    const strips: readonly Strip[] = [
+      strip({
+        screenY: 430,
+        screenW: 220,
+        segment: { ...strip({}).segment, index: 0, hazardIds: ["tunnel"] },
+      }),
+      strip({
+        screenY: 330,
+        screenW: 120,
+        segment: { ...strip({}).segment, index: 1, hazardIds: ["tunnel"] },
+      }),
+    ];
+
+    drawRoad(spy.ctx, strips, VIEWPORT, {
+      tunnelAdaptation: { enabled: false },
+    });
+
+    expect(
+      spy.calls.some(
+        (call) =>
+          call.type === "fillRect" &&
+          call.fillStyle === TUNNEL_ADAPTATION_OVERLAY_FILL,
+      ),
+    ).toBe(false);
   });
 });
 

--- a/src/render/pseudoRoadCanvas.ts
+++ b/src/render/pseudoRoadCanvas.ts
@@ -76,6 +76,10 @@ export const PLAYER_CAR_DEFAULT_SPRITE_ID = "sparrow_clean";
 export const ROADSIDE_DRAW_PERIOD = 10;
 export const ROADSIDE_MAX_HEIGHT_FRACTION = 0.22;
 export const WEATHER_EFFECT_REDUCTION_SCALE = 0.35;
+export const TUNNEL_ADAPTATION_OVERLAY_FILL = "#05070d";
+export const TUNNEL_ADAPTATION_HIGHLIGHT_FILL = "#f2e18a";
+export const TUNNEL_ADAPTATION_MAX_ALPHA = 0.38;
+export const TUNNEL_ADAPTATION_HIGHLIGHT_MAX_ALPHA = 0.24;
 const LANE_DASH_CYCLE_METERS = LANE_STRIPE_LEN * SEGMENT_LENGTH;
 const LANE_DASH_VISIBLE_METERS = SEGMENT_LENGTH * 2;
 
@@ -141,6 +145,17 @@ export interface DrawRoadOptions {
     highContrastRoadsideSigns?: boolean;
     fogFloorClamp?: number;
     flashReduction?: boolean;
+  };
+  /**
+   * Optional tunnel light-adaptation pass. Authored tunnel hazard IDs are
+   * compiled onto strips, and the renderer darkens the world view when a
+   * visible tunnel strip is in the projected road. This keeps tunnel
+   * metadata visual-only while collision logic continues to ignore tunnel
+   * hazards.
+   */
+  tunnelAdaptation?: {
+    enabled?: boolean;
+    intensityScale?: number;
   };
   /**
    * Optional ghost car overlay per F-022. The §6 Time Trial flow drives
@@ -314,6 +329,8 @@ export function drawRoad(
       );
     }
   }
+
+  drawTunnelAdaptation(ctx, strips, viewport, options.tunnelAdaptation);
 
   // Ghost car paints over the road strips so the player sees their best
   // line, but BEFORE the dust pool so off-road dust the live car kicks
@@ -539,6 +556,46 @@ function drawWeatherEffects(
     case "overcast":
       return;
   }
+}
+
+function drawTunnelAdaptation(
+  ctx: CanvasRenderingContext2D,
+  strips: readonly Strip[],
+  viewport: Viewport,
+  options: DrawRoadOptions["tunnelAdaptation"],
+): void {
+  if (options?.enabled === false) return;
+  if (viewport.width <= 0 || viewport.height <= 0) return;
+  const intensity = tunnelAdaptationIntensity(strips) * clampUnit(options?.intensityScale ?? 1);
+  if (intensity <= 0) return;
+
+  const prevFill = ctx.fillStyle;
+  const prevAlpha = ctx.globalAlpha;
+  try {
+    ctx.globalAlpha = TUNNEL_ADAPTATION_MAX_ALPHA * intensity;
+    ctx.fillStyle = TUNNEL_ADAPTATION_OVERLAY_FILL;
+    ctx.fillRect(0, 0, viewport.width, viewport.height);
+
+    ctx.globalAlpha = TUNNEL_ADAPTATION_HIGHLIGHT_MAX_ALPHA * intensity;
+    ctx.fillStyle = TUNNEL_ADAPTATION_HIGHLIGHT_FILL;
+    const bandHeight = Math.max(2, viewport.height * 0.018);
+    ctx.fillRect(0, viewport.height * 0.22, viewport.width, bandHeight);
+  } finally {
+    ctx.fillStyle = prevFill;
+    ctx.globalAlpha = prevAlpha;
+  }
+}
+
+function tunnelAdaptationIntensity(strips: readonly Strip[]): number {
+  let visible = 0;
+  let tunnel = 0;
+  for (const strip of strips) {
+    if (!strip.visible) continue;
+    visible += 1;
+    if (strip.segment.hazardIds.includes("tunnel")) tunnel += 1;
+  }
+  if (visible === 0 || tunnel === 0) return 0;
+  return 0.55 + Math.min(0.45, tunnel / visible);
 }
 
 interface ResolvedWeatherEffectSettings {

--- a/src/render/pseudoRoadCanvas.ts
+++ b/src/render/pseudoRoadCanvas.ts
@@ -330,8 +330,6 @@ export function drawRoad(
     }
   }
 
-  drawTunnelAdaptation(ctx, strips, viewport, options.tunnelAdaptation);
-
   // Ghost car paints over the road strips so the player sees their best
   // line, but BEFORE the dust pool so off-road dust the live car kicks
   // up still occludes the ghost rather than the ghost showing through
@@ -353,6 +351,8 @@ export function drawRoad(
   if (options.weatherEffects) {
     drawWeatherEffects(ctx, viewport, options.weatherEffects);
   }
+
+  drawTunnelAdaptation(ctx, strips, viewport, options.tunnelAdaptation);
 
   if (options.playerCar) {
     drawPlayerCar(ctx, options.playerCar, viewport);


### PR DESCRIPTION
## Summary
- render tunnel light adaptation from projected tunnel hazard metadata
- keep tunnel hazards as visual metadata while gameplay collision remains unchanged
- add renderer coverage and GDD coverage ledger entry

## GDD
- docs/gdd/09-track-design.md
- docs/gdd/14-weather-and-environmental-systems.md
- docs/gdd/16-rendering-and-visual-design.md
- docs/gdd/22-data-schemas.md

## Progress log
- docs/PROGRESS_LOG.md: 2026-04-28 Tunnel light adaptation

## Test plan
- npx vitest run src/render/__tests__/pseudoRoadCanvas.test.ts
- npm run typecheck
- npm run lint
- npm run content-lint
- npm run verify
- npm run test:e2e

## Followups
- Tunnel audio remains under VibeGear2-implement-sound-music-1611f9dd
