### PR TITLE
feat(modes): add daily challenge selection

### DIFF
--- a/docs/GDD_COVERAGE.json
+++ b/docs/GDD_COVERAGE.json
@@ -2,6 +2,27 @@
   "version": 1,
   "requirements": [
     {
+      "id": "GDD-06-DAILY-CHALLENGE-SELECTION",
+      "gddSections": [
+        "docs/gdd/06-game-modes.md",
+        "docs/gdd/21-technical-design-for-web-implementation.md"
+      ],
+      "requirement": "The daily challenge mode derives a deterministic UTC-day seed, selects a fixed bundled track, authored weather option, and car class for that day, and exposes a shareable entry route.",
+      "coverage": ["implemented-code", "automated-test"],
+      "implementationRefs": [
+        "src/game/modes/dailyChallenge.ts",
+        "src/app/daily/page.tsx",
+        "src/app/daily/DailyShareButton.tsx",
+        "src/app/page.tsx"
+      ],
+      "testRefs": [
+        "src/game/modes/__tests__/dailyChallenge.test.ts",
+        "src/app/__tests__/page.test.tsx",
+        "e2e/title-screen.spec.ts"
+      ],
+      "followupRefs": []
+    },
+    {
       "id": "GDD-14-OVERCAST-WEATHER-OPTION",
       "gddSections": [
         "docs/gdd/14-weather-and-environmental-systems.md",

--- a/docs/GDD_COVERAGE.json
+++ b/docs/GDD_COVERAGE.json
@@ -7,7 +7,7 @@
         "docs/gdd/06-game-modes.md",
         "docs/gdd/21-technical-design-for-web-implementation.md"
       ],
-      "requirement": "The daily challenge mode derives a deterministic UTC-day seed, selects a fixed bundled track, authored weather option, and car class for that day, and exposes a shareable entry route.",
+      "requirement": "The daily challenge mode derives a deterministic UTC-day seed, selects a fixed bundled track and authored weather option, recommends a car class for that day, and exposes a shareable entry route.",
       "coverage": ["implemented-code", "automated-test"],
       "implementationRefs": [
         "src/game/modes/dailyChallenge.ts",

--- a/docs/PROGRESS_LOG.md
+++ b/docs/PROGRESS_LOG.md
@@ -17,8 +17,8 @@ runtime conventions.
 
 ### Done
 - `src/game/modes/dailyChallenge.ts`: added deterministic UTC-day seed
-  generation, fixed daily track / weather / car-class selection, race
-  link construction, and share-text formatting.
+  generation, fixed daily track / weather selection, car-class
+  recommendation, race-link construction, and share-text formatting.
 - `src/app/daily/page.tsx`: added the Daily Challenge entry route with
   today's fixed challenge, a time-trial race link, and copyable share
   text fallback.
@@ -27,22 +27,24 @@ runtime conventions.
 
 ### Verified
 - `npx vitest run src/game/modes/__tests__/dailyChallenge.test.ts src/app/__tests__/page.test.tsx`
-  green, 21 passed.
+  green, 22 passed.
 - `npm run typecheck` green.
 - `npx playwright test e2e/title-screen.spec.ts` green, 7 passed.
-- `npm run verify` green, 2410 passed.
+- `npm run verify` green, 2411 passed.
 - `npm run test:e2e` green, 72 passed.
 
 ### Decisions and assumptions
 - Daily selection uses UTC date keys so the challenge is stable across
   local time zones and browser sessions.
 - The first Daily Challenge race link reuses Time Trial mode with a
-  fixed track and weather. Dedicated daily result persistence and
-  actual run-time share strings remain adjacent work.
+  fixed track and weather. Car class is a recommendation until `/race`
+  can enforce or temporarily loan eligible cars. Dedicated daily result
+  persistence and actual run-time share strings remain adjacent work.
 
 ### Coverage ledger
 - GDD-06-DAILY-CHALLENGE-SELECTION covers deterministic daily seed,
-  selection, title navigation, and the entry route.
+  fixed track / weather selection, car-class recommendation, title
+  navigation, and the entry route.
 - Uncovered adjacent requirements: result-backed Daily Challenge share
   text, UTC-midnight fake-clock e2e, and full Time Trial PB save button
   remain under the §6 modes parent dot.

--- a/docs/PROGRESS_LOG.md
+++ b/docs/PROGRESS_LOG.md
@@ -6,6 +6,53 @@ Correct them by adding a new entry that references the old one.
 
 ---
 
+## 2026-04-28: Slice: Daily Challenge seed selection
+
+**GDD sections touched:**
+[§6](gdd/06-game-modes.md) Community challenge,
+[§21](gdd/21-technical-design-for-web-implementation.md) deterministic
+runtime conventions.
+**Branch / PR:** `feat/daily-challenge-seed-selection`, PR pending.
+**Status:** Implemented.
+
+### Done
+- `src/game/modes/dailyChallenge.ts`: added deterministic UTC-day seed
+  generation, fixed daily track / weather / car-class selection, race
+  link construction, and share-text formatting.
+- `src/app/daily/page.tsx`: added the Daily Challenge entry route with
+  today's fixed challenge, a time-trial race link, and copyable share
+  text fallback.
+- `src/app/page.tsx`: added Daily Challenge to the title menu.
+- `docs/GDD_COVERAGE.json`: added GDD-06-DAILY-CHALLENGE-SELECTION.
+
+### Verified
+- `npx vitest run src/game/modes/__tests__/dailyChallenge.test.ts src/app/__tests__/page.test.tsx`
+  green, 21 passed.
+- `npm run typecheck` green.
+- `npx playwright test e2e/title-screen.spec.ts` green, 7 passed.
+- `npm run verify` green, 2410 passed.
+- `npm run test:e2e` green, 72 passed.
+
+### Decisions and assumptions
+- Daily selection uses UTC date keys so the challenge is stable across
+  local time zones and browser sessions.
+- The first Daily Challenge race link reuses Time Trial mode with a
+  fixed track and weather. Dedicated daily result persistence and
+  actual run-time share strings remain adjacent work.
+
+### Coverage ledger
+- GDD-06-DAILY-CHALLENGE-SELECTION covers deterministic daily seed,
+  selection, title navigation, and the entry route.
+- Uncovered adjacent requirements: result-backed Daily Challenge share
+  text, UTC-midnight fake-clock e2e, and full Time Trial PB save button
+  remain under the §6 modes parent dot.
+
+### Followups created
+None.
+
+### GDD edits
+None.
+
 ## 2026-04-28: Slice: reduce tour-flow e2e runtime
 
 **GDD sections touched:**

--- a/e2e/title-screen.spec.ts
+++ b/e2e/title-screen.spec.ts
@@ -25,6 +25,11 @@ test.describe("title screen", () => {
     await expect(timeTrial).toHaveText("Time Trial");
     await expect(timeTrial).toHaveAttribute("href", "/time-trial");
 
+    const daily = page.getByTestId("menu-daily");
+    await expect(daily).toBeVisible();
+    await expect(daily).toHaveText("Daily Challenge");
+    await expect(daily).toHaveAttribute("href", "/daily");
+
     const garage = page.getByTestId("menu-garage");
     await expect(garage).toBeVisible();
     await expect(garage).toHaveText("Garage");
@@ -64,6 +69,17 @@ test.describe("title screen", () => {
     await expect(page.getByTestId("race-canvas")).toHaveAttribute(
       "data-mode",
       "timeTrial",
+    );
+  });
+
+  test("Daily Challenge link navigates to /daily", async ({ page }) => {
+    await page.goto("/");
+    await page.getByTestId("menu-daily").click();
+    await expect(page).toHaveURL(/\/daily$/);
+    await expect(page.getByTestId("daily-page")).toBeVisible();
+    await expect(page.getByTestId("daily-start")).toHaveAttribute(
+      "href",
+      /\/race\?mode=timeTrial&track=.+&weather=.+/,
     );
   });
 

--- a/src/app/__tests__/page.test.tsx
+++ b/src/app/__tests__/page.test.tsx
@@ -38,6 +38,12 @@ describe("TitlePage", () => {
     expect(match?.[0]).toContain('href="/time-trial"');
   });
 
+  it("renders Daily Challenge as an anchor pointing at /daily", () => {
+    const match = html.match(/<a[^>]*data-testid="menu-daily"[^>]*>/);
+    expect(match, "menu-daily anchor not found").not.toBeNull();
+    expect(match?.[0]).toContain('href="/daily"');
+  });
+
   it("renders World Tour as an anchor pointing at /world", () => {
     const match = html.match(/<a[^>]*data-testid="menu-world"[^>]*>/);
     expect(match, "menu-world anchor not found").not.toBeNull();
@@ -56,16 +62,18 @@ describe("TitlePage", () => {
     expect(match?.[0]).toContain('href="/options"');
   });
 
-  it("places Start Race before World Tour before Time Trial before Garage before Options in tab order", () => {
+  it("places Start Race before World Tour before Time Trial before Daily before Garage before Options in tab order", () => {
     const startIdx = html.indexOf('data-testid="menu-start-race"');
     const worldIdx = html.indexOf('data-testid="menu-world"');
     const timeTrialIdx = html.indexOf('data-testid="menu-time-trial"');
+    const dailyIdx = html.indexOf('data-testid="menu-daily"');
     const garageIdx = html.indexOf('data-testid="menu-garage"');
     const optionsIdx = html.indexOf('data-testid="menu-options"');
     expect(startIdx).toBeGreaterThan(-1);
     expect(worldIdx).toBeGreaterThan(startIdx);
     expect(timeTrialIdx).toBeGreaterThan(worldIdx);
-    expect(garageIdx).toBeGreaterThan(timeTrialIdx);
+    expect(dailyIdx).toBeGreaterThan(timeTrialIdx);
+    expect(garageIdx).toBeGreaterThan(dailyIdx);
     expect(optionsIdx).toBeGreaterThan(garageIdx);
   });
 

--- a/src/app/daily/DailyShareButton.tsx
+++ b/src/app/daily/DailyShareButton.tsx
@@ -1,0 +1,50 @@
+"use client";
+
+import { useState } from "react";
+
+interface DailyShareButtonProps {
+  readonly text: string;
+}
+
+export function DailyShareButton({ text }: DailyShareButtonProps) {
+  const [status, setStatus] = useState<"idle" | "copied" | "fallback">("idle");
+
+  async function copyShareText(): Promise<void> {
+    if (navigator.clipboard?.writeText) {
+      try {
+        await navigator.clipboard.writeText(text);
+        setStatus("copied");
+        return;
+      } catch {
+        setStatus("fallback");
+        return;
+      }
+    }
+    setStatus("fallback");
+  }
+
+  return (
+    <div>
+      <button
+        type="button"
+        onClick={() => void copyShareText()}
+        data-testid="daily-share"
+      >
+        Copy daily share
+      </button>
+      <textarea
+        aria-label="Daily challenge share text"
+        data-testid="daily-share-text"
+        readOnly
+        value={text}
+      />
+      <p aria-live="polite" data-testid="daily-share-status">
+        {status === "copied"
+          ? "Copied"
+          : status === "fallback"
+            ? "Copy the text manually"
+            : "Ready"}
+      </p>
+    </div>
+  );
+}

--- a/src/app/daily/page.module.css
+++ b/src/app/daily/page.module.css
@@ -1,0 +1,137 @@
+.main {
+  min-height: 100vh;
+  padding: 48px 20px;
+  background: #0b0e14;
+  color: #e6e8eb;
+}
+
+.shell {
+  width: min(840px, 100%);
+  margin: 0 auto;
+}
+
+.header {
+  display: grid;
+  gap: 12px;
+  margin-bottom: 28px;
+}
+
+.eyebrow {
+  margin: 0;
+  color: #93c5fd;
+  font-size: 0.86rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.title {
+  margin: 0;
+  font-size: clamp(2rem, 7vw, 4.5rem);
+  line-height: 0.95;
+}
+
+.summary {
+  max-width: 64ch;
+  margin: 0;
+  color: #b8c0cc;
+  font-size: 1.05rem;
+  line-height: 1.6;
+}
+
+.panel {
+  display: grid;
+  gap: 18px;
+  padding: 24px;
+  border: 1px solid #28415f;
+  border-radius: 8px;
+  background: #111827;
+}
+
+.stats {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 12px;
+  margin: 0;
+}
+
+.stat {
+  padding: 12px;
+  background: #172033;
+}
+
+.stat dt {
+  margin-bottom: 4px;
+  color: #9aa3ad;
+  font-size: 0.82rem;
+  text-transform: uppercase;
+}
+
+.stat dd {
+  margin: 0;
+  font-size: 1.15rem;
+  font-weight: 700;
+}
+
+.actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+}
+
+.button,
+.secondary {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 44px;
+  padding: 0 16px;
+  border-radius: 6px;
+  font-weight: 800;
+  text-decoration: none;
+}
+
+.button {
+  background: #facc15;
+  color: #111827;
+}
+
+.secondary {
+  border: 1px solid #334155;
+  color: #e6e8eb;
+}
+
+.share textarea {
+  width: 100%;
+  min-height: 72px;
+  margin-top: 12px;
+  padding: 10px;
+  border: 1px solid #334155;
+  border-radius: 6px;
+  background: #0b0e14;
+  color: #e6e8eb;
+  font: inherit;
+  resize: vertical;
+}
+
+.share button {
+  min-height: 40px;
+  padding: 0 14px;
+  border: 0;
+  border-radius: 6px;
+  background: #60a5fa;
+  color: #07111f;
+  font-weight: 800;
+  cursor: pointer;
+}
+
+.share p {
+  margin: 8px 0 0;
+  color: #9aa3ad;
+}
+
+@media (max-width: 640px) {
+  .stats {
+    grid-template-columns: 1fr;
+  }
+}

--- a/src/app/daily/page.tsx
+++ b/src/app/daily/page.tsx
@@ -33,7 +33,8 @@ export default function DailyChallengePage() {
             {challenge.dateKey}
           </h1>
           <p className={styles.summary}>
-            Fixed track, fixed weather, and fixed car class for one UTC day.
+            Fixed track and weather for one UTC day, with a daily car class
+            recommendation.
           </p>
         </header>
 
@@ -50,7 +51,7 @@ export default function DailyChallengePage() {
               </dd>
             </div>
             <div className={styles.stat}>
-              <dt>Car class</dt>
+              <dt>Recommended class</dt>
               <dd data-testid="daily-car-class">
                 {formatCarClass(challenge.carClass)}
               </dd>

--- a/src/app/daily/page.tsx
+++ b/src/app/daily/page.tsx
@@ -1,0 +1,111 @@
+import Link from "next/link";
+
+import { CARS, TRACK_IDS, TRACK_RAW } from "@/data";
+import { TrackSchema, type CarClass } from "@/data/schemas";
+import {
+  dailyChallengeRaceHref,
+  formatDailyChallengeShareText,
+  selectDailyChallenge,
+  type DailyChallengeTrack,
+} from "@/game/modes/dailyChallenge";
+import { weatherLabel } from "@/game/preRaceCard";
+
+import { DailyShareButton } from "./DailyShareButton";
+import styles from "./page.module.css";
+
+export const dynamic = "force-dynamic";
+
+export default function DailyChallengePage() {
+  const challenge = selectDailyChallenge(
+    new Date(),
+    bundledDailyTracks(),
+    bundledCarClasses(),
+  );
+  const shareText = formatDailyChallengeShareText(challenge);
+  const raceHref = dailyChallengeRaceHref(challenge);
+
+  return (
+    <main className={styles.main} data-testid="daily-page">
+      <section className={styles.shell} aria-labelledby="daily-title">
+        <header className={styles.header}>
+          <p className={styles.eyebrow}>Daily Challenge</p>
+          <h1 className={styles.title} id="daily-title">
+            {challenge.dateKey}
+          </h1>
+          <p className={styles.summary}>
+            Fixed track, fixed weather, and fixed car class for one UTC day.
+          </p>
+        </header>
+
+        <article className={styles.panel}>
+          <dl className={styles.stats}>
+            <div className={styles.stat}>
+              <dt>Track</dt>
+              <dd data-testid="daily-track">{challenge.trackId}</dd>
+            </div>
+            <div className={styles.stat}>
+              <dt>Weather</dt>
+              <dd data-testid="daily-weather">
+                {weatherLabel(challenge.weather)}
+              </dd>
+            </div>
+            <div className={styles.stat}>
+              <dt>Car class</dt>
+              <dd data-testid="daily-car-class">
+                {formatCarClass(challenge.carClass)}
+              </dd>
+            </div>
+            <div className={styles.stat}>
+              <dt>Seed</dt>
+              <dd data-testid="daily-seed">{challenge.seed}</dd>
+            </div>
+          </dl>
+
+          <div className={styles.actions}>
+            <Link
+              className={styles.button}
+              href={raceHref}
+              data-testid="daily-start"
+            >
+              Start run
+            </Link>
+            <Link
+              className={styles.secondary}
+              href="/"
+              data-testid="daily-back"
+            >
+              Back to title
+            </Link>
+          </div>
+
+          <div className={styles.share}>
+            <DailyShareButton text={shareText} />
+          </div>
+        </article>
+      </section>
+    </main>
+  );
+}
+
+function bundledDailyTracks(): DailyChallengeTrack[] {
+  return TRACK_IDS.filter((id) => !id.startsWith("test/")).map((id) => {
+    const parsed = TrackSchema.parse(TRACK_RAW[id]);
+    return {
+      id,
+      weatherOptions: parsed.weatherOptions,
+    };
+  });
+}
+
+function bundledCarClasses(): CarClass[] {
+  const seen = new Set<CarClass>();
+  for (const car of CARS) seen.add(car.class);
+  return [...seen];
+}
+
+function formatCarClass(carClass: CarClass): string {
+  return carClass
+    .split("-")
+    .map((part) => `${part[0]?.toUpperCase() ?? ""}${part.slice(1)}`)
+    .join(" ");
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -8,13 +8,14 @@ import styles from "./page.module.css";
  *
  * Renders the top-level main menu items per GDD §5 and §20:
  * Start Race -> `/race`, World Tour -> `/world`, Time Trial ->
- * `/time-trial`, Garage -> `/garage`, Options -> `/options`. The Options entry was a disabled placeholder
+ * `/time-trial`, Daily Challenge -> `/daily`, Garage -> `/garage`,
+ * Options -> `/options`. The Options entry was a disabled placeholder
  * (`menu-options-pending`) until the `/options` scaffold landed in
  * `VibeGear2-implement-options-screen-a9379c4a`. Its replacement keeps
  * the original `menu-options` test id that the e2e suite asserts on.
  *
- * Keyboard order is Start Race -> World Tour -> Time Trial -> Garage -> Options
- * (DOM order).
+ * Keyboard order is Start Race -> World Tour -> Time Trial -> Daily
+ * Challenge -> Garage -> Options (DOM order).
  *
  * The footer carries two pieces of metadata. The pre-existing
  * `build-status` line tracks the design phase (kept verbatim so the
@@ -35,6 +36,7 @@ const MENU: ReadonlyArray<MenuItem> = [
   { label: "Start Race", href: "/race", testId: "menu-start-race" },
   { label: "World Tour", href: "/world", testId: "menu-world" },
   { label: "Time Trial", href: "/time-trial", testId: "menu-time-trial" },
+  { label: "Daily Challenge", href: "/daily", testId: "menu-daily" },
   { label: "Garage", href: "/garage", testId: "menu-garage" },
   { label: "Options", href: "/options", testId: "menu-options" },
 ];

--- a/src/game/modes/__tests__/dailyChallenge.test.ts
+++ b/src/game/modes/__tests__/dailyChallenge.test.ts
@@ -74,6 +74,26 @@ describe("selectDailyChallenge", () => {
     expect(track?.weatherOptions).toContain(challenge.weather);
   });
 
+  it("is independent from authored weather option order", () => {
+    const reordered = TRACKS.map((track) => ({
+      ...track,
+      weatherOptions: [...track.weatherOptions].reverse(),
+    }));
+    expect(
+      selectDailyChallenge(
+        new Date("2026-04-26T03:00:00Z"),
+        reordered,
+        ["balance", "power"],
+      ),
+    ).toEqual(
+      selectDailyChallenge(
+        new Date("2026-04-26T03:00:00Z"),
+        TRACKS,
+        ["balance", "power"],
+      ),
+    );
+  });
+
   it("filters duplicate car classes into schema order", () => {
     const challenge = selectDailyChallenge(
       new Date("2026-04-26T03:00:00Z"),

--- a/src/game/modes/__tests__/dailyChallenge.test.ts
+++ b/src/game/modes/__tests__/dailyChallenge.test.ts
@@ -1,0 +1,133 @@
+import { describe, expect, it } from "vitest";
+
+import type { DailyChallengeTrack } from "../dailyChallenge";
+import {
+  dailyChallengeRaceHref,
+  dailyDateKey,
+  dailySeed,
+  formatDailyChallengeShareText,
+  selectDailyChallenge,
+} from "../dailyChallenge";
+
+const TRACKS: readonly DailyChallengeTrack[] = [
+  { id: "velvet-coast/harbor-run", weatherOptions: ["clear", "rain", "fog"] },
+  { id: "iron-borough/foundry-mile", weatherOptions: ["clear", "rain"] },
+  { id: "velvet-coast/sunpier-loop", weatherOptions: ["clear", "rain"] },
+];
+
+describe("dailyDateKey", () => {
+  it("uses the UTC day rather than local time", () => {
+    expect(dailyDateKey(new Date("2026-04-26T03:00:00Z"))).toBe(
+      "2026-04-26",
+    );
+    expect(dailyDateKey(new Date("2026-04-26T22:00:00Z"))).toBe(
+      "2026-04-26",
+    );
+  });
+});
+
+describe("dailySeed", () => {
+  it("is stable within one UTC day and changes on the next UTC day", () => {
+    const early = dailySeed(new Date("2026-04-26T03:00:00Z"));
+    const late = dailySeed(new Date("2026-04-26T22:00:00Z"));
+    const next = dailySeed(new Date("2026-04-27T01:00:00Z"));
+    expect(late).toBe(early);
+    expect(next).not.toBe(early);
+  });
+
+  it("generates a distinct seed for 30 sequential UTC days", () => {
+    const seeds = new Set<number>();
+    for (let day = 1; day <= 30; day += 1) {
+      const key = `2026-04-${`${day}`.padStart(2, "0")}T12:00:00Z`;
+      seeds.add(dailySeed(new Date(key)));
+    }
+    expect(seeds.size).toBe(30);
+  });
+});
+
+describe("selectDailyChallenge", () => {
+  it("returns the same selection for repeated calls with the same inputs", () => {
+    const date = new Date("2026-04-26T03:00:00Z");
+    const first = selectDailyChallenge(date, TRACKS, ["balance", "power"]);
+    for (let i = 0; i < 1000; i += 1) {
+      expect(selectDailyChallenge(date, TRACKS, ["balance", "power"])).toEqual(
+        first,
+      );
+    }
+  });
+
+  it("is independent from input track order", () => {
+    const date = new Date("2026-04-26T03:00:00Z");
+    const shuffled = [TRACKS[2]!, TRACKS[0]!, TRACKS[1]!];
+    expect(selectDailyChallenge(date, shuffled, ["balance", "power"])).toEqual(
+      selectDailyChallenge(date, TRACKS, ["balance", "power"]),
+    );
+  });
+
+  it("chooses only authored weather for the selected track", () => {
+    const challenge = selectDailyChallenge(
+      new Date("2026-04-26T03:00:00Z"),
+      TRACKS,
+      ["balance", "power"],
+    );
+    const track = TRACKS.find((item) => item.id === challenge.trackId);
+    expect(track?.weatherOptions).toContain(challenge.weather);
+  });
+
+  it("filters duplicate car classes into schema order", () => {
+    const challenge = selectDailyChallenge(
+      new Date("2026-04-26T03:00:00Z"),
+      TRACKS,
+      ["power", "balance", "power"],
+    );
+    expect(["balance", "power"]).toContain(challenge.carClass);
+  });
+
+  it("rejects empty track and car-class pools", () => {
+    expect(() =>
+      selectDailyChallenge(new Date("2026-04-26T03:00:00Z"), []),
+    ).toThrow("eligible track");
+    expect(() =>
+      selectDailyChallenge(new Date("2026-04-26T03:00:00Z"), TRACKS, []),
+    ).toThrow("car class");
+  });
+});
+
+describe("dailyChallengeRaceHref", () => {
+  it("builds a time-trial race link with fixed track and weather", () => {
+    const challenge = selectDailyChallenge(
+      new Date("2026-04-26T03:00:00Z"),
+      TRACKS,
+      ["balance", "power"],
+    );
+    const href = dailyChallengeRaceHref(challenge);
+    expect(href).toContain("/race?");
+    expect(href).toContain("mode=timeTrial");
+    expect(href).toContain(`track=${encodeURIComponent(challenge.trackId)}`);
+    expect(href).toContain(`weather=${challenge.weather}`);
+  });
+});
+
+describe("formatDailyChallengeShareText", () => {
+  it("formats an unfinished challenge with a no-result marker", () => {
+    const challenge = selectDailyChallenge(
+      new Date("2026-04-26T03:00:00Z"),
+      TRACKS,
+      ["balance", "power"],
+    );
+    expect(formatDailyChallengeShareText(challenge)).toContain(
+      "VibeGear2 Daily 2026-04-26 no result",
+    );
+  });
+
+  it("formats a completed challenge time", () => {
+    const challenge = selectDailyChallenge(
+      new Date("2026-04-26T03:00:00Z"),
+      TRACKS,
+      ["balance", "power"],
+    );
+    expect(formatDailyChallengeShareText(challenge, 83_456)).toContain(
+      "VibeGear2 Daily 2026-04-26 1:23.456",
+    );
+  });
+});

--- a/src/game/modes/dailyChallenge.ts
+++ b/src/game/modes/dailyChallenge.ts
@@ -1,5 +1,5 @@
 import type { CarClass, WeatherOption } from "@/data/schemas";
-import { CarClassSchema } from "@/data/schemas";
+import { CarClassSchema, WeatherOptionSchema } from "@/data/schemas";
 import { createRng } from "@/game/rng";
 
 export interface DailyChallengeTrack {
@@ -52,8 +52,8 @@ export function selectDailyChallenge(
   if (track === undefined) {
     throw new Error("selectDailyChallenge failed to choose a track");
   }
-  const weather =
-    track.weatherOptions[rng.nextInt(0, track.weatherOptions.length)];
+  const weatherOptions = uniqueWeatherOptions(track.weatherOptions);
+  const weather = weatherOptions[rng.nextInt(0, weatherOptions.length)];
   if (weather === undefined) {
     throw new Error("selectDailyChallenge failed to choose weather");
   }
@@ -102,6 +102,13 @@ export function formatDailyChallengeShareText(
 function uniqueCarClasses(carClasses: readonly CarClass[]): CarClass[] {
   const allowed = new Set<CarClass>(carClasses);
   return CarClassSchema.options.filter((carClass) => allowed.has(carClass));
+}
+
+function uniqueWeatherOptions(
+  weatherOptions: readonly WeatherOption[],
+): WeatherOption[] {
+  const allowed = new Set<WeatherOption>(weatherOptions);
+  return WeatherOptionSchema.options.filter((weather) => allowed.has(weather));
 }
 
 function formatResultTime(ms: number): string {

--- a/src/game/modes/dailyChallenge.ts
+++ b/src/game/modes/dailyChallenge.ts
@@ -1,0 +1,125 @@
+import type { CarClass, WeatherOption } from "@/data/schemas";
+import { CarClassSchema } from "@/data/schemas";
+import { createRng } from "@/game/rng";
+
+export interface DailyChallengeTrack {
+  readonly id: string;
+  readonly weatherOptions: readonly WeatherOption[];
+}
+
+export interface DailyChallengeSelection {
+  readonly dateKey: string;
+  readonly seed: number;
+  readonly trackId: string;
+  readonly weather: WeatherOption;
+  readonly carClass: CarClass;
+}
+
+export const DEFAULT_DAILY_CAR_CLASSES: readonly CarClass[] =
+  CarClassSchema.options;
+
+export function dailyDateKey(date: Date): string {
+  const year = date.getUTCFullYear();
+  const month = `${date.getUTCMonth() + 1}`.padStart(2, "0");
+  const day = `${date.getUTCDate()}`.padStart(2, "0");
+  return `${year}-${month}-${day}`;
+}
+
+export function dailySeed(date: Date): number {
+  return hashString32(`vibegear2-daily:${dailyDateKey(date)}`);
+}
+
+export function selectDailyChallenge(
+  date: Date,
+  tracks: readonly DailyChallengeTrack[],
+  carClasses: readonly CarClass[] = DEFAULT_DAILY_CAR_CLASSES,
+): DailyChallengeSelection {
+  const eligibleTracks = [...tracks]
+    .filter((track) => track.weatherOptions.length > 0)
+    .sort((a, b) => a.id.localeCompare(b.id));
+  if (eligibleTracks.length === 0) {
+    throw new Error("selectDailyChallenge requires at least one eligible track");
+  }
+
+  const eligibleClasses = uniqueCarClasses(carClasses);
+  if (eligibleClasses.length === 0) {
+    throw new Error("selectDailyChallenge requires at least one car class");
+  }
+
+  const seed = dailySeed(date);
+  const rng = createRng(seed);
+  const track = eligibleTracks[rng.nextInt(0, eligibleTracks.length)];
+  if (track === undefined) {
+    throw new Error("selectDailyChallenge failed to choose a track");
+  }
+  const weather =
+    track.weatherOptions[rng.nextInt(0, track.weatherOptions.length)];
+  if (weather === undefined) {
+    throw new Error("selectDailyChallenge failed to choose weather");
+  }
+  const carClass = eligibleClasses[rng.nextInt(0, eligibleClasses.length)];
+  if (carClass === undefined) {
+    throw new Error("selectDailyChallenge failed to choose a car class");
+  }
+
+  return {
+    dateKey: dailyDateKey(date),
+    seed,
+    trackId: track.id,
+    weather,
+    carClass,
+  };
+}
+
+export function dailyChallengeRaceHref(
+  challenge: DailyChallengeSelection,
+): string {
+  const params = new URLSearchParams({
+    mode: "timeTrial",
+    track: challenge.trackId,
+    weather: challenge.weather,
+  });
+  return `/race?${params.toString()}`;
+}
+
+export function formatDailyChallengeShareText(
+  challenge: DailyChallengeSelection,
+  bestMs?: number | null,
+): string {
+  const time = Number.isFinite(bestMs ?? Number.NaN)
+    ? formatResultTime(bestMs as number)
+    : "no result";
+  return [
+    "VibeGear2 Daily",
+    challenge.dateKey,
+    time,
+    challenge.trackId,
+    challenge.weather,
+    challenge.carClass,
+  ].join(" ");
+}
+
+function uniqueCarClasses(carClasses: readonly CarClass[]): CarClass[] {
+  const allowed = new Set<CarClass>(carClasses);
+  return CarClassSchema.options.filter((carClass) => allowed.has(carClass));
+}
+
+function formatResultTime(ms: number): string {
+  const clamped = Math.max(0, Math.floor(ms));
+  const minutes = Math.floor(clamped / 60_000);
+  const seconds = Math.floor((clamped % 60_000) / 1_000);
+  const millis = clamped % 1_000;
+  return `${minutes}:${`${seconds}`.padStart(2, "0")}.${`${millis}`.padStart(
+    3,
+    "0",
+  )}`;
+}
+
+function hashString32(value: string): number {
+  let hash = 0x811c9dc5;
+  for (let i = 0; i < value.length; i += 1) {
+    hash ^= value.charCodeAt(i);
+    hash = Math.imul(hash, 0x01000193) >>> 0;
+  }
+  return hash;
+}


### PR DESCRIPTION
## Summary
- Add deterministic UTC Daily Challenge seed and selection helpers.
- Add the /daily entry page with fixed track, weather, car class, race link, and copyable share text.
- Add Daily Challenge to the title menu and record GDD coverage.

## GDD
- §6 Community challenge.
- §21 deterministic runtime conventions.
- Coverage row: GDD-06-DAILY-CHALLENGE-SELECTION.

## Progress log
- docs/PROGRESS_LOG.md entry: 2026-04-28 Slice: Daily Challenge seed selection.

## Adjacent work
- Result-backed Daily Challenge share text, UTC-midnight fake-clock e2e, and the full Time Trial PB save button remain under the §6 modes parent dot.

## Test plan
- npx vitest run src/game/modes/__tests__/dailyChallenge.test.ts src/app/__tests__/page.test.tsx
- npm run typecheck
- npx playwright test e2e/title-screen.spec.ts
- npm run verify
- npm run test:e2e
- npm run content-lint
- grep -rn $'\\u2014\\|\\u2013' src/game/modes/dailyChallenge.ts src/game/modes/__tests__/dailyChallenge.test.ts src/app/daily src/app/page.tsx src/app/__tests__/page.test.tsx e2e/title-screen.spec.ts docs/PROGRESS_LOG.md docs/GDD_COVERAGE.json || true