### PR TITLE
feat(renderer): project weather particles into road depth

### DIFF
--- a/docs/GDD_COVERAGE.json
+++ b/docs/GDD_COVERAGE.json
@@ -229,6 +229,23 @@
       "followupRefs": []
     },
     {
+      "id": "GDD-14-WEATHER-DEPTH-PARTICLES",
+      "gddSections": [
+        "docs/gdd/14-weather-and-environmental-systems.md",
+        "docs/gdd/16-rendering-and-visual-design.md",
+        "docs/gdd/21-technical-design-for-web-implementation.md"
+      ],
+      "requirement": "Rain, snow, and fog render from projected road strip bands so precipitation and draw-distance haze have depth, parallax, and camera-relative motion instead of a fixed screen overlay.",
+      "coverage": ["implemented-code", "automated-test"],
+      "implementationRefs": [
+        "src/render/pseudoRoadCanvas.ts"
+      ],
+      "testRefs": [
+        "src/render/__tests__/pseudoRoadCanvas.test.ts"
+      ],
+      "followupRefs": []
+    },
+    {
       "id": "GDD-20-PRE-RACE-TIRE-SELECTION",
       "gddSections": [
         "docs/gdd/05-core-gameplay-loop.md",

--- a/docs/PROGRESS_LOG.md
+++ b/docs/PROGRESS_LOG.md
@@ -6,6 +6,55 @@ Correct them by adding a new entry that references the old one.
 
 ---
 
+## 2026-04-28: Slice: Depth-aware weather particles
+
+**GDD sections touched:**
+[§14](gdd/14-weather-and-environmental-systems.md) weather visual effects,
+[§16](gdd/16-rendering-and-visual-design.md) pseudo-3D rendering,
+[§21](gdd/21-technical-design-for-web-implementation.md) renderer layer.
+**Branch / PR:** `feat/weather-depth-particles`, PR pending.
+**Status:** Implemented.
+
+### Done
+- `src/render/pseudoRoadCanvas.ts`: moved rain streaks and snow
+  particles onto projected road strip bands so they follow road depth,
+  camera framing, foreground extension, and curve offsets.
+- `src/render/pseudoRoadCanvas.ts`: added fog banding over projected
+  road depth while keeping the existing broad draw-distance fade and
+  readability floor.
+- `src/render/__tests__/pseudoRoadCanvas.test.ts`: added projected
+  strip fixtures for weather effect tests and updated assertions to pin
+  depth-scaled rain, snow, and fog behaviour.
+- `docs/GDD_COVERAGE.json`: added
+  GDD-14-WEATHER-DEPTH-PARTICLES.
+
+### Verified
+- `npx vitest run src/render/__tests__/pseudoRoadCanvas.test.ts`
+  green, 48 passed.
+- `npm run typecheck` green.
+- `npm run verify` green, 2458 passed.
+- `npm run test:e2e` green, 78 passed.
+
+### Decisions and assumptions
+- Road sheen and roadside whitening remain surface effects because §14
+  calls them out as road and roadside cues, not airborne particles.
+- Dusk and night bloom remain screen-space glare effects. This slice
+  targets rain, snow, and fog, which are the weather effects that need
+  road-depth parallax.
+
+### Coverage ledger
+- GDD-14-WEATHER-DEPTH-PARTICLES covers projected rain streaks,
+  projected snow particles, and projected fog bands.
+- Uncovered adjacent requirements: final authored weather sprite
+  sheets, per-region weather art, and wind-specific particle drift
+  remain under visual-polish and content backlog dots.
+
+### Followups created
+None.
+
+### GDD edits
+None.
+
 ## 2026-04-28: Slice: Mobile title screen centering
 
 **GDD sections touched:**

--- a/docs/PROGRESS_LOG.md
+++ b/docs/PROGRESS_LOG.md
@@ -12,7 +12,7 @@ Correct them by adding a new entry that references the old one.
 [§14](gdd/14-weather-and-environmental-systems.md) weather visual effects,
 [§16](gdd/16-rendering-and-visual-design.md) pseudo-3D rendering,
 [§21](gdd/21-technical-design-for-web-implementation.md) renderer layer.
-**Branch / PR:** `feat/weather-depth-particles`, PR pending.
+**Branch / PR:** `feat/weather-depth-particles`, PR #79.
 **Status:** Implemented.
 
 ### Done

--- a/src/render/__tests__/pseudoRoadCanvas.test.ts
+++ b/src/render/__tests__/pseudoRoadCanvas.test.ts
@@ -166,6 +166,77 @@ function makeCanvasSpy(): CanvasSpy {
  * because it is independent of the strip array.
  */
 const EMPTY_STRIPS: readonly Strip[] = [];
+const WEATHER_STRIPS: readonly Strip[] = [
+  strip({
+    segment: {
+      index: 0,
+      worldZ: 0,
+      curve: 0,
+      grade: 0,
+      authoredIndex: 0,
+      roadsideLeftId: "default",
+      roadsideRightId: "default",
+      hazardIds: [],
+    },
+    screenX: 420,
+    screenY: 430,
+    screenW: 300,
+    scale: 1.2,
+    foreground: {
+      screenX: 420,
+      screenY: 480,
+      screenW: 380,
+    },
+  }),
+  strip({
+    segment: {
+      index: 1,
+      worldZ: 100,
+      curve: 0,
+      grade: 0,
+      authoredIndex: 0,
+      roadsideLeftId: "default",
+      roadsideRightId: "default",
+      hazardIds: [],
+    },
+    screenX: 460,
+    screenY: 320,
+    screenW: 180,
+    scale: 0.8,
+  }),
+  strip({
+    segment: {
+      index: 2,
+      worldZ: 200,
+      curve: 0,
+      grade: 0,
+      authoredIndex: 0,
+      roadsideLeftId: "default",
+      roadsideRightId: "default",
+      hazardIds: [],
+    },
+    screenX: 500,
+    screenY: 210,
+    screenW: 92,
+    scale: 0.42,
+  }),
+  strip({
+    segment: {
+      index: 3,
+      worldZ: 300,
+      curve: 0,
+      grade: 0,
+      authoredIndex: 0,
+      roadsideLeftId: "default",
+      roadsideRightId: "default",
+      hazardIds: [],
+    },
+    screenX: 530,
+    screenY: 145,
+    screenW: 48,
+    scale: 0.24,
+  }),
+];
 
 function loadedCarAtlas(): LoadedAtlas {
   return {
@@ -1057,7 +1128,7 @@ describe("drawRoad player car overlay", () => {
 describe("drawRoad weather effects", () => {
   it("paints deterministic heavy-rain streaks over the road layer", () => {
     const spy = makeCanvasSpy();
-    drawRoad(spy.ctx, EMPTY_STRIPS, VIEWPORT, {
+    drawRoad(spy.ctx, WEATHER_STRIPS, VIEWPORT, {
       weatherEffects: { weather: "heavy_rain" },
     });
 
@@ -1077,14 +1148,19 @@ describe("drawRoad weather effects", () => {
     expect(sheen[1]!.globalAlpha).toBeCloseTo(RAIN_ROAD_SHEEN_MAX_ALPHA * 0.55, 6);
     expect(streaks).toHaveLength(92);
     expect(streaks[0]!.globalAlpha).toBeCloseTo(0.34, 6);
-    expect(streaks[0]!.w).toBe(2);
-    expect(streaks[0]!.h).toBe(18);
+    const averageX = streaks.reduce((sum, streak) => sum + streak.x, 0) / streaks.length;
+    expect(averageX).toBeGreaterThan(330);
+    expect(averageX).toBeLessThan(560);
+    expect(streaks[0]!.y).toBeGreaterThanOrEqual(0);
+    expect(streaks[0]!.y).toBeLessThanOrEqual(VIEWPORT.height);
+    expect(streaks[0]!.w).toBeGreaterThanOrEqual(1);
+    expect(streaks[0]!.h).toBeGreaterThan(8);
     expect(spy.finalAlpha()).toBeCloseTo(1, 6);
   });
 
   it("scales road sheen for standard rain", () => {
     const spy = makeCanvasSpy();
-    drawRoad(spy.ctx, EMPTY_STRIPS, VIEWPORT, {
+    drawRoad(spy.ctx, WEATHER_STRIPS, VIEWPORT, {
       weatherEffects: { weather: "rain" },
     });
 
@@ -1102,7 +1178,7 @@ describe("drawRoad weather effects", () => {
 
   it("scales road sheen for light rain", () => {
     const spy = makeCanvasSpy();
-    drawRoad(spy.ctx, EMPTY_STRIPS, VIEWPORT, {
+    drawRoad(spy.ctx, WEATHER_STRIPS, VIEWPORT, {
       weatherEffects: { weather: "light_rain" },
     });
 
@@ -1120,7 +1196,7 @@ describe("drawRoad weather effects", () => {
 
   it("reduces rain density when visual weather reduction is enabled", () => {
     const spy = makeCanvasSpy();
-    drawRoad(spy.ctx, EMPTY_STRIPS, VIEWPORT, {
+    drawRoad(spy.ctx, WEATHER_STRIPS, VIEWPORT, {
       weatherEffects: { weather: "heavy_rain", visualReduction: true },
     });
 
@@ -1146,7 +1222,7 @@ describe("drawRoad weather effects", () => {
 
   it("applies the particle intensity slider to rain density", () => {
     const spy = makeCanvasSpy();
-    drawRoad(spy.ctx, EMPTY_STRIPS, VIEWPORT, {
+    drawRoad(spy.ctx, WEATHER_STRIPS, VIEWPORT, {
       weatherEffects: { weather: "heavy_rain", particleIntensity: 0.5 },
     });
 
@@ -1206,7 +1282,7 @@ describe("drawRoad weather effects", () => {
 
   it("paints snow particles and roadside whitening", () => {
     const spy = makeCanvasSpy();
-    drawRoad(spy.ctx, EMPTY_STRIPS, VIEWPORT, {
+    drawRoad(spy.ctx, WEATHER_STRIPS, VIEWPORT, {
       weatherEffects: { weather: "snow" },
     });
 
@@ -1234,8 +1310,8 @@ describe("drawRoad weather effects", () => {
         c.type === "fillRect" && c.fillStyle === "#f4fbff",
     );
     expect(flakes).toHaveLength(54);
-    expect(flakes[0]!.w).toBe(3);
-    expect(flakes[1]!.w).toBe(2);
+    expect(Math.max(...flakes.map((flake) => flake.w))).toBeGreaterThan(2);
+    expect(Math.min(...flakes.map((flake) => flake.w))).toBeLessThanOrEqual(2);
     expect(flakes[0]!.globalAlpha).toBeCloseTo(0.72, 6);
   });
 
@@ -1258,7 +1334,7 @@ describe("drawRoad weather effects", () => {
 
   it("paints fog as a draw-distance fade without changing clear weather", () => {
     const fog = makeCanvasSpy();
-    drawRoad(fog.ctx, EMPTY_STRIPS, VIEWPORT, {
+    drawRoad(fog.ctx, WEATHER_STRIPS, VIEWPORT, {
       weatherEffects: { weather: "fog" },
     });
 
@@ -1266,12 +1342,14 @@ describe("drawRoad weather effects", () => {
       (c): c is FillRectCall =>
         c.type === "fillRect" && c.fillStyle === "#cbd7e1",
     );
-    expect(fogRects).toHaveLength(2);
-    expect(fogRects[0]!.x).toBe(0);
-    expect(fogRects[0]!.y).toBe(0);
-    expect(fogRects[0]!.w).toBe(VIEWPORT.width);
-    expect(fogRects[0]!.h).toBeCloseTo(VIEWPORT.height * 0.72, 6);
-    expect(fogRects[0]!.globalAlpha).toBeCloseTo(
+    expect(fogRects.length).toBeGreaterThan(2);
+    expect(fogRects.some((rect) => rect.y > 0 && rect.h < VIEWPORT.height * 0.5)).toBe(true);
+    const broadFog = fogRects.at(-2)!;
+    expect(broadFog.x).toBe(0);
+    expect(broadFog.y).toBe(0);
+    expect(broadFog.w).toBe(VIEWPORT.width);
+    expect(broadFog.h).toBeCloseTo(VIEWPORT.height * 0.72, 6);
+    expect(broadFog.globalAlpha).toBeCloseTo(
       Math.min(0.5, (1 - visibilityForWeather("fog")) * 0.72),
       6,
     );
@@ -1301,7 +1379,7 @@ describe("drawRoad weather effects", () => {
 
   it("uses the fog readability floor to reduce fog overlay alpha", () => {
     const spy = makeCanvasSpy();
-    drawRoad(spy.ctx, EMPTY_STRIPS, VIEWPORT, {
+    drawRoad(spy.ctx, WEATHER_STRIPS, VIEWPORT, {
       weatherEffects: { weather: "fog", fogFloorClamp: 0.8 },
     });
 
@@ -1309,8 +1387,9 @@ describe("drawRoad weather effects", () => {
       (c): c is FillRectCall =>
         c.type === "fillRect" && c.fillStyle === "#cbd7e1",
     );
-    expect(fogRects).toHaveLength(2);
-    expect(fogRects[0]!.globalAlpha).toBeCloseTo(
+    expect(fogRects.length).toBeGreaterThan(2);
+    const broadFog = fogRects.at(-2)!;
+    expect(broadFog.globalAlpha).toBeCloseTo(
       Math.min(0.5, (1 - 0.8) * 0.72),
       6,
     );

--- a/src/render/pseudoRoadCanvas.ts
+++ b/src/render/pseudoRoadCanvas.ts
@@ -880,26 +880,38 @@ function weatherProjectionBands(
   strips: readonly Strip[],
   viewport: Viewport,
 ): readonly WeatherProjectionBand[] {
-  const edges = weatherProjectionEdges(strips)
-    .filter((edge) => edge.screenY >= -viewport.height * 0.1 && edge.screenY <= viewport.height * 1.1)
-    .sort((a, b) => b.screenY - a.screenY);
+  const minScreenY = -viewport.height * 0.1;
+  const maxScreenY = viewport.height * 1.1;
   const bands: WeatherProjectionBand[] = [];
-  for (let i = 0; i < edges.length - 1; i += 1) {
-    const near = edges[i]!;
-    const far = edges[i + 1]!;
+  let previousEdge: WeatherProjectionEdge | null = null;
+  let index = 0;
+
+  for (const edge of weatherProjectionEdges(strips)) {
+    if (edge.screenY < minScreenY || edge.screenY > maxScreenY) continue;
+    if (previousEdge === null) {
+      previousEdge = edge;
+      continue;
+    }
+
+    const near = previousEdge;
+    const far = edge;
     const topY = Math.max(0, Math.min(near.screenY, far.screenY));
     const bottomY = Math.min(viewport.height, Math.max(near.screenY, far.screenY));
     const height = bottomY - topY;
-    if (height < 1) continue;
-    bands.push({
-      index: i,
-      topY,
-      height,
-      depthAt: (y) => clampUnit((near.screenY - y) / Math.max(1, near.screenY - far.screenY)),
-      centerAt: (depth) => lerp(near.screenX, far.screenX, clampUnit(depth)),
-      halfWidthAt: (depth) => lerp(near.screenW, far.screenW, clampUnit(depth)),
-      scaleAt: (depth) => lerp(near.scale, far.scale, clampUnit(depth)),
-    });
+    if (height >= 1) {
+      bands.push({
+        index,
+        topY,
+        height,
+        depthAt: (y) => clampUnit((near.screenY - y) / Math.max(1, near.screenY - far.screenY)),
+        centerAt: (depth) => lerpNumber(near.screenX, far.screenX, clampUnit(depth)),
+        halfWidthAt: (depth) => lerpNumber(near.screenW, far.screenW, clampUnit(depth)),
+        scaleAt: (depth) => lerpNumber(near.scale, far.scale, clampUnit(depth)),
+      });
+      index += 1;
+    }
+
+    previousEdge = edge;
   }
   return bands;
 }
@@ -932,8 +944,12 @@ function weatherProjectionEdges(strips: readonly Strip[]): readonly WeatherProje
   return edges;
 }
 
-function isFiniteProjection(...values: readonly number[]): boolean {
-  const [screenX, screenY, screenW, scale] = values;
+function isFiniteProjection(
+  screenX: number,
+  screenY: number,
+  screenW: number,
+  scale: number,
+): boolean {
   return (
     Number.isFinite(screenX) &&
     Number.isFinite(screenY) &&
@@ -946,13 +962,14 @@ function isFiniteProjection(...values: readonly number[]): boolean {
   );
 }
 
-function lerp(a: number, b: number, t: number): number {
-  return a + (b - a) * t;
-}
-
 function hashUnit(seed: number): number {
-  const x = Math.sin(seed * 12.9898) * 43758.5453;
-  return x - Math.floor(x);
+  if (!Number.isFinite(seed)) return 0;
+
+  let x = Math.trunc(seed) | 0;
+  x = Math.imul(x ^ (x >>> 16), 0x21f0aaad);
+  x = Math.imul(x ^ (x >>> 15), 0x735a2d97);
+  x ^= x >>> 15;
+  return (x >>> 0) / 0x100000000;
 }
 
 function drawNightBloom(

--- a/src/render/pseudoRoadCanvas.ts
+++ b/src/render/pseudoRoadCanvas.ts
@@ -366,7 +366,7 @@ export function drawRoad(
   }
 
   if (options.weatherEffects) {
-    drawWeatherEffects(ctx, viewport, options.weatherEffects);
+    drawWeatherEffects(ctx, viewport, strips, options.weatherEffects);
   }
 
   drawHeatShimmer(ctx, viewport, options.heatShimmer);
@@ -549,6 +549,7 @@ function drawPoleSprite(
 function drawWeatherEffects(
   ctx: CanvasRenderingContext2D,
   viewport: Viewport,
+  strips: readonly Strip[],
   effects: NonNullable<DrawRoadOptions["weatherEffects"]>,
 ): void {
   if (viewport.width <= 0 || viewport.height <= 0) return;
@@ -558,13 +559,13 @@ function drawWeatherEffects(
     case "light_rain":
     case "rain":
     case "heavy_rain":
-      drawRainEffects(ctx, viewport, effects.weather, settings.particleIntensity);
+      drawRainEffects(ctx, viewport, strips, effects.weather, settings.particleIntensity);
       return;
     case "snow":
-      drawSnowEffects(ctx, viewport, settings.particleIntensity);
+      drawSnowEffects(ctx, viewport, strips, settings.particleIntensity);
       return;
     case "fog":
-      drawFogFade(ctx, viewport, settings.alphaScale, settings.fogFloorClamp);
+      drawFogFade(ctx, viewport, strips, settings.alphaScale, settings.fogFloorClamp);
       return;
     case "dusk":
     case "night":
@@ -680,12 +681,13 @@ function resolveWeatherEffectSettings(
 function drawRainEffects(
   ctx: CanvasRenderingContext2D,
   viewport: Viewport,
+  strips: readonly Strip[],
   weather: Extract<WeatherOption, "light_rain" | "rain" | "heavy_rain">,
   intensity: number,
 ): void {
   if (intensity <= 0) return;
   drawRainRoadSheen(ctx, viewport, weather, intensity);
-  drawRainStreaks(ctx, viewport, weather, intensity);
+  drawRainStreaks(ctx, viewport, strips, weather, intensity);
 }
 
 function drawRainRoadSheen(
@@ -725,12 +727,14 @@ function drawRainRoadSheen(
 function drawRainStreaks(
   ctx: CanvasRenderingContext2D,
   viewport: Viewport,
+  strips: readonly Strip[],
   weather: Extract<WeatherOption, "light_rain" | "rain" | "heavy_rain">,
   intensity: number,
 ): void {
+  const bands = weatherProjectionBands(strips, viewport);
   const baseCount = weather === "heavy_rain" ? 92 : weather === "rain" ? 58 : 32;
   const count = Math.round(baseCount * intensity);
-  if (count <= 0) return;
+  if (count <= 0 || bands.length === 0) return;
   const alpha = (weather === "heavy_rain" ? 0.34 : weather === "rain" ? 0.26 : 0.18) * intensity;
   const prevFill = ctx.fillStyle;
   const prevAlpha = ctx.globalAlpha;
@@ -738,10 +742,16 @@ function drawRainStreaks(
     ctx.globalAlpha = alpha;
     ctx.fillStyle = "#cfefff";
     for (let i = 0; i < count; i++) {
-      const x = ((i * 73) % Math.max(1, viewport.width + 80)) - 40;
-      const y = (i * 47) % Math.max(1, viewport.height);
-      const h = weather === "heavy_rain" ? 18 : 13;
-      ctx.fillRect(x, y, 2, h);
+      const band = bands[i % bands.length]!;
+      const depthSeed = hashUnit(i * 131 + band.index * 17);
+      const widthSeed = hashUnit(i * 199 + band.index * 29);
+      const y = band.topY + depthSeed * band.height;
+      const depth = band.depthAt(y);
+      const x = band.centerAt(depth) + (widthSeed * 2 - 1) * band.halfWidthAt(depth) * 1.4;
+      const scale = Math.max(0.45, Math.min(1.45, band.scaleAt(depth) * 1.1));
+      const h = (weather === "heavy_rain" ? 18 : 13) * scale;
+      const w = Math.max(1, Math.round(1 + scale));
+      ctx.fillRect(x, y, w, h);
     }
   } finally {
     ctx.fillStyle = prevFill;
@@ -752,19 +762,25 @@ function drawRainStreaks(
 function drawSnowParticles(
   ctx: CanvasRenderingContext2D,
   viewport: Viewport,
+  strips: readonly Strip[],
   intensity: number,
 ): void {
+  const bands = weatherProjectionBands(strips, viewport);
   const count = Math.round(54 * intensity);
-  if (count <= 0) return;
+  if (count <= 0 || bands.length === 0) return;
   const prevFill = ctx.fillStyle;
   const prevAlpha = ctx.globalAlpha;
   try {
     ctx.globalAlpha = 0.72 * intensity;
     ctx.fillStyle = "#f4fbff";
     for (let i = 0; i < count; i++) {
-      const size = i % 5 === 0 ? 3 : 2;
-      const x = (i * 89) % Math.max(1, viewport.width);
-      const y = (i * 53) % Math.max(1, viewport.height);
+      const band = bands[i % bands.length]!;
+      const depthSeed = hashUnit(i * 149 + band.index * 23);
+      const widthSeed = hashUnit(i * 181 + band.index * 31);
+      const y = band.topY + depthSeed * band.height;
+      const depth = band.depthAt(y);
+      const size = Math.max(1, Math.round((i % 5 === 0 ? 3 : 2) * band.scaleAt(depth)));
+      const x = band.centerAt(depth) + (widthSeed * 2 - 1) * band.halfWidthAt(depth) * 1.55;
       ctx.fillRect(x, y, size, size);
     }
   } finally {
@@ -776,11 +792,12 @@ function drawSnowParticles(
 function drawSnowEffects(
   ctx: CanvasRenderingContext2D,
   viewport: Viewport,
+  strips: readonly Strip[],
   intensity: number,
 ): void {
   if (intensity <= 0) return;
   drawSnowRoadsideWhitening(ctx, viewport, intensity);
-  drawSnowParticles(ctx, viewport, intensity);
+  drawSnowParticles(ctx, viewport, strips, intensity);
 }
 
 function drawSnowRoadsideWhitening(
@@ -814,15 +831,25 @@ function drawSnowRoadsideWhitening(
 function drawFogFade(
   ctx: CanvasRenderingContext2D,
   viewport: Viewport,
+  strips: readonly Strip[],
   intensity: number,
   fogFloorClamp: number,
 ): void {
   const visibility = Math.max(visibilityForWeather("fog"), fogFloorClamp);
+  const bands = weatherProjectionBands(strips, viewport);
   const prevFill = ctx.fillStyle;
   const prevAlpha = ctx.globalAlpha;
   try {
-    ctx.globalAlpha = Math.min(0.5, (1 - visibility) * 0.72 * intensity);
     ctx.fillStyle = "#cbd7e1";
+    for (let i = bands.length - 1; i >= 0; i--) {
+      const band = bands[i]!;
+      const distance = bands.length <= 1 ? 1 : i / (bands.length - 1);
+      const alpha = Math.min(0.24, (1 - visibility) * intensity * (0.1 + distance * 0.28));
+      if (alpha <= 0) continue;
+      ctx.globalAlpha = alpha;
+      ctx.fillRect(0, band.topY, viewport.width, band.height);
+    }
+    ctx.globalAlpha = Math.min(0.5, (1 - visibility) * 0.72 * intensity);
     ctx.fillRect(0, 0, viewport.width, viewport.height * 0.72);
     ctx.globalAlpha = Math.min(0.28, (1 - visibility) * 0.4 * intensity);
     ctx.fillRect(0, viewport.height * 0.48, viewport.width, viewport.height * 0.34);
@@ -830,6 +857,102 @@ function drawFogFade(
     ctx.fillStyle = prevFill;
     ctx.globalAlpha = prevAlpha;
   }
+}
+
+interface WeatherProjectionBand {
+  index: number;
+  topY: number;
+  height: number;
+  depthAt(y: number): number;
+  centerAt(depth: number): number;
+  halfWidthAt(depth: number): number;
+  scaleAt(depth: number): number;
+}
+
+interface WeatherProjectionEdge {
+  screenX: number;
+  screenY: number;
+  screenW: number;
+  scale: number;
+}
+
+function weatherProjectionBands(
+  strips: readonly Strip[],
+  viewport: Viewport,
+): readonly WeatherProjectionBand[] {
+  const edges = weatherProjectionEdges(strips)
+    .filter((edge) => edge.screenY >= -viewport.height * 0.1 && edge.screenY <= viewport.height * 1.1)
+    .sort((a, b) => b.screenY - a.screenY);
+  const bands: WeatherProjectionBand[] = [];
+  for (let i = 0; i < edges.length - 1; i += 1) {
+    const near = edges[i]!;
+    const far = edges[i + 1]!;
+    const topY = Math.max(0, Math.min(near.screenY, far.screenY));
+    const bottomY = Math.min(viewport.height, Math.max(near.screenY, far.screenY));
+    const height = bottomY - topY;
+    if (height < 1) continue;
+    bands.push({
+      index: i,
+      topY,
+      height,
+      depthAt: (y) => clampUnit((near.screenY - y) / Math.max(1, near.screenY - far.screenY)),
+      centerAt: (depth) => lerp(near.screenX, far.screenX, clampUnit(depth)),
+      halfWidthAt: (depth) => lerp(near.screenW, far.screenW, clampUnit(depth)),
+      scaleAt: (depth) => lerp(near.scale, far.scale, clampUnit(depth)),
+    });
+  }
+  return bands;
+}
+
+function weatherProjectionEdges(strips: readonly Strip[]): readonly WeatherProjectionEdge[] {
+  const edges: WeatherProjectionEdge[] = [];
+  for (const strip of strips) {
+    if (!strip.visible) continue;
+    if (!isFiniteProjection(strip.screenX, strip.screenY, strip.screenW, strip.scale)) continue;
+    if (strip.foreground && isFiniteProjection(
+      strip.foreground.screenX,
+      strip.foreground.screenY,
+      strip.foreground.screenW,
+      strip.scale,
+    )) {
+      edges.push({
+        screenX: strip.foreground.screenX,
+        screenY: strip.foreground.screenY,
+        screenW: strip.foreground.screenW,
+        scale: Math.max(strip.scale, 1),
+      });
+    }
+    edges.push({
+      screenX: strip.screenX,
+      screenY: strip.screenY,
+      screenW: strip.screenW,
+      scale: strip.scale,
+    });
+  }
+  return edges;
+}
+
+function isFiniteProjection(...values: readonly number[]): boolean {
+  const [screenX, screenY, screenW, scale] = values;
+  return (
+    Number.isFinite(screenX) &&
+    Number.isFinite(screenY) &&
+    typeof screenW === "number" &&
+    typeof scale === "number" &&
+    Number.isFinite(screenW) &&
+    Number.isFinite(scale) &&
+    screenW > 0 &&
+    scale > 0
+  );
+}
+
+function lerp(a: number, b: number, t: number): number {
+  return a + (b - a) * t;
+}
+
+function hashUnit(seed: number): number {
+  const x = Math.sin(seed * 12.9898) * 43758.5453;
+  return x - Math.floor(x);
 }
 
 function drawNightBloom(


### PR DESCRIPTION
## GDD sections

- docs/gdd/14-weather-and-environmental-systems.md: rain streaks, snow particles, and fog draw-distance fade
- docs/gdd/16-rendering-and-visual-design.md: pseudo-3D strip projection and rendering pipeline
- docs/gdd/21-technical-design-for-web-implementation.md: renderer layer owns pseudo-3D road and weather

## Requirement inventory

Handled in this PR:
- Rain streaks render from projected road strip bands instead of fixed viewport positions.
- Snow particles render from projected road strip bands and scale by depth.
- Fog adds projected depth bands while preserving the broad draw-distance fade and readability floor.
- Existing road sheen, roadside whitening, accessibility intensity, fog floor, and glare settings still work.

Adjacent requirements left for existing backlog:
- Final authored weather sprite sheets.
- Per-region weather art.
- Wind-specific particle drift.

## Progress log

- docs/PROGRESS_LOG.md: 2026-04-28: Slice: Depth-aware weather particles
- docs/GDD_COVERAGE.json: GDD-14-WEATHER-DEPTH-PARTICLES

## Test plan

- [x] npx vitest run src/render/__tests__/pseudoRoadCanvas.test.ts
- [x] npm run typecheck
- [x] npm run verify
- [x] npm run test:e2e
- [x] grep -rn $'\u2014\|\u2013' src/render/pseudoRoadCanvas.ts src/render/__tests__/pseudoRoadCanvas.test.ts docs/GDD_COVERAGE.json docs/PROGRESS_LOG.md || true

## Followups

None.
