### PR TITLE
fix(input): repair mobile touch controls

### DIFF
--- a/docs/GDD_COVERAGE.json
+++ b/docs/GDD_COVERAGE.json
@@ -415,7 +415,7 @@
         "docs/gdd/20-hud-and-ui-ux.md",
         "docs/gdd/21-technical-design-for-web-implementation.md"
       ],
-      "requirement": "The live race route fills mobile viewports without page scroll and mounts touch controls that feed steering, throttle, brake, nitro, and pause into the race input pipeline.",
+      "requirement": "The live race route fills mobile viewports without page scroll and mounts transient left-half steering plus reachable right-thumb touch controls that feed steering, throttle, brake, nitro, and pause into the race input pipeline.",
       "coverage": ["implemented-code", "automated-test"],
       "implementationRefs": [
         "src/app/race/page.tsx",

--- a/docs/PROGRESS_LOG.md
+++ b/docs/PROGRESS_LOG.md
@@ -6,6 +6,57 @@ Correct them by adding a new entry that references the old one.
 
 ---
 
+## 2026-04-28: Slice: Mobile touch controls
+
+**GDD sections touched:**
+[§19](gdd/19-controls-and-input.md) touch input,
+[§20](gdd/20-hud-and-ui-ux.md) race HUD control surface,
+[§21](gdd/21-technical-design-for-web-implementation.md) web runtime.
+**Branch / PR:** `fix/mobile-touch-controls`, PR pending.
+**Status:** Implemented.
+
+### Done
+- `src/components/touch/TouchControls.tsx`: made the steering stick
+  transient, thumb-anchored on left-half pointerdown, and invisible
+  after release while keeping the overlay from intercepting the live
+  canvas input source.
+- `src/game/inputTouch.ts`: moved accelerator and brake hit targets to
+  the lower-right thumb arc and prevents browser gestures from stealing
+  active touch pointers.
+- `e2e/race-mobile.spec.ts`: added live `/race` iPhone coverage for
+  left-half stick spawning, sign-correct steering, stick release, and
+  right-thumb control placement.
+- `docs/GDD_COVERAGE.json`: tightened GDD-19-MOBILE-RACE-INPUT to cover
+  the transient steering and reachable right-thumb controls.
+
+### Verified
+- `npx vitest run src/game/inputTouch.test.ts` green, 39 passed.
+- `npx playwright test e2e/race-mobile.spec.ts --project=mobile-chromium`
+  green, 3 passed.
+- `npx playwright test e2e/touch-input.spec.ts --project=mobile-chromium`
+  green, 4 passed.
+- `npm run typecheck` green.
+- `npm run verify` green, 2413 passed.
+- `npm run test:e2e` green, 73 passed.
+
+### Decisions and assumptions
+- The visual overlay observes document pointer events while remaining
+  `pointer-events: none`, so the canvas remains the single live input
+  target and the stick still mirrors real touches.
+- Nitro and pause stay at the top-right edge for now because the bug
+  report only calls out GAS and BRK reachability.
+
+### Coverage ledger
+- GDD-19-MOBILE-RACE-INPUT now covers transient left-half steering and
+  reachable right-thumb GAS / BRK placement on the mounted race route.
+- Uncovered adjacent requirements: none created by this slice.
+
+### Followups created
+None.
+
+### GDD edits
+None.
+
 ## 2026-04-28: Slice: Daily Challenge seed selection
 
 **GDD sections touched:**

--- a/docs/PROGRESS_LOG.md
+++ b/docs/PROGRESS_LOG.md
@@ -30,13 +30,13 @@ Correct them by adding a new entry that references the old one.
   the transient steering and reachable right-thumb controls.
 
 ### Verified
-- `npx vitest run src/game/inputTouch.test.ts` green, 39 passed.
+- `npx vitest run src/game/inputTouch.test.ts` green, 40 passed.
 - `npx playwright test e2e/race-mobile.spec.ts --project=mobile-chromium`
   green, 3 passed.
 - `npx playwright test e2e/touch-input.spec.ts --project=mobile-chromium`
   green, 4 passed.
 - `npm run typecheck` green.
-- `npm run verify` green, 2413 passed.
+- `npm run verify` green, 2414 passed.
 - `npm run test:e2e` green, 73 passed.
 
 ### Decisions and assumptions

--- a/e2e/race-mobile.spec.ts
+++ b/e2e/race-mobile.spec.ts
@@ -27,7 +27,7 @@ test.describe("mobile race playability", () => {
     expect(scrollState.docScrollHeight).toBeLessThanOrEqual(scrollState.innerHeight + 1);
   });
 
-  test("touch overlay drives steering and pause on the live race route", async ({ page }) => {
+  test("transient left-half stick drives steering on the live race route", async ({ page }) => {
     await page.goto("/race");
 
     await expect(page.getByTestId("touch-controls")).toBeVisible();
@@ -36,12 +36,19 @@ test.describe("mobile race playability", () => {
     expect(surfaceBox).not.toBeNull();
     if (!surfaceBox) return;
 
-    const startX = surfaceBox.x + surfaceBox.width * 0.18;
-    const startY = surfaceBox.y + surfaceBox.height * 0.7;
+    const startX = surfaceBox.x + surfaceBox.width * 0.24;
+    const startY = surfaceBox.y + surfaceBox.height * 0.52;
     const endX = startX + Math.min(180, surfaceBox.width * 0.35);
 
+    await expect(page.getByTestId("touch-stick")).toHaveCount(0);
     await pressPointer(page, startX, startY, 1);
     try {
+      await expect(page.getByTestId("touch-stick")).toBeVisible();
+      const knobBox = await page.getByTestId("touch-stick-knob").boundingBox();
+      expect(knobBox).not.toBeNull();
+      if (!knobBox) return;
+      expect(knobBox.x + knobBox.width / 2).toBeCloseTo(startX, 2);
+      expect(knobBox.y + knobBox.height / 2).toBeCloseTo(startY, 2);
       await movePointer(page, endX, startY, 1);
       await expect(page.getByTestId("race-touch-active")).toHaveText("yes");
       await expect.poll(async () => Number(await page.getByTestId("race-last-steer").innerText()))
@@ -49,6 +56,27 @@ test.describe("mobile race playability", () => {
     } finally {
       await releasePointer(page, endX, startY, 1);
     }
+    await expect(page.getByTestId("touch-stick")).toHaveCount(0);
+  });
+
+  test("right-thumb controls are reachable and pause still works", async ({ page }) => {
+    await page.goto("/race");
+
+    await expect(page.getByTestId("touch-controls")).toBeVisible();
+
+    const accelBox = await page.getByTestId("touch-accelerate").boundingBox();
+    const brakeBox = await page.getByTestId("touch-brake").boundingBox();
+    expect(accelBox).not.toBeNull();
+    expect(brakeBox).not.toBeNull();
+    if (!accelBox || !brakeBox) return;
+
+    const viewport = page.viewportSize();
+    expect(viewport).not.toBeNull();
+    if (!viewport) return;
+
+    expect(accelBox.y + accelBox.height / 2).toBeGreaterThan(viewport.height * 0.6);
+    expect(brakeBox.y + brakeBox.height / 2).toBeGreaterThan(viewport.height * 0.7);
+    expect(accelBox.x + accelBox.width / 2).toBeGreaterThan(viewport.width * 0.75);
 
     const pauseBox = await page.getByTestId("touch-pause").boundingBox();
     expect(pauseBox).not.toBeNull();
@@ -73,7 +101,7 @@ async function pressPointer(
 ): Promise<void> {
   await page.evaluate(
     ({ x: px, y: py, pointerId: id }) => {
-      const target = document.querySelector("[data-testid='race-canvas-element']");
+      const target = document.elementFromPoint(px, py);
       if (!target) return;
       target.dispatchEvent(
         new PointerEvent("pointerdown", {
@@ -98,7 +126,7 @@ async function movePointer(
 ): Promise<void> {
   await page.evaluate(
     ({ toX: bx, toY: by, pointerId: id }) => {
-      const target = document.querySelector("[data-testid='race-canvas-element']");
+      const target = document.elementFromPoint(bx, by);
       if (!target) return;
       target.dispatchEvent(
         new PointerEvent("pointermove", {
@@ -123,7 +151,7 @@ async function releasePointer(
 ): Promise<void> {
   await page.evaluate(
     ({ x: px, y: py, pointerId: id }) => {
-      const target = document.querySelector("[data-testid='race-canvas-element']");
+      const target = document.elementFromPoint(px, py);
       if (!target) return;
       target.dispatchEvent(
         new PointerEvent("pointerup", {

--- a/src/components/touch/TouchControls.tsx
+++ b/src/components/touch/TouchControls.tsx
@@ -3,9 +3,9 @@
 /**
  * Visual overlay for the touch input source (closes F-013).
  *
- * Renders a translucent SVG over the canvas: a left-side virtual stick
- * (anchor circle plus a knob that follows the most recent steer pointer),
- * a right-side accelerator and brake button, plus thumb-zone nitro and
+ * Renders a translucent SVG over the canvas: a transient left-side
+ * virtual stick anchored at the current thumb-down position, a
+ * lower-right accelerator and brake pair, plus thumb-zone nitro and
  * pause buttons. Layout matches `DEFAULT_TOUCH_LAYOUT` in
  * `src/game/inputTouch.ts` so the overlay and the input source agree
  * out of the box.
@@ -107,9 +107,10 @@ export function TouchControls(props: TouchControlsProps): ReactElement | null {
   const svgRef = useRef<SVGSVGElement | null>(null);
   const [knob, setKnob] = useState<KnobState>(NEUTRAL_KNOB);
 
-  // Subscribe to pointer events on the SVG so the knob can mirror the
-  // underlying input source visually. The actual input is read by the
-  // touch input source; this listener only drives the visual knob.
+  // Observe pointer events at the document level so the overlay can
+  // stay `pointer-events: none` and never intercept the canvas input
+  // source. The actual input is read by the touch input source; this
+  // listener only drives the visual knob.
   useEffect(() => {
     if (!visible) return;
     const el = svgRef.current;
@@ -134,15 +135,15 @@ export function TouchControls(props: TouchControlsProps): ReactElement | null {
       setKnob((prev) => (prev.pointerId === ev.pointerId ? NEUTRAL_KNOB : prev));
     };
 
-    el.addEventListener("pointerdown", onDown);
-    el.addEventListener("pointermove", onMove);
-    el.addEventListener("pointerup", onRelease);
-    el.addEventListener("pointercancel", onRelease);
+    document.addEventListener("pointerdown", onDown, true);
+    document.addEventListener("pointermove", onMove, true);
+    document.addEventListener("pointerup", onRelease, true);
+    document.addEventListener("pointercancel", onRelease, true);
     return () => {
-      el.removeEventListener("pointerdown", onDown);
-      el.removeEventListener("pointermove", onMove);
-      el.removeEventListener("pointerup", onRelease);
-      el.removeEventListener("pointercancel", onRelease);
+      document.removeEventListener("pointerdown", onDown, true);
+      document.removeEventListener("pointermove", onMove, true);
+      document.removeEventListener("pointerup", onRelease, true);
+      document.removeEventListener("pointercancel", onRelease, true);
     };
   }, [visible, layout.width, layout.steerZoneRatio]);
 
@@ -154,18 +155,17 @@ export function TouchControls(props: TouchControlsProps): ReactElement | null {
 
   if (!visible) return null;
 
-  const stickAnchorX = layout.width * 0.18;
-  const stickAnchorY = layout.height * 0.7;
   const stickRadius = layout.stickMaxRadius;
-  const knobX = knob.pointerId !== null ? knob.originX : stickAnchorX;
-  const knobY = knob.pointerId !== null ? knob.originY : stickAnchorY;
+  const knobX = knob.originX;
+  const knobY = knob.originY;
   const knobDrawnX = knobX + knobOffset.dx;
   const knobDrawnY = knobY + knobOffset.dy;
 
-  const accelX = layout.width - layout.width * 0.15;
-  const accelY = layout.height * 0.4;
-  const brakeX = accelX;
-  const brakeY = layout.height - layout.height * 0.18;
+  const thumbRadius = Math.max(52, Math.min(88, layout.width * 0.14));
+  const accelX = layout.width * 0.86;
+  const accelY = layout.height * 0.72;
+  const brakeX = layout.width * 0.68;
+  const brakeY = layout.height * 0.82;
   const nitroX = layout.width - layout.nitroCornerSize / 2;
   const nitroY = layout.nitroCornerSize / 2;
   const pauseX = layout.width - layout.nitroCornerSize - layout.pauseCornerSize / 2;
@@ -194,32 +194,36 @@ export function TouchControls(props: TouchControlsProps): ReactElement | null {
         ...props.style,
       }}
     >
-      {/* Stick anchor (the dimmer outer ring shows the rest position). */}
-      <circle
-        cx={stickAnchorX}
-        cy={stickAnchorY}
-        r={stickRadius}
-        fill="rgba(255, 255, 255, 0.05)"
-        stroke="rgba(255, 255, 255, 0.25)"
-        strokeWidth={2}
-      />
-      {/* Knob (the brighter inner disc; tracks the dragged finger). */}
-      <circle
-        data-testid="touch-stick-knob"
-        cx={knobDrawnX}
-        cy={knobDrawnY}
-        r={stickRadius * 0.45}
-        fill="rgba(255, 255, 255, 0.35)"
-        stroke="rgba(255, 255, 255, 0.6)"
-        strokeWidth={2}
-        style={transitionStyle}
-      />
+      {knob.pointerId !== null ? (
+        <g data-testid="touch-stick">
+          {/* Stick anchor is drawn exactly where the left thumb touched down. */}
+          <circle
+            cx={knobX}
+            cy={knobY}
+            r={stickRadius}
+            fill="rgba(255, 255, 255, 0.05)"
+            stroke="rgba(255, 255, 255, 0.25)"
+            strokeWidth={2}
+          />
+          {/* Knob tracks the dragged finger, clamped to the steer radius. */}
+          <circle
+            data-testid="touch-stick-knob"
+            cx={knobDrawnX}
+            cy={knobDrawnY}
+            r={stickRadius * 0.45}
+            fill="rgba(255, 255, 255, 0.35)"
+            stroke="rgba(255, 255, 255, 0.6)"
+            strokeWidth={2}
+            style={transitionStyle}
+          />
+        </g>
+      ) : null}
       {/* Accelerator. */}
       <g data-testid="touch-accelerate">
         <circle
           cx={accelX}
           cy={accelY}
-          r={layout.width * 0.08}
+          r={thumbRadius}
           fill="rgba(80, 220, 120, 0.2)"
           stroke="rgba(80, 220, 120, 0.6)"
           strokeWidth={2}
@@ -240,7 +244,7 @@ export function TouchControls(props: TouchControlsProps): ReactElement | null {
         <circle
           cx={brakeX}
           cy={brakeY}
-          r={layout.width * 0.07}
+          r={thumbRadius * 0.95}
           fill="rgba(220, 90, 90, 0.2)"
           stroke="rgba(220, 90, 90, 0.6)"
           strokeWidth={2}

--- a/src/components/touch/TouchControls.tsx
+++ b/src/components/touch/TouchControls.tsx
@@ -26,7 +26,7 @@
 
 import { useEffect, useMemo, useRef, useState, type CSSProperties, type ReactElement } from "react";
 
-import { DEFAULT_TOUCH_LAYOUT, type TouchLayout } from "@/game/inputTouch";
+import { DEFAULT_TOUCH_LAYOUT, thumbButtonLayout, type TouchLayout } from "@/game/inputTouch";
 
 export interface TouchControlsProps {
   /**
@@ -161,11 +161,11 @@ export function TouchControls(props: TouchControlsProps): ReactElement | null {
   const knobDrawnX = knobX + knobOffset.dx;
   const knobDrawnY = knobY + knobOffset.dy;
 
-  const thumbRadius = Math.max(52, Math.min(88, layout.width * 0.14));
-  const accelX = layout.width * 0.86;
-  const accelY = layout.height * 0.72;
-  const brakeX = layout.width * 0.68;
-  const brakeY = layout.height * 0.82;
+  const thumbButtons = thumbButtonLayout(layout);
+  const accelX = thumbButtons.accelerate.centerX;
+  const accelY = thumbButtons.accelerate.centerY;
+  const brakeX = thumbButtons.brake.centerX;
+  const brakeY = thumbButtons.brake.centerY;
   const nitroX = layout.width - layout.nitroCornerSize / 2;
   const nitroY = layout.nitroCornerSize / 2;
   const pauseX = layout.width - layout.nitroCornerSize - layout.pauseCornerSize / 2;
@@ -223,7 +223,7 @@ export function TouchControls(props: TouchControlsProps): ReactElement | null {
         <circle
           cx={accelX}
           cy={accelY}
-          r={thumbRadius}
+          r={thumbButtons.accelerate.radius}
           fill="rgba(80, 220, 120, 0.2)"
           stroke="rgba(80, 220, 120, 0.6)"
           strokeWidth={2}
@@ -244,7 +244,7 @@ export function TouchControls(props: TouchControlsProps): ReactElement | null {
         <circle
           cx={brakeX}
           cy={brakeY}
-          r={thumbRadius * 0.95}
+          r={thumbButtons.brake.radius}
           fill="rgba(220, 90, 90, 0.2)"
           stroke="rgba(220, 90, 90, 0.6)"
           strokeWidth={2}

--- a/src/game/inputTouch.test.ts
+++ b/src/game/inputTouch.test.ts
@@ -19,6 +19,7 @@ import {
   DEFAULT_TOUCH_LAYOUT,
   createTouchInputSource,
   inputFromTouchState,
+  thumbButtonLayout,
   type TouchLayout,
   type TouchPointer,
   type TouchState,
@@ -111,9 +112,15 @@ function state(layout: TouchLayout, pointers: TouchPointer[]): TouchState {
 
 const LAYOUT: TouchLayout = { ...DEFAULT_TOUCH_LAYOUT };
 const STEER_ZONE_MAX = LAYOUT.width * LAYOUT.steerZoneRatio;
-const THUMB_BUTTON_RADIUS = Math.max(52, Math.min(88, LAYOUT.width * 0.14));
-const ACCEL_CENTER: [number, number] = [LAYOUT.width * 0.86, LAYOUT.height * 0.72];
-const BRAKE_CENTER: [number, number] = [LAYOUT.width * 0.68, LAYOUT.height * 0.82];
+const THUMB_BUTTONS = thumbButtonLayout(LAYOUT);
+const ACCEL_CENTER: [number, number] = [
+  THUMB_BUTTONS.accelerate.centerX,
+  THUMB_BUTTONS.accelerate.centerY,
+];
+const BRAKE_CENTER: [number, number] = [
+  THUMB_BUTTONS.brake.centerX,
+  THUMB_BUTTONS.brake.centerY,
+];
 
 // Pure helper --------------------------------------------------------------
 
@@ -226,16 +233,43 @@ describe("inputFromTouchState", () => {
       state(LAYOUT, [
         pointer({
           id: 1,
-          origin: [ACCEL_CENTER[0] + THUMB_BUTTON_RADIUS * 0.85, ACCEL_CENTER[1]],
+          origin: [
+            ACCEL_CENTER[0] + THUMB_BUTTONS.accelerate.radius * 0.85,
+            ACCEL_CENTER[1],
+          ],
         }),
         pointer({
           id: 2,
-          origin: [BRAKE_CENTER[0] - THUMB_BUTTON_RADIUS * 0.65, BRAKE_CENTER[1]],
+          origin: [BRAKE_CENTER[0] - THUMB_BUTTONS.brake.radius * 0.65, BRAKE_CENTER[1]],
         }),
       ]),
     );
     expect(got.throttle).toBe(1);
     expect(got.brake).toBe(1);
+  });
+
+  it("resolves overlapping thumb-button taps to the closer center", () => {
+    const overlapNearBrake = inputFromTouchState(
+      state(LAYOUT, [
+        pointer({
+          id: 1,
+          origin: [610, 371],
+        }),
+      ]),
+    );
+    expect(overlapNearBrake.brake).toBe(1);
+    expect(overlapNearBrake.throttle).toBe(0);
+
+    const overlapNearAccelerate = inputFromTouchState(
+      state(LAYOUT, [
+        pointer({
+          id: 1,
+          origin: [622, 368],
+        }),
+      ]),
+    );
+    expect(overlapNearAccelerate.throttle).toBe(1);
+    expect(overlapNearAccelerate.brake).toBe(0);
   });
 
   it("multi-touch: steer + accelerate populate both fields", () => {

--- a/src/game/inputTouch.test.ts
+++ b/src/game/inputTouch.test.ts
@@ -111,7 +111,9 @@ function state(layout: TouchLayout, pointers: TouchPointer[]): TouchState {
 
 const LAYOUT: TouchLayout = { ...DEFAULT_TOUCH_LAYOUT };
 const STEER_ZONE_MAX = LAYOUT.width * LAYOUT.steerZoneRatio;
-const ACCEL_BRAKE_BOUNDARY_Y = LAYOUT.height * (1 - LAYOUT.brakeFraction);
+const THUMB_BUTTON_RADIUS = Math.max(52, Math.min(88, LAYOUT.width * 0.14));
+const ACCEL_CENTER: [number, number] = [LAYOUT.width * 0.86, LAYOUT.height * 0.72];
+const BRAKE_CENTER: [number, number] = [LAYOUT.width * 0.68, LAYOUT.height * 0.82];
 
 // Pure helper --------------------------------------------------------------
 
@@ -199,23 +201,41 @@ describe("inputFromTouchState", () => {
 
   it("maps an accelerator-zone tap to throttle = 1", () => {
     const got = inputFromTouchState(
-      state(LAYOUT, [pointer({ id: 1, origin: [STEER_ZONE_MAX + 50, 100] })]),
+      state(LAYOUT, [pointer({ id: 1, origin: ACCEL_CENTER })]),
     );
     expect(got.throttle).toBe(1);
     expect(got.brake).toBe(0);
   });
 
   it("maps a brake-zone tap to brake = 1", () => {
+    const got = inputFromTouchState(state(LAYOUT, [pointer({ id: 1, origin: BRAKE_CENTER })]));
+    expect(got.brake).toBe(1);
+    expect(got.throttle).toBe(0);
+  });
+
+  it("keeps upper-right empty space from pressing accelerator", () => {
+    const got = inputFromTouchState(
+      state(LAYOUT, [pointer({ id: 1, origin: [STEER_ZONE_MAX + 50, 100] })]),
+    );
+    expect(got.throttle).toBe(0);
+    expect(got.brake).toBe(0);
+  });
+
+  it("accepts thumb-arc button taps inside their circular hit areas", () => {
     const got = inputFromTouchState(
       state(LAYOUT, [
         pointer({
           id: 1,
-          origin: [STEER_ZONE_MAX + 50, ACCEL_BRAKE_BOUNDARY_Y + 10],
+          origin: [ACCEL_CENTER[0] + THUMB_BUTTON_RADIUS * 0.85, ACCEL_CENTER[1]],
+        }),
+        pointer({
+          id: 2,
+          origin: [BRAKE_CENTER[0] - THUMB_BUTTON_RADIUS * 0.65, BRAKE_CENTER[1]],
         }),
       ]),
     );
+    expect(got.throttle).toBe(1);
     expect(got.brake).toBe(1);
-    expect(got.throttle).toBe(0);
   });
 
   it("multi-touch: steer + accelerate populate both fields", () => {
@@ -226,7 +246,7 @@ describe("inputFromTouchState", () => {
           origin: [80, 240],
           current: [80 + LAYOUT.stickMaxRadius, 240],
         }),
-        pointer({ id: 2, origin: [STEER_ZONE_MAX + 50, 100] }),
+        pointer({ id: 2, origin: ACCEL_CENTER }),
       ]),
     );
     expect(got.steer).toBe(1);
@@ -254,11 +274,8 @@ describe("inputFromTouchState", () => {
   it("two pointers in the right zone: any in accelerator counts", () => {
     const got = inputFromTouchState(
       state(LAYOUT, [
-        pointer({ id: 1, origin: [STEER_ZONE_MAX + 50, 100] }),
-        pointer({
-          id: 2,
-          origin: [STEER_ZONE_MAX + 80, ACCEL_BRAKE_BOUNDARY_Y + 5],
-        }),
+        pointer({ id: 1, origin: ACCEL_CENTER }),
+        pointer({ id: 2, origin: BRAKE_CENTER }),
       ]),
     );
     expect(got.throttle).toBe(1);
@@ -288,7 +305,7 @@ describe("inputFromTouchState", () => {
 
   it("never sets handbrake / shifts (not bound on touch in this slice)", () => {
     const got = inputFromTouchState(
-      state(LAYOUT, [pointer({ id: 1, origin: [STEER_ZONE_MAX + 50, 100] })]),
+      state(LAYOUT, [pointer({ id: 1, origin: ACCEL_CENTER })]),
     );
     expect(got.handbrake).toBe(false);
     expect(got.shiftUp).toBe(false);
@@ -409,7 +426,7 @@ describe("createTouchInputSource", () => {
       clientX: 80 + DEFAULT_TOUCH_LAYOUT.stickMaxRadius,
       clientY: 240,
     });
-    tt.fire("pointerdown", { pointerId: 2, clientX: STEER_ZONE_MAX + 50, clientY: 100 });
+    tt.fire("pointerdown", { pointerId: 2, clientX: ACCEL_CENTER[0], clientY: ACCEL_CENTER[1] });
 
     const got = src.sample();
     expect(got.steer).toBe(1);
@@ -442,7 +459,7 @@ describe("createTouchInputSource", () => {
     const tt = makeTouchTarget();
     const src = createTouchInputSource({ target: tt.target });
     tt.fire("pointerdown", { pointerId: 1, clientX: 80, clientY: 240 });
-    tt.fire("pointerdown", { pointerId: 2, clientX: STEER_ZONE_MAX + 50, clientY: 100 });
+    tt.fire("pointerdown", { pointerId: 2, clientX: ACCEL_CENTER[0], clientY: ACCEL_CENTER[1] });
     expect(src.hasActivePointers()).toBe(true);
 
     tt.fire("blur");
@@ -551,7 +568,7 @@ describe("createInputManager(touchTarget)", () => {
     });
     expect(mgr.hasTouch()).toBe(false);
 
-    tt.fire("pointerdown", { pointerId: 1, clientX: STEER_ZONE_MAX + 50, clientY: 100 });
+    tt.fire("pointerdown", { pointerId: 1, clientX: ACCEL_CENTER[0], clientY: ACCEL_CENTER[1] });
     expect(mgr.hasTouch()).toBe(true);
     expect(mgr.sample().throttle).toBe(1);
 

--- a/src/game/inputTouch.ts
+++ b/src/game/inputTouch.ts
@@ -71,6 +71,17 @@ export const DEFAULT_TOUCH_LAYOUT: Readonly<TouchLayout> = Object.freeze({
   brakeFraction: 0.4,
 });
 
+export interface TouchButtonCircle {
+  centerX: number;
+  centerY: number;
+  radius: number;
+}
+
+export interface TouchThumbButtonLayout {
+  accelerate: TouchButtonCircle;
+  brake: TouchButtonCircle;
+}
+
 /**
  * Snapshot of one tracked pointer at a moment in time. The pure helper
  * accepts a list of these and the layout, and emits an `Input`.
@@ -109,15 +120,33 @@ function thumbButtonRadius(layout: TouchLayout): number {
   return Math.max(52, Math.min(88, layout.width * 0.14));
 }
 
+export function thumbButtonLayout(layout: TouchLayout): TouchThumbButtonLayout {
+  const radius = thumbButtonRadius(layout);
+  return {
+    accelerate: {
+      centerX: layout.width * 0.86,
+      centerY: layout.height * 0.72,
+      radius,
+    },
+    brake: {
+      centerX: layout.width * 0.68,
+      centerY: layout.height * 0.82,
+      radius: radius * 0.95,
+    },
+  };
+}
+
+function distanceSqToCircleCenter(p: TouchPointer, circle: TouchButtonCircle): number {
+  const dx = p.originX - circle.centerX;
+  const dy = p.originY - circle.centerY;
+  return dx * dx + dy * dy;
+}
+
 function isInsideCircle(
   p: TouchPointer,
-  centerX: number,
-  centerY: number,
-  radius: number,
+  circle: TouchButtonCircle,
 ): boolean {
-  const dx = p.originX - centerX;
-  const dy = p.originY - centerY;
-  return dx * dx + dy * dy <= radius * radius;
+  return distanceSqToCircleCenter(p, circle) <= circle.radius * circle.radius;
 }
 
 /**
@@ -141,11 +170,7 @@ function classifyPointers(state: TouchState): ZoneClassification {
   const pauseMaxX = nitroMinX;
   const pauseMinX = pauseMaxX - layout.pauseCornerSize;
   const pauseMaxY = layout.pauseCornerSize;
-  const buttonRadius = thumbButtonRadius(layout);
-  const accelCenterX = layout.width * 0.86;
-  const accelCenterY = layout.height * 0.72;
-  const brakeCenterX = layout.width * 0.68;
-  const brakeCenterY = layout.height * 0.82;
+  const thumbButtons = thumbButtonLayout(layout);
 
   let steer: TouchPointer | null = null;
   let accelerate = false;
@@ -181,9 +206,16 @@ function classifyPointers(state: TouchState): ZoneClassification {
       pause = true;
       continue;
     }
-    if (isInsideCircle(p, accelCenterX, accelCenterY, buttonRadius)) {
+    const insideAccelerate = isInsideCircle(p, thumbButtons.accelerate);
+    const insideBrake = isInsideCircle(p, thumbButtons.brake);
+    if (insideAccelerate && insideBrake) {
+      const accelDistance = distanceSqToCircleCenter(p, thumbButtons.accelerate);
+      const brakeDistance = distanceSqToCircleCenter(p, thumbButtons.brake);
+      if (accelDistance <= brakeDistance) accelerate = true;
+      else brake = true;
+    } else if (insideAccelerate) {
       accelerate = true;
-    } else if (isInsideCircle(p, brakeCenterX, brakeCenterY, buttonRadius * 0.95)) {
+    } else if (insideBrake) {
       brake = true;
     }
   }

--- a/src/game/inputTouch.ts
+++ b/src/game/inputTouch.ts
@@ -10,9 +10,9 @@
  *   an offset clamped to a configurable max radius and normalised into
  *   `[-1, 1]` along the X axis. Y axis offset is ignored for now (steer
  *   only). Lifting the finger releases the stick.
- * - Right zone: discrete touch buttons stacked vertically. Top half is
- *   accelerator, bottom half is brake. A nitro and pause button live in
- *   the right thumb-zone too (top corner and bottom corner respectively).
+ * - Right zone: discrete touch buttons in the lower-right thumb arc.
+ *   Accelerator and brake are circular hit targets near the natural
+ *   phone grip position. Nitro and pause stay on the top-right edge.
  *
  * Multi-touch is required so a player can hold accelerator with one
  * finger and steer with another. The stateful manager tracks each
@@ -48,8 +48,8 @@ import { NEUTRAL_INPUT } from "./input";
  * - `pauseCornerSize`: side length of the top-right pause tap target.
  *   Pause sits inboard of nitro so a thumb reach to the corner does not
  *   accidentally pause the race.
- * - `brakeFraction`: fraction of the right zone height occupied by the
- *   brake button (bottom half). Accelerator fills the rest.
+ * - `brakeFraction`: retained for older layout callers. The current
+ *   lower-right button classifier uses derived circular hit targets.
  */
 export interface TouchLayout {
   width: number;
@@ -105,6 +105,21 @@ interface ZoneClassification {
   pause: boolean;
 }
 
+function thumbButtonRadius(layout: TouchLayout): number {
+  return Math.max(52, Math.min(88, layout.width * 0.14));
+}
+
+function isInsideCircle(
+  p: TouchPointer,
+  centerX: number,
+  centerY: number,
+  radius: number,
+): boolean {
+  const dx = p.originX - centerX;
+  const dy = p.originY - centerY;
+  return dx * dx + dy * dy <= radius * radius;
+}
+
 /**
  * Classify a pointer's origin into the layout zones. The zones are
  * computed off the origin position, not the current position, so a drag
@@ -119,7 +134,6 @@ interface ZoneClassification {
 function classifyPointers(state: TouchState): ZoneClassification {
   const { layout } = state;
   const steerZoneMaxX = layout.width * layout.steerZoneRatio;
-  const accelBrakeBoundaryY = layout.height * (1 - layout.brakeFraction);
   const nitroMinX = layout.width - layout.nitroCornerSize;
   const nitroMaxY = layout.nitroCornerSize;
   // Pause sits inboard of nitro on the top edge: it lives just to the
@@ -127,6 +141,11 @@ function classifyPointers(state: TouchState): ZoneClassification {
   const pauseMaxX = nitroMinX;
   const pauseMinX = pauseMaxX - layout.pauseCornerSize;
   const pauseMaxY = layout.pauseCornerSize;
+  const buttonRadius = thumbButtonRadius(layout);
+  const accelCenterX = layout.width * 0.86;
+  const accelCenterY = layout.height * 0.72;
+  const brakeCenterX = layout.width * 0.68;
+  const brakeCenterY = layout.height * 0.82;
 
   let steer: TouchPointer | null = null;
   let accelerate = false;
@@ -162,10 +181,10 @@ function classifyPointers(state: TouchState): ZoneClassification {
       pause = true;
       continue;
     }
-    if (p.originY >= accelBrakeBoundaryY) {
-      brake = true;
-    } else {
+    if (isInsideCircle(p, accelCenterX, accelCenterY, buttonRadius)) {
       accelerate = true;
+    } else if (isInsideCircle(p, brakeCenterX, brakeCenterY, buttonRadius * 0.95)) {
+      brake = true;
     }
   }
 
@@ -345,21 +364,28 @@ export function createTouchInputSource(options: TouchInputSourceOptions = {}): T
   }
 
   const onPointerDown = (ev: Event): void => {
-    upsertPointer(ev as unknown as PointerLike, true);
+    const ple = ev as unknown as PointerLike;
+    ple.preventDefault?.();
+    upsertPointer(ple, true);
   };
   const onPointerMove = (ev: Event): void => {
     const ple = ev as unknown as PointerLike;
     if (!pointers.has(ple.pointerId)) return;
+    ple.preventDefault?.();
     upsertPointer(ple, false);
   };
   const onPointerUp = (ev: Event): void => {
-    releasePointer(ev as unknown as PointerLike);
+    const ple = ev as unknown as PointerLike;
+    ple.preventDefault?.();
+    releasePointer(ple);
   };
   const onPointerCancel = (ev: Event): void => {
     // Cancellation = the system stole the pointer (gesture, palm reject,
     // OS modal). Release it as if the finger lifted so the manager does
     // not hold a phantom stick.
-    releasePointer(ev as unknown as PointerLike);
+    const ple = ev as unknown as PointerLike;
+    ple.preventDefault?.();
+    releasePointer(ple);
   };
   const onBlur = (): void => {
     clearAll();


### PR DESCRIPTION
## GDD
- §19 Controls and input: touch input.
- §20 HUD and UI/UX: race HUD control surface.
- §21 Technical design: web runtime input path.

## Requirement Inventory
- Make the live race steering stick transient and thumb-anchored on left-half touch start.
- Keep the visual stick from intercepting the canvas input target.
- Move GAS and BRK into the lower-right thumb arc.
- Pin the mounted `/race` mobile route with iPhone e2e coverage for steering, release, and right-thumb placement.

Nearby behavior left for later:
- Nitro and pause remain in the existing top-right touch zone because this bug report only identified GAS and BRK reachability.

## Progress Log
- `docs/PROGRESS_LOG.md`: 2026-04-28 Slice: Mobile touch controls.

## Test Plan
- [x] `npx vitest run src/game/inputTouch.test.ts`
- [x] `npx playwright test e2e/race-mobile.spec.ts --project=mobile-chromium`
- [x] `npx playwright test e2e/touch-input.spec.ts --project=mobile-chromium`
- [x] `npm run typecheck`
- [x] `npm run verify`
- [x] `npm run test:e2e`

## Followups
- None.
