### PR TITLE
feat(render): add snow roadside whitening

### DIFF
--- a/docs/GDD_COVERAGE.json
+++ b/docs/GDD_COVERAGE.json
@@ -197,6 +197,22 @@
       "followupRefs": []
     },
     {
+      "id": "GDD-14-SNOW-ROADSIDE-WHITENING",
+      "gddSections": [
+        "docs/gdd/14-weather-and-environmental-systems.md",
+        "docs/gdd/16-rendering-and-visual-design.md"
+      ],
+      "requirement": "Snow weather paints deterministic soft roadside whitening alongside snow particles, with accessibility weather intensity controls scaling the effect.",
+      "coverage": ["implemented-code", "automated-test"],
+      "implementationRefs": [
+        "src/render/pseudoRoadCanvas.ts"
+      ],
+      "testRefs": [
+        "src/render/__tests__/pseudoRoadCanvas.test.ts"
+      ],
+      "followupRefs": []
+    },
+    {
       "id": "GDD-21-RNG-CONSUMERS",
       "gddSections": [
         "docs/gdd/15-cpu-opponents-and-ai.md",

--- a/docs/PROGRESS_LOG.md
+++ b/docs/PROGRESS_LOG.md
@@ -6,6 +6,54 @@ Correct them by adding a new entry that references the old one.
 
 ---
 
+## 2026-04-28: Slice: Snow roadside whitening renderer
+
+**GDD sections touched:**
+[§14](gdd/14-weather-and-environmental-systems.md) snow particles and
+soft roadside whitening,
+[§16](gdd/16-rendering-and-visual-design.md) weather visual feedback.
+**Branch / PR:** `feat/snow-roadside-whitening`, PR pending.
+**Status:** Implemented.
+
+### Done
+- `src/render/pseudoRoadCanvas.ts`: added deterministic soft roadside
+  whitening for snow weather and kept it scaled by the existing weather
+  visual intensity controls.
+- `src/render/__tests__/pseudoRoadCanvas.test.ts`: covered whitening
+  geometry, snow alpha, accessibility reduction, and disabled snow
+  visuals.
+- `docs/GDD_COVERAGE.json`: added
+  GDD-14-SNOW-ROADSIDE-WHITENING.
+
+### Verified
+- `npx vitest run src/render/__tests__/pseudoRoadCanvas.test.ts` green,
+  48 passed.
+- `npm run verify` initially failed on a stale live `.next` source-map
+  scrub check. After `npm run test:e2e` rebuilt and scrubbed `.next`,
+  the rerun was green.
+- `npm run verify` green, 2363 passed.
+- `npm run test:e2e` green, 71 passed.
+
+### Decisions and assumptions
+- Roadside whitening is visual only. It shares the snow effect intensity
+  so weather accessibility controls reduce both flakes and roadside
+  whitening together.
+- The whitening pass uses a distinct fill from snow flakes so tests can
+  assert both effects independently.
+
+### Coverage ledger
+- GDD-14-SNOW-ROADSIDE-WHITENING covers the roadside whitening portion
+  of snow weather presentation.
+- Uncovered adjacent requirements: weather collision-risk tuning,
+  surface-temperature display, and full region art packages remain future
+  slices.
+
+### Followups created
+None.
+
+### GDD edits
+None.
+
 ## 2026-04-28: Slice: Rain road sheen renderer
 
 **GDD sections touched:**

--- a/src/render/__tests__/pseudoRoadCanvas.test.ts
+++ b/src/render/__tests__/pseudoRoadCanvas.test.ts
@@ -1204,7 +1204,7 @@ describe("drawRoad weather effects", () => {
     ).toBe(false);
   });
 
-  it("paints snow particles with reduced square sizes", () => {
+  it("paints snow particles and roadside whitening", () => {
     const spy = makeCanvasSpy();
     drawRoad(spy.ctx, EMPTY_STRIPS, VIEWPORT, {
       weatherEffects: { weather: "snow" },

--- a/src/render/__tests__/pseudoRoadCanvas.test.ts
+++ b/src/render/__tests__/pseudoRoadCanvas.test.ts
@@ -39,6 +39,8 @@ import {
   PLAYER_CAR_WIDTH_TO_HEIGHT,
   RAIN_ROAD_SHEEN_FILL,
   RAIN_ROAD_SHEEN_MAX_ALPHA,
+  SNOW_ROADSIDE_WHITENING_FILL,
+  SNOW_ROADSIDE_WHITENING_MAX_ALPHA,
   TUNNEL_ADAPTATION_HIGHLIGHT_FILL,
   TUNNEL_ADAPTATION_HIGHLIGHT_MAX_ALPHA,
   TUNNEL_ADAPTATION_MAX_ALPHA,
@@ -1174,6 +1176,12 @@ describe("drawRoad weather effects", () => {
           c.type === "fillRect" && c.fillStyle === "#f4fbff",
       ),
     ).toBe(false);
+    expect(
+      spy.calls.some(
+        (c): c is FillRectCall =>
+          c.type === "fillRect" && c.fillStyle === SNOW_ROADSIDE_WHITENING_FILL,
+      ),
+    ).toBe(false);
   });
 
   it("allows rain streaks and sheen to be disabled", () => {
@@ -1202,6 +1210,25 @@ describe("drawRoad weather effects", () => {
       weatherEffects: { weather: "snow" },
     });
 
+    const roadsideWhitening = spy.calls.filter(
+      (c): c is FillRectCall =>
+        c.type === "fillRect" && c.fillStyle === SNOW_ROADSIDE_WHITENING_FILL,
+    );
+    expect(roadsideWhitening).toHaveLength(3);
+    expect(roadsideWhitening[0]!.x).toBe(0);
+    expect(roadsideWhitening[0]!.y).toBeCloseTo(VIEWPORT.height * 0.42, 6);
+    expect(roadsideWhitening[0]!.w).toBe(VIEWPORT.width);
+    expect(roadsideWhitening[0]!.globalAlpha).toBeCloseTo(
+      SNOW_ROADSIDE_WHITENING_MAX_ALPHA * 0.65,
+      6,
+    );
+    expect(roadsideWhitening[1]!.w).toBeCloseTo(VIEWPORT.width * 0.2, 6);
+    expect(roadsideWhitening[2]!.x).toBeCloseTo(VIEWPORT.width * 0.8, 6);
+    expect(roadsideWhitening[1]!.globalAlpha).toBeCloseTo(
+      SNOW_ROADSIDE_WHITENING_MAX_ALPHA,
+      6,
+    );
+
     const flakes = spy.calls.filter(
       (c): c is FillRectCall =>
         c.type === "fillRect" && c.fillStyle === "#f4fbff",
@@ -1210,6 +1237,23 @@ describe("drawRoad weather effects", () => {
     expect(flakes[0]!.w).toBe(3);
     expect(flakes[1]!.w).toBe(2);
     expect(flakes[0]!.globalAlpha).toBeCloseTo(0.72, 6);
+  });
+
+  it("reduces snow roadside whitening with visual weather reduction", () => {
+    const spy = makeCanvasSpy();
+    drawRoad(spy.ctx, EMPTY_STRIPS, VIEWPORT, {
+      weatherEffects: { weather: "snow", visualReduction: true },
+    });
+
+    const roadsideWhitening = spy.calls.filter(
+      (c): c is FillRectCall =>
+        c.type === "fillRect" && c.fillStyle === SNOW_ROADSIDE_WHITENING_FILL,
+    );
+    expect(roadsideWhitening).toHaveLength(3);
+    expect(roadsideWhitening[1]!.globalAlpha).toBeCloseTo(
+      SNOW_ROADSIDE_WHITENING_MAX_ALPHA * WEATHER_EFFECT_REDUCTION_SCALE,
+      6,
+    );
   });
 
   it("paints fog as a draw-distance fade without changing clear weather", () => {

--- a/src/render/pseudoRoadCanvas.ts
+++ b/src/render/pseudoRoadCanvas.ts
@@ -85,6 +85,8 @@ export const HEAT_SHIMMER_MAX_ALPHA = 0.16;
 export const HEAT_SHIMMER_BAND_COUNT = 6;
 export const RAIN_ROAD_SHEEN_FILL = "#d8f4ff";
 export const RAIN_ROAD_SHEEN_MAX_ALPHA = 0.16;
+export const SNOW_ROADSIDE_WHITENING_FILL = "#edf7ff";
+export const SNOW_ROADSIDE_WHITENING_MAX_ALPHA = 0.2;
 const LANE_DASH_CYCLE_METERS = LANE_STRIPE_LEN * SEGMENT_LENGTH;
 const LANE_DASH_VISIBLE_METERS = SEGMENT_LENGTH * 2;
 
@@ -559,7 +561,7 @@ function drawWeatherEffects(
       drawRainEffects(ctx, viewport, effects.weather, settings.particleIntensity);
       return;
     case "snow":
-      drawSnowParticles(ctx, viewport, settings.particleIntensity);
+      drawSnowEffects(ctx, viewport, settings.particleIntensity);
       return;
     case "fog":
       drawFogFade(ctx, viewport, settings.alphaScale, settings.fogFloorClamp);
@@ -765,6 +767,44 @@ function drawSnowParticles(
       const y = (i * 53) % Math.max(1, viewport.height);
       ctx.fillRect(x, y, size, size);
     }
+  } finally {
+    ctx.fillStyle = prevFill;
+    ctx.globalAlpha = prevAlpha;
+  }
+}
+
+function drawSnowEffects(
+  ctx: CanvasRenderingContext2D,
+  viewport: Viewport,
+  intensity: number,
+): void {
+  if (intensity <= 0) return;
+  drawSnowRoadsideWhitening(ctx, viewport, intensity);
+  drawSnowParticles(ctx, viewport, intensity);
+}
+
+function drawSnowRoadsideWhitening(
+  ctx: CanvasRenderingContext2D,
+  viewport: Viewport,
+  intensity: number,
+): void {
+  const alpha = SNOW_ROADSIDE_WHITENING_MAX_ALPHA * intensity;
+  if (alpha <= 0) return;
+
+  const prevFill = ctx.fillStyle;
+  const prevAlpha = ctx.globalAlpha;
+  try {
+    ctx.fillStyle = SNOW_ROADSIDE_WHITENING_FILL;
+    ctx.globalAlpha = alpha * 0.65;
+    ctx.fillRect(0, viewport.height * 0.42, viewport.width, viewport.height * 0.08);
+    ctx.globalAlpha = alpha;
+    ctx.fillRect(0, viewport.height * 0.62, viewport.width * 0.2, viewport.height * 0.28);
+    ctx.fillRect(
+      viewport.width * 0.8,
+      viewport.height * 0.62,
+      viewport.width * 0.2,
+      viewport.height * 0.28,
+    );
   } finally {
     ctx.fillStyle = prevFill;
     ctx.globalAlpha = prevAlpha;


### PR DESCRIPTION
## Summary
- Add deterministic soft roadside whitening for snow weather in the pseudo-road renderer
- Scale whitening with the existing weather visual intensity controls
- Add renderer tests and GDD coverage for GDD-14-SNOW-ROADSIDE-WHITENING

## GDD
- docs/gdd/14-weather-and-environmental-systems.md
- docs/gdd/16-rendering-and-visual-design.md

## Progress log
- docs/PROGRESS_LOG.md: 2026-04-28 Slice: Snow roadside whitening renderer

## Test plan
- npx vitest run src/render/__tests__/pseudoRoadCanvas.test.ts
- npm run verify
- npm run test:e2e

## Notes
- The first verify run failed because an existing live .next source map still had a workspace prefix. Running e2e rebuilt and scrubbed .next, then verify passed.

## Followups
- Weather collision-risk tuning, surface-temperature display, and full region art packages remain future weather slices.