### PR TITLE
fix(physics): let stopped grass cars launch

### DIFF
--- a/docs/GDD_COVERAGE.json
+++ b/docs/GDD_COVERAGE.json
@@ -43,6 +43,18 @@
       "followupRefs": []
     },
     {
+      "id": "GDD-10-GRASS-RESTART-PHYSICS",
+      "gddSections": [
+        "docs/gdd/10-driving-model-and-physics.md",
+        "docs/gdd/21-technical-design-for-web-implementation.md"
+      ],
+      "requirement": "Off-road grass applies strong drag and a speed cap without trapping a stopped car at zero speed when the player reapplies throttle.",
+      "coverage": ["implemented-code", "automated-test"],
+      "implementationRefs": ["src/game/physics.ts"],
+      "testRefs": ["src/game/__tests__/physics.test.ts"],
+      "followupRefs": ["VibeGear2-bug-car-can-94bcb553"]
+    },
+    {
       "id": "GDD-18-AUDIO-ENGINE-MIXER-PRIMITIVES",
       "gddSections": [
         "docs/gdd/18-sound-and-music-design.md",

--- a/docs/PROGRESS_LOG.md
+++ b/docs/PROGRESS_LOG.md
@@ -6,6 +6,54 @@ Correct them by adding a new entry that references the old one.
 
 ---
 
+## 2026-04-28: Slice: Grass restart physics fix
+
+**GDD sections touched:**
+[§10](gdd/10-driving-model-and-physics.md) off-road slowdown and
+driving model, [§21](gdd/21-technical-design-for-web-implementation.md)
+deterministic physics.
+**Branch / PR:** `fix/grass-restart-stuck`, PR pending.
+**Status:** Implemented.
+
+### Done
+- `src/game/physics.ts`: reordered off-road drag so it applies to the
+  incoming speed before throttle. A stopped car on grass can now build
+  forward speed while rolling cars still receive grass drag and the
+  off-road speed cap.
+- `src/game/physics.ts`: bumped `PHYSICS_VERSION` from 2 to 3 because
+  the integration order changed and old ghost recordings should not be
+  compared against the new physics math.
+- `src/game/__tests__/physics.test.ts`: added a regression test for
+  launching from a full stop on grass under throttle.
+
+### Verified
+- `npx vitest run src/game/__tests__/physics.test.ts src/game/__tests__/ghost.test.ts src/game/__tests__/ghostDriver.test.ts src/game/__tests__/timeTrial.test.ts`
+  green, 117 passed.
+- `npm run typecheck` green.
+- `npm run content-lint` green.
+- `npm run verify` green, 2458 passed.
+- `npm run test:e2e` green, 75 passed.
+
+### Decisions and assumptions
+- This is a physics integration-order fix, not an assist or traction
+  shortcut. The car still slows down on grass and remains capped by
+  `OFF_ROAD_CAP_M_PER_S`.
+
+### Coverage ledger
+- GDD-10-GRASS-RESTART-PHYSICS covers stopped-on-grass throttle
+  recovery, off-road drag preservation, speed-cap preservation, and the
+  physics-version bump for ghost compatibility.
+- Uncovered adjacent requirements: reverse gear, traction loss, spinout
+  recovery, jump landing behavior, surface-specific tire audio, and
+  per-surface VFX tuning remain under their respective gameplay,
+  audio, and visual-polish backlog dots.
+
+### Followups created
+None.
+
+### GDD edits
+None.
+
 ## 2026-04-28: Slice: Procedural nitro engage SFX runtime
 
 **GDD sections touched:**

--- a/src/game/__tests__/physics.test.ts
+++ b/src/game/__tests__/physics.test.ts
@@ -247,6 +247,18 @@ describe("step (off-road)", () => {
     expect(s.speed).toBeLessThanOrEqual(OFF_ROAD_CAP_M_PER_S);
   });
 
+  it("can launch from a full stop on grass under throttle", () => {
+    const start = freshState({
+      speed: 0,
+      x: ROAD.roadHalfWidth * RUMBLE_HALF_WIDTH_SCALE + 1,
+      surface: "grass",
+    });
+    const s = step(start, withInput({ throttle: 1 }), STARTER_STATS, ROAD, DT);
+    expect(s.speed).toBeGreaterThan(0);
+    expect(s.z).toBeGreaterThan(start.z);
+    expect(s.surface).toBe("grass");
+  });
+
   it("off-road for one frame does not damage state shape", () => {
     // No damage modelled yet; just verify we get back a usable CarState.
     const start = freshState({ speed: 30, x: ROAD.roadHalfWidth + 0.5 });

--- a/src/game/physics.ts
+++ b/src/game/physics.ts
@@ -96,8 +96,12 @@ const IDENTITY_ASSIST_SCALARS: Readonly<AssistScalars> = Object.freeze({
  *     session resolves and forwards the player's preset scalars; the
  *     bump rejects v1 ghosts so the §20 PB compare layer never compares
  *     across pre-binding and post-binding math.
+ *   - 3: Off-road drag now applies to incoming speed before throttle.
+ *     This preserves grass slowdown while allowing a stopped off-road
+ *     car to launch under throttle instead of being clamped back to
+ *     zero by same-frame drag.
  */
-export const PHYSICS_VERSION = 2;
+export const PHYSICS_VERSION = 3;
 
 /**
  * Off-road handling tunables from §10 "Suggested tunable constants".
@@ -339,19 +343,6 @@ export function step(
   const topSpeedScalar = clamp(damageScalars.topSpeedScalar, 0, 1);
   const damagedTopSpeed = stats.topSpeed * topSpeedScalar;
 
-  if (throttle > 0) {
-    nextSpeed += stats.accel * throttle * draftBonus * accelMultiplier * dt;
-  }
-  if (brake > 0) {
-    // Brake decelerates toward zero. Never inverts velocity.
-    const delta = stats.brake * brake * dt;
-    nextSpeed = Math.max(0, nextSpeed - delta);
-  } else if (throttle === 0) {
-    // Coasting drag. Decays toward zero only; cannot push us below 0.
-    const delta = COASTING_DRAG_M_PER_S2 * dt;
-    nextSpeed = Math.max(0, nextSpeed - delta);
-  }
-
   // §28 difficulty preset scalars: identity when no preset is forwarded
   // so existing call sites keep their pre-binding behaviour. Each scalar
   // is clamped defensively against the §28 documented bands so a buggy
@@ -369,9 +360,23 @@ export function step(
     // forgiveness so a wide line is not race-ending).
     const dragDelta = OFF_ROAD_DRAG_M_PER_S2 * offRoadDragScale * dt;
     nextSpeed = Math.max(0, nextSpeed - dragDelta);
-    if (nextSpeed > OFF_ROAD_CAP_M_PER_S) {
-      nextSpeed = OFF_ROAD_CAP_M_PER_S;
-    }
+  }
+
+  if (throttle > 0) {
+    nextSpeed += stats.accel * throttle * draftBonus * accelMultiplier * dt;
+  }
+  if (brake > 0) {
+    // Brake decelerates toward zero. Never inverts velocity.
+    const delta = stats.brake * brake * dt;
+    nextSpeed = Math.max(0, nextSpeed - delta);
+  } else if (throttle === 0) {
+    // Coasting drag. Decays toward zero only; cannot push us below 0.
+    const delta = COASTING_DRAG_M_PER_S2 * dt;
+    nextSpeed = Math.max(0, nextSpeed - delta);
+  }
+
+  if (offRoad && nextSpeed > OFF_ROAD_CAP_M_PER_S) {
+    nextSpeed = OFF_ROAD_CAP_M_PER_S;
   }
 
   // Top-speed clamp last so accel cannot overshoot via accumulated dt.


### PR DESCRIPTION
## Summary
- fix the grass-stuck bug by applying off-road drag to incoming speed before throttle
- keep off-road slowdown and the speed cap intact while allowing stopped grass launches
- bump PHYSICS_VERSION to 3 and add coverage and progress docs

## GDD
- §10 driving model and physics
- §21 technical design for deterministic physics and ghost compatibility
- Progress log: docs/PROGRESS_LOG.md, 2026-04-28 grass restart physics fix

## Test plan
- npx vitest run src/game/__tests__/physics.test.ts src/game/__tests__/ghost.test.ts src/game/__tests__/ghostDriver.test.ts src/game/__tests__/timeTrial.test.ts
- npm run typecheck
- npm run content-lint
- npm run verify
- npm run test:e2e
