### PR TITLE
feat(audio): add procedural impact sfx

### DIFF
--- a/docs/GDD_COVERAGE.json
+++ b/docs/GDD_COVERAGE.json
@@ -110,6 +110,25 @@
       "followupRefs": ["VibeGear2-implement-sound-music-1611f9dd"]
     },
     {
+      "id": "GDD-18-PROCEDURAL-IMPACT-SFX",
+      "gddSections": [
+        "docs/gdd/18-sound-and-music-design.md",
+        "docs/gdd/21-technical-design-for-web-implementation.md"
+      ],
+      "requirement": "Live races emit player impact cues from the pure race-session damage pass and play procedural impact tones through the shared SFX runtime for car contact, wall, hazard, and rub-style hits.",
+      "coverage": ["implemented-code", "automated-test"],
+      "implementationRefs": [
+        "src/game/raceSession.ts",
+        "src/audio/sfx.ts",
+        "src/app/race/page.tsx"
+      ],
+      "testRefs": [
+        "src/game/__tests__/raceSession.test.ts",
+        "src/audio/sfx.test.ts"
+      ],
+      "followupRefs": ["VibeGear2-implement-sound-music-1611f9dd"]
+    },
+    {
       "id": "GDD-14-OVERCAST-WEATHER-OPTION",
       "gddSections": [
         "docs/gdd/14-weather-and-environmental-systems.md",

--- a/docs/PROGRESS_LOG.md
+++ b/docs/PROGRESS_LOG.md
@@ -6,6 +6,62 @@ Correct them by adding a new entry that references the old one.
 
 ---
 
+## 2026-04-28: Slice: Procedural impact SFX runtime
+
+**GDD sections touched:**
+[§18](gdd/18-sound-and-music-design.md) vehicle and race SFX,
+[§21](gdd/21-technical-design-for-web-implementation.md) audio pipeline.
+**Branch / PR:** `feat/procedural-impact-sfx`, PR pending.
+**Status:** Implemented.
+
+### Done
+- `src/game/raceSession.ts`: added transient per-tick player impact
+  audio events emitted from the deterministic damage pass for car,
+  wall, hazard, and rub-style hit kinds.
+- `src/audio/sfx.ts`: added procedural impact tones with hit-kind
+  specific oscillator shape, duration, pitch, and gain scaling.
+- `src/app/race/page.tsx`: plays each player impact event once per
+  simulation tick through the existing shared audio context and SFX
+  mixer settings.
+- `docs/GDD_COVERAGE.json`: added
+  GDD-18-PROCEDURAL-IMPACT-SFX.
+
+### Verified
+- `npx vitest run src/audio/sfx.test.ts src/game/__tests__/raceSession.test.ts`
+  green, 124 passed.
+- `npm run typecheck` green.
+- `npm run content-lint` green.
+- `npx vitest run src/audio/sfx.test.ts src/game/__tests__/raceSession.test.ts src/game/__tests__/raceSessionActions.test.ts`
+  green, 133 passed.
+- `npm run build` green and postbuild source-map scrub completed.
+- `npm run verify` green, 2456 passed.
+- `npm run test:e2e` green, 75 passed.
+
+### Decisions and assumptions
+- This slice plays local player impacts only. AI-only contact stays
+  silent until a field-mix or spectator audio policy exists.
+- Off-road persistent damage is not emitted as an impact cue because it
+  represents continuous surface punishment; the §18 off-road rumble and
+  weather hush layers remain under the sound parent dot.
+- The race session exposes transient event data while keeping physics
+  deterministic. Audio playback remains a page-level side effect.
+
+### Coverage ledger
+- GDD-18-PROCEDURAL-IMPACT-SFX covers player impact cue emission,
+  car-contact playback, wall or hazard hit playback, rub-style tone
+  shaping, persisted SFX gain use, no-context no-op behavior, silent
+  SFX no-op behavior, and race teardown cleanup.
+- Uncovered adjacent requirements: nitro engage, gear shift, brake
+  scrub, tire squeal, spray or snow hush, lap complete, results
+  stinger, music playback, region stem metadata, and placeholder audio
+  assets remain under the §18 audio parent dot.
+
+### Followups created
+None.
+
+### GDD edits
+None.
+
 ## 2026-04-28: Slice: Procedural countdown SFX runtime
 
 **GDD sections touched:**

--- a/src/app/race/page.tsx
+++ b/src/app/race/page.tsx
@@ -52,7 +52,12 @@ import {
   loadTrack,
 } from "@/data";
 import carsAtlasFixture from "@/data/atlas/cars.json";
-import { AtlasMetaSchema, TrackSchema, type Track } from "@/data/schemas";
+import {
+  AtlasMetaSchema,
+  TrackSchema,
+  type AudioSettings,
+  type Track,
+} from "@/data/schemas";
 import {
   applyTimeTrialResult,
   buildFinalCarInputsFromSession,
@@ -76,6 +81,7 @@ import {
   stepRaceSession,
   totalProgress,
   type LoopHandle,
+  type RaceSessionAudioEvent,
   type RaceSessionConfig,
   type RaceSessionState,
   type RankedCar,
@@ -216,6 +222,21 @@ function currentEngineAudioContext(): EngineAudioContextLike | null {
 function currentSfxAudioContext(): SfxAudioContextLike | null {
   const context = currentRaceAudioContext();
   return context === null ? null : (context as SfxAudioContextLike);
+}
+
+function playRaceImpactSfx(
+  runtime: ProceduralSfxRuntime,
+  events: ReadonlyArray<RaceSessionAudioEvent>,
+  audio: AudioSettings | undefined,
+): void {
+  for (const event of events) {
+    if (event.kind !== "impact") continue;
+    runtime.playImpact({
+      hitKind: event.hitKind,
+      speedFactor: event.speedFactor,
+      audio,
+    });
+  }
 }
 
 function createLayerCanvas(
@@ -854,6 +875,7 @@ function RaceCanvas({
     let engineAudioTeardown = false;
     let lastEngineAudioUpdateMs = 0;
     let lastCountdownSfxStep: number | null = null;
+    let lastImpactSfxTick: number | null = null;
     const tryStartEngineAudio = (): void => {
       if (engineAudioTeardown || engineStartPending || engineAudio.isRunning()) {
         return;
@@ -916,6 +938,7 @@ function RaceCanvas({
       setCountdownSecondsLeft(Math.ceil(config.countdownSec ?? 3));
       setResultMs(null);
       lastCountdownSfxStep = null;
+      lastImpactSfxTick = null;
       setHudSnapshot({
         speed: 0,
         lap: 1,
@@ -1043,6 +1066,10 @@ function RaceCanvas({
         if (audioUpdateMs - lastEngineAudioUpdateMs >= 50) {
           lastEngineAudioUpdateMs = audioUpdateMs;
           engineAudio.update(latestEngineInput);
+        }
+        if (lastImpactSfxTick !== session.tick) {
+          lastImpactSfxTick = session.tick;
+          playRaceImpactSfx(raceSfx, session.audioEvents, persistedSettings.audio);
         }
         const renderWeather = activeWeatherForState(session.weather);
 

--- a/src/audio/sfx.test.ts
+++ b/src/audio/sfx.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it, vi } from "vitest";
 
 import {
   countdownFrequency,
+  impactFrequency,
   ProceduralSfxRuntime,
   type SfxAudioContextLike,
   type SfxAudioParamLike,
@@ -18,6 +19,21 @@ describe("countdownFrequency", () => {
   it("treats invalid and negative steps as the go pitch", () => {
     expect(countdownFrequency(Number.NaN)).toBe(880);
     expect(countdownFrequency(-1)).toBe(880);
+  });
+});
+
+describe("impactFrequency", () => {
+  it("maps harder impacts to higher pitch within the same hit kind", () => {
+    expect(impactFrequency("carHit", 1)).toBeGreaterThan(
+      impactFrequency("carHit", 0),
+    );
+  });
+
+  it("clamps invalid impact speed factors", () => {
+    expect(impactFrequency("wallHit", Number.NaN)).toBe(
+      impactFrequency("wallHit", 0),
+    );
+    expect(impactFrequency("wallHit", 3)).toBe(impactFrequency("wallHit", 1));
   });
 });
 
@@ -78,6 +94,55 @@ describe("ProceduralSfxRuntime", () => {
     expect(context.oscillators[0]?.frequency.value).toBe(
       countdownFrequency(0),
     );
+  });
+
+  it("plays car impact tones through the SFX bus", () => {
+    const context = new FakeAudioContext();
+    const runtime = new ProceduralSfxRuntime({
+      context: () => context,
+      baseGain: 0.2,
+      durationSeconds: 0.1,
+    });
+
+    expect(
+      runtime.playImpact({
+        hitKind: "carHit",
+        speedFactor: 0.5,
+        audio: AUDIO,
+      }),
+    ).toBe(true);
+
+    expect(context.oscillators).toHaveLength(1);
+    expect(context.oscillators[0]?.type).toBe("square");
+    expect(context.oscillators[0]?.frequency.value).toBe(
+      impactFrequency("carHit", 0.5),
+    );
+    expect(context.gains[0]?.gain.linearRampToValueAtTime).toHaveBeenCalledWith(
+      1 * 0.9 * 0.2 * 0.875,
+      0.01,
+    );
+    expect(context.oscillators[0]?.stop).toHaveBeenCalledWith(0.16);
+  });
+
+  it("uses a shorter low-gain scrape for rub impacts", () => {
+    const context = new FakeAudioContext();
+    const runtime = new ProceduralSfxRuntime({
+      context: () => context,
+      baseGain: 0.2,
+    });
+
+    runtime.playImpact({
+      hitKind: "rub",
+      speedFactor: 0,
+      audio: AUDIO,
+    });
+
+    expect(context.oscillators[0]?.type).toBe("sawtooth");
+    expect(context.gains[0]?.gain.linearRampToValueAtTime).toHaveBeenCalledWith(
+      1 * 0.9 * 0.2 * 0.35,
+      0.01,
+    );
+    expect(context.oscillators[0]?.stop).toHaveBeenCalledWith(0.08);
   });
 
   it("disconnects finished one-shots", () => {

--- a/src/audio/sfx.ts
+++ b/src/audio/sfx.ts
@@ -36,6 +36,19 @@ export interface CountdownSfxInput {
   readonly audio: AudioSettings | undefined;
 }
 
+export type ImpactSfxKind =
+  | "rub"
+  | "carHit"
+  | "wallHit"
+  | "offRoadObject"
+  | "offRoadPersistent";
+
+export interface ImpactSfxInput {
+  readonly hitKind: ImpactSfxKind;
+  readonly speedFactor: number;
+  readonly audio: AudioSettings | undefined;
+}
+
 export interface ProceduralSfxRuntimeOptions {
   readonly context: () => SfxAudioContextLike | null;
   readonly baseGain?: number;
@@ -73,6 +86,38 @@ export class ProceduralSfxRuntime {
   }
 
   playCountdownTick(input: CountdownSfxInput): boolean {
+    return this.playTone({
+      audio: input.audio,
+      frequency: countdownFrequency(input.step),
+      oscillatorType: input.step <= 0 ? "square" : "triangle",
+      gainScale: 1,
+      durationSeconds: this.durationSeconds,
+    });
+  }
+
+  playImpact(input: ImpactSfxInput): boolean {
+    return this.playTone({
+      audio: input.audio,
+      frequency: impactFrequency(input.hitKind, input.speedFactor),
+      oscillatorType: impactOscillatorType(input.hitKind),
+      gainScale: impactGainScale(input.hitKind, input.speedFactor),
+      durationSeconds: impactDurationSeconds(input.hitKind),
+    });
+  }
+
+  stopAll(): void {
+    for (const graph of Array.from(this.active)) {
+      this.disconnect(graph);
+    }
+  }
+
+  private playTone(input: {
+    readonly audio: AudioSettings | undefined;
+    readonly frequency: number;
+    readonly oscillatorType: OscillatorType;
+    readonly gainScale: number;
+    readonly durationSeconds: number;
+  }): boolean {
     const gain = this.effectiveGain(input.audio);
     if (gain === 0) return false;
 
@@ -82,13 +127,13 @@ export class ProceduralSfxRuntime {
     const output = context.createGain();
     const oscillator = context.createOscillator();
     const startTime = context.currentTime;
-    const stopTime = startTime + this.durationSeconds;
+    const stopTime = startTime + input.durationSeconds;
     const graph: OneShotGraph = { oscillator, output };
 
-    oscillator.type = input.step <= 0 ? "square" : "triangle";
-    setParam(oscillator.frequency, countdownFrequency(input.step), startTime);
+    oscillator.type = input.oscillatorType;
+    setParam(oscillator.frequency, input.frequency, startTime);
     setParam(output.gain, 0, startTime);
-    rampParam(output.gain, gain, startTime + 0.01);
+    rampParam(output.gain, gain * input.gainScale, startTime + 0.01);
     rampParam(output.gain, 0, stopTime);
     oscillator.connect(output);
     output.connect(context.destination);
@@ -99,12 +144,6 @@ export class ProceduralSfxRuntime {
     oscillator.start(startTime);
     oscillator.stop(stopTime);
     return true;
-  }
-
-  stopAll(): void {
-    for (const graph of Array.from(this.active)) {
-      this.disconnect(graph);
-    }
   }
 
   private disconnect(graph: OneShotGraph): void {
@@ -124,6 +163,43 @@ export class ProceduralSfxRuntime {
 export function countdownFrequency(step: number): number {
   if (!Number.isFinite(step) || step <= 0) return 880;
   return step === 1 ? 660 : 520;
+}
+
+export function impactFrequency(
+  hitKind: ImpactSfxKind,
+  speedFactor: number,
+): number {
+  const speed = clampUnit(speedFactor);
+  const base =
+    hitKind === "rub" || hitKind === "offRoadPersistent"
+      ? 180
+      : hitKind === "carHit"
+        ? 250
+        : 120;
+  const range =
+    hitKind === "rub" || hitKind === "offRoadPersistent"
+      ? 90
+      : hitKind === "carHit"
+        ? 150
+        : 80;
+  return Math.round(base + range * speed);
+}
+
+function impactOscillatorType(hitKind: ImpactSfxKind): OscillatorType {
+  return hitKind === "rub" || hitKind === "offRoadPersistent"
+    ? "sawtooth"
+    : "square";
+}
+
+function impactGainScale(hitKind: ImpactSfxKind, speedFactor: number): number {
+  const speed = clampUnit(speedFactor);
+  const base =
+    hitKind === "rub" || hitKind === "offRoadPersistent" ? 0.35 : 0.6;
+  return base + speed * 0.55;
+}
+
+function impactDurationSeconds(hitKind: ImpactSfxKind): number {
+  return hitKind === "rub" || hitKind === "offRoadPersistent" ? 0.08 : 0.16;
 }
 
 function setParam(
@@ -154,4 +230,9 @@ function nonNegativeOr(value: number | undefined, fallback: number): number {
   return value === undefined || !Number.isFinite(value) || value < 0
     ? fallback
     : value;
+}
+
+function clampUnit(value: number): number {
+  if (!Number.isFinite(value)) return 0;
+  return Math.min(1, Math.max(0, value));
 }

--- a/src/game/__tests__/raceSession.test.ts
+++ b/src/game/__tests__/raceSession.test.ts
@@ -394,9 +394,16 @@ describe("stepRaceSession (racing)", () => {
     const afterFirstHit = first.player.damage.total;
     expect(afterFirstHit).toBeGreaterThan(0);
     expect(first.brokenHazards).toContain("40:traffic_cone");
+    expect(first.audioEvents).toHaveLength(1);
+    expect(first.audioEvents[0]).toMatchObject({
+      kind: "impact",
+      carId: "player",
+      hitKind: "offRoadObject",
+    });
 
     const second = stepRaceSession(first, NEUTRAL_INPUT, config, DT);
     expect(second.player.damage.total).toBe(afterFirstHit);
+    expect(second.audioEvents).toEqual([]);
   });
 
   it("preserves broken hazards when the player is no longer racing", () => {
@@ -2052,6 +2059,16 @@ describe("stepRaceSession (§13 damage wiring, F-047)", () => {
     session = stepRaceSession(session, fullThrottle(), config, DT);
     expect(session.player.damage.total).toBeGreaterThan(0);
     expect(session.ai[0]?.damage.total ?? 0).toBeGreaterThan(0);
+    expect(session.audioEvents).toHaveLength(1);
+    expect(session.audioEvents[0]).toMatchObject({
+      kind: "impact",
+      carId: "player",
+      hitKind: "carHit",
+    });
+    expect(session.audioEvents[0]?.speedFactor).toBeCloseTo(
+      40.2266666667 / COLLISION_REFERENCE_TOP_SPEED_M_PER_S,
+      8,
+    );
   });
 
   it("does not register a collision when cars are laterally separated past CAR_WIDTH_M", () => {
@@ -2076,6 +2093,7 @@ describe("stepRaceSession (§13 damage wiring, F-047)", () => {
     session = stepRaceSession(session, fullThrottle(), config, DT);
     expect(session.player.damage.total).toBe(0);
     expect(session.ai[0]?.damage.total ?? 0).toBe(0);
+    expect(session.audioEvents).toEqual([]);
   });
 
   it("does not damage a car for being in contact with a non-racing car", () => {

--- a/src/game/raceSession.ts
+++ b/src/game/raceSession.ts
@@ -212,6 +212,15 @@ export interface RaceSessionAI {
   upgrades?: Readonly<CarUpgradeTiers> | null;
 }
 
+export interface RaceSessionImpactAudioEvent {
+  readonly kind: "impact";
+  readonly carId: string;
+  readonly hitKind: HitKind;
+  readonly speedFactor: number;
+}
+
+export type RaceSessionAudioEvent = RaceSessionImpactAudioEvent;
+
 export interface RaceSessionConfig {
   /** Compiled track to drive on. Frozen output of `compileTrack`. */
   track: CompiledTrack;
@@ -521,6 +530,12 @@ export interface RaceSessionState {
   weather: WeatherState;
   /** Serialized deterministic PRNG state reserved for weather transitions. */
   weatherRngState: number;
+  /**
+   * Transient per-tick audio cues emitted by the pure race reducer. The
+   * runtime may play them once per tick, but replays and tests can ignore
+   * them without affecting physics determinism.
+   */
+  audioEvents: ReadonlyArray<RaceSessionAudioEvent>;
 }
 
 /**
@@ -708,6 +723,7 @@ export function createRaceSession(config: RaceSessionConfig): RaceSessionState {
     brokenHazards: [],
     weather,
     weatherRngState: serializeRng(weatherRng),
+    audioEvents: [],
   };
 }
 
@@ -872,6 +888,7 @@ export function stepRaceSession(
         brokenHazards: state.brokenHazards,
         weather: cloneWeatherState(state.weather),
         weatherRngState: state.weatherRngState,
+        audioEvents: [],
       };
     }
     // Lights out. Flip to racing, zero the tick clock, reset the sector
@@ -899,6 +916,7 @@ export function stepRaceSession(
       brokenHazards: state.brokenHazards,
       weather: cloneWeatherState(state.weather),
       weatherRngState: state.weatherRngState,
+      audioEvents: [],
     };
     return stepRaceSession(promoted, playerInput, config, dt);
   }
@@ -1394,6 +1412,14 @@ export function stepRaceSession(
       hitsByCarId.set(b.id, bHits);
     }
   }
+  const playerImpactEvents = (hitsByCarId.get(PLAYER_CAR_ID) ?? []).map(
+    (hit): RaceSessionImpactAudioEvent => ({
+      kind: "impact",
+      carId: PLAYER_CAR_ID,
+      hitKind: hit.kind,
+      speedFactor: hit.speedFactor,
+    }),
+  );
   // Helper: advance one car's damage by the off-road drip + the
   // accumulated `carHit` events. Returns the post-update damage and
   // whether the car wrecked this tick (so the caller can flip status).
@@ -1681,6 +1707,7 @@ export function stepRaceSession(
         : Array.from(nextBrokenHazards),
     weather: nextWeather,
     weatherRngState: nextWeatherRngState,
+    audioEvents: playerImpactEvents,
   };
 }
 
@@ -1724,6 +1751,7 @@ function cloneSessionState(state: Readonly<RaceSessionState>): RaceSessionState 
     brokenHazards: state.brokenHazards.slice(),
     weather: cloneWeatherState(state.weather),
     weatherRngState: state.weatherRngState,
+    audioEvents: state.audioEvents.slice(),
   };
 }
 

--- a/src/game/raceSessionActions.ts
+++ b/src/game/raceSessionActions.ts
@@ -110,6 +110,7 @@ export function retireRaceSession(
     brokenHazards: state.brokenHazards.slice(),
     weather: cloneWeatherPure(state.weather),
     weatherRngState: state.weatherRngState,
+    audioEvents: [],
   };
 }
 
@@ -159,6 +160,7 @@ function clonePure(state: Readonly<RaceSessionState>): RaceSessionState {
     brokenHazards: state.brokenHazards.slice(),
     weather: cloneWeatherPure(state.weather),
     weatherRngState: state.weatherRngState,
+    audioEvents: state.audioEvents.slice(),
   };
 }
 


### PR DESCRIPTION
## GDD sections
- docs/gdd/18-sound-and-music-design.md: vehicle and race SFX
- docs/gdd/21-technical-design-for-web-implementation.md: audio pipeline

## Requirement inventory
This PR handles:
- Emits transient player impact audio events from the deterministic race-session damage pass.
- Plays procedural SFX for player car contact, wall or hazard hits, and rub-style low impacts through the shared SFX runtime.
- Applies persisted master and SFX gain settings.
- Keeps no-context and silent-SFX paths no-op.
- Stops active one-shots on race teardown through the existing SFX runtime cleanup.

Left to followup under `VibeGear2-implement-sound-music-1611f9dd`:
- Nitro engage, gear shift, brake scrub, tire squeal, spray or snow hush, lap-complete, results stinger, music playback, region stem metadata, and placeholder audio assets.
- AI-only contact audio remains silent until a field-mix or spectator audio policy exists.

## Progress log
- docs/PROGRESS_LOG.md: `2026-04-28: Slice: Procedural impact SFX runtime`

## Followups
- None created.

## Test plan
- [x] `npx vitest run src/audio/sfx.test.ts src/game/__tests__/raceSession.test.ts`
- [x] `npm run typecheck`
- [x] `npm run content-lint`
- [x] `npx vitest run src/audio/sfx.test.ts src/game/__tests__/raceSession.test.ts src/game/__tests__/raceSessionActions.test.ts`
- [x] `npm run build`
- [x] `npm run verify`
- [x] `npm run test:e2e`
