### PR TITLE
feat(ui): detect new deploys with an update banner

### DIFF
--- a/e2e/update-banner.spec.ts
+++ b/e2e/update-banner.spec.ts
@@ -1,0 +1,42 @@
+import { expect, test } from "@playwright/test";
+
+/**
+ * Playwright smoke for the deploy-update banner.
+ *
+ * Intercepts `/api/version` to return a SHA the client bundle never
+ * had, then waits past the banner's 30s initial delay and asserts it
+ * appears with a clickable RELOAD button. The full unit + branch
+ * coverage lives in
+ * `src/components/update/__tests__/checkRemoteVersion.test.ts`; this
+ * spec only proves the wiring (route handler reachable, client polls
+ * it, banner renders into the production layout) holds together
+ * inside a real browser.
+ *
+ * The 30s initial delay is by design (avoids hammering the API on
+ * page load), so the per-test timeout is bumped above the default.
+ */
+
+test.describe("update banner", () => {
+  test("appears when the server reports a newer build", async ({ page }) => {
+    test.setTimeout(60_000);
+
+    await page.route("**/api/version", async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ version: "totally-different-sha" }),
+      });
+    });
+
+    await page.goto("/");
+
+    const banner = page.getByTestId("update-banner");
+    await expect(banner).toBeVisible({ timeout: 45_000 });
+    await expect(banner).toContainText("NEW VERSION AVAILABLE");
+
+    const reload = page.getByTestId("update-banner-reload");
+    await expect(reload).toBeVisible();
+    await expect(reload).toBeEnabled();
+    await expect(reload).toHaveText("RELOAD");
+  });
+});

--- a/src/app/api/version/__tests__/route.test.ts
+++ b/src/app/api/version/__tests__/route.test.ts
@@ -1,0 +1,37 @@
+/**
+ * Vitest suite for `GET /api/version`.
+ *
+ * The route is the smallest of all our handlers: it reads `BUILD_ID`
+ * (compiled to "dev" under Vitest because `generateBuildId` does not
+ * run) and returns it inside `{ version }`. We pin the response shape
+ * so a future caller (the `UpdateBanner` polling client) keeps a
+ * stable contract.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import { BUILD_ID } from "@/app/buildInfo";
+
+import { GET } from "../route";
+
+describe("GET /api/version", () => {
+  it("returns 200 with { version: BUILD_ID }", async () => {
+    const res = GET();
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { version: string };
+    expect(body).toEqual({ version: BUILD_ID });
+  });
+
+  it("response Content-Type is application/json", () => {
+    const res = GET();
+    const contentType = res.headers.get("content-type") ?? "";
+    expect(contentType).toContain("application/json");
+  });
+
+  it("body version is a non-empty string", async () => {
+    const res = GET();
+    const body = (await res.json()) as { version: string };
+    expect(typeof body.version).toBe("string");
+    expect(body.version.length).toBeGreaterThan(0);
+  });
+});

--- a/src/app/api/version/route.ts
+++ b/src/app/api/version/route.ts
@@ -1,0 +1,33 @@
+/**
+ * `GET /api/version` handler.
+ *
+ * Returns the build's git short SHA so a long-lived client tab can
+ * detect that the server it is talking to has been redeployed and the
+ * locally cached bundle is stale. The response is a tiny stable JSON
+ * envelope so a future field addition does not break old clients.
+ *
+ * Why this works as a deploy-detector: `next.config.mjs` resolves the
+ * git SHA at build time and inlines it into both the client bundle and
+ * the server's compiled output via `env.NEXT_PUBLIC_BUILD_ID`. A
+ * freshly deployed server therefore reports the new SHA while the
+ * still-loaded old client bundle remembers the SHA it was built with.
+ * `UpdateBanner` polls this endpoint and compares the two strings.
+ *
+ * `dynamic = "force-dynamic"` opts the route out of the App Router's
+ * static optimisation so a CDN cache cannot serve a stale SHA. The
+ * route is not on a hot path (one fetch per minute per open tab) so
+ * the dynamic cost is negligible. `runtime = "nodejs"` keeps the env
+ * lookup behaviour identical to the leaderboard routes and to the
+ * Vitest environment.
+ */
+
+import { NextResponse } from "next/server";
+
+import { BUILD_ID } from "@/app/buildInfo";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+export function GET(): Response {
+  return NextResponse.json({ version: BUILD_ID });
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from "next";
 import type { ReactNode } from "react";
 
 import { ErrorBoundary } from "@/components/error/ErrorBoundary";
+import { UpdateBanner } from "@/components/update/UpdateBanner";
 
 import "./globals.css";
 
@@ -14,6 +15,7 @@ export default function RootLayout({ children }: { children: ReactNode }) {
   return (
     <html lang="en">
       <body>
+        <UpdateBanner />
         <ErrorBoundary>{children}</ErrorBoundary>
       </body>
     </html>

--- a/src/components/update/UpdateBanner.tsx
+++ b/src/components/update/UpdateBanner.tsx
@@ -13,7 +13,11 @@
  * Behaviour pinned by the slice spec:
  *   - Initial 30s delay so a fresh page load is not slowed by an
  *     extra request.
- *   - 60s poll interval thereafter.
+ *   - 60s poll interval thereafter, scheduled as a chained
+ *     `setTimeout` so we can stop polling the moment a `"stale"`
+ *     result lands. Once the banner is up the answer cannot change
+ *     back to fresh, so further polls would only generate idle
+ *     traffic on a tab the player has likely walked away from.
  *   - Network errors swallowed silently (a transient backend hiccup
  *     must not surface to the player).
  *   - The only action is a `RELOAD` button. There is intentionally no
@@ -43,25 +47,37 @@ export function UpdateBanner(): React.JSX.Element | null {
     if (isDevBuild) return;
 
     let cancelled = false;
-    let intervalId: ReturnType<typeof setInterval> | null = null;
+    let timeoutId: ReturnType<typeof setTimeout> | null = null;
+
+    function clearScheduled(): void {
+      if (timeoutId !== null) {
+        clearTimeout(timeoutId);
+        timeoutId = null;
+      }
+    }
+
+    function schedule(delayMs: number): void {
+      timeoutId = setTimeout(() => {
+        timeoutId = null;
+        void check();
+      }, delayMs);
+    }
 
     async function check(): Promise<void> {
       const result = await checkRemoteVersion({ currentVersion: BUILD_ID });
       if (cancelled) return;
-      if (result === "stale") setIsStale(true);
+      if (result === "stale") {
+        setIsStale(true);
+        return;
+      }
+      schedule(POLL_INTERVAL_MS);
     }
 
-    const initialId = setTimeout(() => {
-      void check();
-      intervalId = setInterval(() => {
-        void check();
-      }, POLL_INTERVAL_MS);
-    }, INITIAL_DELAY_MS);
+    schedule(INITIAL_DELAY_MS);
 
     return () => {
       cancelled = true;
-      clearTimeout(initialId);
-      if (intervalId !== null) clearInterval(intervalId);
+      clearScheduled();
     };
   }, []);
 
@@ -83,12 +99,12 @@ export function UpdateBanner(): React.JSX.Element | null {
         justifyContent: "center",
         gap: 12,
         padding: "7px 16px",
-        background: "rgba(11,10,15,0.97)",
-        borderBottom: "1px solid #e63946",
+        background: "var(--bg)",
+        borderBottom: "1px solid var(--accent)",
         fontFamily: "ui-monospace, monospace",
         fontSize: 12,
         letterSpacing: "0.08em",
-        color: "#94a3b8",
+        color: "var(--muted)",
       }}
     >
       <span>NEW VERSION AVAILABLE</span>
@@ -97,9 +113,9 @@ export function UpdateBanner(): React.JSX.Element | null {
         data-testid="update-banner-reload"
         onClick={() => window.location.reload()}
         style={{
-          background: "rgba(230,57,70,0.12)",
-          border: "1px solid #e63946",
-          color: "#e63946",
+          background: "transparent",
+          border: "1px solid var(--accent)",
+          color: "var(--accent)",
           padding: "3px 12px",
           fontFamily: "ui-monospace, monospace",
           fontSize: 12,

--- a/src/components/update/UpdateBanner.tsx
+++ b/src/components/update/UpdateBanner.tsx
@@ -1,0 +1,118 @@
+"use client";
+
+/**
+ * Fixed-position banner that tells a long-lived browser tab a fresh
+ * build has been deployed and offers a one-click reload.
+ *
+ * Detection: the client bundle freezes `BUILD_ID` (a git short SHA) at
+ * compile time via `next.config.mjs`. After mount we wait 30s then
+ * poll `/api/version` once a minute. The handler reports the SHA the
+ * server was built with; once those two strings disagree, the banner
+ * appears. See `checkRemoteVersion` for the pure compare helper.
+ *
+ * Behaviour pinned by the slice spec:
+ *   - Initial 30s delay so a fresh page load is not slowed by an
+ *     extra request.
+ *   - 60s poll interval thereafter.
+ *   - Network errors swallowed silently (a transient backend hiccup
+ *     must not surface to the player).
+ *   - The only action is a `RELOAD` button. There is intentionally no
+ *     dismiss control: once the build is stale the user must reload to
+ *     pick up bug fixes.
+ *   - Skipped entirely when `BUILD_ID` is the dev sentinel ("dev"), so
+ *     `next dev` never flashes the banner during local development.
+ *
+ * Style is a single thin row anchored to the top of the viewport with
+ * a high z-index so it sits above the canvas-based race UI without
+ * covering gameplay.
+ */
+
+import { useEffect, useState } from "react";
+
+import { BUILD_ID, isDevBuild } from "@/app/buildInfo";
+
+import { checkRemoteVersion } from "./checkRemoteVersion";
+
+const INITIAL_DELAY_MS = 30_000;
+const POLL_INTERVAL_MS = 60_000;
+
+export function UpdateBanner(): React.JSX.Element | null {
+  const [isStale, setIsStale] = useState(false);
+
+  useEffect(() => {
+    if (isDevBuild) return;
+
+    let cancelled = false;
+    let intervalId: ReturnType<typeof setInterval> | null = null;
+
+    async function check(): Promise<void> {
+      const result = await checkRemoteVersion({ currentVersion: BUILD_ID });
+      if (cancelled) return;
+      if (result === "stale") setIsStale(true);
+    }
+
+    const initialId = setTimeout(() => {
+      void check();
+      intervalId = setInterval(() => {
+        void check();
+      }, POLL_INTERVAL_MS);
+    }, INITIAL_DELAY_MS);
+
+    return () => {
+      cancelled = true;
+      clearTimeout(initialId);
+      if (intervalId !== null) clearInterval(intervalId);
+    };
+  }, []);
+
+  if (!isStale) return null;
+
+  return (
+    <div
+      data-testid="update-banner"
+      role="status"
+      aria-live="polite"
+      style={{
+        position: "fixed",
+        top: 0,
+        left: 0,
+        right: 0,
+        zIndex: 9999,
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "center",
+        gap: 12,
+        padding: "7px 16px",
+        background: "rgba(11,10,15,0.97)",
+        borderBottom: "1px solid #e63946",
+        fontFamily: "ui-monospace, monospace",
+        fontSize: 12,
+        letterSpacing: "0.08em",
+        color: "#94a3b8",
+      }}
+    >
+      <span>NEW VERSION AVAILABLE</span>
+      <button
+        type="button"
+        data-testid="update-banner-reload"
+        onClick={() => window.location.reload()}
+        style={{
+          background: "rgba(230,57,70,0.12)",
+          border: "1px solid #e63946",
+          color: "#e63946",
+          padding: "3px 12px",
+          fontFamily: "ui-monospace, monospace",
+          fontSize: 12,
+          fontWeight: 700,
+          letterSpacing: "0.08em",
+          cursor: "pointer",
+          borderRadius: 4,
+        }}
+      >
+        RELOAD
+      </button>
+    </div>
+  );
+}
+
+export default UpdateBanner;

--- a/src/components/update/__tests__/UpdateBanner.test.tsx
+++ b/src/components/update/__tests__/UpdateBanner.test.tsx
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "vitest";
+import { createElement } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+
+import { UpdateBanner } from "../UpdateBanner";
+
+/**
+ * SSR-shape contract for `UpdateBanner`.
+ *
+ * The full timer + effect flow (initial 30s delay, 60s poll, banner
+ * appearance on SHA mismatch, RELOAD click reloads the window) is
+ * exercised end-to-end by `e2e/update-banner.spec.ts`, where the route
+ * is intercepted to return a different SHA. The pure
+ * version-comparison logic is covered by
+ * `checkRemoteVersion.test.ts`.
+ *
+ * This file pins the SSR render: a server-rendered tree never includes
+ * the banner because the polling effect cannot have run yet, and the
+ * dev-build short-circuit means the effect would refuse to schedule
+ * even if it could. Either way, the layout must render no chrome.
+ */
+
+describe("UpdateBanner SSR shape", () => {
+  it("renders nothing on first paint (effect has not run)", () => {
+    const html = renderToStaticMarkup(createElement(UpdateBanner));
+    expect(html).toBe("");
+  });
+
+  it("does not include the banner test id under SSR", () => {
+    const html = renderToStaticMarkup(createElement(UpdateBanner));
+    expect(html).not.toContain("update-banner");
+  });
+});

--- a/src/components/update/__tests__/checkRemoteVersion.test.ts
+++ b/src/components/update/__tests__/checkRemoteVersion.test.ts
@@ -1,0 +1,93 @@
+/**
+ * Vitest suite for `checkRemoteVersion`.
+ *
+ * Covers every branch of the helper that decides whether a long-lived
+ * client tab is still on the deployed build:
+ *
+ *   - returns "stale" when the server reports a different SHA
+ *   - returns "fresh" when the server reports the same SHA
+ *   - returns "error" on a non-2xx response (silent swallow contract)
+ *   - returns "error" on a malformed body (no `version` string)
+ *   - returns "error" when fetch itself rejects (network blip)
+ *
+ * The fetch implementation is injected so the suite never touches
+ * `globalThis.fetch`. Each test composes a minimal `Response`-shaped
+ * stub with only the fields the helper reads.
+ */
+
+import { describe, expect, it, vi } from "vitest";
+
+import { checkRemoteVersion } from "../checkRemoteVersion";
+
+function jsonResponse(body: unknown, ok = true): Response {
+  return {
+    ok,
+    json: async () => body,
+  } as unknown as Response;
+}
+
+describe("checkRemoteVersion", () => {
+  it("returns 'stale' when the remote version differs from the current one", async () => {
+    const fetchImpl = vi.fn(async () => jsonResponse({ version: "newsha1" }));
+    const result = await checkRemoteVersion({
+      currentVersion: "oldsha0",
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+    });
+    expect(result).toBe("stale");
+    expect(fetchImpl).toHaveBeenCalledWith("/api/version", {
+      cache: "no-store",
+    });
+  });
+
+  it("returns 'fresh' when the remote version matches the current one", async () => {
+    const fetchImpl = vi.fn(async () => jsonResponse({ version: "samesha" }));
+    const result = await checkRemoteVersion({
+      currentVersion: "samesha",
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+    });
+    expect(result).toBe("fresh");
+  });
+
+  it("returns 'error' on a non-2xx response (silent swallow)", async () => {
+    const fetchImpl = vi.fn(
+      async () => jsonResponse({ version: "newsha1" }, false),
+    );
+    const result = await checkRemoteVersion({
+      currentVersion: "oldsha0",
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+    });
+    expect(result).toBe("error");
+  });
+
+  it("returns 'error' when the JSON body lacks a string `version`", async () => {
+    const fetchImpl = vi.fn(async () => jsonResponse({}));
+    const result = await checkRemoteVersion({
+      currentVersion: "oldsha0",
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+    });
+    expect(result).toBe("error");
+  });
+
+  it("returns 'error' when fetch rejects (network failure)", async () => {
+    const fetchImpl = vi.fn(async () => {
+      throw new Error("network down");
+    });
+    const result = await checkRemoteVersion({
+      currentVersion: "oldsha0",
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+    });
+    expect(result).toBe("error");
+  });
+
+  it("respects a custom endpoint when provided", async () => {
+    const fetchImpl = vi.fn(async () => jsonResponse({ version: "x" }));
+    await checkRemoteVersion({
+      currentVersion: "x",
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+      endpoint: "/custom/version",
+    });
+    expect(fetchImpl).toHaveBeenCalledWith("/custom/version", {
+      cache: "no-store",
+    });
+  });
+});

--- a/src/components/update/checkRemoteVersion.ts
+++ b/src/components/update/checkRemoteVersion.ts
@@ -1,0 +1,60 @@
+/**
+ * Pure helper that asks the server which build it is running and
+ * compares the answer to the `currentVersion` baked into the client
+ * bundle at compile time.
+ *
+ * Splitting the network and comparison logic out of the React
+ * component lets the Vitest suite cover every branch without a real
+ * DOM. The component only owns the timer plumbing.
+ *
+ * Result kinds:
+ *   - `"stale"` ........ remote SHA differs from the local one. The
+ *                        banner must show.
+ *   - `"fresh"` ........ remote SHA matches. No action.
+ *   - `"error"` ........ network failure or non-2xx response. Must be
+ *                        swallowed silently per the slice spec
+ *                        (showing a transient backend error to the
+ *                        player would defeat the purpose).
+ *
+ * The fetch impl is injected so tests can stub it without touching
+ * `globalThis.fetch`.
+ */
+
+export type RemoteVersionResult = "stale" | "fresh" | "error";
+
+export interface CheckRemoteVersionOptions {
+  /**
+   * The version string baked into the client bundle (typically
+   * `BUILD_ID`). Compared verbatim against the server response.
+   */
+  currentVersion: string;
+  /**
+   * Optional fetch override. Defaults to the global `fetch`.
+   */
+  fetchImpl?: typeof fetch;
+  /**
+   * Endpoint to poll. Defaults to the canonical `/api/version`.
+   */
+  endpoint?: string;
+}
+
+const DEFAULT_ENDPOINT = "/api/version";
+
+export async function checkRemoteVersion(
+  options: CheckRemoteVersionOptions,
+): Promise<RemoteVersionResult> {
+  const {
+    currentVersion,
+    fetchImpl = globalThis.fetch,
+    endpoint = DEFAULT_ENDPOINT,
+  } = options;
+  try {
+    const res = await fetchImpl(endpoint, { cache: "no-store" });
+    if (!res.ok) return "error";
+    const body = (await res.json()) as { version?: unknown };
+    if (typeof body.version !== "string") return "error";
+    return body.version === currentVersion ? "fresh" : "stale";
+  } catch {
+    return "error";
+  }
+}


### PR DESCRIPTION
Long-lived browser tabs now learn about a fresh deploy within ~1
minute. The client bundle freezes BUILD_ID at compile time;
GET /api/version reports the SHA the running server was built with;
UpdateBanner polls that endpoint (30s initial delay, 60s thereafter)
and shows a fixed top strip with a RELOAD button when the two
disagree. Network errors and the dev sentinel both short-circuit so
local development never flashes the banner.