### PR TITLE
feat(audio): add engine mixer primitives

### DIFF
--- a/docs/GDD_COVERAGE.json
+++ b/docs/GDD_COVERAGE.json
@@ -43,6 +43,25 @@
       "followupRefs": []
     },
     {
+      "id": "GDD-18-AUDIO-ENGINE-MIXER-PRIMITIVES",
+      "gddSections": [
+        "docs/gdd/18-sound-and-music-design.md",
+        "docs/gdd/20-hud-and-ui-ux.md",
+        "docs/gdd/21-technical-design-for-web-implementation.md"
+      ],
+      "requirement": "The audio layer has pure primitives for speed-driven engine pitch and metadata-driven master, music, and SFX bus gain resolution.",
+      "coverage": ["implemented-code", "automated-test"],
+      "implementationRefs": [
+        "src/audio/engine.ts",
+        "src/audio/mixer.ts"
+      ],
+      "testRefs": [
+        "src/audio/engine.test.ts",
+        "src/audio/mixer.test.ts"
+      ],
+      "followupRefs": ["VibeGear2-implement-sound-music-1611f9dd"]
+    },
+    {
       "id": "GDD-14-OVERCAST-WEATHER-OPTION",
       "gddSections": [
         "docs/gdd/14-weather-and-environmental-systems.md",

--- a/docs/PROGRESS_LOG.md
+++ b/docs/PROGRESS_LOG.md
@@ -6,6 +6,56 @@ Correct them by adding a new entry that references the old one.
 
 ---
 
+## 2026-04-28: Slice: Audio engine and mixer primitives
+
+**GDD sections touched:**
+[§18](gdd/18-sound-and-music-design.md) sound and music design,
+[§20](gdd/20-hud-and-ui-ux.md) settings,
+[§21](gdd/21-technical-design-for-web-implementation.md) audio pipeline.
+**Branch / PR:** `feat/audio-engine-mixer`, PR pending.
+**Status:** Implemented.
+
+### Done
+- `src/audio/engine.ts`: added a pure speed-to-engine-pitch model with
+  idle, redline, exponential rise, and overrun clamps.
+- `src/audio/mixer.ts`: added master, music, and SFX gain resolution
+  from persisted audio settings, plus a disabled-audio null path for
+  later Web Audio callers.
+- `src/audio/engine.test.ts` and `src/audio/mixer.test.ts`: pinned
+  monotonic pitch, pure repeatability, defensive clamps, gain products,
+  disabled audio, and silence detection.
+- `docs/GDD_COVERAGE.json`: added
+  GDD-18-AUDIO-ENGINE-MIXER-PRIMITIVES.
+
+### Verified
+- `npx vitest run src/audio/engine.test.ts src/audio/mixer.test.ts`
+  green, 10 passed.
+- `npm run typecheck` green.
+- `npm run content-lint` green.
+- `npm run verify` green, 2425 passed.
+
+### Decisions and assumptions
+- This slice does not create an `AudioContext`, play sounds, or add
+  placeholder audio files. It only lands the pure math contracts that
+  the later runtime and asset slices will consume.
+- `resolveMixerGains` returns `null` when audio is disabled so future
+  engine, SFX, and music callers can short-circuit before creating
+  Web Audio nodes.
+
+### Coverage ledger
+- GDD-18-AUDIO-ENGINE-MIXER-PRIMITIVES covers engine pitch and mix-bus
+  gain primitives.
+- Uncovered adjacent requirements: AudioContext lifecycle, engine
+  playback, SFX playback, music playback, region stem metadata,
+  placeholder audio assets, visibility suspension, and settings UI
+  sliders remain under the §18 audio parent dots.
+
+### Followups created
+None.
+
+### GDD edits
+None.
+
 ## 2026-04-28: Slice: Time Trial PB records
 
 **GDD sections touched:**

--- a/src/audio/engine.test.ts
+++ b/src/audio/engine.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "vitest";
+
+import { DEFAULT_ENGINE_PITCH, enginePitchHz, engineSpeedRatio } from "./engine";
+
+describe("enginePitchHz", () => {
+  it("maps zero speed to idle pitch", () => {
+    expect(enginePitchHz({ speed: 0, topSpeed: 60 })).toBe(
+      DEFAULT_ENGINE_PITCH.idleHz,
+    );
+  });
+
+  it("is monotonic from rest to top speed", () => {
+    let previous = enginePitchHz({ speed: 0, topSpeed: 60 });
+    for (let i = 1; i <= 100; i += 1) {
+      const speed = (60 * i) / 100;
+      const pitch = enginePitchHz({ speed, topSpeed: 60 });
+      expect(pitch).toBeGreaterThanOrEqual(previous);
+      previous = pitch;
+    }
+  });
+
+  it("caps overrun speed at redline", () => {
+    expect(enginePitchHz({ speed: 600, topSpeed: 60 })).toBeLessThanOrEqual(
+      DEFAULT_ENGINE_PITCH.redlineHz,
+    );
+  });
+
+  it("is pure for the same input", () => {
+    const input = { speed: 31.5, topSpeed: 61 };
+    expect(enginePitchHz(input)).toBe(enginePitchHz(input));
+    expect(engineSpeedRatio(input)).toBe(engineSpeedRatio(input));
+  });
+
+  it("handles invalid speed and top speed defensively", () => {
+    expect(enginePitchHz({ speed: Number.NaN, topSpeed: 60 })).toBe(
+      DEFAULT_ENGINE_PITCH.idleHz,
+    );
+    expect(enginePitchHz({ speed: 20, topSpeed: 0 })).toBe(
+      DEFAULT_ENGINE_PITCH.idleHz,
+    );
+    expect(engineSpeedRatio({ speed: 20, topSpeed: 0 })).toBe(0);
+  });
+});

--- a/src/audio/engine.ts
+++ b/src/audio/engine.ts
@@ -1,0 +1,69 @@
+export interface EnginePitchConfig {
+  readonly idleHz: number;
+  readonly redlineHz: number;
+  readonly riseCurve: number;
+  readonly overrunRatio: number;
+}
+
+export interface EnginePitchInput {
+  readonly speed: number;
+  readonly topSpeed: number;
+  readonly config?: Partial<EnginePitchConfig>;
+}
+
+export const DEFAULT_ENGINE_PITCH: EnginePitchConfig = Object.freeze({
+  idleHz: 80,
+  redlineHz: 320,
+  riseCurve: 3,
+  overrunRatio: 1.1,
+});
+
+export function engineSpeedRatio(input: EnginePitchInput): number {
+  const config = resolveEnginePitchConfig(input.config);
+  if (!Number.isFinite(input.speed) || !Number.isFinite(input.topSpeed)) {
+    return 0;
+  }
+  if (input.speed <= 0 || input.topSpeed <= 0) {
+    return 0;
+  }
+  return clamp(input.speed / input.topSpeed, 0, config.overrunRatio);
+}
+
+export function enginePitchHz(input: EnginePitchInput): number {
+  const config = resolveEnginePitchConfig(input.config);
+  const ratio = engineSpeedRatio({ ...input, config });
+  const spread = config.redlineHz - config.idleHz;
+  const raised = config.idleHz + spread * (1 - Math.exp(-config.riseCurve * ratio));
+  return clamp(raised, config.idleHz, config.redlineHz);
+}
+
+function resolveEnginePitchConfig(
+  override: Partial<EnginePitchConfig> | undefined,
+): EnginePitchConfig {
+  const idleHz = positiveOr(override?.idleHz, DEFAULT_ENGINE_PITCH.idleHz);
+  const redlineHz = Math.max(
+    idleHz,
+    positiveOr(override?.redlineHz, DEFAULT_ENGINE_PITCH.redlineHz),
+  );
+  return {
+    idleHz,
+    redlineHz,
+    riseCurve: positiveOr(override?.riseCurve, DEFAULT_ENGINE_PITCH.riseCurve),
+    overrunRatio: positiveOr(
+      override?.overrunRatio,
+      DEFAULT_ENGINE_PITCH.overrunRatio,
+    ),
+  };
+}
+
+function positiveOr(value: number | undefined, fallback: number): number {
+  if (value === undefined) return fallback;
+  return Number.isFinite(value) && value > 0 ? value : fallback;
+}
+
+function clamp(value: number, min: number, max: number): number {
+  if (!Number.isFinite(value)) return min;
+  if (value <= min) return min;
+  if (value >= max) return max;
+  return value;
+}

--- a/src/audio/mixer.test.ts
+++ b/src/audio/mixer.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "vitest";
+
+import { isMixerSilent, resolveMixerGains } from "./mixer";
+
+describe("resolveMixerGains", () => {
+  it("multiplies music and sfx buses by the master gain", () => {
+    expect(
+      resolveMixerGains({ master: 0.5, music: 0.8, sfx: 0.25 }),
+    ).toEqual({
+      master: 0.5,
+      music: 0.4,
+      sfx: 0.125,
+    });
+  });
+
+  it("covers boundary values", () => {
+    expect(resolveMixerGains({ master: 0, music: 1, sfx: 1 })).toEqual({
+      master: 0,
+      music: 0,
+      sfx: 0,
+    });
+    expect(resolveMixerGains({ master: 1, music: 1, sfx: 1 })).toEqual({
+      master: 1,
+      music: 1,
+      sfx: 1,
+    });
+  });
+
+  it("clamps out-of-range values for defensive runtime callers", () => {
+    expect(resolveMixerGains({ master: 2, music: -1, sfx: 0.5 })).toEqual({
+      master: 1,
+      music: 0,
+      sfx: 0.5,
+    });
+  });
+
+  it("returns null when audio is disabled", () => {
+    expect(
+      resolveMixerGains({ master: 1, music: 1, sfx: 1, enabled: false }),
+    ).toBeNull();
+  });
+});
+
+describe("isMixerSilent", () => {
+  it("treats disabled or fully zero gains as silent", () => {
+    expect(isMixerSilent(null)).toBe(true);
+    expect(isMixerSilent({ master: 0, music: 0, sfx: 0 })).toBe(true);
+    expect(isMixerSilent({ master: 0, music: 0.5, sfx: 0 })).toBe(false);
+  });
+});

--- a/src/audio/mixer.ts
+++ b/src/audio/mixer.ts
@@ -1,0 +1,34 @@
+import type { AudioSettings } from "@/data/schemas";
+
+export interface MixerSettings extends AudioSettings {
+  readonly enabled?: boolean;
+}
+
+export interface MixerGains {
+  readonly master: number;
+  readonly music: number;
+  readonly sfx: number;
+}
+
+export function resolveMixerGains(settings: MixerSettings): MixerGains | null {
+  if (settings.enabled === false) {
+    return null;
+  }
+
+  const master = clamp01(settings.master);
+  return {
+    master,
+    music: master * clamp01(settings.music),
+    sfx: master * clamp01(settings.sfx),
+  };
+}
+
+export function isMixerSilent(gains: MixerGains | null): boolean {
+  return gains === null || (gains.master === 0 && gains.music === 0 && gains.sfx === 0);
+}
+
+function clamp01(value: number): number {
+  if (!Number.isFinite(value) || value <= 0) return 0;
+  if (value >= 1) return 1;
+  return value;
+}


### PR DESCRIPTION
GDD sections:
- docs/gdd/18-sound-and-music-design.md
- docs/gdd/20-hud-and-ui-ux.md
- docs/gdd/21-technical-design-for-web-implementation.md

Requirement inventory:
- Adds pure engine pitch primitives for speed-driven harmonic content.
- Adds pure mixer gain resolution for master, music, and SFX buses from persisted audio settings.
- Adds a disabled-audio null path for later Web Audio callers to avoid node creation.
- Leaves AudioContext lifecycle, playback, SFX, music stems, placeholder audio files, visibility suspension, and settings sliders to the §18 parent dots.

Progress log:
- docs/PROGRESS_LOG.md entry: `2026-04-28: Slice: Audio engine and mixer primitives`

Test plan:
- [x] `npx vitest run src/audio/engine.test.ts src/audio/mixer.test.ts`
- [x] `npm run typecheck`
- [x] `npm run content-lint`
- [x] `npm run verify`

E2E:
- Not run locally for this pure module slice. The PR CI gate still runs full Playwright.

Followups created:
- None
