### PR TITLE
feat(audio): add procedural countdown sfx

### DIFF
--- a/docs/GDD_COVERAGE.json
+++ b/docs/GDD_COVERAGE.json
@@ -92,6 +92,24 @@
       "followupRefs": ["VibeGear2-implement-sound-music-1611f9dd"]
     },
     {
+      "id": "GDD-18-PROCEDURAL-COUNTDOWN-SFX",
+      "gddSections": [
+        "docs/gdd/18-sound-and-music-design.md",
+        "docs/gdd/21-technical-design-for-web-implementation.md"
+      ],
+      "requirement": "Live races play procedural countdown and go tones through the shared Web Audio context and persisted SFX mixer gain, while no-context and silent-mixer paths remain no-op.",
+      "coverage": ["implemented-code", "automated-test"],
+      "implementationRefs": [
+        "src/audio/sfx.ts",
+        "src/app/race/page.tsx"
+      ],
+      "testRefs": [
+        "src/audio/sfx.test.ts",
+        "e2e/race-demo.spec.ts"
+      ],
+      "followupRefs": ["VibeGear2-implement-sound-music-1611f9dd"]
+    },
+    {
       "id": "GDD-14-OVERCAST-WEATHER-OPTION",
       "gddSections": [
         "docs/gdd/14-weather-and-environmental-systems.md",

--- a/docs/PROGRESS_LOG.md
+++ b/docs/PROGRESS_LOG.md
@@ -6,6 +6,59 @@ Correct them by adding a new entry that references the old one.
 
 ---
 
+## 2026-04-28: Slice: Procedural countdown SFX runtime
+
+**GDD sections touched:**
+[§18](gdd/18-sound-and-music-design.md) vehicle and race SFX,
+[§21](gdd/21-technical-design-for-web-implementation.md) audio pipeline.
+**Branch / PR:** `feat/procedural-countdown-sfx`, PR pending.
+**Status:** Implemented.
+
+### Done
+- `src/audio/sfx.ts`: added a procedural SFX runtime for countdown and
+  go tones, with shared-context lookup, master and SFX mixer gain,
+  no-context no-op behavior, silent-mixer no-op behavior, and one-shot
+  teardown.
+- `src/app/race/page.tsx`: plays countdown tones on countdown step
+  changes, plays the go tone when racing begins, and stops active SFX
+  on race teardown.
+- `docs/GDD_COVERAGE.json`: added
+  GDD-18-PROCEDURAL-COUNTDOWN-SFX.
+
+### Verified
+- `npx vitest run src/audio/sfx.test.ts src/audio/mixer.test.ts src/audio/context.test.ts src/audio/engineRuntime.test.ts`
+  green, 26 passed.
+- `npm run typecheck` green.
+- `npx playwright test e2e/race-demo.spec.ts --project=chromium`
+  green, 3 passed.
+- `npm run verify` green, 2452 passed.
+- `npm run test:e2e` green, 75 passed.
+
+### Decisions and assumptions
+- This slice ships procedural countdown and go tones only. It does not
+  add licensed audio assets, music stems, impact SFX, menu clicks, or
+  lap/result stingers.
+- Countdown playback uses the existing gesture-resumed shared audio
+  context. If the context has not been resumed yet, countdown SFX is a
+  no-op rather than creating audio outside a user gesture.
+- The numbered countdown uses triangle tones; the go tone uses a
+  brighter square tone.
+
+### Coverage ledger
+- GDD-18-PROCEDURAL-COUNTDOWN-SFX covers countdown and go SFX playback,
+  persisted master and SFX gain, no-context no-op behavior, silent SFX
+  no-op behavior, and race teardown cleanup.
+- Uncovered adjacent requirements: nitro, gear shift, brake scrub,
+  tire squeal, wall hit, car rub, weather hush, lap complete, results
+  stinger, music playback, region stem metadata, and placeholder audio
+  assets remain under the §18 audio parent dot.
+
+### Followups created
+None.
+
+### GDD edits
+None.
+
 ## 2026-04-28: Slice: Procedural engine runtime
 
 **GDD sections touched:**

--- a/src/app/race/page.tsx
+++ b/src/app/race/page.tsx
@@ -139,6 +139,10 @@ import {
   type EngineAudioContextLike,
   type EngineRuntimeInput,
 } from "@/audio/engineRuntime";
+import {
+  ProceduralSfxRuntime,
+  type SfxAudioContextLike,
+} from "@/audio/sfx";
 
 const VIEWPORT_WIDTH = 800;
 const VIEWPORT_HEIGHT = 480;
@@ -202,6 +206,20 @@ function currentEngineAudioContext(): EngineAudioContextLike | null {
     return null;
   }
   return context as EngineAudioContextLike;
+}
+
+function currentSfxAudioContext(): SfxAudioContextLike | null {
+  const context = getAudioContext();
+  if (
+    context === null ||
+    !("createOscillator" in context) ||
+    !("createGain" in context) ||
+    !("currentTime" in context) ||
+    !("destination" in context)
+  ) {
+    return null;
+  }
+  return context as SfxAudioContextLike;
 }
 
 function createLayerCanvas(
@@ -828,6 +846,9 @@ function RaceCanvas({
     const engineAudio = new ProceduralEngineRuntime({
       context: currentEngineAudioContext,
     });
+    const raceSfx = new ProceduralSfxRuntime({
+      context: currentSfxAudioContext,
+    });
     let latestEngineInput: EngineRuntimeInput = {
       speed: 0,
       topSpeed: STARTER_STATS.topSpeed,
@@ -836,6 +857,7 @@ function RaceCanvas({
     let engineStartPending = false;
     let engineAudioTeardown = false;
     let lastEngineAudioUpdateMs = 0;
+    let lastCountdownSfxStep: number | null = null;
     const tryStartEngineAudio = (): void => {
       if (engineAudioTeardown || engineStartPending || engineAudio.isRunning()) {
         return;
@@ -866,6 +888,7 @@ function RaceCanvas({
       unbindEngineAudio();
       handleRef.current?.stop();
       engineAudio.stop();
+      raceSfx.stopAll();
       handleRef.current = null;
       sessionRef.current = null;
       inputManager.dispose();
@@ -896,6 +919,7 @@ function RaceCanvas({
       setPhase("countdown");
       setCountdownSecondsLeft(Math.ceil(config.countdownSec ?? 3));
       setResultMs(null);
+      lastCountdownSfxStep = null;
       setHudSnapshot({
         speed: 0,
         lap: 1,
@@ -1180,7 +1204,15 @@ function RaceCanvas({
         // reflects countdown / phase changes for Playwright.
         setPhase(session.race.phase);
         if (session.race.phase === "countdown") {
-          setCountdownSecondsLeft(Math.ceil(session.race.countdownRemainingSec));
+          const countdownStep = Math.ceil(session.race.countdownRemainingSec);
+          if (countdownStep !== lastCountdownSfxStep) {
+            lastCountdownSfxStep = countdownStep;
+            raceSfx.playCountdownTick({
+              step: countdownStep,
+              audio: persistedSettings.audio,
+            });
+          }
+          setCountdownSecondsLeft(countdownStep);
         } else if (session.race.phase === "finished") {
           setResultMs(Math.round(session.race.elapsed * 1000));
           // Natural finish wiring per F-038. The render callback fires
@@ -1263,6 +1295,12 @@ function RaceCanvas({
             stopRaceRuntime();
             router.push("/race/results");
           }
+        } else if (lastCountdownSfxStep !== 0) {
+          lastCountdownSfxStep = 0;
+          raceSfx.playCountdownTick({
+            step: 0,
+            audio: persistedSettings.audio,
+          });
         }
         setHudSnapshot({
           speed: hud.speed,

--- a/src/app/race/page.tsx
+++ b/src/app/race/page.tsx
@@ -194,7 +194,7 @@ function touchLayoutFor(viewport: Viewport): TouchLayout {
   };
 }
 
-function currentEngineAudioContext(): EngineAudioContextLike | null {
+function currentRaceAudioContext(): unknown | null {
   const context = getAudioContext();
   if (
     context === null ||
@@ -205,21 +205,17 @@ function currentEngineAudioContext(): EngineAudioContextLike | null {
   ) {
     return null;
   }
-  return context as EngineAudioContextLike;
+  return context;
+}
+
+function currentEngineAudioContext(): EngineAudioContextLike | null {
+  const context = currentRaceAudioContext();
+  return context === null ? null : (context as EngineAudioContextLike);
 }
 
 function currentSfxAudioContext(): SfxAudioContextLike | null {
-  const context = getAudioContext();
-  if (
-    context === null ||
-    !("createOscillator" in context) ||
-    !("createGain" in context) ||
-    !("currentTime" in context) ||
-    !("destination" in context)
-  ) {
-    return null;
-  }
-  return context as SfxAudioContextLike;
+  const context = currentRaceAudioContext();
+  return context === null ? null : (context as SfxAudioContextLike);
 }
 
 function createLayerCanvas(

--- a/src/audio/sfx.test.ts
+++ b/src/audio/sfx.test.ts
@@ -101,8 +101,8 @@ describe("ProceduralSfxRuntime", () => {
     runtime.stopAll();
 
     expect(runtime.activeCount()).toBe(0);
-    expect(context.oscillators[0]?.stop).toHaveBeenCalledTimes(2);
-    expect(context.oscillators[1]?.stop).toHaveBeenCalledTimes(2);
+    expect(context.oscillators[0]?.stop).toHaveBeenCalledTimes(1);
+    expect(context.oscillators[1]?.stop).toHaveBeenCalledTimes(1);
     expect(context.gains[0]?.disconnected).toBe(true);
     expect(context.gains[1]?.disconnected).toBe(true);
   });

--- a/src/audio/sfx.test.ts
+++ b/src/audio/sfx.test.ts
@@ -1,0 +1,174 @@
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  countdownFrequency,
+  ProceduralSfxRuntime,
+  type SfxAudioContextLike,
+  type SfxAudioParamLike,
+} from "./sfx";
+
+const AUDIO = { master: 1, music: 0.8, sfx: 0.9 };
+
+describe("countdownFrequency", () => {
+  it("uses a higher pitch for go than numbered countdown ticks", () => {
+    expect(countdownFrequency(0)).toBeGreaterThan(countdownFrequency(1));
+    expect(countdownFrequency(1)).toBeGreaterThan(countdownFrequency(3));
+  });
+
+  it("treats invalid and negative steps as the go pitch", () => {
+    expect(countdownFrequency(Number.NaN)).toBe(880);
+    expect(countdownFrequency(-1)).toBe(880);
+  });
+});
+
+describe("ProceduralSfxRuntime", () => {
+  it("does not create a graph when no context is available", () => {
+    const runtime = new ProceduralSfxRuntime({ context: () => null });
+
+    expect(runtime.playCountdownTick({ step: 3, audio: AUDIO })).toBe(false);
+    expect(runtime.activeCount()).toBe(0);
+  });
+
+  it("does not create a graph when the SFX bus is silent", () => {
+    const context = new FakeAudioContext();
+    const runtime = new ProceduralSfxRuntime({ context: () => context });
+
+    expect(
+      runtime.playCountdownTick({
+        step: 3,
+        audio: { master: 1, music: 1, sfx: 0 },
+      }),
+    ).toBe(false);
+
+    expect(context.oscillators).toHaveLength(0);
+  });
+
+  it("plays a numbered countdown tick through the SFX bus", () => {
+    const context = new FakeAudioContext();
+    const runtime = new ProceduralSfxRuntime({
+      context: () => context,
+      baseGain: 0.2,
+      durationSeconds: 0.1,
+    });
+
+    expect(runtime.playCountdownTick({ step: 2, audio: AUDIO })).toBe(true);
+
+    expect(context.oscillators).toHaveLength(1);
+    expect(context.gains).toHaveLength(1);
+    expect(context.oscillators[0]?.type).toBe("triangle");
+    expect(context.oscillators[0]?.frequency.value).toBe(
+      countdownFrequency(2),
+    );
+    expect(context.gains[0]?.gain.linearRampToValueAtTime).toHaveBeenCalledWith(
+      1 * 0.9 * 0.2,
+      0.01,
+    );
+    expect(context.oscillators[0]?.start).toHaveBeenCalledWith(0);
+    expect(context.oscillators[0]?.stop).toHaveBeenCalledWith(0.1);
+    expect(runtime.activeCount()).toBe(1);
+  });
+
+  it("uses the go tone for step zero", () => {
+    const context = new FakeAudioContext();
+    const runtime = new ProceduralSfxRuntime({ context: () => context });
+
+    runtime.playCountdownTick({ step: 0, audio: AUDIO });
+
+    expect(context.oscillators[0]?.type).toBe("square");
+    expect(context.oscillators[0]?.frequency.value).toBe(
+      countdownFrequency(0),
+    );
+  });
+
+  it("disconnects finished one-shots", () => {
+    const context = new FakeAudioContext();
+    const runtime = new ProceduralSfxRuntime({ context: () => context });
+
+    runtime.playCountdownTick({ step: 1, audio: AUDIO });
+    context.oscillators[0]?.finish();
+
+    expect(runtime.activeCount()).toBe(0);
+    expect(context.oscillators[0]?.disconnected).toBe(true);
+    expect(context.gains[0]?.disconnected).toBe(true);
+  });
+
+  it("stops all active one-shots", () => {
+    const context = new FakeAudioContext();
+    const runtime = new ProceduralSfxRuntime({ context: () => context });
+
+    runtime.playCountdownTick({ step: 3, audio: AUDIO });
+    runtime.playCountdownTick({ step: 2, audio: AUDIO });
+    runtime.stopAll();
+
+    expect(runtime.activeCount()).toBe(0);
+    expect(context.oscillators[0]?.stop).toHaveBeenCalledTimes(2);
+    expect(context.oscillators[1]?.stop).toHaveBeenCalledTimes(2);
+    expect(context.gains[0]?.disconnected).toBe(true);
+    expect(context.gains[1]?.disconnected).toBe(true);
+  });
+});
+
+class FakeAudioParam implements SfxAudioParamLike {
+  value = 0;
+  readonly setValueAtTime = vi.fn((value: number, _startTime: number) => {
+    this.value = value;
+  });
+  readonly linearRampToValueAtTime = vi.fn(
+    (value: number, _endTime: number) => {
+      this.value = value;
+    },
+  );
+}
+
+class FakeOscillator {
+  type: OscillatorType = "sine";
+  readonly frequency = new FakeAudioParam();
+  onended: (() => void) | null = null;
+  disconnected = false;
+  readonly start = vi.fn((_when?: number) => undefined);
+  readonly stop = vi.fn((_when?: number) => undefined);
+
+  connect(_destination: unknown): unknown {
+    return undefined;
+  }
+
+  disconnect(): void {
+    this.disconnected = true;
+  }
+
+  finish(): void {
+    this.onended?.();
+  }
+}
+
+class FakeGain {
+  readonly gain = new FakeAudioParam();
+  disconnected = false;
+
+  connect(_destination: unknown): unknown {
+    return undefined;
+  }
+
+  disconnect(): void {
+    this.disconnected = true;
+  }
+}
+
+class FakeAudioContext implements SfxAudioContextLike {
+  readonly currentTime = 0;
+  readonly destination = {};
+  readonly oscillators: FakeOscillator[] = [];
+  readonly gains: FakeGain[] = [];
+
+  createOscillator(): FakeOscillator {
+    const oscillator = new FakeOscillator();
+    this.oscillators.push(oscillator);
+    return oscillator;
+  }
+
+  createGain(): FakeGain {
+    const gain = new FakeGain();
+    this.gains.push(gain);
+    return gain;
+  }
+}

--- a/src/audio/sfx.ts
+++ b/src/audio/sfx.ts
@@ -103,7 +103,6 @@ export class ProceduralSfxRuntime {
 
   stopAll(): void {
     for (const graph of Array.from(this.active)) {
-      graph.oscillator.stop();
       this.disconnect(graph);
     }
   }

--- a/src/audio/sfx.ts
+++ b/src/audio/sfx.ts
@@ -1,0 +1,158 @@
+import type { AudioSettings } from "@/data/schemas";
+
+import { isMixerSilent, resolveMixerGains } from "./mixer";
+
+export interface SfxAudioParamLike {
+  value: number;
+  setValueAtTime?(value: number, startTime: number): void;
+  linearRampToValueAtTime?(value: number, endTime: number): void;
+}
+
+export interface SfxOscillatorLike {
+  type: OscillatorType;
+  frequency: SfxAudioParamLike;
+  onended: (() => void) | null;
+  connect(destination: unknown): unknown;
+  start(when?: number): void;
+  stop(when?: number): void;
+  disconnect(): void;
+}
+
+export interface SfxGainLike {
+  gain: SfxAudioParamLike;
+  connect(destination: unknown): unknown;
+  disconnect(): void;
+}
+
+export interface SfxAudioContextLike {
+  readonly currentTime: number;
+  readonly destination: unknown;
+  createOscillator(): SfxOscillatorLike;
+  createGain(): SfxGainLike;
+}
+
+export interface CountdownSfxInput {
+  readonly step: number;
+  readonly audio: AudioSettings | undefined;
+}
+
+export interface ProceduralSfxRuntimeOptions {
+  readonly context: () => SfxAudioContextLike | null;
+  readonly baseGain?: number;
+  readonly durationSeconds?: number;
+}
+
+interface OneShotGraph {
+  readonly oscillator: SfxOscillatorLike;
+  readonly output: SfxGainLike;
+}
+
+const DEFAULT_BASE_GAIN = 0.22;
+const DEFAULT_DURATION_SECONDS = 0.12;
+const SILENT_AUDIO: AudioSettings = Object.freeze({
+  master: 0,
+  music: 0,
+  sfx: 0,
+});
+
+export class ProceduralSfxRuntime {
+  private readonly active = new Set<OneShotGraph>();
+  private readonly baseGain: number;
+  private readonly durationSeconds: number;
+
+  constructor(private readonly options: ProceduralSfxRuntimeOptions) {
+    this.baseGain = nonNegativeOr(options.baseGain, DEFAULT_BASE_GAIN);
+    this.durationSeconds = nonNegativeOr(
+      options.durationSeconds,
+      DEFAULT_DURATION_SECONDS,
+    );
+  }
+
+  activeCount(): number {
+    return this.active.size;
+  }
+
+  playCountdownTick(input: CountdownSfxInput): boolean {
+    const gain = this.effectiveGain(input.audio);
+    if (gain === 0) return false;
+
+    const context = this.options.context();
+    if (context === null) return false;
+
+    const output = context.createGain();
+    const oscillator = context.createOscillator();
+    const startTime = context.currentTime;
+    const stopTime = startTime + this.durationSeconds;
+    const graph: OneShotGraph = { oscillator, output };
+
+    oscillator.type = input.step <= 0 ? "square" : "triangle";
+    setParam(oscillator.frequency, countdownFrequency(input.step), startTime);
+    setParam(output.gain, 0, startTime);
+    rampParam(output.gain, gain, startTime + 0.01);
+    rampParam(output.gain, 0, stopTime);
+    oscillator.connect(output);
+    output.connect(context.destination);
+    oscillator.onended = () => {
+      this.disconnect(graph);
+    };
+    this.active.add(graph);
+    oscillator.start(startTime);
+    oscillator.stop(stopTime);
+    return true;
+  }
+
+  stopAll(): void {
+    for (const graph of Array.from(this.active)) {
+      graph.oscillator.stop();
+      this.disconnect(graph);
+    }
+  }
+
+  private disconnect(graph: OneShotGraph): void {
+    if (!this.active.delete(graph)) return;
+    graph.oscillator.onended = null;
+    graph.oscillator.disconnect();
+    graph.output.disconnect();
+  }
+
+  private effectiveGain(audio: AudioSettings | undefined): number {
+    const gains = resolveMixerGains(audio ?? SILENT_AUDIO);
+    if (gains === null || isMixerSilent(gains) || gains.sfx === 0) return 0;
+    return gains.master * gains.sfx * this.baseGain;
+  }
+}
+
+export function countdownFrequency(step: number): number {
+  if (!Number.isFinite(step) || step <= 0) return 880;
+  return step === 1 ? 660 : 520;
+}
+
+function setParam(
+  param: SfxAudioParamLike,
+  value: number,
+  time: number,
+): void {
+  if (param.setValueAtTime) {
+    param.setValueAtTime(value, time);
+    return;
+  }
+  param.value = value;
+}
+
+function rampParam(
+  param: SfxAudioParamLike,
+  value: number,
+  time: number,
+): void {
+  if (param.linearRampToValueAtTime) {
+    param.linearRampToValueAtTime(value, time);
+    return;
+  }
+  setParam(param, value, time);
+}
+
+function nonNegativeOr(value: number | undefined, fallback: number): number {
+  return value === undefined || !Number.isFinite(value) || value < 0
+    ? fallback
+    : value;
+}


### PR DESCRIPTION
## GDD sections
- §18 Sound and music design
- §21 Technical design audio pipeline

## Requirement inventory
- Adds a procedural countdown SFX runtime for numbered ticks and the go tone.
- Uses the shared Web Audio context without creating audio before a user gesture.
- Applies persisted master and SFX mixer gain.
- Keeps no-context browsers and silent SFX settings as no-op paths.
- Stops active one-shots during race teardown.
- Leaves nitro, gear shift, brake scrub, tire squeal, wall hit, car rub, weather hush, lap complete, results stinger, music playback, region stem metadata, and placeholder audio assets to the §18 audio parent dot.

## Progress log
- `docs/PROGRESS_LOG.md`: `2026-04-28: Slice: Procedural countdown SFX runtime`
- `docs/GDD_COVERAGE.json`: `GDD-18-PROCEDURAL-COUNTDOWN-SFX`

## Test plan
- [x] `npx vitest run src/audio/sfx.test.ts src/audio/mixer.test.ts src/audio/context.test.ts src/audio/engineRuntime.test.ts` green, 26 passed.
- [x] `npm run typecheck` green.
- [x] `npx playwright test e2e/race-demo.spec.ts --project=chromium` green, 3 passed.
- [x] `npm run verify` green, 2452 passed.
- [x] `npm run test:e2e` green, 75 passed.