### PR TITLE
feat(render): add rain road sheen

### DIFF
--- a/docs/GDD_COVERAGE.json
+++ b/docs/GDD_COVERAGE.json
@@ -181,6 +181,22 @@
       ]
     },
     {
+      "id": "GDD-14-RAIN-ROAD-SHEEN",
+      "gddSections": [
+        "docs/gdd/14-weather-and-environmental-systems.md",
+        "docs/gdd/16-rendering-and-visual-design.md"
+      ],
+      "requirement": "Rain weather paints deterministic wet-road sheen alongside rain streaks, with accessibility weather intensity controls scaling the effect.",
+      "coverage": ["implemented-code", "automated-test"],
+      "implementationRefs": [
+        "src/render/pseudoRoadCanvas.ts"
+      ],
+      "testRefs": [
+        "src/render/__tests__/pseudoRoadCanvas.test.ts"
+      ],
+      "followupRefs": []
+    },
+    {
       "id": "GDD-21-RNG-CONSUMERS",
       "gddSections": [
         "docs/gdd/15-cpu-opponents-and-ai.md",

--- a/docs/PROGRESS_LOG.md
+++ b/docs/PROGRESS_LOG.md
@@ -26,11 +26,11 @@ road sheen,
 
 ### Verified
 - `npx vitest run src/render/__tests__/pseudoRoadCanvas.test.ts` green,
-  45 passed.
+  47 passed.
 - `npm run typecheck` clean.
 - `npm run lint` clean.
 - `npm run content-lint` clean.
-- `npm run verify` green, 2360 passed.
+- `npm run verify` green, 2362 passed.
 - `npm run test:e2e` green, 71 passed.
 
 ### Decisions and assumptions

--- a/docs/PROGRESS_LOG.md
+++ b/docs/PROGRESS_LOG.md
@@ -6,6 +6,53 @@ Correct them by adding a new entry that references the old one.
 
 ---
 
+## 2026-04-28: Slice: Rain road sheen renderer
+
+**GDD sections touched:**
+[§14](gdd/14-weather-and-environmental-systems.md) rain streaks and
+road sheen,
+[§16](gdd/16-rendering-and-visual-design.md) weather visual feedback.
+**Branch / PR:** `feat/rain-road-sheen`, PR pending.
+**Status:** Implemented.
+
+### Done
+- `src/render/pseudoRoadCanvas.ts`: added deterministic wet-road sheen
+  for rain weather and kept it scaled by the existing weather visual
+  intensity controls.
+- `src/render/__tests__/pseudoRoadCanvas.test.ts`: covered sheen
+  geometry, heavy-rain alpha, accessibility reduction, particle-intensity
+  reduction, and disabled rain visuals.
+- `docs/GDD_COVERAGE.json`: added GDD-14-RAIN-ROAD-SHEEN.
+
+### Verified
+- `npx vitest run src/render/__tests__/pseudoRoadCanvas.test.ts` green,
+  45 passed.
+- `npm run typecheck` clean.
+- `npm run lint` clean.
+- `npm run content-lint` clean.
+- `npm run verify` green, 2360 passed.
+- `npm run test:e2e` green, 71 passed.
+
+### Decisions and assumptions
+- Road sheen is visual only. It shares the rain effect intensity so the
+  weather accessibility controls reduce both streaks and wet-road glare
+  together.
+- The sheen pass uses a distinct fill from rain streaks so tests can
+  assert both effects independently.
+
+### Coverage ledger
+- GDD-14-RAIN-ROAD-SHEEN covers the road-sheen portion of rainy weather
+  presentation.
+- Uncovered adjacent requirements: snow roadside whitening, weather
+  collision-risk tuning, surface-temperature display, and full region art
+  packages remain future slices.
+
+### Followups created
+None.
+
+### GDD edits
+None.
+
 ## 2026-04-28: Slice: Heat shimmer renderer
 
 **GDD sections touched:**

--- a/src/render/__tests__/pseudoRoadCanvas.test.ts
+++ b/src/render/__tests__/pseudoRoadCanvas.test.ts
@@ -37,6 +37,8 @@ import {
   PLAYER_CAR_DEFAULT_WINDSHIELD,
   PLAYER_CAR_HEIGHT_FRACTION,
   PLAYER_CAR_WIDTH_TO_HEIGHT,
+  RAIN_ROAD_SHEEN_FILL,
+  RAIN_ROAD_SHEEN_MAX_ALPHA,
   TUNNEL_ADAPTATION_HIGHLIGHT_FILL,
   TUNNEL_ADAPTATION_HIGHLIGHT_MAX_ALPHA,
   TUNNEL_ADAPTATION_MAX_ALPHA,
@@ -1061,6 +1063,16 @@ describe("drawRoad weather effects", () => {
       (c): c is FillRectCall =>
         c.type === "fillRect" && c.fillStyle === "#cfefff",
     );
+    const sheen = spy.calls.filter(
+      (c): c is FillRectCall =>
+        c.type === "fillRect" && c.fillStyle === RAIN_ROAD_SHEEN_FILL,
+    );
+    expect(sheen).toHaveLength(2);
+    expect(sheen[0]!.globalAlpha).toBeCloseTo(RAIN_ROAD_SHEEN_MAX_ALPHA, 6);
+    expect(sheen[0]!.x).toBeCloseTo(VIEWPORT.width * 0.08, 6);
+    expect(sheen[0]!.y).toBeCloseTo(VIEWPORT.height * 0.62, 6);
+    expect(sheen[0]!.w).toBeCloseTo(VIEWPORT.width * 0.84, 6);
+    expect(sheen[1]!.globalAlpha).toBeCloseTo(RAIN_ROAD_SHEEN_MAX_ALPHA * 0.55, 6);
     expect(streaks).toHaveLength(92);
     expect(streaks[0]!.globalAlpha).toBeCloseTo(0.34, 6);
     expect(streaks[0]!.w).toBe(2);
@@ -1077,6 +1089,15 @@ describe("drawRoad weather effects", () => {
     const streaks = spy.calls.filter(
       (c): c is FillRectCall =>
         c.type === "fillRect" && c.fillStyle === "#cfefff",
+    );
+    const sheen = spy.calls.filter(
+      (c): c is FillRectCall =>
+        c.type === "fillRect" && c.fillStyle === RAIN_ROAD_SHEEN_FILL,
+    );
+    expect(sheen).toHaveLength(2);
+    expect(sheen[0]!.globalAlpha).toBeCloseTo(
+      RAIN_ROAD_SHEEN_MAX_ALPHA * WEATHER_EFFECT_REDUCTION_SCALE,
+      6,
     );
     expect(streaks).toHaveLength(Math.round(92 * WEATHER_EFFECT_REDUCTION_SCALE));
     expect(streaks[0]!.globalAlpha).toBeCloseTo(
@@ -1095,6 +1116,12 @@ describe("drawRoad weather effects", () => {
       (c): c is FillRectCall =>
         c.type === "fillRect" && c.fillStyle === "#cfefff",
     );
+    const sheen = spy.calls.filter(
+      (c): c is FillRectCall =>
+        c.type === "fillRect" && c.fillStyle === RAIN_ROAD_SHEEN_FILL,
+    );
+    expect(sheen).toHaveLength(2);
+    expect(sheen[0]!.globalAlpha).toBeCloseTo(RAIN_ROAD_SHEEN_MAX_ALPHA * 0.5, 6);
     expect(streaks).toHaveLength(Math.round(92 * 0.5));
     expect(streaks[0]!.globalAlpha).toBeCloseTo(0.34 * 0.5, 6);
   });
@@ -1109,6 +1136,26 @@ describe("drawRoad weather effects", () => {
       spy.calls.some(
         (c): c is FillRectCall =>
           c.type === "fillRect" && c.fillStyle === "#f4fbff",
+      ),
+    ).toBe(false);
+  });
+
+  it("allows rain streaks and sheen to be disabled", () => {
+    const spy = makeCanvasSpy();
+    drawRoad(spy.ctx, EMPTY_STRIPS, VIEWPORT, {
+      weatherEffects: { weather: "heavy_rain", particleIntensity: 0 },
+    });
+
+    expect(
+      spy.calls.some(
+        (c): c is FillRectCall =>
+          c.type === "fillRect" && c.fillStyle === "#cfefff",
+      ),
+    ).toBe(false);
+    expect(
+      spy.calls.some(
+        (c): c is FillRectCall =>
+          c.type === "fillRect" && c.fillStyle === RAIN_ROAD_SHEEN_FILL,
       ),
     ).toBe(false);
   });

--- a/src/render/__tests__/pseudoRoadCanvas.test.ts
+++ b/src/render/__tests__/pseudoRoadCanvas.test.ts
@@ -1080,6 +1080,42 @@ describe("drawRoad weather effects", () => {
     expect(spy.finalAlpha()).toBeCloseTo(1, 6);
   });
 
+  it("scales road sheen for standard rain", () => {
+    const spy = makeCanvasSpy();
+    drawRoad(spy.ctx, EMPTY_STRIPS, VIEWPORT, {
+      weatherEffects: { weather: "rain" },
+    });
+
+    const sheen = spy.calls.filter(
+      (c): c is FillRectCall =>
+        c.type === "fillRect" && c.fillStyle === RAIN_ROAD_SHEEN_FILL,
+    );
+    expect(sheen).toHaveLength(2);
+    expect(sheen[0]!.globalAlpha).toBeCloseTo(RAIN_ROAD_SHEEN_MAX_ALPHA * 0.72, 6);
+    expect(sheen[1]!.globalAlpha).toBeCloseTo(
+      RAIN_ROAD_SHEEN_MAX_ALPHA * 0.72 * 0.55,
+      6,
+    );
+  });
+
+  it("scales road sheen for light rain", () => {
+    const spy = makeCanvasSpy();
+    drawRoad(spy.ctx, EMPTY_STRIPS, VIEWPORT, {
+      weatherEffects: { weather: "light_rain" },
+    });
+
+    const sheen = spy.calls.filter(
+      (c): c is FillRectCall =>
+        c.type === "fillRect" && c.fillStyle === RAIN_ROAD_SHEEN_FILL,
+    );
+    expect(sheen).toHaveLength(2);
+    expect(sheen[0]!.globalAlpha).toBeCloseTo(RAIN_ROAD_SHEEN_MAX_ALPHA * 0.45, 6);
+    expect(sheen[1]!.globalAlpha).toBeCloseTo(
+      RAIN_ROAD_SHEEN_MAX_ALPHA * 0.45 * 0.55,
+      6,
+    );
+  });
+
   it("reduces rain density when visual weather reduction is enabled", () => {
     const spy = makeCanvasSpy();
     drawRoad(spy.ctx, EMPTY_STRIPS, VIEWPORT, {

--- a/src/render/pseudoRoadCanvas.ts
+++ b/src/render/pseudoRoadCanvas.ts
@@ -83,6 +83,8 @@ export const TUNNEL_ADAPTATION_HIGHLIGHT_MAX_ALPHA = 0.24;
 export const HEAT_SHIMMER_FILL = "#f4ddb0";
 export const HEAT_SHIMMER_MAX_ALPHA = 0.16;
 export const HEAT_SHIMMER_BAND_COUNT = 6;
+export const RAIN_ROAD_SHEEN_FILL = "#d8f4ff";
+export const RAIN_ROAD_SHEEN_MAX_ALPHA = 0.16;
 const LANE_DASH_CYCLE_METERS = LANE_STRIPE_LEN * SEGMENT_LENGTH;
 const LANE_DASH_VISIBLE_METERS = SEGMENT_LENGTH * 2;
 
@@ -554,7 +556,7 @@ function drawWeatherEffects(
     case "light_rain":
     case "rain":
     case "heavy_rain":
-      drawRainStreaks(ctx, viewport, effects.weather, settings.particleIntensity);
+      drawRainEffects(ctx, viewport, effects.weather, settings.particleIntensity);
       return;
     case "snow":
       drawSnowParticles(ctx, viewport, settings.particleIntensity);
@@ -671,6 +673,51 @@ function resolveWeatherEffectSettings(
     fogFloorClamp: clampUnit(effects.fogFloorClamp ?? 0),
     bloomScale: reductionScale * glareScale * flashScale,
   };
+}
+
+function drawRainEffects(
+  ctx: CanvasRenderingContext2D,
+  viewport: Viewport,
+  weather: Extract<WeatherOption, "light_rain" | "rain" | "heavy_rain">,
+  intensity: number,
+): void {
+  if (intensity <= 0) return;
+  drawRainRoadSheen(ctx, viewport, weather, intensity);
+  drawRainStreaks(ctx, viewport, weather, intensity);
+}
+
+function drawRainRoadSheen(
+  ctx: CanvasRenderingContext2D,
+  viewport: Viewport,
+  weather: Extract<WeatherOption, "light_rain" | "rain" | "heavy_rain">,
+  intensity: number,
+): void {
+  const weatherScale = weather === "heavy_rain" ? 1 : weather === "rain" ? 0.72 : 0.45;
+  const alpha = RAIN_ROAD_SHEEN_MAX_ALPHA * weatherScale * intensity;
+  if (alpha <= 0) return;
+
+  const prevFill = ctx.fillStyle;
+  const prevAlpha = ctx.globalAlpha;
+  try {
+    ctx.fillStyle = RAIN_ROAD_SHEEN_FILL;
+    ctx.globalAlpha = alpha;
+    ctx.fillRect(
+      viewport.width * 0.08,
+      viewport.height * 0.62,
+      viewport.width * 0.84,
+      viewport.height * 0.075,
+    );
+    ctx.globalAlpha = alpha * 0.55;
+    ctx.fillRect(
+      viewport.width * 0.18,
+      viewport.height * 0.78,
+      viewport.width * 0.64,
+      viewport.height * 0.045,
+    );
+  } finally {
+    ctx.fillStyle = prevFill;
+    ctx.globalAlpha = prevAlpha;
+  }
 }
 
 function drawRainStreaks(


### PR DESCRIPTION
## Summary
- Add deterministic wet-road sheen for rain weather in the pseudo-road renderer
- Scale sheen with the existing weather visual intensity controls
- Add renderer tests and GDD coverage for GDD-14-RAIN-ROAD-SHEEN

## GDD
- docs/gdd/14-weather-and-environmental-systems.md
- docs/gdd/16-rendering-and-visual-design.md

## Progress log
- docs/PROGRESS_LOG.md: 2026-04-28 Slice: Rain road sheen renderer

## Test plan
- npx vitest run src/render/__tests__/pseudoRoadCanvas.test.ts
- npm run typecheck
- npm run lint
- npm run content-lint
- npm run verify
- npm run test:e2e

## Followups
- Snow roadside whitening, weather collision-risk tuning, surface-temperature display, and full region art packages remain future weather slices.