### PR TITLE
feat(audio): add context lifecycle primitives

### DIFF
--- a/docs/GDD_COVERAGE.json
+++ b/docs/GDD_COVERAGE.json
@@ -62,6 +62,18 @@
       "followupRefs": ["VibeGear2-implement-sound-music-1611f9dd"]
     },
     {
+      "id": "GDD-18-AUDIO-CONTEXT-LIFECYCLE",
+      "gddSections": [
+        "docs/gdd/18-sound-and-music-design.md",
+        "docs/gdd/21-technical-design-for-web-implementation.md"
+      ],
+      "requirement": "The audio layer can lazily create, resume, and suspend a shared Web Audio context while treating unavailable Web Audio as a no-op and suspending audio when the page is hidden.",
+      "coverage": ["implemented-code", "automated-test"],
+      "implementationRefs": ["src/audio/context.ts"],
+      "testRefs": ["src/audio/context.test.ts"],
+      "followupRefs": ["VibeGear2-implement-sound-music-1611f9dd"]
+    },
+    {
       "id": "GDD-14-OVERCAST-WEATHER-OPTION",
       "gddSections": [
         "docs/gdd/14-weather-and-environmental-systems.md",

--- a/docs/PROGRESS_LOG.md
+++ b/docs/PROGRESS_LOG.md
@@ -6,6 +6,52 @@ Correct them by adding a new entry that references the old one.
 
 ---
 
+## 2026-04-28: Slice: Audio context lifecycle primitives
+
+**GDD sections touched:**
+[§18](gdd/18-sound-and-music-design.md) sound and music design,
+[§21](gdd/21-technical-design-for-web-implementation.md) audio pipeline.
+**Branch / PR:** `feat/audio-context-lifecycle`, PR pending.
+**Status:** Implemented.
+
+### Done
+- `src/audio/context.ts`: added a shared Web Audio context controller
+  with lazy creation, resume, suspend, unavailable-Web-Audio no-op
+  behavior, closed-context replacement, and hidden-page suspension.
+- `src/audio/context.test.ts`: pinned deferred creation, first-resume
+  creation, no duplicate resumes, unavailable Web Audio, visibility
+  suspension, and no create-on-hidden behavior.
+- `docs/GDD_COVERAGE.json`: added
+  GDD-18-AUDIO-CONTEXT-LIFECYCLE.
+
+### Verified
+- `npx vitest run src/audio/context.test.ts` green, 6 passed.
+- `npm run typecheck` green.
+- `npm run verify` green, 2431 passed.
+
+### Decisions and assumptions
+- This slice lands the lifecycle primitive only. It does not start
+  engine, SFX, or music playback, and it does not add audio assets.
+- Visibility hidden suspends an existing running context, but visibility
+  visible does not auto-resume because browser resume still needs an
+  explicit user gesture.
+- If Web Audio is unavailable, the controller returns `null` and callers
+  can treat audio as a no-op.
+
+### Coverage ledger
+- GDD-18-AUDIO-CONTEXT-LIFECYCLE covers lazy shared context creation,
+  resume, suspension, unavailable-Web-Audio no-op behavior, and hidden
+  page suspension.
+- Uncovered adjacent requirements: engine playback, SFX playback, music
+  playback, region stem metadata, placeholder audio assets, and settings
+  UI sliders remain under the §18 audio parent dots.
+
+### Followups created
+None.
+
+### GDD edits
+None.
+
 ## 2026-04-28: Slice: Audio engine and mixer primitives
 
 **GDD sections touched:**

--- a/docs/PROGRESS_LOG.md
+++ b/docs/PROGRESS_LOG.md
@@ -20,12 +20,12 @@ Correct them by adding a new entry that references the old one.
   behavior, closed-context replacement, and hidden-page suspension.
 - `src/audio/context.test.ts`: pinned deferred creation, first-resume
   creation, no duplicate resumes, unavailable Web Audio, visibility
-  suspension, and no create-on-hidden behavior.
+  suspension, already-hidden binding, and no create-on-hidden behavior.
 - `docs/GDD_COVERAGE.json`: added
   GDD-18-AUDIO-CONTEXT-LIFECYCLE.
 
 ### Verified
-- `npx vitest run src/audio/context.test.ts` green, 6 passed.
+- `npx vitest run src/audio/context.test.ts` green, 7 passed.
 - `npm run typecheck` green.
 - `npm run verify` green, 2431 passed.
 
@@ -35,6 +35,9 @@ Correct them by adding a new entry that references the old one.
 - Visibility hidden suspends an existing running context, but visibility
   visible does not auto-resume because browser resume still needs an
   explicit user gesture.
+- Binding visibility suspension while the page is already hidden
+  immediately suspends an existing running context without creating a
+  new one.
 - If Web Audio is unavailable, the controller returns `null` and callers
   can treat audio as a no-op.
 

--- a/src/audio/context.test.ts
+++ b/src/audio/context.test.ts
@@ -1,0 +1,120 @@
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  AudioContextController,
+  type AudioContextLike,
+  type AudioContextStateLike,
+} from "./context";
+
+class FakeAudioContext implements AudioContextLike {
+  public state: AudioContextStateLike;
+  public readonly resumeSpy = vi.fn(async () => {
+    this.state = "running";
+  });
+  public readonly suspendSpy = vi.fn(async () => {
+    this.state = "suspended";
+  });
+
+  constructor(state: AudioContextStateLike = "suspended") {
+    this.state = state;
+  }
+
+  resume(): Promise<void> {
+    return this.resumeSpy();
+  }
+
+  suspend(): Promise<void> {
+    return this.suspendSpy();
+  }
+}
+
+class FakeDocument {
+  public hidden = false;
+  public listener: (() => void) | null = null;
+
+  addEventListener(_type: "visibilitychange", listener: () => void): void {
+    this.listener = listener;
+  }
+
+  removeEventListener(_type: "visibilitychange", listener: () => void): void {
+    if (this.listener === listener) {
+      this.listener = null;
+    }
+  }
+
+  dispatchVisibility(hidden: boolean): void {
+    this.hidden = hidden;
+    this.listener?.();
+  }
+}
+
+describe("AudioContextController", () => {
+  it("does not create a context until ensure or resume is called", () => {
+    const create = vi.fn(() => new FakeAudioContext());
+    const controller = new AudioContextController(create);
+
+    expect(controller.get()).toBeNull();
+    expect(create).not.toHaveBeenCalled();
+
+    expect(controller.ensure()).toBeInstanceOf(FakeAudioContext);
+    expect(create).toHaveBeenCalledTimes(1);
+  });
+
+  it("resumes suspended contexts created by the first gesture call", async () => {
+    const context = new FakeAudioContext("suspended");
+    const controller = new AudioContextController(() => context);
+
+    await expect(controller.resume()).resolves.toBe(context);
+    expect(context.resumeSpy).toHaveBeenCalledTimes(1);
+    expect(context.state).toBe("running");
+  });
+
+  it("does not recreate or resume a running context", async () => {
+    const context = new FakeAudioContext("running");
+    const create = vi.fn(() => context);
+    const controller = new AudioContextController(create);
+
+    await controller.resume();
+    await controller.resume();
+
+    expect(create).toHaveBeenCalledTimes(1);
+    expect(context.resumeSpy).not.toHaveBeenCalled();
+  });
+
+  it("returns null without throwing when Web Audio is unavailable", async () => {
+    const controller = new AudioContextController(() => null);
+
+    expect(controller.ensure()).toBeNull();
+    await expect(controller.resume()).resolves.toBeNull();
+    await expect(controller.suspend()).resolves.toBeUndefined();
+  });
+
+  it("suspends an existing running context on hidden visibility changes", () => {
+    const context = new FakeAudioContext("running");
+    const controller = new AudioContextController(() => context);
+    const documentLike = new FakeDocument();
+
+    controller.ensure();
+    const unbind = controller.bindVisibilitySuspension(documentLike);
+
+    documentLike.dispatchVisibility(true);
+
+    expect(context.suspendSpy).toHaveBeenCalledTimes(1);
+    expect(context.state).toBe("suspended");
+
+    unbind();
+    expect(documentLike.listener).toBeNull();
+  });
+
+  it("does not create a context just because the page becomes hidden", () => {
+    const create = vi.fn(() => new FakeAudioContext("running"));
+    const controller = new AudioContextController(create);
+    const documentLike = new FakeDocument();
+
+    controller.bindVisibilitySuspension(documentLike);
+    documentLike.dispatchVisibility(true);
+
+    expect(create).not.toHaveBeenCalled();
+    expect(controller.get()).toBeNull();
+  });
+});

--- a/src/audio/context.test.ts
+++ b/src/audio/context.test.ts
@@ -106,6 +106,19 @@ describe("AudioContextController", () => {
     expect(documentLike.listener).toBeNull();
   });
 
+  it("suspends an existing running context when bound while already hidden", () => {
+    const context = new FakeAudioContext("running");
+    const controller = new AudioContextController(() => context);
+    const documentLike = new FakeDocument();
+
+    controller.ensure();
+    documentLike.hidden = true;
+    controller.bindVisibilitySuspension(documentLike);
+
+    expect(context.suspendSpy).toHaveBeenCalledTimes(1);
+    expect(context.state).toBe("suspended");
+  });
+
   it("does not create a context just because the page becomes hidden", () => {
     const create = vi.fn(() => new FakeAudioContext("running"));
     const controller = new AudioContextController(create);

--- a/src/audio/context.ts
+++ b/src/audio/context.ts
@@ -55,6 +55,7 @@ export class AudioContextController {
       }
     };
     documentLike.addEventListener("visibilitychange", onVisibilityChange);
+    onVisibilityChange();
     return () => documentLike.removeEventListener("visibilitychange", onVisibilityChange);
   }
 }

--- a/src/audio/context.ts
+++ b/src/audio/context.ts
@@ -1,0 +1,96 @@
+export type AudioContextStateLike = "closed" | "interrupted" | "running" | "suspended";
+
+export interface AudioContextLike {
+  readonly state: AudioContextStateLike;
+  resume(): Promise<void>;
+  suspend(): Promise<void>;
+}
+
+export interface AudioDocumentLike {
+  readonly hidden: boolean;
+  addEventListener(type: "visibilitychange", listener: () => void): void;
+  removeEventListener(type: "visibilitychange", listener: () => void): void;
+}
+
+export type AudioContextFactory = () => AudioContextLike | null;
+
+export class AudioContextController {
+  private context: AudioContextLike | null = null;
+
+  constructor(private readonly createContext: AudioContextFactory = browserAudioContextFactory) {}
+
+  get(): AudioContextLike | null {
+    return this.context;
+  }
+
+  ensure(): AudioContextLike | null {
+    if (this.context?.state === "closed") {
+      this.context = null;
+    }
+    if (this.context === null) {
+      this.context = this.createContext();
+    }
+    return this.context;
+  }
+
+  async resume(): Promise<AudioContextLike | null> {
+    const context = this.ensure();
+    if (context === null) return null;
+    if (context.state === "suspended" || context.state === "interrupted") {
+      await context.resume();
+    }
+    return context;
+  }
+
+  async suspend(): Promise<void> {
+    const context = this.context;
+    if (context === null || context.state !== "running") return;
+    await context.suspend();
+  }
+
+  bindVisibilitySuspension(documentLike: AudioDocumentLike): () => void {
+    const onVisibilityChange = () => {
+      if (documentLike.hidden) {
+        void this.suspend();
+      }
+    };
+    documentLike.addEventListener("visibilitychange", onVisibilityChange);
+    return () => documentLike.removeEventListener("visibilitychange", onVisibilityChange);
+  }
+}
+
+const defaultController = new AudioContextController();
+
+export function getAudioContext(): AudioContextLike | null {
+  return defaultController.get();
+}
+
+export function ensureAudioContext(): AudioContextLike | null {
+  return defaultController.ensure();
+}
+
+export function resumeAudioContext(): Promise<AudioContextLike | null> {
+  return defaultController.resume();
+}
+
+export function suspendAudioContext(): Promise<void> {
+  return defaultController.suspend();
+}
+
+export function bindAudioVisibilitySuspension(
+  documentLike: AudioDocumentLike | undefined = globalThis.document,
+): () => void {
+  if (documentLike === undefined) return () => {};
+  return defaultController.bindVisibilitySuspension(documentLike);
+}
+
+function browserAudioContextFactory(): AudioContextLike | null {
+  if (typeof window === "undefined") return null;
+
+  const AudioContextCtor =
+    window.AudioContext ??
+    (window as typeof window & { webkitAudioContext?: typeof AudioContext })
+      .webkitAudioContext;
+
+  return AudioContextCtor === undefined ? null : new AudioContextCtor();
+}


### PR DESCRIPTION
## Summary
- add a shared AudioContext controller with lazy creation, resume, suspend, and unavailable-Web-Audio no-op paths
- add hidden-page visibility suspension without creating audio on tab hide
- record GDD coverage and progress for the lifecycle slice

## GDD
- docs/gdd/18-sound-and-music-design.md
- docs/gdd/21-technical-design-for-web-implementation.md

## Requirement inventory
- Implements lazy shared Web Audio context creation for future procedural and stem playback callers.
- Implements explicit resume and suspend helpers for future first-gesture wiring.
- Implements hidden-page suspension for an already running context.
- Leaves engine playback, SFX playback, music playback, region metadata, placeholder audio assets, and settings UI sliders to later §18 slices.

## Progress log
- docs/PROGRESS_LOG.md: Audio context lifecycle primitives

## Test plan
- npx vitest run src/audio/context.test.ts
- npx vitest run src/audio/context.test.ts src/audio/engine.test.ts src/audio/mixer.test.ts
- npm run typecheck
- npm run content-lint
- npm run verify

## Followups
- None