### PR TITLE
fix(ui): center mobile title screen

### DIFF
--- a/docs/GDD_COVERAGE.json
+++ b/docs/GDD_COVERAGE.json
@@ -325,6 +325,18 @@
       "followupRefs": []
     },
     {
+      "id": "GDD-20-MOBILE-TITLE-CENTERING",
+      "gddSections": [
+        "docs/gdd/04-player-experience-goals.md",
+        "docs/gdd/20-hud-and-ui-ux.md"
+      ],
+      "requirement": "The title screen stays centered, fully visible, and free of horizontal overflow on short mobile viewports so players can launch quickly from the main menu.",
+      "coverage": ["implemented-code", "automated-test"],
+      "implementationRefs": ["src/app/page.module.css"],
+      "testRefs": ["e2e/title-screen.spec.ts"],
+      "followupRefs": []
+    },
+    {
       "id": "GDD-14-WEATHER-GRIP-RUNTIME",
       "gddSections": [
         "docs/gdd/14-weather-and-environmental-systems.md",

--- a/docs/PROGRESS_LOG.md
+++ b/docs/PROGRESS_LOG.md
@@ -6,6 +6,50 @@ Correct them by adding a new entry that references the old one.
 
 ---
 
+## 2026-04-28: Slice: Mobile title screen centering
+
+**GDD sections touched:**
+[§4](gdd/04-player-experience-goals.md) quick launch,
+[§20](gdd/20-hud-and-ui-ux.md) title-level menu UX.
+**Branch / PR:** `fix/mobile-title-centering`, PR pending.
+**Status:** Implemented.
+
+### Done
+- `src/app/page.module.css`: switched the title shell to dynamic
+  viewport height with responsive outer padding so mobile browser
+  chrome does not push the centered layout out of frame.
+- `src/app/page.module.css`: added compact short-viewport menu spacing,
+  title sizing, and footer sizing for phone screens.
+- `e2e/title-screen.spec.ts`: added a short-mobile regression that
+  verifies the title screen is centered, fully visible, and does not
+  create horizontal overflow at 320 by 568 and 390 by 667.
+- `docs/GDD_COVERAGE.json`: added GDD-20-MOBILE-TITLE-CENTERING.
+
+### Verified
+- `npx playwright test e2e/title-screen.spec.ts --project=chromium`
+  green, 8 passed.
+- `npm run verify` green, 2458 passed.
+- `npm run test:e2e` green, 78 passed.
+
+### Decisions and assumptions
+- This slice keeps the existing title screen hierarchy and menu order.
+  It only changes responsive spacing and sizing for short mobile
+  viewports.
+
+### Coverage ledger
+- GDD-20-MOBILE-TITLE-CENTERING covers centered title-screen layout,
+  full visibility, and no horizontal overflow on short phone viewports.
+- Uncovered adjacent requirements: final title-screen art direction,
+  background media, full controller navigation polish, and full mobile
+  options presentation remain under existing UI, visual-polish, and
+  input backlog dots.
+
+### Followups created
+None.
+
+### GDD edits
+None.
+
 ## 2026-04-28: Slice: Disable game UI text selection
 
 **GDD sections touched:**

--- a/e2e/title-screen.spec.ts
+++ b/e2e/title-screen.spec.ts
@@ -30,9 +30,9 @@ test.describe("title screen", () => {
 
       expect(metrics.left).toBeGreaterThanOrEqual(0);
       expect(metrics.top).toBeGreaterThanOrEqual(0);
-      expect(metrics.right).toBeLessThanOrEqual(metrics.viewportWidth);
-      expect(metrics.bottom).toBeLessThanOrEqual(metrics.viewportHeight);
-      expect(metrics.scrollWidth).toBe(metrics.viewportWidth);
+      expect(metrics.right).toBeLessThanOrEqual(metrics.viewportWidth + 1);
+      expect(metrics.bottom).toBeLessThanOrEqual(metrics.viewportHeight + 1);
+      expect(metrics.scrollWidth).toBeLessThanOrEqual(metrics.viewportWidth + 1);
       expect(
         Math.abs(metrics.centerX - metrics.viewportWidth / 2),
       ).toBeLessThanOrEqual(1);

--- a/e2e/title-screen.spec.ts
+++ b/e2e/title-screen.spec.ts
@@ -1,6 +1,47 @@
 import { expect, test } from "@playwright/test";
 
 test.describe("title screen", () => {
+  test("keeps the title screen centered on short mobile viewports", async ({
+    page,
+  }) => {
+    const viewports = [
+      { width: 320, height: 568 },
+      { width: 390, height: 667 },
+    ];
+
+    for (const viewport of viewports) {
+      await page.setViewportSize(viewport);
+      await page.goto("/");
+
+      const metrics = await page.getByLabel("Title screen").evaluate((node) => {
+        const rect = node.getBoundingClientRect();
+        return {
+          centerX: rect.left + rect.width / 2,
+          centerY: rect.top + rect.height / 2,
+          left: rect.left,
+          right: rect.right,
+          top: rect.top,
+          bottom: rect.bottom,
+          viewportWidth: window.innerWidth,
+          viewportHeight: window.innerHeight,
+          scrollWidth: document.documentElement.scrollWidth,
+        };
+      });
+
+      expect(metrics.left).toBeGreaterThanOrEqual(0);
+      expect(metrics.top).toBeGreaterThanOrEqual(0);
+      expect(metrics.right).toBeLessThanOrEqual(metrics.viewportWidth);
+      expect(metrics.bottom).toBeLessThanOrEqual(metrics.viewportHeight);
+      expect(metrics.scrollWidth).toBe(metrics.viewportWidth);
+      expect(
+        Math.abs(metrics.centerX - metrics.viewportWidth / 2),
+      ).toBeLessThanOrEqual(1);
+      expect(
+        Math.abs(metrics.centerY - metrics.viewportHeight / 2),
+      ).toBeLessThanOrEqual(12);
+    }
+  });
+
   test("renders the game title and main menu wiring", async ({ page }) => {
     await page.goto("/");
 

--- a/src/app/page.module.css
+++ b/src/app/page.module.css
@@ -4,7 +4,6 @@
   display: grid;
   place-items: center;
   padding: clamp(1rem, 4vh, 2rem);
-  overflow-x: hidden;
 }
 
 .titleScreen {
@@ -13,7 +12,7 @@
   align-items: center;
   gap: 1.5rem;
   text-align: center;
-  width: min(100%, 32rem);
+  width: 100%;
   max-width: 32rem;
 }
 

--- a/src/app/page.module.css
+++ b/src/app/page.module.css
@@ -1,8 +1,10 @@
 .main {
   min-height: 100vh;
+  min-height: 100dvh;
   display: grid;
   place-items: center;
-  padding: 2rem;
+  padding: clamp(1rem, 4vh, 2rem);
+  overflow-x: hidden;
 }
 
 .titleScreen {
@@ -11,6 +13,7 @@
   align-items: center;
   gap: 1.5rem;
   text-align: center;
+  width: min(100%, 32rem);
   max-width: 32rem;
 }
 
@@ -74,4 +77,32 @@
   font-size: 0.75rem;
   opacity: 0.7;
   font-variant-numeric: tabular-nums;
+}
+
+@media (max-width: 480px), (max-height: 700px) {
+  .titleScreen {
+    gap: 0.875rem;
+  }
+
+  .title {
+    font-size: clamp(2.25rem, 13vw, 3.25rem);
+  }
+
+  .tagline {
+    font-size: 0.9375rem;
+  }
+
+  .menu {
+    gap: 0.375rem;
+    max-width: 15rem;
+  }
+
+  .menuItem {
+    padding: 0.5625rem 1rem;
+  }
+
+  .footer {
+    margin-top: 0.25rem;
+    font-size: 0.75rem;
+  }
 }


### PR DESCRIPTION
## GDD sections

- docs/gdd/04-player-experience-goals.md quick launch
- docs/gdd/20-hud-and-ui-ux.md title-level menu UX

## Requirement inventory

This PR handles:

- Title screen stays centered on short mobile viewports.
- Main menu remains fully visible on 320 by 568 and 390 by 667 screens.
- Title page does not introduce horizontal overflow on phone widths.

Left to existing backlog:

- Final title-screen art direction and background media.
- Full controller navigation polish.
- Full mobile options presentation.

## Progress log

- docs/PROGRESS_LOG.md entry: 2026-04-28 Slice: Mobile title screen centering
- docs/GDD_COVERAGE.json: GDD-20-MOBILE-TITLE-CENTERING

## Test plan

- [x] npx playwright test e2e/title-screen.spec.ts --project=chromium
- [x] npm run verify
- [x] npm run test:e2e

## Followups

None.
