### PR TITLE
feat(options): add audio mix pane

### DIFF
--- a/docs/GDD_COVERAGE.json
+++ b/docs/GDD_COVERAGE.json
@@ -826,6 +826,29 @@
       "followupRefs": ["F-049"]
     },
     {
+      "id": "GDD-20-AUDIO-OPTIONS-PANE",
+      "gddSections": [
+        "docs/gdd/18-sound-and-music-design.md",
+        "docs/gdd/20-hud-and-ui-ux.md",
+        "docs/gdd/21-technical-design-for-web-implementation.md",
+        "docs/gdd/22-data-schemas.md"
+      ],
+      "requirement": "The options screen exposes persisted master, music, and SFX sliders backed by the save audio settings and consumed by the audio mixer contract.",
+      "coverage": ["implemented-code", "automated-test"],
+      "implementationRefs": [
+        "src/app/options/page.tsx",
+        "src/components/options/AudioPane.tsx",
+        "src/components/options/audioPaneState.ts",
+        "src/components/options/optionsResetState.ts"
+      ],
+      "testRefs": [
+        "src/components/options/__tests__/audioPaneState.test.ts",
+        "src/components/options/__tests__/optionsResetState.test.ts",
+        "e2e/options-screen.spec.ts"
+      ],
+      "followupRefs": ["VibeGear2-implement-sound-music-1611f9dd"]
+    },
+    {
       "id": "GDD-19-KEY-REMAPPING",
       "gddSections": [
         "docs/gdd/19-controls-and-input.md",

--- a/docs/PROGRESS_LOG.md
+++ b/docs/PROGRESS_LOG.md
@@ -13,7 +13,7 @@ Correct them by adding a new entry that references the old one.
 [§20](gdd/20-hud-and-ui-ux.md) settings,
 [§21](gdd/21-technical-design-for-web-implementation.md) audio pipeline,
 [§22](gdd/22-data-schemas.md) save audio schema.
-**Branch / PR:** `feat/audio-options-pane`, PR pending.
+**Branch / PR:** `feat/audio-options-pane`, PR #67.
 **Status:** Implemented.
 
 ### Done

--- a/docs/PROGRESS_LOG.md
+++ b/docs/PROGRESS_LOG.md
@@ -6,6 +6,59 @@ Correct them by adding a new entry that references the old one.
 
 ---
 
+## 2026-04-28: Slice: Audio options pane
+
+**GDD sections touched:**
+[§18](gdd/18-sound-and-music-design.md) sound and music design,
+[§20](gdd/20-hud-and-ui-ux.md) settings,
+[§21](gdd/21-technical-design-for-web-implementation.md) audio pipeline,
+[§22](gdd/22-data-schemas.md) save audio schema.
+**Branch / PR:** `feat/audio-options-pane`, PR pending.
+**Status:** Implemented.
+
+### Done
+- `src/app/options/page.tsx`: replaced the Audio placeholder with a
+  shipped pane.
+- `src/components/options/AudioPane.tsx` and
+  `src/components/options/audioPaneState.ts`: added persisted master,
+  music, and SFX sliders backed by `SaveGame.settings.audio`.
+- `src/components/options/optionsResetState.ts`: made reset-to-defaults
+  own audio settings now that the pane has shipped.
+- `docs/GDD_COVERAGE.json`: added GDD-20-AUDIO-OPTIONS-PANE.
+
+### Verified
+- `npx vitest run src/components/options/__tests__/audioPaneState.test.ts src/components/options/__tests__/optionsResetState.test.ts src/app/options/__tests__/page.test.tsx`
+  green, 19 passed.
+- `npm run lint` green.
+- `npm run typecheck` green.
+- `npm run content-lint` green.
+- `npx playwright test e2e/options-screen.spec.ts --project=chromium`
+  green, 9 passed.
+- `npm run verify` green, 2438 passed.
+- `npm run test:e2e` green, 75 passed.
+
+### Decisions and assumptions
+- This slice persists the §20 mix controls only. It does not create or
+  resume the Web Audio context, and it does not start engine, SFX, or
+  music playback.
+- Slider values use the existing unit-interval save schema with 5
+  percent UI steps and two-decimal clamping in the pure helper.
+- Reset-to-defaults now resets audio because Audio is no longer a
+  placeholder pane.
+
+### Coverage ledger
+- GDD-20-AUDIO-OPTIONS-PANE covers master, music, and SFX settings UI,
+  save persistence, default fallback, clamping, and reset ownership.
+- Uncovered adjacent requirements: engine playback, SFX playback, music
+  playback, region stem metadata, and placeholder audio assets remain
+  under the §18 audio parent dot.
+
+### Followups created
+None.
+
+### GDD edits
+None.
+
 ## 2026-04-28: Slice: Audio context lifecycle primitives
 
 **GDD sections touched:**

--- a/e2e/options-screen.spec.ts
+++ b/e2e/options-screen.spec.ts
@@ -114,9 +114,58 @@ test.describe("options screen", () => {
     expect(persisted?.settings?.displaySpeedUnit).toBe("mph");
     expect(persisted?.settings?.transmissionMode).toBe("manual");
     expect(persisted?.settings?.audio).toEqual({
-      master: 0.2,
-      music: 0.3,
-      sfx: 0.4,
+      master: 1,
+      music: 0.8,
+      sfx: 0.9,
+    });
+  });
+
+  test("Audio mix sliders persist master, music, and SFX settings", async ({
+    page,
+  }) => {
+    await page.goto("/options");
+    await page.getByTestId("options-tab-audio").click();
+
+    await expect(page.getByTestId("audio-pane")).toBeVisible();
+    await expect(page.getByTestId("audio-value-master")).toHaveText("100%");
+    await expect(page.getByTestId("audio-value-music")).toHaveText("80%");
+    await expect(page.getByTestId("audio-value-sfx")).toHaveText("90%");
+
+    const setSlider = async (testId: string, value: string) => {
+      await page.getByTestId(testId).evaluate((node, nextValue) => {
+        const input = node as HTMLInputElement;
+        const setter = Object.getOwnPropertyDescriptor(
+          HTMLInputElement.prototype,
+          "value",
+        )?.set;
+        if (!setter) throw new Error("HTMLInputElement value setter missing");
+        setter.call(input, nextValue);
+        input.dispatchEvent(new Event("input", { bubbles: true }));
+        input.dispatchEvent(new Event("change", { bubbles: true }));
+      }, value);
+    };
+
+    await setSlider("audio-slider-master", "0.45");
+    await expect(page.getByTestId("audio-value-master")).toHaveText("45%");
+    await expect(page.getByTestId("audio-status")).toContainText(
+      "Master set to 45%",
+    );
+
+    await setSlider("audio-slider-music", "0.65");
+    await expect(page.getByTestId("audio-value-music")).toHaveText("65%");
+
+    await setSlider("audio-slider-sfx", "0.25");
+    await expect(page.getByTestId("audio-value-sfx")).toHaveText("25%");
+
+    const persisted = await page.evaluate((key) => {
+      const raw = window.localStorage.getItem(key);
+      return raw ? JSON.parse(raw) : null;
+    }, "vibegear2:save:v3");
+
+    expect(persisted?.settings?.audio).toEqual({
+      master: 0.45,
+      music: 0.65,
+      sfx: 0.25,
     });
   });
 

--- a/src/app/options/page.tsx
+++ b/src/app/options/page.tsx
@@ -27,6 +27,7 @@ import { useCallback, useEffect, useRef, useState } from "react";
 import type { CSSProperties, KeyboardEvent, ReactElement } from "react";
 
 import { AccessibilityPane } from "@/components/options/AccessibilityPane";
+import { AudioPane } from "@/components/options/AudioPane";
 import { ControlsPane } from "@/components/options/ControlsPane";
 import { DifficultyPane } from "@/components/options/DifficultyPane";
 import { ProfileSection } from "@/components/options/ProfileSection";
@@ -70,9 +71,7 @@ const TABS: ReadonlyArray<TabSpec> = [
   {
     key: "audio",
     label: "Audio",
-    headline: "Audio mix coming soon",
-    body: "Master, music, SFX, and engine bus volumes plus mute toggles ship with the sound and music systems.",
-    dotId: "VibeGear2-implement-sound-music-1611f9dd",
+    pane: () => <AudioPane />,
   },
   {
     key: "controls",

--- a/src/components/options/AudioPane.tsx
+++ b/src/components/options/AudioPane.tsx
@@ -1,0 +1,247 @@
+"use client";
+
+import type { CSSProperties, ReactElement } from "react";
+import { useCallback, useEffect, useState } from "react";
+
+import type { AudioSettings, SaveGame } from "@/data/schemas";
+import { defaultSave, loadSave, saveSave } from "@/persistence";
+
+import {
+  AUDIO_CONTROLS,
+  AUDIO_PANE_HEADLINE,
+  AUDIO_PANE_SUBTITLE,
+  applyAudioLevel,
+  formatAudioPercent,
+  readAudioSettings,
+  type AudioLevelKey,
+} from "./audioPaneState";
+
+interface PaneStatus {
+  kind: "idle" | "info" | "error";
+  message: string;
+}
+
+export function AudioPane(): ReactElement {
+  const [save, setSave] = useState<SaveGame | null>(null);
+  const [status, setStatus] = useState<PaneStatus>({
+    kind: "idle",
+    message: "",
+  });
+
+  useEffect(() => {
+    const outcome = loadSave();
+    if (outcome.kind === "loaded") {
+      setSave(outcome.save);
+      return;
+    }
+
+    setSave(defaultSave());
+    if (outcome.reason !== "missing" && outcome.reason !== "no-storage") {
+      setStatus({
+        kind: "info",
+        message: `Loaded default save (reason: ${outcome.reason}).`,
+      });
+    }
+  }, []);
+
+  const persist = useCallback((next: SaveGame, successMessage: string) => {
+    const writeResult = saveSave(next);
+    if (writeResult.kind === "ok") {
+      setSave({
+        ...next,
+        writeCounter: (next.writeCounter ?? 0) + 1,
+      });
+      setStatus({ kind: "info", message: successMessage });
+      return;
+    }
+
+    setSave(next);
+    setStatus({
+      kind: "error",
+      message: `Save failed (${writeResult.reason}); change kept in memory only.`,
+    });
+  }, []);
+
+  const onSlider = useCallback(
+    (key: AudioLevelKey, rawValue: string) => {
+      if (!save) return;
+      const result = applyAudioLevel(save, key, Number(rawValue));
+      if (result.kind === "noop") return;
+      const nextAudio = readAudioSettings(result.save);
+      const control = AUDIO_CONTROLS.find((c) => c.key === key);
+      persist(
+        result.save,
+        `${control?.label ?? key} set to ${formatAudioPercent(nextAudio[key])}.`,
+      );
+    },
+    [persist, save],
+  );
+
+  if (!save) {
+    return (
+      <div data-testid="audio-pane-loading" style={loadingStyle}>
+        Loading audio settings.
+      </div>
+    );
+  }
+
+  const audio = readAudioSettings(save);
+
+  return (
+    <div data-testid="audio-pane" style={paneStyle}>
+      <header style={headerStyle}>
+        <h2 style={headlineStyle}>{AUDIO_PANE_HEADLINE}</h2>
+        <p style={subtitleStyle}>{AUDIO_PANE_SUBTITLE}</p>
+      </header>
+
+      <fieldset style={fieldsetStyle} aria-label="Audio mix">
+        <legend style={legendStyle}>Mix levels</legend>
+        <ul style={listStyle}>
+          {AUDIO_CONTROLS.map((control) => (
+            <AudioSlider
+              key={control.key}
+              control={control}
+              audio={audio}
+              onSlider={onSlider}
+            />
+          ))}
+        </ul>
+      </fieldset>
+
+      {status.kind !== "idle" ? (
+        <p data-testid="audio-status" style={statusStyle(status.kind)}>
+          {status.message}
+        </p>
+      ) : null}
+    </div>
+  );
+}
+
+interface AudioSliderProps {
+  readonly control: (typeof AUDIO_CONTROLS)[number];
+  readonly audio: AudioSettings;
+  readonly onSlider: (key: AudioLevelKey, value: string) => void;
+}
+
+function AudioSlider({
+  control,
+  audio,
+  onSlider,
+}: AudioSliderProps): ReactElement {
+  const id = `audio-slider-${control.key}`;
+  const value = audio[control.key];
+
+  return (
+    <li style={itemStyle} data-testid={`audio-row-${control.key}`}>
+      <label htmlFor={id} style={labelStyle}>
+        <span style={labelTextStyle}>
+          <span style={titleStyle}>{control.label}</span>
+          <span style={descStyle}>{control.description}</span>
+        </span>
+        <span style={valueStyle} data-testid={`audio-value-${control.key}`}>
+          {formatAudioPercent(value)}
+        </span>
+      </label>
+      <input
+        id={id}
+        type="range"
+        min="0"
+        max="1"
+        step="0.05"
+        value={value}
+        onChange={(e) => onSlider(control.key, e.currentTarget.value)}
+        data-testid={`audio-slider-${control.key}`}
+        style={sliderStyle}
+      />
+    </li>
+  );
+}
+
+const paneStyle: CSSProperties = {
+  display: "grid",
+  gap: "1rem",
+};
+
+const loadingStyle: CSSProperties = {
+  color: "#e8eef7",
+};
+
+const headerStyle: CSSProperties = {
+  display: "grid",
+  gap: "0.35rem",
+};
+
+const headlineStyle: CSSProperties = {
+  margin: 0,
+  fontSize: "1.2rem",
+};
+
+const subtitleStyle: CSSProperties = {
+  margin: 0,
+  maxWidth: "44rem",
+  color: "#b8c4d6",
+  lineHeight: 1.45,
+};
+
+const fieldsetStyle: CSSProperties = {
+  border: "1px solid rgba(162, 198, 255, 0.35)",
+  borderRadius: "8px",
+  padding: "1rem",
+};
+
+const legendStyle: CSSProperties = {
+  padding: "0 0.4rem",
+  color: "#e8eef7",
+  fontWeight: 700,
+};
+
+const listStyle: CSSProperties = {
+  display: "grid",
+  gap: "1rem",
+  listStyle: "none",
+  margin: 0,
+  padding: 0,
+};
+
+const itemStyle: CSSProperties = {
+  display: "grid",
+  gap: "0.45rem",
+};
+
+const labelStyle: CSSProperties = {
+  display: "grid",
+  gap: "0.5rem",
+  gridTemplateColumns: "minmax(0, 1fr) auto",
+  alignItems: "start",
+};
+
+const labelTextStyle: CSSProperties = {
+  display: "grid",
+  gap: "0.2rem",
+};
+
+const titleStyle: CSSProperties = {
+  color: "#f8fbff",
+  fontWeight: 700,
+};
+
+const descStyle: CSSProperties = {
+  color: "#b8c4d6",
+  lineHeight: 1.35,
+};
+
+const valueStyle: CSSProperties = {
+  color: "#f8fbff",
+  fontVariantNumeric: "tabular-nums",
+  minWidth: "3rem",
+  textAlign: "right",
+};
+
+const sliderStyle: CSSProperties = {
+  width: "100%",
+};
+
+const statusStyle = (kind: PaneStatus["kind"]): CSSProperties => ({
+  margin: 0,
+  color: kind === "error" ? "#ffb4b4" : "#c7f5d1",
+});

--- a/src/components/options/AudioPane.tsx
+++ b/src/components/options/AudioPane.tsx
@@ -163,7 +163,7 @@ const paneStyle: CSSProperties = {
 };
 
 const loadingStyle: CSSProperties = {
-  color: "#e8eef7",
+  color: "var(--muted, #aaa)",
 };
 
 const headerStyle: CSSProperties = {
@@ -173,25 +173,26 @@ const headerStyle: CSSProperties = {
 
 const headlineStyle: CSSProperties = {
   margin: 0,
+  color: "var(--fg, #ddd)",
   fontSize: "1.2rem",
 };
 
 const subtitleStyle: CSSProperties = {
   margin: 0,
   maxWidth: "44rem",
-  color: "#b8c4d6",
+  color: "var(--muted, #aaa)",
   lineHeight: 1.45,
 };
 
 const fieldsetStyle: CSSProperties = {
-  border: "1px solid rgba(162, 198, 255, 0.35)",
+  border: "1px solid var(--muted, #444)",
   borderRadius: "8px",
   padding: "1rem",
 };
 
 const legendStyle: CSSProperties = {
   padding: "0 0.4rem",
-  color: "#e8eef7",
+  color: "var(--accent, #8cf)",
   fontWeight: 700,
 };
 
@@ -221,17 +222,17 @@ const labelTextStyle: CSSProperties = {
 };
 
 const titleStyle: CSSProperties = {
-  color: "#f8fbff",
+  color: "var(--fg, #ddd)",
   fontWeight: 700,
 };
 
 const descStyle: CSSProperties = {
-  color: "#b8c4d6",
+  color: "var(--muted, #aaa)",
   lineHeight: 1.35,
 };
 
 const valueStyle: CSSProperties = {
-  color: "#f8fbff",
+  color: "var(--fg, #ddd)",
   fontVariantNumeric: "tabular-nums",
   minWidth: "3rem",
   textAlign: "right",
@@ -243,5 +244,5 @@ const sliderStyle: CSSProperties = {
 
 const statusStyle = (kind: PaneStatus["kind"]): CSSProperties => ({
   margin: 0,
-  color: kind === "error" ? "#ffb4b4" : "#c7f5d1",
+  color: kind === "error" ? "var(--danger, #ff8f8f)" : "var(--accent, #8cf)",
 });

--- a/src/components/options/__tests__/audioPaneState.test.ts
+++ b/src/components/options/__tests__/audioPaneState.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from "vitest";
+
+import { defaultSave } from "@/persistence";
+
+import {
+  AUDIO_CONTROLS,
+  AUDIO_SETTINGS_DEFAULTS,
+  applyAudioLevel,
+  formatAudioPercent,
+  readAudioSettings,
+} from "../audioPaneState";
+
+describe("audioPaneState", () => {
+  it("lists the persisted audio controls in §20 order", () => {
+    expect(AUDIO_CONTROLS.map((control) => control.key)).toEqual([
+      "master",
+      "music",
+      "sfx",
+    ]);
+  });
+
+  it("reads existing audio settings", () => {
+    const save = {
+      ...defaultSave(),
+      settings: {
+        ...defaultSave().settings,
+        audio: { master: 0.4, music: 0.6, sfx: 0.8 },
+      },
+    };
+
+    expect(readAudioSettings(save)).toEqual({
+      master: 0.4,
+      music: 0.6,
+      sfx: 0.8,
+    });
+  });
+
+  it("falls back to documented defaults when a migrated save lacks audio", () => {
+    const save = {
+      ...defaultSave(),
+      settings: {
+        ...defaultSave().settings,
+        audio: undefined,
+      },
+    };
+
+    expect(readAudioSettings(save)).toEqual(AUDIO_SETTINGS_DEFAULTS);
+  });
+
+  it("applies a clamped audio level without mutating other buses", () => {
+    const save = defaultSave();
+    const result = applyAudioLevel(save, "music", 2);
+
+    expect(result.kind).toBe("applied");
+    if (result.kind === "applied") {
+      expect(result.save.settings.audio).toEqual({
+        master: 1,
+        music: 1,
+        sfx: 0.9,
+      });
+      expect(save.settings.audio?.music).toBe(0.8);
+    }
+  });
+
+  it("returns noop when the value is unchanged", () => {
+    expect(applyAudioLevel(defaultSave(), "master", 1)).toEqual({
+      kind: "noop",
+      reason: "same-value",
+    });
+  });
+
+  it("formats clamped percentages", () => {
+    expect(formatAudioPercent(0.75)).toBe("75%");
+    expect(formatAudioPercent(2)).toBe("100%");
+    expect(formatAudioPercent(Number.NaN)).toBe("0%");
+  });
+});

--- a/src/components/options/__tests__/optionsResetState.test.ts
+++ b/src/components/options/__tests__/optionsResetState.test.ts
@@ -5,7 +5,7 @@ import { defaultSave } from "@/persistence";
 import { resetShippedOptionsToDefaults } from "../optionsResetState";
 
 describe("resetShippedOptionsToDefaults", () => {
-  it("resets assists and difficulty to defaults", () => {
+  it("resets assists, audio, and difficulty to defaults", () => {
     const save = defaultSave();
     const customised = {
       ...save,
@@ -16,6 +16,7 @@ describe("resetShippedOptionsToDefaults", () => {
           autoAccelerate: true,
           brakeAssist: true,
         },
+        audio: { master: 0.25, music: 0.35, sfx: 0.45 },
         difficultyPreset: "hard" as const,
       },
     };
@@ -25,6 +26,7 @@ describe("resetShippedOptionsToDefaults", () => {
     expect(result.kind).toBe("applied");
     if (result.kind === "applied") {
       expect(result.save.settings.assists).toEqual(defaultSave().settings.assists);
+      expect(result.save.settings.audio).toEqual(defaultSave().settings.audio);
       expect(result.save.settings.difficultyPreset).toBe("normal");
     }
   });
@@ -69,7 +71,7 @@ describe("resetShippedOptionsToDefaults", () => {
       expect(result.save.garage.credits).toBe(1234);
       expect(result.save.settings.displaySpeedUnit).toBe("mph");
       expect(result.save.settings.transmissionMode).toBe("manual");
-      expect(result.save.settings.audio).toEqual(customised.settings.audio);
+      expect(result.save.settings.audio).toEqual(defaultSave().settings.audio);
       expect(result.save.settings.accessibility).toEqual(
         customised.settings.accessibility,
       );

--- a/src/components/options/audioPaneState.ts
+++ b/src/components/options/audioPaneState.ts
@@ -1,0 +1,85 @@
+import type { AudioSettings, SaveGame } from "@/data/schemas";
+
+export type AudioLevelKey = keyof AudioSettings;
+
+export interface AudioControlSpec {
+  readonly key: AudioLevelKey;
+  readonly label: string;
+  readonly description: string;
+}
+
+export const AUDIO_SETTINGS_DEFAULTS: AudioSettings = Object.freeze({
+  master: 1,
+  music: 0.8,
+  sfx: 0.9,
+});
+
+export const AUDIO_CONTROLS: ReadonlyArray<AudioControlSpec> = [
+  {
+    key: "master",
+    label: "Master",
+    description: "Overall output level for every audio bus.",
+  },
+  {
+    key: "music",
+    label: "Music",
+    description: "Menu and race music bus level before master output.",
+  },
+  {
+    key: "sfx",
+    label: "SFX",
+    description: "Engine, tire, hazard, countdown, and UI sound level before master output.",
+  },
+];
+
+export const AUDIO_PANE_HEADLINE = "Audio mix";
+export const AUDIO_PANE_SUBTITLE =
+  "§20 mix controls for master, music, and SFX levels. These settings persist to your save and feed the §18 mixer.";
+
+export type ApplyAudioLevelResult =
+  | { kind: "applied"; save: SaveGame }
+  | { kind: "noop"; reason: "same-value" };
+
+export function readAudioSettings(save: SaveGame): AudioSettings {
+  const audio = save.settings.audio;
+  return {
+    master: clampUnit(audio?.master ?? AUDIO_SETTINGS_DEFAULTS.master),
+    music: clampUnit(audio?.music ?? AUDIO_SETTINGS_DEFAULTS.music),
+    sfx: clampUnit(audio?.sfx ?? AUDIO_SETTINGS_DEFAULTS.sfx),
+  };
+}
+
+export function applyAudioLevel(
+  save: SaveGame,
+  key: AudioLevelKey,
+  value: number,
+): ApplyAudioLevelResult {
+  const nextValue = clampUnit(value);
+  const current = readAudioSettings(save);
+  if (current[key] === nextValue) {
+    return { kind: "noop", reason: "same-value" };
+  }
+  return {
+    kind: "applied",
+    save: {
+      ...save,
+      settings: {
+        ...save.settings,
+        audio: {
+          ...current,
+          [key]: nextValue,
+        },
+      },
+    },
+  };
+}
+
+export function formatAudioPercent(value: number): string {
+  return `${Math.round(clampUnit(value) * 100)}%`;
+}
+
+function clampUnit(value: number): number {
+  if (!Number.isFinite(value) || value <= 0) return 0;
+  if (value >= 1) return 1;
+  return Math.round(value * 100) / 100;
+}

--- a/src/components/options/audioPaneState.ts
+++ b/src/components/options/audioPaneState.ts
@@ -8,7 +8,7 @@ export interface AudioControlSpec {
   readonly description: string;
 }
 
-export const AUDIO_SETTINGS_DEFAULTS: AudioSettings = Object.freeze({
+export const AUDIO_SETTINGS_DEFAULTS: Readonly<AudioSettings> = Object.freeze({
   master: 1,
   music: 0.8,
   sfx: 0.9,

--- a/src/components/options/optionsResetState.ts
+++ b/src/components/options/optionsResetState.ts
@@ -19,6 +19,7 @@ export function resetShippedOptionsToDefaults(
     settings: {
       ...save.settings,
       assists: { ...defaults.settings.assists },
+      audio: defaults.settings.audio,
       difficultyPreset: defaults.settings.difficultyPreset,
       keyBindings: defaults.settings.keyBindings,
     },
@@ -27,6 +28,7 @@ export function resetShippedOptionsToDefaults(
   if (
     JSON.stringify(next.settings.assists) ===
       JSON.stringify(save.settings.assists) &&
+    JSON.stringify(next.settings.audio) === JSON.stringify(save.settings.audio) &&
     next.settings.difficultyPreset === save.settings.difficultyPreset &&
     JSON.stringify(next.settings.keyBindings) ===
       JSON.stringify(save.settings.keyBindings)


### PR DESCRIPTION
## GDD sections
- §18 Sound and music design
- §20 HUD and UI/UX settings
- §21 Technical design audio pipeline
- §22 Save-game audio settings schema

## Requirement inventory
- Replaces the `/options` Audio placeholder with shipped master, music, and SFX sliders.
- Persists slider changes to `SaveGame.settings.audio` using the existing unit-interval schema.
- Falls back to documented audio defaults when an older migrated save lacks the audio bundle.
- Makes reset-to-defaults reset audio now that Audio is a shipped pane.
- Leaves engine playback, SFX playback, music playback, region stem metadata, and placeholder audio assets to the §18 audio parent dot.

## Progress log
- `docs/PROGRESS_LOG.md`: `2026-04-28: Slice: Audio options pane`
- `docs/GDD_COVERAGE.json`: `GDD-20-AUDIO-OPTIONS-PANE`

## Test plan
- [x] `npx vitest run src/components/options/__tests__/audioPaneState.test.ts src/components/options/__tests__/optionsResetState.test.ts src/app/options/__tests__/page.test.tsx`
- [x] `npm run lint`
- [x] `npm run typecheck`
- [x] `npm run content-lint`
- [x] `npx playwright test e2e/options-screen.spec.ts --project=chromium`
- [x] `npm run verify`
- [x] `npm run test:e2e`

## Followups
- No new followups. Remaining adjacent audio work stays under `VibeGear2-implement-sound-music-1611f9dd`.
