### PR TITLE
feat(render): add heat shimmer effect

### DIFF
--- a/docs/GDD_COVERAGE.json
+++ b/docs/GDD_COVERAGE.json
@@ -161,6 +161,26 @@
       ]
     },
     {
+      "id": "GDD-14-HEAT-SHIMMER",
+      "gddSections": [
+        "docs/gdd/14-weather-and-environmental-systems.md",
+        "docs/gdd/17-art-direction.md",
+        "docs/gdd/24-content-plan.md"
+      ],
+      "requirement": "Desert tour races can enable a deterministic heat shimmer visual pass without consuming random state or changing gameplay physics.",
+      "coverage": ["implemented-code", "automated-test"],
+      "implementationRefs": [
+        "src/render/pseudoRoadCanvas.ts",
+        "src/app/race/page.tsx"
+      ],
+      "testRefs": [
+        "src/render/__tests__/pseudoRoadCanvas.test.ts"
+      ],
+      "followupRefs": [
+        "VibeGear2-implement-region-art-43d6f582"
+      ]
+    },
+    {
       "id": "GDD-21-RNG-CONSUMERS",
       "gddSections": [
         "docs/gdd/15-cpu-opponents-and-ai.md",

--- a/docs/PROGRESS_LOG.md
+++ b/docs/PROGRESS_LOG.md
@@ -6,6 +6,53 @@ Correct them by adding a new entry that references the old one.
 
 ---
 
+## 2026-04-28: Slice: Heat shimmer renderer
+
+**GDD sections touched:**
+[§14](gdd/14-weather-and-environmental-systems.md) heat shimmer in
+desert tours,
+[§17](gdd/17-art-direction.md) region visual packages,
+[§24](gdd/24-content-plan.md) Ember Steppe desert tour.
+**Branch / PR:** `feat/heat-shimmer-renderer`, PR pending.
+**Status:** Implemented.
+
+### Done
+- `src/render/pseudoRoadCanvas.ts`: added a deterministic heat shimmer
+  screen-space pass controlled by `DrawRoadOptions.heatShimmer`.
+- `src/app/race/page.tsx`: enables the pass for the authored
+  `ember-steppe` tour hook using camera z as the phase source.
+- `src/render/__tests__/pseudoRoadCanvas.test.ts`: covered enabled,
+  phase-drifting, and disabled shimmer behavior.
+- `docs/GDD_COVERAGE.json`: added GDD-14-HEAT-SHIMMER.
+
+### Verified
+- `npx vitest run src/render/__tests__/pseudoRoadCanvas.test.ts` green,
+  44 passed.
+- `npm run typecheck` clean.
+- `npm run lint` clean.
+- `npm run content-lint` clean.
+- `npm run verify` green, 2359 passed.
+- `npm run test:e2e` green, 71 passed.
+
+### Decisions and assumptions
+- The shimmer pass is visual only and does not consume RNG or alter
+  physics. It uses camera z for deterministic drift.
+- Full Ember Steppe art assets remain under the region art backlog; this
+  slice only ships the §14 effect hook and renderer behavior.
+
+### Coverage ledger
+- GDD-14-HEAT-SHIMMER covers the heat shimmer effect path for desert
+  tours.
+- Uncovered adjacent requirements: snow roadside whitening, road sheen,
+  weather collision-risk tuning, surface-temperature display, and full
+  region art packages remain future slices.
+
+### Followups created
+None.
+
+### GDD edits
+None.
+
 ## 2026-04-28: Slice: Tunnel light adaptation
 
 **GDD sections touched:**

--- a/src/app/race/page.tsx
+++ b/src/app/race/page.tsx
@@ -948,6 +948,10 @@ function RaceCanvas({
             flashReduction:
               persistedSettings.accessibility?.weatherFlashReduction,
           },
+          heatShimmer:
+            tourContext?.tourId === "ember-steppe"
+              ? { enabled: true, phaseMeters: camera.z }
+              : undefined,
           ghostCar: ghostOverlayRef.current
             ? {
                 ...ghostOverlayRef.current,

--- a/src/render/__tests__/pseudoRoadCanvas.test.ts
+++ b/src/render/__tests__/pseudoRoadCanvas.test.ts
@@ -26,6 +26,9 @@ import type { LoadedAtlas } from "../spriteAtlas";
 import {
   GHOST_CAR_DEFAULT_ALPHA,
   GHOST_CAR_DEFAULT_FILL,
+  HEAT_SHIMMER_BAND_COUNT,
+  HEAT_SHIMMER_FILL,
+  HEAT_SHIMMER_MAX_ALPHA,
   PLAYER_CAR_DEFAULT_FILL,
   PLAYER_CAR_DEFAULT_SHADOW,
   PLAYER_CAR_DEFAULT_SPRITE_ID,
@@ -824,6 +827,67 @@ describe("drawRoad tunnel adaptation", () => {
         (call) =>
           call.type === "fillRect" &&
           call.fillStyle === TUNNEL_ADAPTATION_OVERLAY_FILL,
+      ),
+    ).toBe(false);
+  });
+});
+
+describe("drawRoad heat shimmer", () => {
+  it("paints deterministic horizon bands when the desert shimmer pass is enabled", () => {
+    const spy = makeCanvasSpy();
+    drawRoad(spy.ctx, EMPTY_STRIPS, VIEWPORT, {
+      heatShimmer: { enabled: true, phaseMeters: 120 },
+    });
+
+    const shimmerRects = spy.calls.filter(
+      (call): call is FillRectCall =>
+        call.type === "fillRect" && call.fillStyle === HEAT_SHIMMER_FILL,
+    );
+    expect(shimmerRects.length).toBeGreaterThanOrEqual(HEAT_SHIMMER_BAND_COUNT);
+    expect(shimmerRects[0]!.globalAlpha).toBeCloseTo(HEAT_SHIMMER_MAX_ALPHA, 6);
+    expect(shimmerRects[0]!.y).toBeCloseTo(VIEWPORT.height * 0.24, 6);
+    expect(spy.finalAlpha()).toBeCloseTo(1, 6);
+  });
+
+  it("drifts shimmer bands from the deterministic camera-z phase", () => {
+    const first = makeCanvasSpy();
+    const second = makeCanvasSpy();
+    drawRoad(first.ctx, EMPTY_STRIPS, VIEWPORT, {
+      heatShimmer: { enabled: true, phaseMeters: 0 },
+    });
+    drawRoad(second.ctx, EMPTY_STRIPS, VIEWPORT, {
+      heatShimmer: { enabled: true, phaseMeters: 240 },
+    });
+
+    const firstBand = first.calls.find(
+      (call): call is FillRectCall =>
+        call.type === "fillRect" && call.fillStyle === HEAT_SHIMMER_FILL,
+    );
+    const secondBand = second.calls.find(
+      (call): call is FillRectCall =>
+        call.type === "fillRect" && call.fillStyle === HEAT_SHIMMER_FILL,
+    );
+    expect(firstBand).toBeDefined();
+    expect(secondBand).toBeDefined();
+    expect(firstBand!.x).not.toBeCloseTo(secondBand!.x, 6);
+  });
+
+  it("skips heat shimmer when the pass is omitted or disabled", () => {
+    const omitted = makeCanvasSpy();
+    const disabled = makeCanvasSpy();
+    drawRoad(omitted.ctx, EMPTY_STRIPS, VIEWPORT, {});
+    drawRoad(disabled.ctx, EMPTY_STRIPS, VIEWPORT, {
+      heatShimmer: { enabled: false, phaseMeters: 120 },
+    });
+
+    expect(
+      omitted.calls.some(
+        (call) => call.type === "fillRect" && call.fillStyle === HEAT_SHIMMER_FILL,
+      ),
+    ).toBe(false);
+    expect(
+      disabled.calls.some(
+        (call) => call.type === "fillRect" && call.fillStyle === HEAT_SHIMMER_FILL,
       ),
     ).toBe(false);
   });

--- a/src/render/pseudoRoadCanvas.ts
+++ b/src/render/pseudoRoadCanvas.ts
@@ -80,6 +80,9 @@ export const TUNNEL_ADAPTATION_OVERLAY_FILL = "#05070d";
 export const TUNNEL_ADAPTATION_HIGHLIGHT_FILL = "#f2e18a";
 export const TUNNEL_ADAPTATION_MAX_ALPHA = 0.38;
 export const TUNNEL_ADAPTATION_HIGHLIGHT_MAX_ALPHA = 0.24;
+export const HEAT_SHIMMER_FILL = "#f4ddb0";
+export const HEAT_SHIMMER_MAX_ALPHA = 0.16;
+export const HEAT_SHIMMER_BAND_COUNT = 6;
 const LANE_DASH_CYCLE_METERS = LANE_STRIPE_LEN * SEGMENT_LENGTH;
 const LANE_DASH_VISIBLE_METERS = SEGMENT_LENGTH * 2;
 
@@ -156,6 +159,16 @@ export interface DrawRoadOptions {
   tunnelAdaptation?: {
     enabled?: boolean;
     intensityScale?: number;
+  };
+  /**
+   * Optional desert-tour heat shimmer pass for §14. The caller passes
+   * a deterministic phase from camera z so the bands drift with motion
+   * without consuming random state or changing physics.
+   */
+  heatShimmer?: {
+    enabled?: boolean;
+    intensity?: number;
+    phaseMeters?: number;
   };
   /**
    * Optional ghost car overlay per F-022. The §6 Time Trial flow drives
@@ -353,6 +366,7 @@ export function drawRoad(
   }
 
   drawTunnelAdaptation(ctx, strips, viewport, options.tunnelAdaptation);
+  drawHeatShimmer(ctx, viewport, options.heatShimmer);
 
   if (options.playerCar) {
     drawPlayerCar(ctx, options.playerCar, viewport);
@@ -596,6 +610,43 @@ function tunnelAdaptationIntensity(strips: readonly Strip[]): number {
   }
   if (visible === 0 || tunnel === 0) return 0;
   return 0.55 + Math.min(0.45, tunnel / visible);
+}
+
+function drawHeatShimmer(
+  ctx: CanvasRenderingContext2D,
+  viewport: Viewport,
+  options: DrawRoadOptions["heatShimmer"],
+): void {
+  if (options?.enabled !== true) return;
+  if (viewport.width <= 0 || viewport.height <= 0) return;
+  const intensity = clampUnit(options.intensity ?? 1);
+  if (intensity <= 0) return;
+  const phaseMeters =
+    typeof options.phaseMeters === "number" && Number.isFinite(options.phaseMeters)
+      ? options.phaseMeters
+      : 0;
+
+  const prevFill = ctx.fillStyle;
+  const prevAlpha = ctx.globalAlpha;
+  try {
+    ctx.fillStyle = HEAT_SHIMMER_FILL;
+    const segmentWidth = Math.max(24, viewport.width * 0.18);
+    const gap = segmentWidth * 0.92;
+    for (let i = 0; i < HEAT_SHIMMER_BAND_COUNT; i += 1) {
+      const y = viewport.height * (0.24 + i * 0.033);
+      const h = Math.max(1, viewport.height * (0.004 + i * 0.0007));
+      const drift =
+        (((phaseMeters * 0.22 + i * 37) % (segmentWidth + gap)) + segmentWidth + gap) %
+        (segmentWidth + gap);
+      ctx.globalAlpha = HEAT_SHIMMER_MAX_ALPHA * intensity * (1 - i * 0.08);
+      for (let x = -segmentWidth + drift; x < viewport.width; x += segmentWidth + gap) {
+        ctx.fillRect(x, y, segmentWidth, h);
+      }
+    }
+  } finally {
+    ctx.fillStyle = prevFill;
+    ctx.globalAlpha = prevAlpha;
+  }
 }
 
 interface ResolvedWeatherEffectSettings {

--- a/src/render/pseudoRoadCanvas.ts
+++ b/src/render/pseudoRoadCanvas.ts
@@ -365,8 +365,8 @@ export function drawRoad(
     drawWeatherEffects(ctx, viewport, options.weatherEffects);
   }
 
-  drawTunnelAdaptation(ctx, strips, viewport, options.tunnelAdaptation);
   drawHeatShimmer(ctx, viewport, options.heatShimmer);
+  drawTunnelAdaptation(ctx, strips, viewport, options.tunnelAdaptation);
 
   if (options.playerCar) {
     drawPlayerCar(ctx, options.playerCar, viewport);


### PR DESCRIPTION
## Summary
- add deterministic heat shimmer bands to the pseudo road renderer
- enable the shimmer pass for the authored Ember Steppe tour hook
- add renderer coverage and GDD coverage ledger entry

## GDD
- docs/gdd/14-weather-and-environmental-systems.md
- docs/gdd/17-art-direction.md
- docs/gdd/24-content-plan.md

## Progress log
- docs/PROGRESS_LOG.md: 2026-04-28 Heat shimmer renderer

## Test plan
- npx vitest run src/render/__tests__/pseudoRoadCanvas.test.ts
- npm run typecheck
- npm run lint
- npm run content-lint
- npm run verify
- npm run test:e2e

## Followups
- Full Ember Steppe art package remains under VibeGear2-implement-region-art-43d6f582
