### PR TITLE
feat(hud): add damage weather indicators

### DIFF
--- a/docs/GDD_COVERAGE.json
+++ b/docs/GDD_COVERAGE.json
@@ -97,6 +97,26 @@
       "followupRefs": []
     },
     {
+      "id": "GDD-20-HUD-DAMAGE-WEATHER",
+      "gddSections": [
+        "docs/gdd/13-damage-repairs-and-risk.md",
+        "docs/gdd/14-weather-and-environmental-systems.md",
+        "docs/gdd/20-hud-and-ui-ux.md"
+      ],
+      "requirement": "The live race HUD shows damage, active weather, and a grip hint from the current weather and tire setup.",
+      "coverage": ["implemented-code", "automated-test"],
+      "implementationRefs": [
+        "src/game/hudState.ts",
+        "src/render/uiRenderer.ts",
+        "src/app/race/page.tsx"
+      ],
+      "testRefs": [
+        "src/game/__tests__/hudState.test.ts",
+        "src/render/__tests__/uiRenderer.test.ts"
+      ],
+      "followupRefs": []
+    },
+    {
       "id": "GDD-14-WEATHER-GRIP-RUNTIME",
       "gddSections": [
         "docs/gdd/14-weather-and-environmental-systems.md",

--- a/docs/PROGRESS_LOG.md
+++ b/docs/PROGRESS_LOG.md
@@ -6,6 +6,53 @@ Correct them by adding a new entry that references the old one.
 
 ---
 
+## 2026-04-28: Slice: HUD damage and weather grip indicators
+
+**GDD sections touched:**
+[§13](gdd/13-damage-repairs-and-risk.md) damage visualization,
+[§14](gdd/14-weather-and-environmental-systems.md) weather feedback,
+[§20](gdd/20-hud-and-ui-ux.md) race HUD.
+**Branch / PR:** `feat/hud-damage-weather`, PR pending.
+**Status:** Implemented.
+
+### Done
+- `src/game/hudState.ts`: added optional HUD summaries for live damage,
+  active weather, and weather grip hints while preserving the minimal
+  HUD shape for older callers.
+- `src/render/uiRenderer.ts`: added a guarded bottom-left status cluster
+  for damage, weather, and grip, with no drawing when the fields are
+  absent.
+- `src/app/race/page.tsx`: wires live player damage, active race weather,
+  effective weather grip, and persisted speed units into `deriveHudState`.
+- `docs/GDD_COVERAGE.json`: added GDD-20-HUD-DAMAGE-WEATHER.
+
+### Verified
+- `npx vitest run src/game/__tests__/hudState.test.ts src/render/__tests__/uiRenderer.test.ts`
+  green, 68 passed.
+- `npm run typecheck` green.
+- `npm run verify` green, 2381 passed.
+- `npm run test:e2e` green, 71 passed.
+
+### Decisions and assumptions
+- The HUD uses compact ASCII weather chips plus labels instead of new
+  bitmap icon assets, so this slice stays focused on the live status
+  surface. Asset-backed HUD icons remain part of the broader art pass.
+- The damage and weather cluster is drawn above the minimap area to avoid
+  overlap while keeping the §20 bottom-left grouping.
+
+### Coverage ledger
+- GDD-20-HUD-DAMAGE-WEATHER covers the live HUD damage, weather icon, and
+  grip hint requirements.
+- Uncovered adjacent requirements: nitro meter, cash delta, full pause
+  action polish, results styling, and resize reflow verification remain
+  future §20 slices.
+
+### Followups created
+None.
+
+### GDD edits
+None.
+
 ## 2026-04-28: Slice: Weather visibility AI risk
 
 **GDD sections touched:**

--- a/docs/PROGRESS_LOG.md
+++ b/docs/PROGRESS_LOG.md
@@ -30,7 +30,7 @@ Correct them by adding a new entry that references the old one.
 - `npx vitest run src/game/__tests__/hudState.test.ts src/render/__tests__/uiRenderer.test.ts`
   green, 68 passed.
 - `npm run typecheck` green.
-- `npm run verify` green, 2381 passed.
+- `npm run verify` green, 2382 passed.
 - `npm run test:e2e` green, 71 passed.
 
 ### Decisions and assumptions

--- a/src/app/race/page.tsx
+++ b/src/app/race/page.tsx
@@ -114,7 +114,11 @@ import { awardCredits, baseRewardForTrackDifficulty } from "@/game/economy";
 import type { SaveGame } from "@/data/schemas";
 import type { RaceResult } from "@/game/raceResult";
 import { PRISTINE_DAMAGE_STATE, type DamageState } from "@/game/damage";
-import { activeWeatherForState, type TireKind } from "@/game/weather";
+import {
+  activeWeatherForState,
+  weatherGripScalarForState,
+  type TireKind,
+} from "@/game/weather";
 
 const VIEWPORT_WIDTH = 800;
 const VIEWPORT_HEIGHT = 480;
@@ -996,8 +1000,15 @@ function RaceCanvas({
           playerSpeedMetersPerSecond: session.player.car.speed,
           playerId: PLAYER_ID,
           cars,
-          speedUnit: "kph",
+          speedUnit: persistedSettings.displaySpeedUnit,
           assistBadge: session.player.assistBadge ?? undefined,
+          damage: session.player.damage,
+          weather: renderWeather,
+          weatherGripScalar: weatherGripScalarForState(
+            STARTER_STATS,
+            session.weather,
+            config.playerTire ?? "dry",
+          ),
         });
         drawHud(ctx, hud, viewport);
 

--- a/src/game/__tests__/hudState.test.ts
+++ b/src/game/__tests__/hudState.test.ts
@@ -15,11 +15,16 @@ import { describe, expect, it } from "vitest";
 import {
   deriveHudState,
   formatLapTime,
+  gripHintForHud,
   rankPosition,
+  summarizeHudDamage,
+  summarizeHudWeather,
   speedToDisplayUnit,
+  weatherIconForHud,
   type HudStateInput,
   type RankedCar,
 } from "@/game/hudState";
+import { createDamageState } from "@/game/damage";
 
 const PLAYER = "player";
 
@@ -310,6 +315,70 @@ describe("deriveHudState lap-timer fields", () => {
     );
     expect(state.currentLapElapsedMs).toBe(4_321);
     expect(state.bestLapMs).toBe(9_999);
+  });
+});
+
+describe("HUD damage and weather summaries", () => {
+  it("summarizes damage total and zones as rounded percentages", () => {
+    const damage = createDamageState({ engine: 0.123, tires: 0.49, body: 0.8 });
+    expect(summarizeHudDamage(damage)).toEqual({
+      totalPercent: 43,
+      zones: { engine: 12, tires: 49, body: 80 },
+    });
+  });
+
+  it("maps weather variants to compact icon buckets", () => {
+    expect(weatherIconForHud("clear")).toBe("clear");
+    expect(weatherIconForHud("overcast")).toBe("overcast");
+    expect(weatherIconForHud("rain")).toBe("rain");
+    expect(weatherIconForHud("heavy_rain")).toBe("rain");
+    expect(weatherIconForHud("fog")).toBe("fog");
+    expect(weatherIconForHud("snow")).toBe("snow");
+    expect(weatherIconForHud("night")).toBe("night");
+  });
+
+  it("derives readable weather label, grip hint, and grip percent", () => {
+    expect(summarizeHudWeather("heavy_rain", 0.72)).toEqual({
+      icon: "rain",
+      label: "HEAVY RAIN",
+      gripHint: "slick",
+      gripPercent: 72,
+    });
+  });
+
+  it("keeps grip hints deterministic by weather class", () => {
+    expect(gripHintForHud("clear", 1)).toBe("dry");
+    expect(gripHintForHud("rain", 0.85)).toBe("wet");
+    expect(gripHintForHud("rain", 0.72)).toBe("slick");
+    expect(gripHintForHud("fog", 1)).toBe("low-vis");
+    expect(gripHintForHud("snow", 0.6)).toBe("snow");
+    expect(gripHintForHud("night", 1)).toBe("night");
+  });
+
+  it("surfaces damage and weather when the caller supplies live race state", () => {
+    const state = deriveHudState(
+      input({
+        damage: createDamageState({ engine: 0.5, tires: 0.25, body: 0 }),
+        weather: "fog",
+        weatherGripScalar: 0.91,
+      }),
+    );
+    expect(state.damage).toEqual({
+      totalPercent: 28,
+      zones: { engine: 50, tires: 25, body: 0 },
+    });
+    expect(state.weather).toEqual({
+      icon: "fog",
+      label: "FOG",
+      gripHint: "low-vis",
+      gripPercent: 91,
+    });
+  });
+
+  it("omits damage and weather when callers remain on the minimal HUD shape", () => {
+    const state = deriveHudState(input());
+    expect(state.damage).toBeUndefined();
+    expect(state.weather).toBeUndefined();
   });
 });
 

--- a/src/game/hudState.ts
+++ b/src/game/hudState.ts
@@ -23,7 +23,9 @@
  */
 
 import type { SpeedUnit } from "@/data/schemas";
+import type { WeatherOption } from "@/data/schemas";
 import type { AssistBadge } from "./assists";
+import type { DamageState, DamageZone } from "./damage";
 import type { RaceState } from "./raceState";
 
 /** Forward-distance pair used to rank cars on the track. */
@@ -86,6 +88,15 @@ export interface HudStateInput {
    * skip the BEST row entirely.
    */
   bestLapMs?: number | null;
+  /** Optional live §13 damage snapshot for the §20 bottom-left HUD cluster. */
+  damage?: Readonly<DamageState>;
+  /** Optional active §14 weather state for the §20 weather icon. */
+  weather?: WeatherOption;
+  /**
+   * Optional effective player grip scalar after weather and tire choice.
+   * Used only for the §20 grip hint. Omit to hide the hint.
+   */
+  weatherGripScalar?: number;
 }
 
 /** Optional minimap snapshot derived from the compiled track + car field. */
@@ -148,11 +159,111 @@ export interface HudState {
    * field) keeps its existing snapshot shape.
    */
   assistBadge?: AssistBadge;
+  /** Optional §20 damage HUD summary. */
+  damage?: HudDamageSummary;
+  /** Optional §20 weather HUD summary. */
+  weather?: HudWeatherSummary;
+}
+
+export interface HudDamageSummary {
+  totalPercent: number;
+  zones: Readonly<Record<DamageZone, number>>;
+}
+
+export type HudWeatherIcon = "clear" | "rain" | "fog" | "snow" | "night" | "overcast";
+export type HudGripHint = "dry" | "wet" | "slick" | "snow" | "low-vis" | "night";
+
+export interface HudWeatherSummary {
+  icon: HudWeatherIcon;
+  label: string;
+  gripHint?: HudGripHint;
+  gripPercent?: number;
 }
 
 /** Conversion factors. SI base is m/s. */
 const KPH_PER_MPS = 3.6;
 const MPH_PER_MPS = 2.2369362920544025;
+
+function clampUnit(value: number): number {
+  if (!Number.isFinite(value)) return 0;
+  return Math.max(0, Math.min(1, value));
+}
+
+function percentFromUnit(value: number): number {
+  return Math.round(clampUnit(value) * 100);
+}
+
+export function summarizeHudDamage(damage: Readonly<DamageState>): HudDamageSummary {
+  return {
+    totalPercent: percentFromUnit(damage.total),
+    zones: {
+      engine: percentFromUnit(damage.zones.engine),
+      tires: percentFromUnit(damage.zones.tires),
+      body: percentFromUnit(damage.zones.body),
+    },
+  };
+}
+
+export function weatherIconForHud(weather: WeatherOption): HudWeatherIcon {
+  switch (weather) {
+    case "light_rain":
+    case "rain":
+    case "heavy_rain":
+      return "rain";
+    case "fog":
+      return "fog";
+    case "snow":
+      return "snow";
+    case "dusk":
+    case "night":
+      return "night";
+    case "overcast":
+      return "overcast";
+    case "clear":
+      return "clear";
+  }
+}
+
+export function weatherLabelForHud(weather: WeatherOption): string {
+  return weather.replaceAll("_", " ").toUpperCase();
+}
+
+export function gripHintForHud(
+  weather: WeatherOption,
+  weatherGripScalar: number | undefined,
+): HudGripHint | undefined {
+  if (weatherGripScalar === undefined || !Number.isFinite(weatherGripScalar)) {
+    return undefined;
+  }
+  if (weather === "snow") return "snow";
+  if (weather === "fog") return "low-vis";
+  if (weather === "night" || weather === "dusk") return "night";
+  if (
+    weather === "light_rain" ||
+    weather === "rain" ||
+    weather === "heavy_rain"
+  ) {
+    return weatherGripScalar < 0.82 ? "slick" : "wet";
+  }
+  return weatherGripScalar < 0.95 ? "wet" : "dry";
+}
+
+export function summarizeHudWeather(
+  weather: WeatherOption,
+  weatherGripScalar?: number,
+): HudWeatherSummary {
+  const gripPercent =
+    weatherGripScalar !== undefined && Number.isFinite(weatherGripScalar)
+      ? percentFromUnit(weatherGripScalar)
+      : undefined;
+  const gripHint = gripHintForHud(weather, weatherGripScalar);
+  return {
+    icon: weatherIconForHud(weather),
+    label: weatherLabelForHud(weather),
+    ...(gripHint !== undefined ? { gripHint } : {}),
+    ...(gripPercent !== undefined ? { gripPercent } : {}),
+  };
+}
 
 /**
  * Format a lap time in milliseconds as `MM:SS.mmm` for the §20 lap-timer
@@ -268,6 +379,12 @@ export function deriveHudState(input: HudStateInput): HudState {
   }
   if (input.bestLapMs !== undefined) {
     result.bestLapMs = input.bestLapMs;
+  }
+  if (input.damage !== undefined) {
+    result.damage = summarizeHudDamage(input.damage);
+  }
+  if (input.weather !== undefined) {
+    result.weather = summarizeHudWeather(input.weather, input.weatherGripScalar);
   }
   return result;
 }

--- a/src/render/__tests__/uiRenderer.test.ts
+++ b/src/render/__tests__/uiRenderer.test.ts
@@ -277,6 +277,11 @@ describe("drawHud assist badge", () => {
           shadow: "rgba(0,0,0,0.5)",
           assistBadgeFill: "#aabbcc",
           assistBadgeText: "#112233",
+          statusPanelFill: "#010203",
+          damageGood: "#00aa00",
+          damageWarn: "#aaaa00",
+          damageBad: "#aa0000",
+          weatherChipFill: "#002244",
         },
       },
     );
@@ -311,6 +316,98 @@ describe("drawHud assist badge", () => {
       return calls;
     };
     expect(runOnce()).toEqual(runOnce());
+  });
+});
+
+describe("drawHud damage and weather cluster", () => {
+  it("draws no status panel when damage and weather are absent", () => {
+    const { ctx, calls } = makeSpy();
+    drawHud(ctx, BASE_HUD, VIEWPORT);
+    const labels = calls
+      .filter((c) => c.type === "fillText")
+      .map((c) => c.text);
+    expect(labels.some((label) => label.startsWith("DMG"))).toBe(false);
+    expect(labels.some((label) => label.startsWith("GRIP"))).toBe(false);
+  });
+
+  it("draws damage total, per-zone text, and a proportional damage bar", () => {
+    const { ctx, calls } = makeSpy();
+    drawHud(
+      ctx,
+      {
+        ...BASE_HUD,
+        damage: {
+          totalPercent: 50,
+          zones: { engine: 70, tires: 20, body: 10 },
+        },
+      },
+      VIEWPORT,
+    );
+    const fillTexts = calls.filter((c) => c.type === "fillText");
+    expect(fillTexts.some((c) => c.text === "DMG 50%")).toBe(true);
+    expect(fillTexts.some((c) => c.text === "E70 T20 B10")).toBe(true);
+    const fillRects = calls.filter((c) => c.type === "fillRect");
+    expect(fillRects).toHaveLength(3);
+    const damageFill = fillRects.at(-1);
+    expect(damageFill?.fillStyle).toBe("#f3c84b");
+    expect(damageFill?.w).toBe(37);
+  });
+
+  it("draws weather label and uppercase grip hint", () => {
+    const { ctx, calls } = makeSpy();
+    drawHud(
+      ctx,
+      {
+        ...BASE_HUD,
+        weather: {
+          icon: "rain",
+          label: "HEAVY RAIN",
+          gripHint: "slick",
+          gripPercent: 72,
+        },
+      },
+      VIEWPORT,
+    );
+    const labels = calls
+      .filter((c) => c.type === "fillText")
+      .map((c) => c.text);
+    expect(labels).toContain("R");
+    expect(labels).toContain("HEAVY RAIN");
+    expect(labels).toContain("GRIP 72% SLICK");
+  });
+
+  it("draws combined damage and weather inside one bottom-left panel", () => {
+    const { ctx, calls } = makeSpy();
+    drawHud(
+      ctx,
+      {
+        ...BASE_HUD,
+        damage: {
+          totalPercent: 82,
+          zones: { engine: 90, tires: 80, body: 70 },
+        },
+        weather: {
+          icon: "fog",
+          label: "FOG",
+          gripHint: "low-vis",
+          gripPercent: 91,
+        },
+      },
+      VIEWPORT,
+    );
+    const fillRects = calls.filter((c) => c.type === "fillRect");
+    expect(fillRects[0]).toMatchObject({
+      type: "fillRect",
+      fillStyle: "rgba(7, 14, 28, 0.72)",
+      x: 16,
+      w: 142,
+    });
+    expect(fillRects.some((c) => c.fillStyle === "#ef4b4b")).toBe(true);
+    const labels = calls
+      .filter((c) => c.type === "fillText")
+      .map((c) => c.text);
+    expect(labels).toContain("F");
+    expect(labels).toContain("GRIP 91% LOW-VIS");
   });
 });
 

--- a/src/render/__tests__/uiRenderer.test.ts
+++ b/src/render/__tests__/uiRenderer.test.ts
@@ -376,6 +376,26 @@ describe("drawHud damage and weather cluster", () => {
     expect(labels).toContain("GRIP 72% SLICK");
   });
 
+  it("omits the grip row when weather has no grip data", () => {
+    const { ctx, calls } = makeSpy();
+    drawHud(
+      ctx,
+      {
+        ...BASE_HUD,
+        weather: {
+          icon: "clear",
+          label: "CLEAR",
+        },
+      },
+      VIEWPORT,
+    );
+    const labels = calls
+      .filter((c) => c.type === "fillText")
+      .map((c) => c.text);
+    expect(labels).toContain("CLEAR");
+    expect(labels.some((label) => label.startsWith("GRIP"))).toBe(false);
+  });
+
   it("draws combined damage and weather inside one bottom-left panel", () => {
     const { ctx, calls } = makeSpy();
     drawHud(

--- a/src/render/uiRenderer.ts
+++ b/src/render/uiRenderer.ts
@@ -260,8 +260,13 @@ function drawStatusCluster(
   fontFamily: string,
   colors: HudColors,
 ): void {
+  const hasGripRow =
+    state.weather !== undefined &&
+    (state.weather.gripHint !== undefined || state.weather.gripPercent !== undefined);
   const rows =
-    (state.damage !== undefined ? 2 : 0) + (state.weather !== undefined ? 2 : 0);
+    (state.damage !== undefined ? 2 : 0) +
+    (state.weather !== undefined ? 1 : 0) +
+    (hasGripRow ? 1 : 0);
   const panelHeight = rows * STATUS_CLUSTER_ROW_HEIGHT + 14;
   const x = padding;
   const y = Math.max(
@@ -329,19 +334,21 @@ function drawStatusCluster(
       colors.shadow,
       colors.text,
     );
-    rowY += STATUS_CLUSTER_ROW_HEIGHT;
-    const gripLabel =
-      state.weather.gripPercent === undefined
-        ? `GRIP ${state.weather.gripHint ?? "dry"}`
-        : `GRIP ${state.weather.gripPercent}% ${state.weather.gripHint ?? ""}`.trim();
-    drawShadowedText(
-      ctx,
-      gripLabel.toUpperCase(),
-      x + 8,
-      rowY,
-      colors.shadow,
-      colors.textMuted,
-    );
+    if (hasGripRow) {
+      rowY += STATUS_CLUSTER_ROW_HEIGHT;
+      const gripLabel =
+        state.weather.gripPercent === undefined
+          ? `GRIP ${state.weather.gripHint ?? ""}`
+          : `GRIP ${state.weather.gripPercent}% ${state.weather.gripHint ?? ""}`.trim();
+      drawShadowedText(
+        ctx,
+        gripLabel.toUpperCase(),
+        x + 8,
+        rowY,
+        colors.shadow,
+        colors.textMuted,
+      );
+    }
   }
 }
 

--- a/src/render/uiRenderer.ts
+++ b/src/render/uiRenderer.ts
@@ -25,7 +25,7 @@
  * never set them keep their current layout untouched.
  *
  * Other §20 corners (bottom-left damage, weather icon, etc) are
- * intentionally empty in this slice.
+ * renderer-guarded so callers can wire them one at a time.
  */
 
 import { ASSIST_BADGE_LABELS, type AssistBadge } from "@/game/assists";
@@ -46,6 +46,16 @@ export interface HudColors {
   assistBadgeFill: string;
   /** Text colour drawn on top of the assist-badge pill. */
   assistBadgeText: string;
+  /** Bottom-left status panel fill for damage and weather. */
+  statusPanelFill: string;
+  /** Healthy damage bar fill. */
+  damageGood: string;
+  /** Warning damage bar fill. */
+  damageWarn: string;
+  /** Critical damage bar fill. */
+  damageBad: string;
+  /** Weather icon chip fill. */
+  weatherChipFill: string;
 }
 
 export interface DrawHudOptions {
@@ -69,6 +79,11 @@ const DEFAULT_COLORS: HudColors = {
   shadow: "rgba(0, 0, 0, 0.65)",
   assistBadgeFill: "rgba(80, 130, 220, 0.85)",
   assistBadgeText: "#ffffff",
+  statusPanelFill: "rgba(7, 14, 28, 0.72)",
+  damageGood: "#66d17a",
+  damageWarn: "#f3c84b",
+  damageBad: "#ef4b4b",
+  weatherChipFill: "rgba(104, 160, 220, 0.78)",
 };
 
 const DEFAULT_PADDING = 16;
@@ -103,6 +118,11 @@ const ASSIST_BADGE_PADDING_Y = 4;
 const ASSIST_BADGE_HEIGHT = 20;
 /** Badge label font size. Matches the splits sector label so the corner reads cohesive. */
 const ASSIST_BADGE_FONT_SIZE = 12;
+const STATUS_CLUSTER_WIDTH = 142;
+const STATUS_CLUSTER_ROW_HEIGHT = 16;
+const STATUS_CLUSTER_BOTTOM_OFFSET = 156;
+const DAMAGE_BAR_WIDTH = 74;
+const DAMAGE_BAR_HEIGHT = 5;
 
 /**
  * Draw a string with a one-pixel drop shadow underlay so it reads over
@@ -195,6 +215,10 @@ export function drawHud(
     );
   }
 
+  if (state.damage !== undefined || state.weather !== undefined) {
+    drawStatusCluster(ctx, state, viewport, padding, fontFamily, colors);
+  }
+
   // Bottom-right: large speed value with a small unit label below.
   ctx.font = `700 36px ${fontFamily}`;
   ctx.textAlign = "right";
@@ -226,6 +250,122 @@ export function drawHud(
   ctx.font = prevFont;
   ctx.textAlign = prevAlign;
   ctx.textBaseline = prevBaseline;
+}
+
+function drawStatusCluster(
+  ctx: CanvasRenderingContext2D,
+  state: HudState,
+  viewport: Viewport,
+  padding: number,
+  fontFamily: string,
+  colors: HudColors,
+): void {
+  const rows =
+    (state.damage !== undefined ? 2 : 0) + (state.weather !== undefined ? 2 : 0);
+  const panelHeight = rows * STATUS_CLUSTER_ROW_HEIGHT + 14;
+  const x = padding;
+  const y = Math.max(
+    padding + 88,
+    viewport.height - padding - STATUS_CLUSTER_BOTTOM_OFFSET - panelHeight,
+  );
+  ctx.fillStyle = colors.statusPanelFill;
+  ctx.fillRect(x, y, STATUS_CLUSTER_WIDTH, panelHeight);
+
+  let rowY = y + 8;
+  ctx.textAlign = "left";
+  ctx.textBaseline = "top";
+  ctx.font = `600 11px ${fontFamily}`;
+
+  if (state.damage !== undefined) {
+    const total = state.damage.totalPercent;
+    drawShadowedText(
+      ctx,
+      `DMG ${total}%`,
+      x + 8,
+      rowY,
+      colors.shadow,
+      colors.text,
+    );
+    const barX = x + 60;
+    const barY = rowY + 5;
+    ctx.fillStyle = "rgba(255, 255, 255, 0.22)";
+    ctx.fillRect(barX, barY, DAMAGE_BAR_WIDTH, DAMAGE_BAR_HEIGHT);
+    ctx.fillStyle = damageColor(total, colors);
+    ctx.fillRect(
+      barX,
+      barY,
+      Math.round((DAMAGE_BAR_WIDTH * Math.max(0, Math.min(100, total))) / 100),
+      DAMAGE_BAR_HEIGHT,
+    );
+    rowY += STATUS_CLUSTER_ROW_HEIGHT;
+    const zoneLabel = `E${state.damage.zones.engine} T${state.damage.zones.tires} B${state.damage.zones.body}`;
+    drawShadowedText(
+      ctx,
+      zoneLabel,
+      x + 8,
+      rowY,
+      colors.shadow,
+      colors.textMuted,
+    );
+    rowY += STATUS_CLUSTER_ROW_HEIGHT;
+  }
+
+  if (state.weather !== undefined) {
+    ctx.fillStyle = colors.weatherChipFill;
+    ctx.fillRect(x + 8, rowY + 1, 22, 12);
+    drawShadowedText(
+      ctx,
+      weatherIconText(state.weather.icon),
+      x + 13,
+      rowY + 1,
+      colors.shadow,
+      colors.text,
+    );
+    drawShadowedText(
+      ctx,
+      state.weather.label,
+      x + 36,
+      rowY,
+      colors.shadow,
+      colors.text,
+    );
+    rowY += STATUS_CLUSTER_ROW_HEIGHT;
+    const gripLabel =
+      state.weather.gripPercent === undefined
+        ? `GRIP ${state.weather.gripHint ?? "dry"}`
+        : `GRIP ${state.weather.gripPercent}% ${state.weather.gripHint ?? ""}`.trim();
+    drawShadowedText(
+      ctx,
+      gripLabel.toUpperCase(),
+      x + 8,
+      rowY,
+      colors.shadow,
+      colors.textMuted,
+    );
+  }
+}
+
+function damageColor(totalPercent: number, colors: HudColors): string {
+  if (totalPercent >= 70) return colors.damageBad;
+  if (totalPercent >= 35) return colors.damageWarn;
+  return colors.damageGood;
+}
+
+function weatherIconText(icon: NonNullable<HudState["weather"]>["icon"]): string {
+  switch (icon) {
+    case "rain":
+      return "R";
+    case "fog":
+      return "F";
+    case "snow":
+      return "S";
+    case "night":
+      return "N";
+    case "overcast":
+      return "O";
+    case "clear":
+      return "C";
+  }
 }
 
 /**


### PR DESCRIPTION
## Summary
- add optional HUD summaries for live damage, active weather, and weather grip
- draw a guarded bottom-left damage and weather cluster on the canvas HUD
- wire race route HUD state to live damage, active weather, grip scalar, and persisted speed units

## GDD
- docs/gdd/13-damage-repairs-and-risk.md
- docs/gdd/14-weather-and-environmental-systems.md
- docs/gdd/20-hud-and-ui-ux.md

## Progress log
- docs/PROGRESS_LOG.md: 2026-04-28 Slice: HUD damage and weather grip indicators

## Test plan
- npx vitest run src/game/__tests__/hudState.test.ts src/render/__tests__/uiRenderer.test.ts
- npm run typecheck
- npm run verify
- npm run test:e2e

## Followups
- None