### PR TITLE
feat(hud): add cash delta

### DIFF
--- a/docs/GDD_COVERAGE.json
+++ b/docs/GDD_COVERAGE.json
@@ -136,6 +136,25 @@
       "followupRefs": []
     },
     {
+      "id": "GDD-20-HUD-CASH-DELTA",
+      "gddSections": [
+        "docs/gdd/12-upgrade-and-economy-system.md",
+        "docs/gdd/20-hud-and-ui-ux.md"
+      ],
+      "requirement": "The live race HUD shows a guarded cash delta row from the current projected race payout.",
+      "coverage": ["implemented-code", "automated-test"],
+      "implementationRefs": [
+        "src/game/hudState.ts",
+        "src/render/uiRenderer.ts",
+        "src/app/race/page.tsx"
+      ],
+      "testRefs": [
+        "src/game/__tests__/hudState.test.ts",
+        "src/render/__tests__/uiRenderer.test.ts"
+      ],
+      "followupRefs": []
+    },
+    {
       "id": "GDD-14-WEATHER-GRIP-RUNTIME",
       "gddSections": [
         "docs/gdd/14-weather-and-environmental-systems.md",

--- a/docs/PROGRESS_LOG.md
+++ b/docs/PROGRESS_LOG.md
@@ -6,6 +6,49 @@ Correct them by adding a new entry that references the old one.
 
 ---
 
+## 2026-04-28: Slice: HUD cash delta
+
+**GDD sections touched:**
+[§12](gdd/12-upgrade-and-economy-system.md) race reward formula,
+[§20](gdd/20-hud-and-ui-ux.md) race HUD.
+**Branch / PR:** `feat/hud-cash-delta`, PR pending.
+**Status:** Implemented.
+
+### Done
+- `src/game/hudState.ts`: added an optional cash delta summary with
+  signed credit formatting.
+- `src/render/uiRenderer.ts`: draws a guarded §20 CASH row under the
+  top-left HUD timer stack when cash data is supplied.
+- `src/app/race/page.tsx`: wires live projected race payout from current
+  player position, track difficulty, and difficulty preset into
+  `deriveHudState` for economy modes.
+- `docs/GDD_COVERAGE.json`: added GDD-20-HUD-CASH-DELTA.
+
+### Verified
+- `npx vitest run src/game/__tests__/hudState.test.ts src/render/__tests__/uiRenderer.test.ts`
+  green, 85 passed.
+- `npm run typecheck` green.
+- `npm run verify` green, 2398 passed.
+- `npm run test:e2e` green, 71 passed.
+
+### Decisions and assumptions
+- The live race HUD uses the current-position projected base payout,
+  excluding bonuses because §5 bonuses are only finalized by the results
+  builder after finish conditions are known.
+- Time Trial omits the cash row because that mode does not commit
+  wallet rewards.
+
+### Coverage ledger
+- GDD-20-HUD-CASH-DELTA covers the live HUD cash delta requirement.
+- Uncovered adjacent requirements: full pause action polish, results
+  styling, and resize reflow verification remain future §20 slices.
+
+### Followups created
+None.
+
+### GDD edits
+None.
+
 ## 2026-04-28: Slice: HUD gear and nitro meter
 
 **GDD sections touched:**

--- a/src/app/race/page.tsx
+++ b/src/app/race/page.tsx
@@ -69,6 +69,7 @@ import {
   applyRaceDamageToGarage,
   applyRaceResultRecords,
   applyTourRaceResult,
+  rankPosition,
   retireRaceSession,
   spawnGrid,
   startLoop,
@@ -115,7 +116,11 @@ import type { ParallaxLayer } from "@/render/parallax";
 import { drawSplitsWidget } from "@/render/hudSplits";
 import { drawHud } from "@/render/uiRenderer";
 import { defaultSave, loadSave, saveSave } from "@/persistence/save";
-import { awardCredits, baseRewardForTrackDifficulty } from "@/game/economy";
+import {
+  awardCredits,
+  baseRewardForTrackDifficulty,
+  computeRaceReward,
+} from "@/game/economy";
 import type { SaveGame } from "@/data/schemas";
 import type { RaceResult } from "@/game/raceResult";
 import { PRISTINE_DAMAGE_STATE, type DamageState } from "@/game/damage";
@@ -1003,6 +1008,16 @@ function RaceCanvas({
         const nitroUpgradeTier = nitroUpgradeTierForUpgrades(
           config.player.upgrades ?? null,
         );
+        const projectedCashDelta = timeTrialEnabled
+          ? undefined
+          : computeRaceReward({
+              place: rankPosition(PLAYER_ID, cars),
+              status: "finished",
+              baseTrackReward: baseRewardForTrackDifficulty(
+                track.compiled.difficulty,
+              ),
+              difficulty: persistedDifficulty ?? "normal",
+            });
         const hud = deriveHudState({
           race: session.race,
           playerSpeedMetersPerSecond: session.player.car.speed,
@@ -1022,6 +1037,7 @@ function RaceCanvas({
             DEFAULT_NITRO_CHARGES + nitroUpgradeTier.chargesBonus,
           nitroChargeDurationSec: nitroDurationForTier(nitroUpgradeTier),
           transmission: session.player.transmission,
+          cashDelta: projectedCashDelta,
         });
         drawHud(ctx, hud, viewport);
 

--- a/src/game/__tests__/hudState.test.ts
+++ b/src/game/__tests__/hudState.test.ts
@@ -20,6 +20,7 @@ import {
   summarizeHudDamage,
   summarizeHudGear,
   summarizeHudNitro,
+  summarizeHudCashDelta,
   summarizeHudWeather,
   speedToDisplayUnit,
   weatherIconForHud,
@@ -441,6 +442,37 @@ describe("HUD gear and nitro summaries", () => {
     const state = deriveHudState(input());
     expect(state.nitro).toBeUndefined();
     expect(state.gear).toBeUndefined();
+  });
+});
+
+describe("HUD cash delta summary", () => {
+  it("formats positive cash with an explicit plus sign", () => {
+    expect(summarizeHudCashDelta(1250)).toEqual({
+      credits: 1250,
+      label: "+1,250 cr",
+    });
+  });
+
+  it("formats negative cash with a minus sign", () => {
+    expect(summarizeHudCashDelta(-375)).toEqual({
+      credits: -375,
+      label: "-375 cr",
+    });
+  });
+
+  it("collapses non-finite cash to zero", () => {
+    expect(summarizeHudCashDelta(Number.NaN)).toEqual({
+      credits: 0,
+      label: "0 cr",
+    });
+  });
+
+  it("surfaces cash delta only when the caller supplies it", () => {
+    expect(deriveHudState(input({ cashDelta: 999 })).cashDelta).toEqual({
+      credits: 999,
+      label: "+999 cr",
+    });
+    expect(deriveHudState(input()).cashDelta).toBeUndefined();
   });
 });
 

--- a/src/game/hudState.ts
+++ b/src/game/hudState.ts
@@ -117,6 +117,11 @@ export interface HudStateInput {
   nitroChargeDurationSec?: number;
   /** Optional live §10 transmission snapshot for the §20 gear label. */
   transmission?: Readonly<TransmissionState>;
+  /**
+   * Optional signed wallet delta or projected race payout in credits.
+   * Callers omit it when a mode should not surface economy progress.
+   */
+  cashDelta?: number;
 }
 
 /** Optional minimap snapshot derived from the compiled track + car field. */
@@ -187,6 +192,8 @@ export interface HudState {
   nitro?: HudNitroSummary;
   /** Optional §20 gear HUD summary. */
   gear?: HudGearSummary;
+  /** Optional §20 cash delta in credits. */
+  cashDelta?: HudCashDeltaSummary;
 }
 
 export interface HudDamageSummary {
@@ -215,6 +222,11 @@ export interface HudGearSummary {
   gear: number;
   rpmPercent: number;
   mode: "auto" | "manual";
+}
+
+export interface HudCashDeltaSummary {
+  credits: number;
+  label: string;
 }
 
 /** Conversion factors. SI base is m/s. */
@@ -334,6 +346,15 @@ export function summarizeHudGear(
     gear,
     rpmPercent: percentFromUnit(transmission.rpm),
     mode: transmission.mode,
+  };
+}
+
+export function summarizeHudCashDelta(credits: number): HudCashDeltaSummary {
+  const clean = Number.isFinite(credits) ? Math.trunc(credits) : 0;
+  const sign = clean > 0 ? "+" : clean < 0 ? "-" : "";
+  return {
+    credits: clean,
+    label: `${sign}${Math.abs(clean).toLocaleString("en-US")} cr`,
   };
 }
 
@@ -467,6 +488,9 @@ export function deriveHudState(input: HudStateInput): HudState {
   }
   if (input.transmission !== undefined) {
     result.gear = summarizeHudGear(input.transmission);
+  }
+  if (input.cashDelta !== undefined) {
+    result.cashDelta = summarizeHudCashDelta(input.cashDelta);
   }
   return result;
 }

--- a/src/render/__tests__/uiRenderer.test.ts
+++ b/src/render/__tests__/uiRenderer.test.ts
@@ -640,3 +640,35 @@ describe("drawHud lap-timer widget", () => {
     expect(fillRect?.y).toBe(16 + 64);
   });
 });
+
+describe("drawHud cash delta widget", () => {
+  it("draws no cash row when cashDelta is absent", () => {
+    const { ctx, calls } = makeSpy();
+    drawHud(ctx, BASE_HUD, VIEWPORT);
+    const labels = calls
+      .filter((c) => c.type === "fillText")
+      .map((c) => c.text);
+    expect(labels.some((label) => label.startsWith("CASH"))).toBe(false);
+  });
+
+  it("draws the cash row under the timer stack when supplied", () => {
+    const { ctx, calls } = makeSpy();
+    drawHud(
+      ctx,
+      {
+        ...BASE_HUD,
+        currentLapElapsedMs: 1_000,
+        bestLapMs: 2_000,
+        cashDelta: { credits: 1250, label: "+1,250 cr" },
+      },
+      VIEWPORT,
+    );
+    const cashCalls = calls
+      .filter((c) => c.type === "fillText")
+      .filter((c) => c.text === "CASH +1,250 cr");
+    expect(cashCalls).toHaveLength(2);
+    const textCall = cashCalls.find((c) => c.fillStyle === "#cfd6e4");
+    expect(textCall?.x).toBe(16);
+    expect(textCall?.y).toBe(16 + 84);
+  });
+});

--- a/src/render/uiRenderer.ts
+++ b/src/render/uiRenderer.ts
@@ -116,6 +116,7 @@ const LAP_TIMER_TOP_OFFSET = 44;
  * y = padding + 64 lines up directly under it.
  */
 const BEST_LAP_TOP_OFFSET = 64;
+const CASH_DELTA_TOP_OFFSET = 84;
 /** Badge pill horizontal padding around the label text. */
 const ASSIST_BADGE_PADDING_X = 8;
 /** Badge pill vertical padding around the label text. */
@@ -219,6 +220,17 @@ export function drawHud(
       bestLabel,
       padding,
       padding + BEST_LAP_TOP_OFFSET,
+      colors.shadow,
+      colors.textMuted,
+    );
+  }
+  if (state.cashDelta !== undefined) {
+    ctx.font = `600 12px ${fontFamily}`;
+    drawShadowedText(
+      ctx,
+      `CASH ${state.cashDelta.label}`,
+      padding,
+      padding + CASH_DELTA_TOP_OFFSET,
       colors.shadow,
       colors.textMuted,
     );


### PR DESCRIPTION
## Summary
- Add optional HUD cash delta state with signed credit formatting.
- Render a guarded CASH row in the race HUD when economy data is present.
- Wire live projected current-position race payout into the HUD for economy modes.

## GDD sections
- docs/gdd/12-upgrade-and-economy-system.md
- docs/gdd/20-hud-and-ui-ux.md

## Progress log
- docs/PROGRESS_LOG.md: 2026-04-28 Slice: HUD cash delta

## Test plan
- npx vitest run src/game/__tests__/hudState.test.ts src/render/__tests__/uiRenderer.test.ts
- npm run typecheck
- npm run verify
- npm run test:e2e

## Followups
- None
