### PR TITLE
feat(time-trial): persist PB records

### DIFF
--- a/docs/GDD_COVERAGE.json
+++ b/docs/GDD_COVERAGE.json
@@ -23,6 +23,26 @@
       "followupRefs": []
     },
     {
+      "id": "GDD-06-TIME-TRIAL-PB-RECORDS",
+      "gddSections": [
+        "docs/gdd/06-game-modes.md",
+        "docs/gdd/21-technical-design-for-web-implementation.md",
+        "docs/gdd/22-data-schemas.md"
+      ],
+      "requirement": "Finished Time Trial runs persist personal-best lap and race records without awarding campaign credits or persisting race damage.",
+      "coverage": ["implemented-code", "automated-test"],
+      "implementationRefs": [
+        "src/app/race/page.tsx",
+        "src/game/raceResult.ts",
+        "src/persistence/save.ts"
+      ],
+      "testRefs": [
+        "src/game/__tests__/raceResult.test.ts",
+        "e2e/race-finish.spec.ts"
+      ],
+      "followupRefs": []
+    },
+    {
       "id": "GDD-14-OVERCAST-WEATHER-OPTION",
       "gddSections": [
         "docs/gdd/14-weather-and-environmental-systems.md",

--- a/docs/PROGRESS_LOG.md
+++ b/docs/PROGRESS_LOG.md
@@ -6,6 +6,52 @@ Correct them by adding a new entry that references the old one.
 
 ---
 
+## 2026-04-28: Slice: Time Trial PB records
+
+**GDD sections touched:**
+[§6](gdd/06-game-modes.md) Time trial,
+[§21](gdd/21-technical-design-for-web-implementation.md) local save runtime,
+[§22](gdd/22-data-schemas.md) save records.
+**Branch / PR:** `feat/time-trial-pb-records`, PR pending.
+**Status:** Implemented.
+
+### Done
+- `src/app/race/page.tsx`: commits Time Trial result PB patches to the
+  local save while keeping `creditsAwarded` at zero and leaving garage
+  damage untouched.
+- `src/game/raceResult.ts`: preserves an existing faster saved lap when
+  a stale result patch is merged after another tab or run has already
+  improved the record.
+- `e2e/race-finish.spec.ts`: added a real Time Trial finish smoke that
+  asserts PB records persist, credits stay unchanged, and pending
+  garage damage stays unchanged.
+- `docs/GDD_COVERAGE.json`: added GDD-06-TIME-TRIAL-PB-RECORDS.
+
+### Verified
+- `npx vitest run src/game/__tests__/raceResult.test.ts` green, 58 passed.
+- `npm run typecheck` green.
+- `npx playwright test e2e/race-finish.spec.ts --project=chromium -g "time trial PB persistence"`
+  green, 1 passed.
+- `npm run verify` green, 2415 passed.
+- `npm run test:e2e` green, 74 passed.
+
+### Decisions and assumptions
+- Time Trial remains a non-economy mode: it can update records and PB
+  ghosts, but it never awards campaign credits or persists race damage.
+
+### Coverage ledger
+- GDD-06-TIME-TRIAL-PB-RECORDS covers Time Trial PB record persistence
+  from a finished run.
+- Uncovered adjacent requirements: developer benchmark display,
+  downloaded ghost selection, result-backed Daily Challenge share text,
+  and UTC-midnight fake-clock e2e remain under the §6 modes parent dot.
+
+### Followups created
+None.
+
+### GDD edits
+None.
+
 ## 2026-04-28: Slice: Mobile touch controls
 
 **GDD sections touched:**

--- a/e2e/race-finish.spec.ts
+++ b/e2e/race-finish.spec.ts
@@ -223,6 +223,57 @@ test.describe("race-finish wiring (F-029 multi-lap)", () => {
   );
 });
 
+test.describe("time trial PB persistence", () => {
+  test("finished time trial writes PB records without credits or damage", async ({
+    page,
+  }) => {
+    test.setTimeout(70_000);
+
+    await page.goto("/");
+    await page.evaluate(
+      ({ key, save }) => window.localStorage.setItem(key, JSON.stringify(save)),
+      { key: SAVE_KEY, save: buildRaceDamageSave() },
+    );
+
+    await page.goto("/race?mode=timeTrial&track=test/straight");
+    const canvas = page.getByTestId("race-canvas-element");
+    await expect(canvas).toBeVisible();
+    await expect(page.getByTestId("race-phase")).toHaveText("racing", {
+      timeout: 10_000,
+    });
+
+    await canvas.focus();
+    await page.keyboard.down("ArrowUp");
+    await expect(page).toHaveURL(/\/race\/results/, { timeout: 45_000 });
+    await page.keyboard.up("ArrowUp");
+
+    await expect(page.getByTestId("results-credits-awarded")).toHaveText("0 cr");
+
+    const persisted = await page.evaluate((key) => {
+      const raw = window.localStorage.getItem(key);
+      return raw
+        ? (JSON.parse(raw) as {
+            garage?: {
+              credits?: number;
+              pendingDamage?: Record<
+                string,
+                { zones?: { body?: number }; total?: number }
+              >;
+            };
+            records?: Record<string, { bestLapMs?: number; bestRaceMs?: number }>;
+          })
+        : null;
+    }, SAVE_KEY);
+
+    expect(persisted?.garage?.credits).toBe(1000);
+    expect(
+      persisted?.garage?.pendingDamage?.["sparrow-gt"]?.zones?.body ?? 0,
+    ).toBe(0.33);
+    expect(persisted?.records?.["test/straight"]?.bestLapMs).toBeGreaterThan(0);
+    expect(persisted?.records?.["test/straight"]?.bestRaceMs).toBeGreaterThan(0);
+  });
+});
+
 function buildRaceDamageSave() {
   return {
     version: 3,

--- a/src/app/race/page.tsx
+++ b/src/app/race/page.tsx
@@ -481,6 +481,25 @@ function commitRaceCredits(input: {
   return transformed.result;
 }
 
+function commitTimeTrialRecords(input: {
+  result: RaceResult;
+  fallbackSave: SaveGame;
+}): { result: RaceResult; save: SaveGame } {
+  const result = { ...input.result, creditsAwarded: 0 };
+  if (result.recordsUpdated === null) {
+    return { result, save: input.fallbackSave };
+  }
+
+  const latest = loadSave();
+  const baseSave = latest.kind === "loaded" ? latest.save : input.fallbackSave;
+  const nextSave = applyRaceResultRecords(baseSave, result);
+  const write = saveSave(nextSave);
+  return {
+    result,
+    save: write.kind === "ok" ? nextSave : baseSave,
+  };
+}
+
 export default function RacePage(): ReactElement {
   return (
     <ErrorBoundary>
@@ -856,8 +875,14 @@ function RaceCanvas({
       // F-034: credit the wallet (DNF cars receive the §12 participation
       // cash) and mirror the delta onto `RaceResult.creditsAwarded` so
       // the §20 results screen renders the actual wallet change.
-      const committed = timeTrialEnabled
-        ? { ...result, creditsAwarded: 0 }
+      const timeTrialCommit = timeTrialEnabled
+        ? commitTimeTrialRecords({ result, fallbackSave: save })
+        : null;
+      if (timeTrialCommit !== null) {
+        timeTrialSaveSnapshot = timeTrialCommit.save;
+      }
+      const committed = timeTrialCommit
+        ? timeTrialCommit.result
         : commitRaceCredits({
             result,
             save,
@@ -1126,8 +1151,14 @@ function RaceCanvas({
             // results screen will render. The `commitRaceCredits`
             // helper persists the merged save and mirrors the
             // wallet delta onto `RaceResult.creditsAwarded`.
-            const committed = timeTrialEnabled
-              ? { ...result, creditsAwarded: 0 }
+            const timeTrialCommit = timeTrialEnabled
+              ? commitTimeTrialRecords({ result, fallbackSave: save })
+              : null;
+            if (timeTrialCommit !== null) {
+              timeTrialSaveSnapshot = timeTrialCommit.save;
+            }
+            const committed = timeTrialCommit
+              ? timeTrialCommit.result
               : commitRaceCredits({
                   result,
                   save,

--- a/src/app/race/page.tsx
+++ b/src/app/race/page.tsx
@@ -496,7 +496,10 @@ function commitTimeTrialRecords(input: {
   const write = saveSave(nextSave);
   return {
     result,
-    save: write.kind === "ok" ? nextSave : baseSave,
+    save:
+      write.kind === "ok"
+        ? { ...nextSave, writeCounter: (nextSave.writeCounter ?? 0) + 1 }
+        : baseSave,
   };
 }
 

--- a/src/game/__tests__/raceResult.test.ts
+++ b/src/game/__tests__/raceResult.test.ts
@@ -818,6 +818,33 @@ describe("buildRaceResult + awardCredits: F-034 race-finish wiring", () => {
       bestRaceMs: 90_000,
     });
   });
+
+  it("preserves an existing faster lap when a stale PB patch is merged", () => {
+    const save = {
+      ...defaultSave(),
+      records: {
+        "test-circuit": {
+          bestLapMs: 25_000,
+          bestRaceMs: 88_000,
+        },
+      },
+    };
+    const result = buildRaceResult(
+      makeInput({
+        save: defaultSave(),
+      }),
+    );
+    expect(result.recordsUpdated).toEqual({
+      trackId: "test-circuit",
+      bestLapMs: 30_000,
+    });
+
+    const committed = applyRaceResultRecords(save, result);
+    expect(committed.records["test-circuit"]).toEqual({
+      bestLapMs: 25_000,
+      bestRaceMs: 88_000,
+    });
+  });
 });
 
 /**

--- a/src/game/__tests__/raceResult.test.ts
+++ b/src/game/__tests__/raceResult.test.ts
@@ -826,6 +826,7 @@ describe("buildRaceResult + awardCredits: F-034 race-finish wiring", () => {
         "test-circuit": {
           bestLapMs: 25_000,
           bestRaceMs: 88_000,
+          bestSplitsMs: [12_000, 18_000],
         },
       },
     };
@@ -843,6 +844,7 @@ describe("buildRaceResult + awardCredits: F-034 race-finish wiring", () => {
     expect(committed.records["test-circuit"]).toEqual({
       bestLapMs: 25_000,
       bestRaceMs: 88_000,
+      bestSplitsMs: [12_000, 18_000],
     });
   });
 });

--- a/src/game/raceResult.ts
+++ b/src/game/raceResult.ts
@@ -503,13 +503,15 @@ export function applyRaceResultRecords(save: SaveGame, result: RaceResult): Save
     existing === null
       ? currentRaceMs
       : Math.min(existing.bestRaceMs, currentRaceMs);
+  const bestLapMs =
+    existing === null ? patch.bestLapMs : Math.min(existing.bestLapMs, patch.bestLapMs);
 
   return {
     ...save,
     records: {
       ...save.records,
       [patch.trackId]: {
-        bestLapMs: patch.bestLapMs,
+        bestLapMs,
         bestRaceMs,
       },
     },

--- a/src/game/raceResult.ts
+++ b/src/game/raceResult.ts
@@ -511,6 +511,7 @@ export function applyRaceResultRecords(save: SaveGame, result: RaceResult): Save
     records: {
       ...save.records,
       [patch.trackId]: {
+        ...(existing ?? {}),
         bestLapMs,
         bestRaceMs,
       },


### PR DESCRIPTION
GDD sections:
- docs/gdd/06-game-modes.md
- docs/gdd/21-technical-design-for-web-implementation.md
- docs/gdd/22-data-schemas.md

Requirement inventory:
- Finished Time Trial runs persist `records[trackId].bestLapMs` and `bestRaceMs`.
- Time Trial remains non-economy: `creditsAwarded` stays `0`, garage credits stay unchanged, and race damage is not persisted.
- Stale PB patches cannot overwrite a faster saved lap.
- Adjacent §6 work left to the parent dot: developer benchmark display, downloaded ghost selection, result-backed Daily Challenge share text, and UTC-midnight fake-clock e2e.

Progress log:
- docs/PROGRESS_LOG.md entry: `2026-04-28: Slice: Time Trial PB records`

Test plan:
- [x] `npx vitest run src/game/__tests__/raceResult.test.ts`
- [x] `npm run typecheck`
- [x] `npx playwright test e2e/race-finish.spec.ts --project=chromium -g "time trial PB persistence"`
- [x] `npm run verify`
- [x] `npm run test:e2e`

Followups created:
- None
