### PR TITLE
fix(ui): disable game text selection

### DIFF
--- a/docs/GDD_COVERAGE.json
+++ b/docs/GDD_COVERAGE.json
@@ -313,6 +313,18 @@
       "followupRefs": []
     },
     {
+      "id": "GDD-20-GAME-UI-SELECTION",
+      "gddSections": [
+        "docs/gdd/20-hud-and-ui-ux.md",
+        "docs/gdd/21-technical-design-for-web-implementation.md"
+      ],
+      "requirement": "The game shell suppresses browser text selection on non-editable UI and race surfaces while keeping editable form controls selectable.",
+      "coverage": ["implemented-code", "automated-test"],
+      "implementationRefs": ["src/app/globals.css"],
+      "testRefs": ["e2e/ui-selection.spec.ts"],
+      "followupRefs": []
+    },
+    {
       "id": "GDD-14-WEATHER-GRIP-RUNTIME",
       "gddSections": [
         "docs/gdd/14-weather-and-environmental-systems.md",

--- a/docs/PROGRESS_LOG.md
+++ b/docs/PROGRESS_LOG.md
@@ -20,8 +20,11 @@ Correct them by adding a new entry that references the old one.
   race surfaces does not highlight page text.
 - `src/app/globals.css`: preserved text selection for editable controls
   such as inputs, textareas, selects, and contenteditable regions.
+- `src/app/globals.css`: restored selection for all non-false
+  contenteditable variants, including plaintext-only.
 - `e2e/ui-selection.spec.ts`: added browser coverage for race UI
-  selection suppression and daily share textarea selection.
+  selection suppression, daily share textarea selection, and
+  plaintext-only contenteditable selection.
 - `docs/GDD_COVERAGE.json`: added GDD-20-GAME-UI-SELECTION.
 
 ### Verified

--- a/docs/PROGRESS_LOG.md
+++ b/docs/PROGRESS_LOG.md
@@ -6,6 +6,52 @@ Correct them by adding a new entry that references the old one.
 
 ---
 
+## 2026-04-28: Slice: Disable game UI text selection
+
+**GDD sections touched:**
+[§20](gdd/20-hud-and-ui-ux.md) game UI behavior,
+[§21](gdd/21-technical-design-for-web-implementation.md) web shell.
+**Branch / PR:** `fix/disable-game-ui-selection`, PR pending.
+**Status:** Implemented.
+
+### Done
+- `src/app/globals.css`: disabled browser text selection across the game
+  shell and non-editable UI so dragging or swiping over HUD, menus, and
+  race surfaces does not highlight page text.
+- `src/app/globals.css`: preserved text selection for editable controls
+  such as inputs, textareas, selects, and contenteditable regions.
+- `e2e/ui-selection.spec.ts`: added browser coverage for race UI
+  selection suppression and daily share textarea selection.
+- `docs/GDD_COVERAGE.json`: added GDD-20-GAME-UI-SELECTION.
+
+### Verified
+- `npx playwright test e2e/ui-selection.spec.ts --project=chromium`
+  green, 1 passed.
+- `npm run typecheck` green.
+- `npm run content-lint` green.
+- `npm run verify` green, 2458 passed.
+- `npm run test:e2e` green, 77 passed.
+
+### Decisions and assumptions
+- Editable controls keep normal selection because the daily share
+  fallback, options forms, and profile import flows still need native
+  browser editing behavior.
+
+### Coverage ledger
+- GDD-20-GAME-UI-SELECTION covers global non-editable UI selection
+  suppression, race surface selection suppression, and editable control
+  selection preservation.
+- Uncovered adjacent requirements: final HUD scale options, display
+  frame-cap settings, full settings profile management polish, and
+  pointer-lock style input capture remain under existing UI and control
+  backlog dots.
+
+### Followups created
+None.
+
+### GDD edits
+None.
+
 ## 2026-04-28: Slice: Garage next race review cleanup
 
 **GDD sections touched:**

--- a/e2e/ui-selection.spec.ts
+++ b/e2e/ui-selection.spec.ts
@@ -29,5 +29,17 @@ test.describe("browser text selection", () => {
       .evaluate((node) => getComputedStyle(node).userSelect);
 
     expect(textareaSelection).toBe("text");
+
+    const editableSelection = await page.evaluate(() => {
+      const editable = document.createElement("div");
+      editable.setAttribute("contenteditable", "plaintext-only");
+      editable.textContent = "Editable note";
+      document.body.append(editable);
+      const userSelect = getComputedStyle(editable).userSelect;
+      editable.remove();
+      return userSelect;
+    });
+
+    expect(editableSelection).toBe("text");
   });
 });

--- a/e2e/ui-selection.spec.ts
+++ b/e2e/ui-selection.spec.ts
@@ -1,0 +1,33 @@
+import { expect, test } from "@playwright/test";
+
+test.describe("browser text selection", () => {
+  test("disables selection on game UI while preserving editable controls", async ({
+    page,
+  }) => {
+    await page.goto("/race");
+    await expect(page.getByTestId("race-canvas")).toBeVisible();
+
+    const raceSelectionStyles = await page.evaluate(() => ({
+      body: getComputedStyle(document.body).userSelect,
+      shell: getComputedStyle(
+        document.querySelector('[data-testid="race-canvas"]')!,
+      ).userSelect,
+      canvas: getComputedStyle(
+        document.querySelector('[data-testid="race-canvas-element"]')!,
+      ).userSelect,
+    }));
+
+    expect(raceSelectionStyles).toEqual({
+      body: "none",
+      shell: "none",
+      canvas: "none",
+    });
+
+    await page.goto("/daily");
+    const textareaSelection = await page
+      .getByTestId("daily-share-text")
+      .evaluate((node) => getComputedStyle(node).userSelect);
+
+    expect(textareaSelection).toBe("text");
+  });
+});

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -20,6 +20,23 @@ body {
   background: var(--bg);
   color: var(--fg);
   min-height: 100vh;
+  -webkit-user-select: none;
+  user-select: none;
+}
+
+body * {
+  -webkit-user-select: none;
+  user-select: none;
+}
+
+input,
+textarea,
+select,
+option,
+[contenteditable="true"],
+[contenteditable="true"] * {
+  -webkit-user-select: text;
+  user-select: text;
 }
 
 button {

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -33,8 +33,8 @@ input,
 textarea,
 select,
 option,
-[contenteditable="true"],
-[contenteditable="true"] * {
+[contenteditable]:not([contenteditable="false"]),
+[contenteditable]:not([contenteditable="false"]) * {
   -webkit-user-select: text;
   user-select: text;
 }


### PR DESCRIPTION
## Summary
- Disable browser text selection across non-editable game UI and race surfaces.
- Preserve selectable text behavior for editable controls such as textareas, selects, inputs, and contenteditable regions.
- Add Playwright coverage for race UI selection suppression and daily share textarea selection.

## GDD
- docs/gdd/20-hud-and-ui-ux.md
- docs/gdd/21-technical-design-for-web-implementation.md
- Coverage: GDD-20-GAME-UI-SELECTION

## Progress log
- docs/PROGRESS_LOG.md: 2026-04-28 Slice: Disable game UI text selection

## Test plan
- npx playwright test e2e/ui-selection.spec.ts --project=chromium
- npm run typecheck
- npm run content-lint
- npm run verify
- npm run test:e2e

## Followups
- None
