### PR TITLE
chore(e2e): reduce tour flow runtime

### DIFF
--- a/docs/PROGRESS_LOG.md
+++ b/docs/PROGRESS_LOG.md
@@ -6,6 +6,43 @@ Correct them by adding a new entry that references the old one.
 
 ---
 
+## 2026-04-28: Slice: reduce tour-flow e2e runtime
+
+**GDD sections touched:**
+No GDD design change. This slice supports the implementation loop and
+verification budget.
+**Branch / PR:** `chore/reduce-tour-e2e-runtime`, PR pending.
+**Status:** Implemented.
+
+### Done
+- `e2e/tour-flow.spec.ts`: removed a redundant second full Velvet Coast
+  tour pass from the world-hub completion smoke.
+- Preserved completed-track coverage and Iron Borough unlock assertions
+  in the same spec.
+
+### Verified
+- `npx playwright test e2e/tour-flow.spec.ts` green, 2 passed in 37.3s.
+- `npm run test:e2e` green, 71 passed in 1.4m.
+- `npm run verify` green, 2398 passed.
+
+### Decisions and assumptions
+- The second full-tour pass duplicated coverage already held by the same
+  test's track completion assertions plus the final-race unlock spec.
+  Keeping one full-tour pass still verifies the route chain and save
+  progression while reducing loop runtime.
+
+### Coverage ledger
+- GDD-24-MVP-TRACK-SET remains the exercised coverage area for this
+  tour-flow smoke. No new ledger row was added because this is a
+  test-harness optimization only.
+- Uncovered adjacent requirements: none created by this slice.
+
+### Followups created
+None.
+
+### GDD edits
+None.
+
 ## 2026-04-28: Slice: HUD cash delta
 
 **GDD sections touched:**

--- a/e2e/tour-flow.spec.ts
+++ b/e2e/tour-flow.spec.ts
@@ -8,16 +8,16 @@ test.describe("World Tour race progression", () => {
   }) => {
     test.setTimeout(420_000);
 
-    const first = await runFullTourFromWorld(page);
-    const second = await runFullTourFromWorld(page);
+    const result = await runFullTourFromWorld(page);
 
-    expect(first.completedTracks).toEqual([
+    expect(result.completedTracks).toEqual([
       "velvet-coast/harbor-run",
       "velvet-coast/sunpier-loop",
       "velvet-coast/cliffline-arc",
       "velvet-coast/lighthouse-fall",
     ]);
-    expect(second).toEqual(first);
+    expect(result.completionText).toContain("Tour complete");
+    expect(result.completionText).toContain("Iron Borough");
   });
 
   test("final Velvet Coast race unlocks Iron Borough", async ({ page }) => {


### PR DESCRIPTION
## Summary
- Remove the duplicate second full Velvet Coast tour pass from the world-hub e2e smoke.
- Keep completed-track assertions and Iron Borough unlock coverage in the tour-flow spec.
- Log the slice in docs/PROGRESS_LOG.md.

## GDD
- No GDD design change. The exercised coverage area remains GDD-24-MVP-TRACK-SET.

## Progress log
- docs/PROGRESS_LOG.md entry: 2026-04-28 Slice: reduce tour-flow e2e runtime.

## Test plan
- npx playwright test e2e/tour-flow.spec.ts
- npm run test:e2e
- npm run verify
- npm run content-lint
- grep -rn $'\\u2014\\|\\u2013' e2e/tour-flow.spec.ts docs/PROGRESS_LOG.md || true