### PR TITLE
feat(audio): add procedural nitro sfx

### DIFF
--- a/docs/GDD_COVERAGE.json
+++ b/docs/GDD_COVERAGE.json
@@ -129,6 +129,25 @@
       "followupRefs": ["VibeGear2-implement-sound-music-1611f9dd"]
     },
     {
+      "id": "GDD-18-PROCEDURAL-NITRO-SFX",
+      "gddSections": [
+        "docs/gdd/18-sound-and-music-design.md",
+        "docs/gdd/21-technical-design-for-web-implementation.md"
+      ],
+      "requirement": "Live races emit a player nitro-engage cue from the pure nitro reducer when a fresh charge starts and play a short rising procedural SFX tone through the shared SFX runtime.",
+      "coverage": ["implemented-code", "automated-test"],
+      "implementationRefs": [
+        "src/game/raceSession.ts",
+        "src/audio/sfx.ts",
+        "src/app/race/page.tsx"
+      ],
+      "testRefs": [
+        "src/game/__tests__/raceSession.test.ts",
+        "src/audio/sfx.test.ts"
+      ],
+      "followupRefs": ["VibeGear2-implement-sound-music-1611f9dd"]
+    },
+    {
       "id": "GDD-14-OVERCAST-WEATHER-OPTION",
       "gddSections": [
         "docs/gdd/14-weather-and-environmental-systems.md",

--- a/docs/PROGRESS_LOG.md
+++ b/docs/PROGRESS_LOG.md
@@ -6,6 +6,56 @@ Correct them by adding a new entry that references the old one.
 
 ---
 
+## 2026-04-28: Slice: Procedural nitro engage SFX runtime
+
+**GDD sections touched:**
+[§18](gdd/18-sound-and-music-design.md) vehicle and race SFX,
+[§21](gdd/21-technical-design-for-web-implementation.md) audio pipeline.
+**Branch / PR:** `feat/procedural-nitro-sfx`, PR pending.
+**Status:** Implemented.
+
+### Done
+- `src/game/raceSession.ts`: added a transient nitro-engage audio
+  event emitted from the deterministic nitro reducer when the player
+  starts a fresh charge.
+- `src/audio/sfx.ts`: added a short rising procedural nitro tone that
+  respects shared-context lookup, master gain, SFX gain, and no-op
+  behavior when audio is unavailable or muted.
+- `src/app/race/page.tsx`: plays race-session audio events once per
+  simulation tick through the existing SFX runtime.
+- `docs/GDD_COVERAGE.json`: added
+  GDD-18-PROCEDURAL-NITRO-SFX.
+
+### Verified
+- `npx vitest run src/audio/sfx.test.ts src/game/__tests__/raceSession.test.ts`
+  green, 125 passed.
+- `npm run typecheck` green.
+- `npm run content-lint` green.
+- `npm run verify` green, 2457 passed.
+- `npm run test:e2e` green, 75 passed.
+
+### Decisions and assumptions
+- Nitro playback is driven by the pure race-session event stream rather
+  than by React input state so replays and tests see the same gameplay
+  source of truth.
+- Only player nitro emits an audible cue in this slice. AI nitro audio
+  remains under the wider §18 field-mix policy.
+
+### Coverage ledger
+- GDD-18-PROCEDURAL-NITRO-SFX covers player nitro start event emission,
+  rising nitro playback, persisted SFX gain use, no-context no-op
+  behavior, silent SFX no-op behavior, and race teardown cleanup.
+- Uncovered adjacent requirements: gear shift, brake scrub, tire squeal,
+  spray or snow hush, lap complete, results stinger, music playback,
+  region stem metadata, and placeholder audio assets remain under the
+  §18 audio parent dot.
+
+### Followups created
+None.
+
+### GDD edits
+None.
+
 ## 2026-04-28: Slice: Procedural impact SFX runtime
 
 **GDD sections touched:**

--- a/src/app/race/page.tsx
+++ b/src/app/race/page.tsx
@@ -224,18 +224,21 @@ function currentSfxAudioContext(): SfxAudioContextLike | null {
   return context === null ? null : (context as SfxAudioContextLike);
 }
 
-function playRaceImpactSfx(
+function playRaceSfxEvents(
   runtime: ProceduralSfxRuntime,
   events: ReadonlyArray<RaceSessionAudioEvent>,
   audio: AudioSettings | undefined,
 ): void {
   for (const event of events) {
-    if (event.kind !== "impact") continue;
-    runtime.playImpact({
-      hitKind: event.hitKind,
-      speedFactor: event.speedFactor,
-      audio,
-    });
+    if (event.kind === "impact") {
+      runtime.playImpact({
+        hitKind: event.hitKind,
+        speedFactor: event.speedFactor,
+        audio,
+      });
+    } else if (event.kind === "nitroEngage") {
+      runtime.playNitroEngage({ audio });
+    }
   }
 }
 
@@ -875,7 +878,7 @@ function RaceCanvas({
     let engineAudioTeardown = false;
     let lastEngineAudioUpdateMs = 0;
     let lastCountdownSfxStep: number | null = null;
-    let lastImpactSfxTick: number | null = null;
+    let lastRaceSfxTick: number | null = null;
     const tryStartEngineAudio = (): void => {
       if (engineAudioTeardown || engineStartPending || engineAudio.isRunning()) {
         return;
@@ -938,7 +941,7 @@ function RaceCanvas({
       setCountdownSecondsLeft(Math.ceil(config.countdownSec ?? 3));
       setResultMs(null);
       lastCountdownSfxStep = null;
-      lastImpactSfxTick = null;
+      lastRaceSfxTick = null;
       setHudSnapshot({
         speed: 0,
         lap: 1,
@@ -1067,9 +1070,9 @@ function RaceCanvas({
           lastEngineAudioUpdateMs = audioUpdateMs;
           engineAudio.update(latestEngineInput);
         }
-        if (lastImpactSfxTick !== session.tick) {
-          lastImpactSfxTick = session.tick;
-          playRaceImpactSfx(raceSfx, session.audioEvents, persistedSettings.audio);
+        if (lastRaceSfxTick !== session.tick) {
+          lastRaceSfxTick = session.tick;
+          playRaceSfxEvents(raceSfx, session.audioEvents, persistedSettings.audio);
         }
         const renderWeather = activeWeatherForState(session.weather);
 

--- a/src/audio/sfx.test.ts
+++ b/src/audio/sfx.test.ts
@@ -145,6 +145,31 @@ describe("ProceduralSfxRuntime", () => {
     expect(context.oscillators[0]?.stop).toHaveBeenCalledWith(0.08);
   });
 
+  it("plays nitro engage as a short rising SFX cue", () => {
+    const context = new FakeAudioContext();
+    const runtime = new ProceduralSfxRuntime({
+      context: () => context,
+      baseGain: 0.2,
+    });
+
+    expect(runtime.playNitroEngage({ audio: AUDIO })).toBe(true);
+
+    expect(context.oscillators).toHaveLength(1);
+    expect(context.oscillators[0]?.type).toBe("sawtooth");
+    expect(context.oscillators[0]?.frequency.setValueAtTime).toHaveBeenCalledWith(
+      980,
+      0,
+    );
+    expect(
+      context.oscillators[0]?.frequency.linearRampToValueAtTime,
+    ).toHaveBeenCalledWith(1460, 0.18);
+    expect(context.gains[0]?.gain.linearRampToValueAtTime).toHaveBeenCalledWith(
+      1 * 0.9 * 0.2 * 0.75,
+      0.01,
+    );
+    expect(context.oscillators[0]?.stop).toHaveBeenCalledWith(0.18);
+  });
+
   it("disconnects finished one-shots", () => {
     const context = new FakeAudioContext();
     const runtime = new ProceduralSfxRuntime({ context: () => context });

--- a/src/audio/sfx.ts
+++ b/src/audio/sfx.ts
@@ -49,6 +49,10 @@ export interface ImpactSfxInput {
   readonly audio: AudioSettings | undefined;
 }
 
+export interface NitroEngageSfxInput {
+  readonly audio: AudioSettings | undefined;
+}
+
 export interface ProceduralSfxRuntimeOptions {
   readonly context: () => SfxAudioContextLike | null;
   readonly baseGain?: number;
@@ -105,6 +109,17 @@ export class ProceduralSfxRuntime {
     });
   }
 
+  playNitroEngage(input: NitroEngageSfxInput): boolean {
+    return this.playTone({
+      audio: input.audio,
+      frequency: 980,
+      oscillatorType: "sawtooth",
+      gainScale: 0.75,
+      durationSeconds: 0.18,
+      endFrequency: 1460,
+    });
+  }
+
   stopAll(): void {
     for (const graph of Array.from(this.active)) {
       this.disconnect(graph);
@@ -117,6 +132,7 @@ export class ProceduralSfxRuntime {
     readonly oscillatorType: OscillatorType;
     readonly gainScale: number;
     readonly durationSeconds: number;
+    readonly endFrequency?: number;
   }): boolean {
     const gain = this.effectiveGain(input.audio);
     if (gain === 0) return false;
@@ -132,6 +148,9 @@ export class ProceduralSfxRuntime {
 
     oscillator.type = input.oscillatorType;
     setParam(oscillator.frequency, input.frequency, startTime);
+    if (input.endFrequency !== undefined) {
+      rampParam(oscillator.frequency, input.endFrequency, stopTime);
+    }
     setParam(output.gain, 0, startTime);
     rampParam(output.gain, gain * input.gainScale, startTime + 0.01);
     rampParam(output.gain, 0, stopTime);

--- a/src/game/__tests__/raceSession.test.ts
+++ b/src/game/__tests__/raceSession.test.ts
@@ -723,6 +723,9 @@ describe("stepRaceSession (nitro)", () => {
     expect(session.player.nitro.charges).toBe(2);
     expect(session.player.nitro.activeRemainingSec).toBeGreaterThan(0);
     expect(session.player.lastNitroPressed).toBe(true);
+    expect(session.audioEvents).toEqual([
+      { kind: "nitroEngage", carId: "player" },
+    ]);
   });
 
   it("does not double-spend charges when nitro is held across ticks", () => {
@@ -733,8 +736,10 @@ describe("stepRaceSession (nitro)", () => {
     session = stepRaceSession(session, nitroTap(), config, DT);
     expect(session.player.nitro.charges).toBe(2);
     session = stepRaceSession(session, nitroTap(), config, DT);
+    expect(session.audioEvents).toEqual([]);
     session = stepRaceSession(session, nitroTap(), config, DT);
     expect(session.player.nitro.charges).toBe(2);
+    expect(session.audioEvents).toEqual([]);
   });
 
   it("releases the held flag so a re-tap consumes the next charge", () => {
@@ -2065,7 +2070,10 @@ describe("stepRaceSession (§13 damage wiring, F-047)", () => {
       carId: "player",
       hitKind: "carHit",
     });
-    expect(session.audioEvents[0]?.speedFactor).toBeCloseTo(
+    const impactEvent = session.audioEvents[0];
+    expect(impactEvent?.kind).toBe("impact");
+    if (impactEvent?.kind !== "impact") throw new Error("expected impact event");
+    expect(impactEvent.speedFactor).toBeCloseTo(
       40.2266666667 / COLLISION_REFERENCE_TOP_SPEED_M_PER_S,
       8,
     );

--- a/src/game/raceSession.ts
+++ b/src/game/raceSession.ts
@@ -90,6 +90,7 @@ import {
   createNitroForCar,
   getNitroAccelMultiplier,
   tickNitro,
+  type NitroStepResult,
   type NitroState,
 } from "./nitro";
 import { createRng, deserializeRng, serializeRng, splitRng } from "./rng";
@@ -219,7 +220,14 @@ export interface RaceSessionImpactAudioEvent {
   readonly speedFactor: number;
 }
 
-export type RaceSessionAudioEvent = RaceSessionImpactAudioEvent;
+export interface RaceSessionNitroAudioEvent {
+  readonly kind: "nitroEngage";
+  readonly carId: string;
+}
+
+export type RaceSessionAudioEvent =
+  | RaceSessionImpactAudioEvent
+  | RaceSessionNitroAudioEvent;
 
 export interface RaceSessionConfig {
   /** Compiled track to drive on. Frozen output of `compileTrack`. */
@@ -1034,7 +1042,11 @@ export function stepRaceSession(
         },
         dt,
       )
-    : { state: state.player.nitro };
+    : ({
+        state: state.player.nitro,
+        code: null,
+        isActive: state.player.nitro.activeRemainingSec > 0,
+      } satisfies NitroStepResult);
   const playerNitroMultiplier = getNitroAccelMultiplier(
     playerNitroResult.state,
     {
@@ -1042,6 +1054,10 @@ export function stepRaceSession(
       carNitroEfficiency: playerStats.nitroEfficiency,
     },
   );
+  const playerNitroEvents: RaceSessionNitroAudioEvent[] =
+    playerNitroResult.code === "started"
+      ? [{ kind: "nitroEngage", carId: PLAYER_CAR_ID }]
+      : [];
 
   // §10 transmission: advance the per-tick gear/RPM reducer using the
   // player's pre-physics speed and the rising-edge shift inputs. The
@@ -1707,7 +1723,10 @@ export function stepRaceSession(
         : Array.from(nextBrokenHazards),
     weather: nextWeather,
     weatherRngState: nextWeatherRngState,
-    audioEvents: playerImpactEvents,
+    audioEvents:
+      playerNitroEvents.length === 0
+        ? playerImpactEvents
+        : [...playerNitroEvents, ...playerImpactEvents],
   };
 }
 


### PR DESCRIPTION
## Summary
- emit player nitro-engage audio events from the pure race session when a fresh charge starts
- add a short rising procedural nitro SFX cue through the shared SFX runtime and mixer
- record GDD coverage and progress for §18 audio work

## GDD
- §18 sound and music design
- §21 technical design for web implementation
- Progress log: docs/PROGRESS_LOG.md, 2026-04-28 procedural nitro engage SFX runtime

## Test plan
- npx vitest run src/audio/sfx.test.ts src/game/__tests__/raceSession.test.ts
- npm run typecheck
- npm run content-lint
- npm run verify
- npm run test:e2e
