### PR TITLE
feat(weather): raise AI risk in low visibility

### DIFF
--- a/docs/GDD_COVERAGE.json
+++ b/docs/GDD_COVERAGE.json
@@ -118,6 +118,25 @@
       "followupRefs": []
     },
     {
+      "id": "GDD-14-VISIBILITY-AI-RISK",
+      "gddSections": [
+        "docs/gdd/14-weather-and-environmental-systems.md",
+        "docs/gdd/15-cpu-opponents-and-ai.md"
+      ],
+      "requirement": "Low-visibility weather increases deterministic AI lane-mistake pressure, with weather skill mitigating the extra risk.",
+      "coverage": ["implemented-code", "automated-test"],
+      "implementationRefs": [
+        "src/game/weather.ts",
+        "src/game/ai.ts",
+        "src/game/raceSession.ts"
+      ],
+      "testRefs": [
+        "src/game/__tests__/weather.test.ts",
+        "src/game/__tests__/ai.test.ts"
+      ],
+      "followupRefs": []
+    },
+    {
       "id": "GDD-14-WEATHER-STATE-MACHINE",
       "gddSections": [
         "docs/gdd/14-weather-and-environmental-systems.md",

--- a/docs/PROGRESS_LOG.md
+++ b/docs/PROGRESS_LOG.md
@@ -6,6 +6,50 @@ Correct them by adding a new entry that references the old one.
 
 ---
 
+## 2026-04-28: Slice: Weather visibility AI risk
+
+**GDD sections touched:**
+[§14](gdd/14-weather-and-environmental-systems.md) heavy weather
+collision risk from reduced visibility,
+[§15](gdd/15-cpu-opponents-and-ai.md) weather-aware CPU skill.
+**Branch / PR:** `feat/weather-visibility-ai-risk`, PR pending.
+**Status:** Implemented.
+
+### Done
+- `src/game/weather.ts`: added a deterministic visibility-risk scalar
+  derived from §14 visibility values and mitigated by AI weather skill.
+- `src/game/ai.ts`: applies that scalar to deterministic lane-target
+  mistake odds so fog, snow, night, and heavy weather can raise collision
+  risk without changing contact geometry.
+- `src/game/raceSession.ts`: wires active race weather and each driver's
+  compact weather-skill row into the AI risk scalar.
+- `docs/GDD_COVERAGE.json`: added GDD-14-VISIBILITY-AI-RISK.
+
+### Verified
+- `npx vitest run src/game/__tests__/weather.test.ts src/game/__tests__/ai.test.ts`
+  green, 111 passed.
+- `npm run verify` green, 2371 passed.
+- `npm run test:e2e` green, 71 passed.
+
+### Decisions and assumptions
+- Visibility risk changes AI line mistakes, not collision dimensions.
+  That keeps §13 hit geometry stable while still making low-visibility
+  races more dangerous through driver behavior.
+- Driver weather skill mitigates only the extra risk above baseline.
+  Unit weather skill preserves the raw `1 / visibility` scalar.
+
+### Coverage ledger
+- GDD-14-VISIBILITY-AI-RISK covers the runtime danger portion of §14
+  weather physics.
+- Uncovered adjacent requirements: full region art packages and sound
+  changes remain future slices.
+
+### Followups created
+None.
+
+### GDD edits
+None.
+
 ## 2026-04-28: Slice: Snow roadside whitening renderer
 
 **GDD sections touched:**

--- a/src/game/__tests__/ai.test.ts
+++ b/src/game/__tests__/ai.test.ts
@@ -578,6 +578,36 @@ describe("tickAI (§23 CPU difficulty mistakeScalar and recoveryScalar)", () => 
     expect(withMistakeRate.nextAiState.seed).not.toBe(7);
   });
 
+  it("low visibility produces more deterministic lane-target mistakes", () => {
+    const mistakeDriver: AIDriver = {
+      ...CLEAN_LINE_DRIVER,
+      mistakeRate: 0.2,
+    };
+    const countMistakes = (visibilityRiskScalar: number): number => {
+      let count = 0;
+      for (let seed = 1; seed <= 120; seed += 1) {
+        const result = tickAI(
+          mistakeDriver,
+          freshAi({ seed }),
+          freshCar({ speed: 20, z: seed * 6 }),
+          PLAYER_FAR_BEHIND,
+          STRAIGHT_TRACK,
+          RACING,
+          STARTER_STATS,
+          DEFAULT_AI_TRACK_CONTEXT,
+          0,
+          IDENTITY_CPU_MODIFIERS,
+          1,
+          visibilityRiskScalar,
+        );
+        if (result.input.steer !== 0) count += 1;
+      }
+      return count;
+    };
+
+    expect(countMistakes(2)).toBeGreaterThan(countMistakes(1));
+  });
+
   it("Master recovery term is larger than Easy under matched trailing gap", () => {
     const easyRecoveryOnly = {
       ...getCpuModifiers("easy"),

--- a/src/game/__tests__/weather.test.ts
+++ b/src/game/__tests__/weather.test.ts
@@ -30,6 +30,7 @@ import {
   stepWeatherState,
   visibilityForWeather,
   visibilityForWeatherState,
+  weatherVisibilityRiskScalar,
   weatherGripScalar,
   weatherGripScalarForState,
   weatherSkillFor,
@@ -271,6 +272,27 @@ describe("visibilityForWeather", () => {
       expect(visibilityForWeather(weather)).toBeCloseTo(expected, 9);
     },
   );
+});
+
+describe("weatherVisibilityRiskScalar", () => {
+  it.each([
+    ["clear", 1],
+    ["overcast", 1 / 0.95],
+    ["heavy_rain", 1 / 0.7],
+    ["fog", 2],
+    ["snow", 1 / 0.6],
+    ["night", 1 / 0.65],
+  ] as ReadonlyArray<readonly [WeatherOption, number]>)(
+    "maps %s visibility into AI mistake pressure",
+    (weather, expected) => {
+      expect(weatherVisibilityRiskScalar(weather)).toBeCloseTo(expected, 9);
+    },
+  );
+
+  it("lets weather skill mitigate the extra low-visibility pressure", () => {
+    expect(weatherVisibilityRiskScalar("fog", 2)).toBeCloseTo(1.5, 9);
+    expect(weatherVisibilityRiskScalar("fog", 0.5)).toBeCloseTo(3, 9);
+  });
 });
 
 describe("weatherSkillFor", () => {

--- a/src/game/ai.ts
+++ b/src/game/ai.ts
@@ -17,7 +17,20 @@
  *
  * The function is pure:
  *
- *   tickAI(driver, aiState, aiCar, player, track, race, dt)
+ *   tickAI(
+ *     driver,
+ *     aiState,
+ *     aiCar,
+ *     player,
+ *     track,
+ *     race,
+ *     stats,
+ *     context,
+ *     dt,
+ *     cpuModifiers,
+ *     weatherSkillScalar,
+ *     visibilityRiskScalar,
+ *   )
  *     -> { input, nextAiState }
  *
  * No globals or time source. Same arguments, including `AIState.seed`,
@@ -69,6 +82,7 @@ import { NEUTRAL_INPUT, type Input } from "./input";
 import type { CarState } from "./physics";
 import type { RaceState } from "./raceState";
 import { deserializeRng } from "./rng";
+import { WEATHER_VISIBILITY_RISK_MAX_SCALAR } from "./weather";
 
 /**
  * Identity §23 CPU modifiers row used as the default when a caller does
@@ -270,9 +284,9 @@ export function tickAI(
     context.roadHalfWidth,
   );
   const effectiveMistakeRate = clamp(
-    driver.mistakeRate *
+      driver.mistakeRate *
       cpuModifiers.mistakeScalar *
-      clamp(visibilityRiskScalar, 1, 3),
+      clamp(visibilityRiskScalar, 1, WEATHER_VISIBILITY_RISK_MAX_SCALAR),
     0,
     1,
   );

--- a/src/game/ai.ts
+++ b/src/game/ai.ts
@@ -41,6 +41,11 @@
  * a number rather than an adjusted modifiers object so the 60 Hz race
  * loop does not allocate one object per AI per tick.
  *
+ * Visibility-risk wiring: callers may pass a §14 low-visibility risk
+ * scalar resolved from active weather. It multiplies deterministic
+ * lane-target mistake odds so heavy weather and fog raise collision
+ * risk through poorer read distance without changing hit geometry.
+ *
  * Out of scope for this slice (deferred to follow-up AI dots):
  * - Overtake / lane-shift behaviour. §15 lists it; the clean_line single
  *   AI may collide with the player. Collision avoidance lands with the
@@ -240,6 +245,7 @@ export function tickAI(
   _dt: number = 0,
   cpuModifiers: Readonly<CpuDifficultyModifiers> = IDENTITY_CPU_MODIFIERS,
   weatherSkillScalar: number = 1,
+  visibilityRiskScalar: number = 1,
 ): AITickResult {
   const segment = currentSegment(track, aiCar.z);
   // `segment.curve` is the per-compiled-segment dx contribution, already
@@ -264,7 +270,9 @@ export function tickAI(
     context.roadHalfWidth,
   );
   const effectiveMistakeRate = clamp(
-    driver.mistakeRate * cpuModifiers.mistakeScalar,
+    driver.mistakeRate *
+      cpuModifiers.mistakeScalar *
+      clamp(visibilityRiskScalar, 1, 3),
     0,
     1,
   );

--- a/src/game/raceSession.ts
+++ b/src/game/raceSession.ts
@@ -104,6 +104,7 @@ import {
   activeWeatherForState,
   createWeatherState,
   stepWeatherState,
+  weatherVisibilityRiskScalar,
   weatherGripScalarForState,
   weatherSkillFor,
   type TireKind,
@@ -1065,6 +1066,7 @@ export function stepRaceSession(
   const aiTickResults = state.ai.map((entry, index) => {
     const aiConfig = config.ai[index];
     if (!aiConfig) return null;
+    const aiWeatherSkill = weatherSkillFor(aiConfig.driver, trackWeather);
     return tickAI(
       aiConfig.driver,
       entry.state,
@@ -1076,7 +1078,8 @@ export function stepRaceSession(
       aiContext,
       dt,
       cpuModifiers,
-      weatherSkillFor(aiConfig.driver, trackWeather),
+      aiWeatherSkill,
+      weatherVisibilityRiskScalar(trackWeather, aiWeatherSkill),
     );
   });
 

--- a/src/game/weather.ts
+++ b/src/game/weather.ts
@@ -193,6 +193,14 @@ export const WEATHER_VISIBILITY: Readonly<Record<WeatherOption, number>> =
   });
 
 /**
+ * Upper bound for §14 low-visibility AI risk. Fog at unit weather skill
+ * reaches 2x mistake pressure because its visibility row is 0.5.
+ * Lower skill can push worse conditions above 2x, but the scalar stays
+ * capped so a poor weather driver cannot become fully random.
+ */
+export const WEATHER_VISIBILITY_RISK_MAX_SCALAR = 3;
+
+/**
  * Type guard for the §23-row subset of `WeatherOption`. Useful at
  * call sites that have a generic `WeatherOption` and need to branch
  * on whether the §23 lookup applies.
@@ -281,6 +289,21 @@ export function weatherGripScalar(
 
 export function visibilityForWeather(weather: WeatherOption): number {
   return WEATHER_VISIBILITY[weather];
+}
+
+/**
+ * Convert §14 visibility loss into deterministic AI mistake pressure.
+ * `weatherSkillScalar` mitigates the extra risk: a driver with 2x skill
+ * takes half the extra pressure, while a weak 0.5x skill doubles it.
+ */
+export function weatherVisibilityRiskScalar(
+  weather: WeatherOption,
+  weatherSkillScalar: number = 1,
+): number {
+  const visibility = clamp(visibilityForWeather(weather), 0.01, 1);
+  const baseExtra = 1 / visibility - 1;
+  const skill = clamp(weatherSkillScalar, 0.25, 2);
+  return clamp(1 + baseExtra / skill, 1, WEATHER_VISIBILITY_RISK_MAX_SCALAR);
 }
 
 export function createWeatherState(

--- a/src/game/weather.ts
+++ b/src/game/weather.ts
@@ -196,7 +196,8 @@ export const WEATHER_VISIBILITY: Readonly<Record<WeatherOption, number>> =
  * Upper bound for §14 low-visibility AI risk. Fog at unit weather skill
  * reaches 2x mistake pressure because its visibility row is 0.5.
  * Lower skill can push worse conditions above 2x, but the scalar stays
- * capped so a poor weather driver cannot become fully random.
+ * capped to limit how much visibility alone can amplify mistake
+ * pressure for poor weather drivers.
  */
 export const WEATHER_VISIBILITY_RISK_MAX_SCALAR = 3;
 


### PR DESCRIPTION
## GDD sections
- docs/gdd/14-weather-and-environmental-systems.md
- docs/gdd/15-cpu-opponents-and-ai.md

## Requirement inventory
- Implements the §14 runtime danger piece where heavy weather and low visibility increase collision risk.
- Keeps §13 contact geometry unchanged; risk changes AI lane-target mistakes instead.
- Uses each driver weather skill to mitigate extra visibility risk.
- Leaves full region art packages and sound changes to existing backlog parents.

## Progress log
- docs/PROGRESS_LOG.md: Weather visibility AI risk

## Test plan
- [x] npx vitest run src/game/__tests__/weather.test.ts src/game/__tests__/ai.test.ts
- [x] npm run verify
- [x] npm run test:e2e
- [x] grep scans for U+2014 and U+2013 on touched files

## Followups
None.