### PR TITLE
feat(hud): add gear nitro meter

### DIFF
--- a/docs/GDD_COVERAGE.json
+++ b/docs/GDD_COVERAGE.json
@@ -117,6 +117,25 @@
       "followupRefs": []
     },
     {
+      "id": "GDD-20-HUD-GEAR-NITRO",
+      "gddSections": [
+        "docs/gdd/10-driving-model-and-physics.md",
+        "docs/gdd/20-hud-and-ui-ux.md"
+      ],
+      "requirement": "The live race HUD shows the current gear, RPM, and nitro charge meter from the runtime transmission and nitro state.",
+      "coverage": ["implemented-code", "automated-test"],
+      "implementationRefs": [
+        "src/game/hudState.ts",
+        "src/render/uiRenderer.ts",
+        "src/app/race/page.tsx"
+      ],
+      "testRefs": [
+        "src/game/__tests__/hudState.test.ts",
+        "src/render/__tests__/uiRenderer.test.ts"
+      ],
+      "followupRefs": []
+    },
+    {
       "id": "GDD-14-WEATHER-GRIP-RUNTIME",
       "gddSections": [
         "docs/gdd/14-weather-and-environmental-systems.md",

--- a/docs/PROGRESS_LOG.md
+++ b/docs/PROGRESS_LOG.md
@@ -6,6 +6,51 @@ Correct them by adding a new entry that references the old one.
 
 ---
 
+## 2026-04-28: Slice: HUD gear and nitro meter
+
+**GDD sections touched:**
+[§10](gdd/10-driving-model-and-physics.md) nitro and transmission state,
+[§20](gdd/20-hud-and-ui-ux.md) race HUD.
+**Branch / PR:** `feat/hud-gear-nitro`, PR pending.
+**Status:** Implemented.
+
+### Done
+- `src/game/hudState.ts`: added optional gear and nitro summaries derived
+  from live transmission and nitro snapshots.
+- `src/render/uiRenderer.ts`: draws the §20 bottom-center nitro meter and
+  bottom-right gear / RPM label only when those fields are supplied.
+- `src/app/race/page.tsx`: wires live player nitro, upgrade-aware nitro
+  duration, maximum charges, and transmission state into `deriveHudState`.
+- `docs/GDD_COVERAGE.json`: added GDD-20-HUD-GEAR-NITRO.
+
+### Verified
+- `npx vitest run src/game/__tests__/hudState.test.ts src/render/__tests__/uiRenderer.test.ts`
+  green, 78 passed.
+- `npm run typecheck` green.
+- `npm run verify` green, 2391 passed.
+- `npm run test:e2e` green, 71 passed.
+
+### Decisions and assumptions
+- The nitro meter displays charge-equivalent fuel: unused full charges
+  plus the active charge fraction. This keeps a single meter readable
+  while matching the §10 tap-or-hold burn model.
+- The gear label includes RPM percentage beside the current gear, giving
+  the §20 gear widget useful transmission context without adding a new
+  large gauge.
+
+### Coverage ledger
+- GDD-20-HUD-GEAR-NITRO covers the live HUD gear and nitro meter
+  requirements.
+- Uncovered adjacent requirements: cash delta, full pause action polish,
+  results styling, and resize reflow verification remain future §20
+  slices.
+
+### Followups created
+None.
+
+### GDD edits
+None.
+
 ## 2026-04-28: Slice: HUD damage and weather grip indicators
 
 **GDD sections touched:**

--- a/docs/PROGRESS_LOG.md
+++ b/docs/PROGRESS_LOG.md
@@ -25,7 +25,7 @@ Correct them by adding a new entry that references the old one.
 
 ### Verified
 - `npx vitest run src/game/__tests__/hudState.test.ts src/render/__tests__/uiRenderer.test.ts`
-  green, 78 passed.
+  green, 79 passed.
 - `npm run typecheck` green.
 - `npm run verify` green, 2391 passed.
 - `npm run test:e2e` green, 71 passed.

--- a/src/app/race/page.tsx
+++ b/src/app/race/page.tsx
@@ -85,6 +85,11 @@ import {
 import { DEFAULT_TOUCH_LAYOUT, type TouchLayout } from "@/game/inputTouch";
 import { FIXED_STEP_SECONDS } from "@/game/loop";
 import {
+  DEFAULT_NITRO_CHARGES,
+  nitroDurationForTier,
+  nitroUpgradeTierForUpgrades,
+} from "@/game/nitro";
+import {
   WeatherOptionSchema,
   type AIDriver,
   type CarBaseStats,
@@ -995,6 +1000,9 @@ function RaceCanvas({
           }),
         ];
 
+        const nitroUpgradeTier = nitroUpgradeTierForUpgrades(
+          config.player.upgrades ?? null,
+        );
         const hud = deriveHudState({
           race: session.race,
           playerSpeedMetersPerSecond: session.player.car.speed,
@@ -1009,6 +1017,11 @@ function RaceCanvas({
             session.weather,
             config.playerTire ?? "dry",
           ),
+          nitro: session.player.nitro,
+          nitroMaxCharges:
+            DEFAULT_NITRO_CHARGES + nitroUpgradeTier.chargesBonus,
+          nitroChargeDurationSec: nitroDurationForTier(nitroUpgradeTier),
+          transmission: session.player.transmission,
         });
         drawHud(ctx, hud, viewport);
 

--- a/src/game/__tests__/hudState.test.ts
+++ b/src/game/__tests__/hudState.test.ts
@@ -18,6 +18,8 @@ import {
   gripHintForHud,
   rankPosition,
   summarizeHudDamage,
+  summarizeHudGear,
+  summarizeHudNitro,
   summarizeHudWeather,
   speedToDisplayUnit,
   weatherIconForHud,
@@ -379,6 +381,66 @@ describe("HUD damage and weather summaries", () => {
     const state = deriveHudState(input());
     expect(state.damage).toBeUndefined();
     expect(state.weather).toBeUndefined();
+  });
+});
+
+describe("HUD gear and nitro summaries", () => {
+  it("summarizes idle nitro as full stock charges", () => {
+    expect(
+      summarizeHudNitro({ charges: 3, activeRemainingSec: 0 }, 3, 1.1),
+    ).toEqual({
+      current: 3,
+      max: 3,
+      active: false,
+      percent: 100,
+    });
+  });
+
+  it("includes the active charge fraction in the nitro meter", () => {
+    expect(
+      summarizeHudNitro({ charges: 2, activeRemainingSec: 0.55 }, 3, 1.1),
+    ).toEqual({
+      current: 2.5,
+      max: 3,
+      active: true,
+      percent: 83,
+    });
+  });
+
+  it("summarizes transmission gear, RPM, and mode", () => {
+    expect(summarizeHudGear({ mode: "manual", gear: 4, rpm: 0.876 })).toEqual({
+      gear: 4,
+      rpmPercent: 88,
+      mode: "manual",
+    });
+  });
+
+  it("surfaces nitro and gear when callers supply runtime state", () => {
+    const state = deriveHudState(
+      input({
+        nitro: { charges: 1, activeRemainingSec: 0.25 },
+        nitroMaxCharges: 3,
+        nitroChargeDurationSec: 1,
+        transmission: { mode: "auto", gear: 2, rpm: 0.42 },
+      }),
+    );
+    expect(state.nitro).toEqual({
+      current: 1.25,
+      max: 3,
+      active: true,
+      percent: 42,
+    });
+    expect(state.gear).toEqual({
+      gear: 2,
+      rpmPercent: 42,
+      mode: "auto",
+    });
+  });
+
+  it("omits nitro and gear for minimal HUD callers", () => {
+    const state = deriveHudState(input());
+    expect(state.nitro).toBeUndefined();
+    expect(state.gear).toBeUndefined();
   });
 });
 

--- a/src/game/hudState.ts
+++ b/src/game/hudState.ts
@@ -26,7 +26,13 @@ import type { SpeedUnit } from "@/data/schemas";
 import type { WeatherOption } from "@/data/schemas";
 import type { AssistBadge } from "./assists";
 import type { DamageState, DamageZone } from "./damage";
+import {
+  BASE_NITRO_DURATION_SEC,
+  DEFAULT_NITRO_CHARGES,
+  type NitroState,
+} from "./nitro";
 import type { RaceState } from "./raceState";
+import type { TransmissionState } from "./transmission";
 
 /** Forward-distance pair used to rank cars on the track. */
 export interface RankedCar {
@@ -97,6 +103,20 @@ export interface HudStateInput {
    * Used only for the §20 grip hint. Omit to hide the hint.
    */
   weatherGripScalar?: number;
+  /** Optional live §10 nitro snapshot for the §20 bottom-center meter. */
+  nitro?: Readonly<NitroState>;
+  /**
+   * Race-start maximum nitro charges. Defaults to the stock §10 value.
+   * Used only to size the meter.
+   */
+  nitroMaxCharges?: number;
+  /**
+   * Full burn duration for one active charge. Defaults to the stock §10
+   * duration so callers can omit it until upgrade-aware HUD sizing lands.
+   */
+  nitroChargeDurationSec?: number;
+  /** Optional live §10 transmission snapshot for the §20 gear label. */
+  transmission?: Readonly<TransmissionState>;
 }
 
 /** Optional minimap snapshot derived from the compiled track + car field. */
@@ -163,6 +183,10 @@ export interface HudState {
   damage?: HudDamageSummary;
   /** Optional §20 weather HUD summary. */
   weather?: HudWeatherSummary;
+  /** Optional §20 nitro HUD summary. */
+  nitro?: HudNitroSummary;
+  /** Optional §20 gear HUD summary. */
+  gear?: HudGearSummary;
 }
 
 export interface HudDamageSummary {
@@ -178,6 +202,19 @@ export interface HudWeatherSummary {
   label: string;
   gripHint?: HudGripHint;
   gripPercent?: number;
+}
+
+export interface HudNitroSummary {
+  current: number;
+  max: number;
+  active: boolean;
+  percent: number;
+}
+
+export interface HudGearSummary {
+  gear: number;
+  rpmPercent: number;
+  mode: "auto" | "manual";
 }
 
 /** Conversion factors. SI base is m/s. */
@@ -262,6 +299,41 @@ export function summarizeHudWeather(
     label: weatherLabelForHud(weather),
     ...(gripHint !== undefined ? { gripHint } : {}),
     ...(gripPercent !== undefined ? { gripPercent } : {}),
+  };
+}
+
+export function summarizeHudNitro(
+  nitro: Readonly<NitroState>,
+  maxCharges: number = DEFAULT_NITRO_CHARGES,
+  chargeDurationSec: number = BASE_NITRO_DURATION_SEC,
+): HudNitroSummary {
+  const max = Math.max(1, Math.round(maxCharges));
+  const activeFraction =
+    chargeDurationSec > 0
+      ? clampUnit(nitro.activeRemainingSec / chargeDurationSec)
+      : 0;
+  const current = Math.max(
+    0,
+    Math.min(max, nitro.charges + activeFraction),
+  );
+  return {
+    current,
+    max,
+    active: activeFraction > 0,
+    percent: percentFromUnit(current / max),
+  };
+}
+
+export function summarizeHudGear(
+  transmission: Readonly<TransmissionState>,
+): HudGearSummary {
+  const gear = Number.isFinite(transmission.gear)
+    ? Math.max(1, Math.trunc(transmission.gear))
+    : 1;
+  return {
+    gear,
+    rpmPercent: percentFromUnit(transmission.rpm),
+    mode: transmission.mode,
   };
 }
 
@@ -385,6 +457,16 @@ export function deriveHudState(input: HudStateInput): HudState {
   }
   if (input.weather !== undefined) {
     result.weather = summarizeHudWeather(input.weather, input.weatherGripScalar);
+  }
+  if (input.nitro !== undefined) {
+    result.nitro = summarizeHudNitro(
+      input.nitro,
+      input.nitroMaxCharges,
+      input.nitroChargeDurationSec,
+    );
+  }
+  if (input.transmission !== undefined) {
+    result.gear = summarizeHudGear(input.transmission);
   }
   return result;
 }

--- a/src/game/hudState.ts
+++ b/src/game/hudState.ts
@@ -1,11 +1,11 @@
 /**
  * HUD state derivation.
  *
- * Source of truth: `docs/gdd/20-hud-and-ui-ux.md`. This is the Phase 1
- * minimal HUD per `docs/IMPLEMENTATION_PLAN.md` Phase 1: speed, current
- * lap / total laps, and current position (1st of N). Polish slice (later
- * dot) handles the full HUD treatment from §20 ("lap timer", "best lap",
- * "nitro meter", "damage", "weather icon", etc).
+ * Source of truth: `docs/gdd/20-hud-and-ui-ux.md`. The required minimal
+ * HUD fields are speed, current lap / total laps, and current position
+ * (1st of N). Additional §20 widgets are optional fields derived only
+ * when callers provide the matching runtime snapshots, including timers,
+ * splits, minimap, assists, damage, weather, gear, and nitro.
  *
  * Pure derivation: `deriveHudState(input) -> HudState` is a pure
  * function of the race and car snapshots passed in. The renderer

--- a/src/render/__tests__/uiRenderer.test.ts
+++ b/src/render/__tests__/uiRenderer.test.ts
@@ -282,6 +282,8 @@ describe("drawHud assist badge", () => {
           damageWarn: "#aaaa00",
           damageBad: "#aa0000",
           weatherChipFill: "#002244",
+          nitroFill: "#0044aa",
+          nitroActiveFill: "#aa7700",
         },
       },
     );
@@ -428,6 +430,82 @@ describe("drawHud damage and weather cluster", () => {
       .map((c) => c.text);
     expect(labels).toContain("F");
     expect(labels).toContain("GRIP 91% LOW-VIS");
+  });
+});
+
+describe("drawHud gear and nitro widgets", () => {
+  it("draws no nitro or gear primitives when fields are absent", () => {
+    const { ctx, calls } = makeSpy();
+    drawHud(ctx, BASE_HUD, VIEWPORT);
+    const labels = calls
+      .filter((c) => c.type === "fillText")
+      .map((c) => c.text);
+    expect(labels.some((label) => label.startsWith("NITRO"))).toBe(false);
+    expect(labels.some((label) => label.startsWith("G"))).toBe(false);
+  });
+
+  it("draws the bottom-center nitro meter with idle fill", () => {
+    const { ctx, calls } = makeSpy();
+    drawHud(
+      ctx,
+      {
+        ...BASE_HUD,
+        nitro: { current: 1.5, max: 3, active: false, percent: 50 },
+      },
+      VIEWPORT,
+    );
+    const fillRects = calls.filter((c) => c.type === "fillRect");
+    expect(fillRects).toHaveLength(2);
+    expect(fillRects[0]).toMatchObject({
+      type: "fillRect",
+      fillStyle: "rgba(7, 14, 28, 0.72)",
+      x: 320,
+      w: 160,
+    });
+    expect(fillRects[1]).toMatchObject({
+      type: "fillRect",
+      fillStyle: "#5ba7ff",
+      x: 320,
+      w: 80,
+    });
+    const labels = calls
+      .filter((c) => c.type === "fillText")
+      .map((c) => c.text);
+    expect(labels).toContain("NITRO 1.5 / 3");
+  });
+
+  it("uses the active nitro fill while a charge is burning", () => {
+    const { ctx, calls } = makeSpy();
+    drawHud(
+      ctx,
+      {
+        ...BASE_HUD,
+        nitro: { current: 2.25, max: 3, active: true, percent: 75 },
+      },
+      VIEWPORT,
+    );
+    const fillRects = calls.filter((c) => c.type === "fillRect");
+    expect(fillRects.at(-1)?.fillStyle).toBe("#f4d24a");
+    expect(fillRects.at(-1)?.w).toBe(120);
+  });
+
+  it("draws the gear and RPM label above the speedometer", () => {
+    const { ctx, calls } = makeSpy();
+    drawHud(
+      ctx,
+      {
+        ...BASE_HUD,
+        gear: { gear: 3, rpmPercent: 68, mode: "auto" },
+      },
+      VIEWPORT,
+    );
+    const gearCalls = calls
+      .filter((c) => c.type === "fillText")
+      .filter((c) => c.text === "G3 68%");
+    expect(gearCalls).toHaveLength(2);
+    const textCall = gearCalls.find((c) => c.fillStyle === "#cfd6e4");
+    expect(textCall?.align).toBe("right");
+    expect(textCall?.x).toBe(VIEWPORT.width - 16);
   });
 });
 

--- a/src/render/__tests__/uiRenderer.test.ts
+++ b/src/render/__tests__/uiRenderer.test.ts
@@ -14,7 +14,7 @@ import { describe, expect, it } from "vitest";
 import type { AssistBadge, AssistBadgeLabel } from "@/game/assists";
 import type { HudState } from "@/game/hudState";
 
-import { drawHud, formatAssistBadgeLabel } from "../uiRenderer";
+import { drawHud, formatAssistBadgeLabel, type HudColors } from "../uiRenderer";
 
 type Call =
   | {
@@ -110,6 +110,21 @@ const BASE_HUD: HudState = {
   totalLaps: 3,
   position: 1,
   totalCars: 4,
+};
+
+const CUSTOM_COLORS: HudColors = {
+  text: "#fff",
+  textMuted: "#ccc",
+  shadow: "rgba(0,0,0,0.5)",
+  assistBadgeFill: "#aabbcc",
+  assistBadgeText: "#112233",
+  statusPanelFill: "#010203",
+  damageGood: "#00aa00",
+  damageWarn: "#aaaa00",
+  damageBad: "#aa0000",
+  weatherChipFill: "#002244",
+  nitroFill: "#0044aa",
+  nitroActiveFill: "#aa7700",
 };
 
 function badge(
@@ -271,20 +286,7 @@ describe("drawHud assist badge", () => {
       { ...BASE_HUD, assistBadge: badge("brake-assist") },
       VIEWPORT,
       {
-        colors: {
-          text: "#fff",
-          textMuted: "#ccc",
-          shadow: "rgba(0,0,0,0.5)",
-          assistBadgeFill: "#aabbcc",
-          assistBadgeText: "#112233",
-          statusPanelFill: "#010203",
-          damageGood: "#00aa00",
-          damageWarn: "#aaaa00",
-          damageBad: "#aa0000",
-          weatherChipFill: "#002244",
-          nitroFill: "#0044aa",
-          nitroActiveFill: "#aa7700",
-        },
+        colors: CUSTOM_COLORS,
       },
     );
     const fillRect = calls.find((c) => c.type === "fillRect");
@@ -487,6 +489,22 @@ describe("drawHud gear and nitro widgets", () => {
     const fillRects = calls.filter((c) => c.type === "fillRect");
     expect(fillRects.at(-1)?.fillStyle).toBe("#f4d24a");
     expect(fillRects.at(-1)?.w).toBe(120);
+  });
+
+  it("uses the status panel color for the nitro meter background", () => {
+    const { ctx, calls } = makeSpy();
+    drawHud(
+      ctx,
+      {
+        ...BASE_HUD,
+        nitro: { current: 1, max: 3, active: false, percent: 33 },
+      },
+      VIEWPORT,
+      { colors: CUSTOM_COLORS },
+    );
+    const fillRects = calls.filter((c) => c.type === "fillRect");
+    expect(fillRects[0]?.fillStyle).toBe("#010203");
+    expect(fillRects[1]?.fillStyle).toBe("#0044aa");
   });
 
   it("draws the gear and RPM label above the speedometer", () => {

--- a/src/render/uiRenderer.ts
+++ b/src/render/uiRenderer.ts
@@ -56,6 +56,10 @@ export interface HudColors {
   damageBad: string;
   /** Weather icon chip fill. */
   weatherChipFill: string;
+  /** Nitro meter fill when idle. */
+  nitroFill: string;
+  /** Nitro meter fill while a charge is active. */
+  nitroActiveFill: string;
 }
 
 export interface DrawHudOptions {
@@ -84,6 +88,8 @@ const DEFAULT_COLORS: HudColors = {
   damageWarn: "#f3c84b",
   damageBad: "#ef4b4b",
   weatherChipFill: "rgba(104, 160, 220, 0.78)",
+  nitroFill: "#5ba7ff",
+  nitroActiveFill: "#f4d24a",
 };
 
 const DEFAULT_PADDING = 16;
@@ -123,6 +129,9 @@ const STATUS_CLUSTER_ROW_HEIGHT = 16;
 const STATUS_CLUSTER_BOTTOM_OFFSET = 156;
 const DAMAGE_BAR_WIDTH = 74;
 const DAMAGE_BAR_HEIGHT = 5;
+const NITRO_METER_WIDTH = 160;
+const NITRO_METER_HEIGHT = 10;
+const NITRO_METER_BOTTOM = 18;
 
 /**
  * Draw a string with a one-pixel drop shadow underlay so it reads over
@@ -239,6 +248,22 @@ export function drawHud(
     colors.textMuted,
   );
 
+  if (state.gear !== undefined) {
+    ctx.font = `600 12px ${fontFamily}`;
+    drawShadowedText(
+      ctx,
+      `G${state.gear.gear} ${state.gear.rpmPercent}%`,
+      speedX,
+      viewport.height - padding - 54,
+      colors.shadow,
+      colors.textMuted,
+    );
+  }
+
+  if (state.nitro !== undefined) {
+    drawNitroMeter(ctx, state, viewport, padding, fontFamily, colors);
+  }
+
   // Top-right (below the splits widget): accessibility-assist badge.
   // Drawer is a no-op when the badge is missing or inactive so the §19
   // assists-off case never paints a phantom pill.
@@ -250,6 +275,46 @@ export function drawHud(
   ctx.font = prevFont;
   ctx.textAlign = prevAlign;
   ctx.textBaseline = prevBaseline;
+}
+
+function drawNitroMeter(
+  ctx: CanvasRenderingContext2D,
+  state: HudState,
+  viewport: Viewport,
+  padding: number,
+  fontFamily: string,
+  colors: HudColors,
+): void {
+  const nitro = state.nitro;
+  if (nitro === undefined) return;
+  const x = Math.round((viewport.width - NITRO_METER_WIDTH) / 2);
+  const y = viewport.height - padding - NITRO_METER_BOTTOM;
+  ctx.fillStyle = "rgba(7, 14, 28, 0.72)";
+  ctx.fillRect(x, y, NITRO_METER_WIDTH, NITRO_METER_HEIGHT);
+  ctx.fillStyle = nitro.active ? colors.nitroActiveFill : colors.nitroFill;
+  ctx.fillRect(
+    x,
+    y,
+    Math.round((NITRO_METER_WIDTH * Math.max(0, Math.min(100, nitro.percent))) / 100),
+    NITRO_METER_HEIGHT,
+  );
+
+  ctx.font = `600 11px ${fontFamily}`;
+  ctx.textAlign = "center";
+  ctx.textBaseline = "bottom";
+  drawShadowedText(
+    ctx,
+    `NITRO ${formatNitroCharges(nitro.current)} / ${nitro.max}`,
+    viewport.width / 2,
+    y - 3,
+    colors.shadow,
+    colors.textMuted,
+  );
+}
+
+function formatNitroCharges(value: number): string {
+  if (!Number.isFinite(value)) return "0.0";
+  return value.toFixed(1);
 }
 
 function drawStatusCluster(

--- a/src/render/uiRenderer.ts
+++ b/src/render/uiRenderer.ts
@@ -1,10 +1,10 @@
 /**
  * Canvas2D HUD overlay drawer.
  *
- * Phase 1 minimal HUD per `docs/IMPLEMENTATION_PLAN.md`. Source of truth:
- * `docs/gdd/20-hud-and-ui-ux.md`. This slice ships only speed, lap, and
- * position; the full HUD treatment (lap timer, best lap, nitro meter,
- * damage, weather icon, minimap) lands in the §20 polish slice.
+ * Source of truth: `docs/gdd/20-hud-and-ui-ux.md`. The HUD grows through
+ * guarded §20 widgets so older callers can still provide only speed, lap,
+ * and position, while live race callers can add timers, splits, minimap,
+ * assists, damage, weather, gear, and nitro state.
  *
  * The drawer is the only HUD module that knows about a Canvas2D
  * context. The `HudState` it consumes comes from `src/game/hudState.ts`
@@ -12,9 +12,9 @@
  * derivation can run headless without canvas mocking.
  *
  * Layout matches §20 "UX wireframe descriptions / Race HUD layout":
- * - Top-left: lap, position, current-lap timer (TIME row, polish slice),
- *   and BEST lap (polish slice) under that.
- * - Bottom-right: speed and unit
+ * - Top-left: lap, position, current-lap timer, and BEST lap when supplied.
+ * - Bottom-right: speed, unit, and optional gear / RPM.
+ * - Bottom-center: optional nitro meter.
  * - Top-right (below the splits widget): accessibility-assist badge,
  *   only when `HudState.assistBadge.active` is true. The badge sits at
  *   `y = padding + 64` so it never overlaps the splits widget's three
@@ -24,8 +24,8 @@
  * is supplied (per-field guard); the legacy minimal-HUD callers that
  * never set them keep their current layout untouched.
  *
- * Other §20 corners (bottom-left damage, weather icon, etc) are
- * renderer-guarded so callers can wire them one at a time.
+ * Other §20 widgets are renderer-guarded so callers can wire them one at
+ * a time.
  */
 
 import { ASSIST_BADGE_LABELS, type AssistBadge } from "@/game/assists";
@@ -289,7 +289,7 @@ function drawNitroMeter(
   if (nitro === undefined) return;
   const x = Math.round((viewport.width - NITRO_METER_WIDTH) / 2);
   const y = viewport.height - padding - NITRO_METER_BOTTOM;
-  ctx.fillStyle = "rgba(7, 14, 28, 0.72)";
+  ctx.fillStyle = colors.statusPanelFill;
   ctx.fillRect(x, y, NITRO_METER_WIDTH, NITRO_METER_HEIGHT);
   ctx.fillStyle = nitro.active ? colors.nitroActiveFill : colors.nitroFill;
   ctx.fillRect(


### PR DESCRIPTION
## Summary
- Add optional HUD summaries for live gear, RPM, and nitro charge state.
- Render a bottom-center nitro meter and bottom-right gear label when runtime data is present.
- Wire live race transmission and upgrade-aware nitro values into the race HUD.

## GDD sections
- docs/gdd/10-driving-model-and-physics.md
- docs/gdd/20-hud-and-ui-ux.md

## Progress log
- docs/PROGRESS_LOG.md: 2026-04-28 Slice: HUD gear and nitro meter

## Test plan
- npx vitest run src/game/__tests__/hudState.test.ts src/render/__tests__/uiRenderer.test.ts
- npm run typecheck
- npm run verify
- npm run test:e2e

## Followups
- None
