### PR TITLE
fix(ui): prevent garage next race overlap

### DIFF
--- a/docs/GDD_COVERAGE.json
+++ b/docs/GDD_COVERAGE.json
@@ -603,6 +603,18 @@
       ]
     },
     {
+      "id": "GDD-20-GARAGE-NEXT-RACE-LAYOUT",
+      "gddSections": [
+        "docs/gdd/05-core-gameplay-loop.md",
+        "docs/gdd/20-hud-and-ui-ux.md"
+      ],
+      "requirement": "The garage next race card presents its explanatory copy and World Tour action as readable, non-overlapping controls at narrow desktop widths.",
+      "coverage": ["implemented-code", "automated-test"],
+      "implementationRefs": ["src/app/garage/page.tsx"],
+      "testRefs": ["e2e/garage-summary.spec.ts"],
+      "followupRefs": ["VibeGear2-fix-overlapping-text-15d34dad"]
+    },
+    {
       "id": "GDD-13-GARAGE-REPAIR-PURCHASE",
       "gddSections": [
         "docs/gdd/05-core-gameplay-loop.md",

--- a/docs/PROGRESS_LOG.md
+++ b/docs/PROGRESS_LOG.md
@@ -6,6 +6,52 @@ Correct them by adding a new entry that references the old one.
 
 ---
 
+## 2026-04-28: Slice: Garage next race layout fix
+
+**GDD sections touched:**
+[§5](gdd/05-core-gameplay-loop.md) garage loop,
+[§20](gdd/20-hud-and-ui-ux.md) garage layout and next race info.
+**Branch / PR:** `fix/garage-next-race-layout`, PR pending.
+**Status:** Implemented.
+
+### Done
+- `src/app/garage/page.tsx`: gave the garage next race card a dedicated
+  column layout with an explicit gap so its explanatory copy and World
+  Tour action cannot collide at narrow desktop widths.
+- `src/app/garage/page.tsx`: added a test id for the World Tour action
+  inside the next race card so browser tests can target the exact
+  control.
+- `e2e/garage-summary.spec.ts`: added a regression check that verifies
+  the next race description renders above the World Tour action without
+  overlap.
+- `docs/GDD_COVERAGE.json`: added
+  GDD-20-GARAGE-NEXT-RACE-LAYOUT.
+
+### Verified
+- `npx playwright test e2e/garage-summary.spec.ts --project=chromium`
+  green, 3 passed.
+- `npm run typecheck` green.
+- `npm run content-lint` green.
+- `npm run verify` green, 2458 passed.
+- `npm run test:e2e` green, 76 passed.
+
+### Decisions and assumptions
+- This is a layout contract fix only. The garage flow, destination route,
+  and next race selection behavior remain unchanged.
+
+### Coverage ledger
+- GDD-20-GARAGE-NEXT-RACE-LAYOUT covers readable non-overlapping garage
+  next race copy and action layout at narrow desktop widths.
+- Uncovered adjacent requirements: full garage tab navigation, tire setup,
+  tour standings, stats or ghost UI, repair forecast details, and bottom
+  CTA row polish remain under their existing garage and UI backlog dots.
+
+### Followups created
+None.
+
+### GDD edits
+None.
+
 ## 2026-04-28: Slice: Grass restart physics fix
 
 **GDD sections touched:**

--- a/e2e/garage-summary.spec.ts
+++ b/e2e/garage-summary.spec.ts
@@ -143,6 +143,35 @@ test.describe("garage summary", () => {
     await expect(page.getByTestId("garage-upgrade-page")).toBeVisible();
   });
 
+  test("keeps next race text clear of the world tour action", async ({
+    page,
+  }) => {
+    await page.evaluate(
+      ({ key, save }) => window.localStorage.setItem(key, JSON.stringify(save)),
+      { key: SAVE_KEY, save: buildGarageSave() },
+    );
+
+    await page.setViewportSize({ width: 640, height: 720 });
+    await page.goto("/garage");
+
+    const card = page.getByTestId("garage-next-card");
+    const description = card.getByText(
+      "Pick the next World Tour event, then return here for repairs and upgrades between races.",
+    );
+    const action = card.getByTestId("garage-open-world-tour-link");
+
+    await expect(description).toBeVisible();
+    await expect(action).toBeVisible();
+
+    const descriptionBox = await description.boundingBox();
+    const actionBox = await action.boundingBox();
+    expect(descriptionBox).not.toBeNull();
+    expect(actionBox).not.toBeNull();
+    expect(descriptionBox!.y + descriptionBox!.height).toBeLessThan(
+      actionBox!.y,
+    );
+  });
+
   test("recovers a save with a missing active car through starter selection", async ({
     page,
   }) => {

--- a/src/app/garage/page.tsx
+++ b/src/app/garage/page.tsx
@@ -189,13 +189,17 @@ export default function GaragePage() {
             </dl>
           </section>
 
-          <aside style={panelStyle} data-testid="garage-next-card">
+          <aside style={nextRacePanelStyle} data-testid="garage-next-card">
             <h2 style={sectionTitleStyle}>Next race</h2>
-            <p style={mutedTextStyle}>
+            <p style={nextRaceTextStyle}>
               Pick the next World Tour event, then return here for repairs and
               upgrades between races.
             </p>
-            <Link href="/world" style={primaryLinkStyle}>
+            <Link
+              href="/world"
+              style={primaryLinkStyle}
+              data-testid="garage-open-world-tour-link"
+            >
               Open world tour
             </Link>
           </aside>
@@ -278,6 +282,20 @@ const panelStyle: CSSProperties = {
   borderRadius: "8px",
   padding: "1rem",
   background: "rgba(255, 255, 255, 0.03)",
+};
+
+const nextRacePanelStyle: CSSProperties = {
+  ...panelStyle,
+  display: "flex",
+  flexDirection: "column",
+  alignItems: "flex-start",
+  gap: "0.85rem",
+};
+
+const nextRaceTextStyle: CSSProperties = {
+  ...mutedTextStyle,
+  margin: 0,
+  maxWidth: "28rem",
 };
 
 const summaryGridStyle: CSSProperties = {


### PR DESCRIPTION
## Summary
- Give the garage next race card a dedicated vertical layout so copy and action controls do not overlap.
- Add a Playwright regression that checks the text sits above the World Tour action at a narrow desktop width.
- Add GDD coverage and progress log entries for the layout contract.

## GDD
- docs/gdd/05-core-gameplay-loop.md
- docs/gdd/20-hud-and-ui-ux.md
- Coverage: GDD-20-GARAGE-NEXT-RACE-LAYOUT

## Progress log
- docs/PROGRESS_LOG.md: 2026-04-28 Slice: Garage next race layout fix

## Test plan
- npx playwright test e2e/garage-summary.spec.ts --project=chromium
- npm run typecheck
- npm run content-lint
- npm run verify
- npm run test:e2e

## Followups
- None
