### PR TITLE
feat(audio): add music runtime

### DIFF
--- a/docs/GDD_COVERAGE.json
+++ b/docs/GDD_COVERAGE.json
@@ -102,6 +102,24 @@
       "followupRefs": ["VibeGear2-implement-placeholder-audio-94594c41"]
     },
     {
+      "id": "GDD-18-MUSIC-RUNTIME",
+      "gddSections": [
+        "docs/gdd/18-sound-and-music-design.md",
+        "docs/gdd/21-technical-design-for-web-implementation.md",
+        "docs/gdd/24-content-plan.md"
+      ],
+      "requirement": "Menu and race routes can play the shipped music bank through the persisted music mixer bus, with regional race cue selection and speed, nitro, and final-lap intensity scaling.",
+      "coverage": ["implemented-code", "automated-test"],
+      "implementationRefs": [
+        "src/audio/music.ts",
+        "src/components/audio/MenuMusicDirector.tsx",
+        "src/app/layout.tsx",
+        "src/app/race/page.tsx"
+      ],
+      "testRefs": ["src/audio/music.test.ts"],
+      "followupRefs": ["VibeGear2-implement-sound-music-1611f9dd"]
+    },
+    {
       "id": "GDD-06-DAILY-CHALLENGE-SELECTION",
       "gddSections": [
         "docs/gdd/06-game-modes.md",

--- a/docs/PROGRESS_LOG.md
+++ b/docs/PROGRESS_LOG.md
@@ -6,6 +6,65 @@ Correct them by adding a new entry that references the old one.
 
 ---
 
+## 2026-04-29: Slice: Sound and music runtime
+
+**GDD sections touched:**
+[§18](gdd/18-sound-and-music-design.md) music direction, race music,
+dynamic audio layers, and SFX guidance,
+[§21](gdd/21-technical-design-for-web-implementation.md) audio
+pipeline,
+[§24](gdd/24-content-plan.md) audio content bank.
+**Branch / PR:** `feat/sound-music-systems`, PR pending.
+**Status:** Implemented.
+
+### Done
+- `src/audio/music.ts`: added a music cue resolver and runtime for the
+  generated music bank, with menu cue playback, regional race cue
+  selection, music-bus gain handling, crossfades, and speed / nitro /
+  final-lap intensity scaling.
+- `src/audio/music.test.ts`: covered cue selection, race intensity
+  scaling, silence handling, fade-up, crossfade, and playback-rate
+  updates.
+- `src/components/audio/MenuMusicDirector.tsx`: added a root-level
+  menu music director that starts title music after the first user
+  gesture on menu routes and stops when leaving those routes.
+- `src/app/layout.tsx`: mounted the menu music director globally.
+- `src/app/race/page.tsx`: starts regional race music from the same
+  gesture path as engine audio, updates intensity from live race state,
+  and stops music during race teardown.
+- `docs/GDD_COVERAGE.json`: added GDD-18-MUSIC-RUNTIME.
+
+### Verified
+- `npx vitest run src/audio/music.test.ts src/audio/mixer.test.ts src/audio/sfx.test.ts src/audio/engineRuntime.test.ts`
+  green, 32 passed.
+- `npm run typecheck` green.
+- `npm run verify` green, 2497 passed.
+- `npm run test:e2e` green, 79 passed.
+
+### Decisions and assumptions
+- Browser autoplay policy still gates playback behind a pointer or key
+  gesture. The runtime returns cleanly when playback is blocked or audio
+  is unavailable.
+- This slice uses the shipped single-loop placeholder files. The runtime
+  exposes intensity through gain and playback-rate scaling until final
+  2 to 3 stem assets exist.
+
+### Coverage ledger
+- GDD-18-MUSIC-RUNTIME covers menu music playback, regional race music
+  selection, persisted music bus levels, smooth cue fades, and race
+  intensity scaling from speed, nitro, and final lap.
+- Uncovered adjacent requirements: true multi-stem music layering,
+  weather stem blending, final-lap stingers, lap-complete SFX, results
+  stingers, surface-specific spray or snow hush SFX, brake scrub, tire
+  squeal, gear shift, and final production music replacement remain
+  under the §18 sound parent dot.
+
+### Followups created
+None.
+
+### GDD edits
+None.
+
 ## 2026-04-29: Slice: Placeholder audio bank
 
 **GDD sections touched:**

--- a/docs/PROGRESS_LOG.md
+++ b/docs/PROGRESS_LOG.md
@@ -36,9 +36,9 @@ pipeline,
 
 ### Verified
 - `npx vitest run src/audio/music.test.ts src/audio/mixer.test.ts src/audio/sfx.test.ts src/audio/engineRuntime.test.ts`
-  green, 32 passed.
+  green, 33 passed.
 - `npm run typecheck` green.
-- `npm run verify` green, 2497 passed.
+- `npm run verify` green, 2498 passed.
 - `npm run test:e2e` green, 79 passed.
 
 ### Decisions and assumptions

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import type { ReactNode } from "react";
 
+import { MenuMusicDirector } from "@/components/audio/MenuMusicDirector";
 import { ErrorBoundary } from "@/components/error/ErrorBoundary";
 import { UpdateBanner } from "@/components/update/UpdateBanner";
 
@@ -16,6 +17,7 @@ export default function RootLayout({ children }: { children: ReactNode }) {
     <html lang="en">
       <body>
         <UpdateBanner />
+        <MenuMusicDirector />
         <ErrorBoundary>{children}</ErrorBoundary>
       </body>
     </html>

--- a/src/app/race/page.tsx
+++ b/src/app/race/page.tsx
@@ -149,6 +149,11 @@ import {
   ProceduralSfxRuntime,
   type SfxAudioContextLike,
 } from "@/audio/sfx";
+import {
+  MusicRuntime,
+  raceMusicCue,
+  raceMusicIntensity,
+} from "@/audio/music";
 
 const VIEWPORT_WIDTH = 800;
 const VIEWPORT_HEIGHT = 480;
@@ -869,11 +874,21 @@ function RaceCanvas({
     const raceSfx = new ProceduralSfxRuntime({
       context: currentSfxAudioContext,
     });
+    const raceMusic = new MusicRuntime();
+    const raceMusicCueForSession = raceMusicCue({
+      trackId: track.id,
+      tourId: tourContext?.tourId,
+      mode,
+    });
     let latestEngineInput: EngineRuntimeInput = {
       speed: 0,
       topSpeed: STARTER_STATS.topSpeed,
       audio: persistedSettings.audio,
     };
+    let latestRaceMusicIntensity = raceMusicIntensity({
+      speed: 0,
+      topSpeed: STARTER_STATS.topSpeed,
+    });
     let engineStartPending = false;
     let engineAudioTeardown = false;
     let lastEngineAudioUpdateMs = 0;
@@ -888,6 +903,11 @@ function RaceCanvas({
         .then(() => {
           if (engineAudioTeardown) return;
           engineAudio.start(latestEngineInput);
+          raceMusic.play(
+            raceMusicCueForSession,
+            persistedSettings.audio,
+            latestRaceMusicIntensity,
+          );
         })
         .finally(() => {
           engineStartPending = false;
@@ -910,6 +930,7 @@ function RaceCanvas({
       handleRef.current?.stop();
       engineAudio.stop();
       raceSfx.stopAll();
+      raceMusic.stop();
       handleRef.current = null;
       sessionRef.current = null;
       inputManager.dispose();
@@ -1065,10 +1086,17 @@ function RaceCanvas({
           topSpeed: STARTER_STATS.topSpeed,
           audio: persistedSettings.audio,
         };
+        latestRaceMusicIntensity = raceMusicIntensity({
+          speed: session.player.car.speed,
+          topSpeed: STARTER_STATS.topSpeed,
+          nitroActive: session.player.nitro.activeRemainingSec > 0,
+          finalLap: session.race.lap >= session.race.totalLaps,
+        });
         const audioUpdateMs = performance.now();
         if (audioUpdateMs - lastEngineAudioUpdateMs >= 50) {
           lastEngineAudioUpdateMs = audioUpdateMs;
           engineAudio.update(latestEngineInput);
+          raceMusic.update(persistedSettings.audio, latestRaceMusicIntensity);
         }
         if (lastRaceSfxTick !== session.tick) {
           lastRaceSfxTick = session.tick;

--- a/src/audio/music.test.ts
+++ b/src/audio/music.test.ts
@@ -1,0 +1,155 @@
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  MUSIC_CUES,
+  MusicRuntime,
+  raceMusicCue,
+  raceMusicIntensity,
+  titleMusicCue,
+  type MusicAudioElementLike,
+} from "./music";
+
+const AUDIO = { master: 1, music: 0.8, sfx: 0.9 };
+
+describe("music cues", () => {
+  it("maps menu playback to the title cue", () => {
+    expect(titleMusicCue()).toEqual(MUSIC_CUES.title);
+  });
+
+  it("maps race tracks and tours to regional cues", () => {
+    expect(raceMusicCue({ trackId: "velvet-coast/harbor-run" }).id).toBe(
+      "velvet-coast",
+    );
+    expect(raceMusicCue({ trackId: "test/elevation", tourId: "iron-borough" }).id).toBe(
+      "iron-borough",
+    );
+    expect(raceMusicCue({ trackId: "neon-meridian/night-loop" }).id).toBe(
+      "neon-meridian",
+    );
+  });
+});
+
+describe("raceMusicIntensity", () => {
+  it("raises volume and playback rate as speed increases", () => {
+    const idle = raceMusicIntensity({ speed: 0, topSpeed: 60 });
+    const fast = raceMusicIntensity({ speed: 55, topSpeed: 60 });
+
+    expect(fast.volumeScale).toBeGreaterThan(idle.volumeScale);
+    expect(fast.playbackRate).toBeGreaterThan(idle.playbackRate);
+  });
+
+  it("adds escalation for nitro and final lap", () => {
+    const baseline = raceMusicIntensity({ speed: 45, topSpeed: 60 });
+    const escalated = raceMusicIntensity({
+      speed: 45,
+      topSpeed: 60,
+      nitroActive: true,
+      finalLap: true,
+    });
+
+    expect(escalated.volumeScale).toBeGreaterThan(baseline.volumeScale);
+    expect(escalated.playbackRate).toBeGreaterThan(baseline.playbackRate);
+  });
+});
+
+describe("MusicRuntime", () => {
+  it("does not create audio when the music bus is silent", () => {
+    const createAudio = vi.fn(() => new FakeMusicElement());
+    const runtime = new MusicRuntime({ createAudio });
+
+    expect(
+      runtime.play(MUSIC_CUES.title, { master: 1, music: 0, sfx: 1 }),
+    ).toBe(false);
+    expect(createAudio).not.toHaveBeenCalled();
+  });
+
+  it("starts a looping element and fades it up through the music bus", () => {
+    let now = 0;
+    const elements: FakeMusicElement[] = [];
+    const runtime = new MusicRuntime({
+      nowSeconds: () => now,
+      fadeSeconds: 1,
+      baseGain: 0.5,
+      createAudio: (src) => {
+        const element = new FakeMusicElement();
+        element.src = src;
+        elements.push(element);
+        return element;
+      },
+    });
+
+    expect(runtime.play(MUSIC_CUES.title, AUDIO)).toBe(true);
+    expect(elements).toHaveLength(1);
+    expect(elements[0]?.loop).toBe(true);
+    expect(elements[0]?.preload).toBe("auto");
+    expect(elements[0]?.play).toHaveBeenCalledTimes(1);
+    expect(elements[0]?.volume).toBe(0);
+
+    now = 0.5;
+    runtime.update(AUDIO);
+    expect(elements[0]?.volume).toBeCloseTo(1 * 0.8 * 0.5 * 0.5);
+
+    now = 1;
+    runtime.update(AUDIO);
+    expect(elements[0]?.volume).toBeCloseTo(1 * 0.8 * 0.5);
+  });
+
+  it("crossfades to a new cue and stops the previous element", () => {
+    let now = 0;
+    const elements: FakeMusicElement[] = [];
+    const runtime = new MusicRuntime({
+      nowSeconds: () => now,
+      fadeSeconds: 1,
+      baseGain: 0.5,
+      createAudio: (src) => {
+        const element = new FakeMusicElement();
+        element.src = src;
+        elements.push(element);
+        return element;
+      },
+    });
+
+    runtime.play(MUSIC_CUES.title, AUDIO);
+    now = 1;
+    runtime.update(AUDIO);
+    runtime.play(MUSIC_CUES["velvet-coast"], AUDIO);
+
+    expect(elements).toHaveLength(2);
+    expect(runtime.currentCueId()).toBe("velvet-coast");
+    expect(elements[0]?.volume).toBeCloseTo(1 * 0.8 * 0.5);
+    expect(elements[1]?.volume).toBe(0);
+
+    now = 2;
+    runtime.update(AUDIO);
+    expect(elements[0]?.pause).toHaveBeenCalledTimes(1);
+    expect(elements[0]?.volume).toBe(0);
+    expect(elements[1]?.volume).toBeCloseTo(1 * 0.8 * 0.5);
+  });
+
+  it("updates playback rate from intensity", () => {
+    const now = 1;
+    const element = new FakeMusicElement();
+    const runtime = new MusicRuntime({
+      nowSeconds: () => now,
+      createAudio: () => element,
+    });
+
+    runtime.play(MUSIC_CUES.title, AUDIO, {
+      volumeScale: 1,
+      playbackRate: 1.04,
+    });
+
+    expect(element.playbackRate).toBe(1.04);
+  });
+});
+
+class FakeMusicElement implements MusicAudioElementLike {
+  src = "";
+  loop = false;
+  preload = "";
+  volume = 0;
+  playbackRate = 1;
+  currentTime = 0;
+  readonly play = vi.fn(() => Promise.resolve());
+  readonly pause = vi.fn(() => undefined);
+}

--- a/src/audio/music.test.ts
+++ b/src/audio/music.test.ts
@@ -126,6 +126,34 @@ describe("MusicRuntime", () => {
     expect(elements[1]?.volume).toBeCloseTo(1 * 0.8 * 0.5);
   });
 
+  it("stops an older fading cue when another cue replaces it", () => {
+    let now = 0;
+    const elements: FakeMusicElement[] = [];
+    const runtime = new MusicRuntime({
+      nowSeconds: () => now,
+      fadeSeconds: 1,
+      createAudio: (src) => {
+        const element = new FakeMusicElement();
+        element.src = src;
+        elements.push(element);
+        return element;
+      },
+    });
+
+    runtime.play(MUSIC_CUES.title, AUDIO);
+    now = 1;
+    runtime.update(AUDIO);
+    runtime.play(MUSIC_CUES["velvet-coast"], AUDIO);
+    now = 1.25;
+    runtime.update(AUDIO);
+    runtime.play(MUSIC_CUES["iron-borough"], AUDIO);
+
+    expect(elements).toHaveLength(3);
+    expect(elements[0]?.pause).toHaveBeenCalledTimes(1);
+    expect(elements[0]?.volume).toBe(0);
+    expect(runtime.currentCueId()).toBe("iron-borough");
+  });
+
   it("updates playback rate from intensity", () => {
     const now = 1;
     const element = new FakeMusicElement();

--- a/src/audio/music.ts
+++ b/src/audio/music.ts
@@ -175,6 +175,7 @@ export class MusicRuntime {
 
     const now = this.nowSeconds();
     if (this.active !== null) {
+      this.stopChannel(this.fadingOut);
       this.fadingOut = {
         ...this.active,
         startedAt: now,

--- a/src/audio/music.ts
+++ b/src/audio/music.ts
@@ -1,0 +1,294 @@
+import type { AudioSettings } from "@/data/schemas";
+
+import { isMixerSilent, resolveMixerGains } from "./mixer";
+
+export type MusicCueId =
+  | "title"
+  | "velvet-coast"
+  | "iron-borough"
+  | "ember-steppe"
+  | "breakwater-isles"
+  | "glass-ridge"
+  | "neon-meridian"
+  | "moss-frontier"
+  | "crown-circuit";
+
+export interface MusicCue {
+  readonly id: MusicCueId;
+  readonly src: string;
+}
+
+export interface MusicIntensity {
+  readonly volumeScale: number;
+  readonly playbackRate: number;
+}
+
+export interface RaceMusicInput {
+  readonly trackId: string;
+  readonly tourId?: string | null;
+  readonly mode?: "race" | "timeTrial";
+}
+
+export interface RaceMusicIntensityInput {
+  readonly speed: number;
+  readonly topSpeed: number;
+  readonly nitroActive?: boolean;
+  readonly finalLap?: boolean;
+}
+
+export interface MusicAudioElementLike {
+  src: string;
+  loop: boolean;
+  preload: string;
+  volume: number;
+  playbackRate: number;
+  currentTime: number;
+  play(): Promise<void> | void;
+  pause(): void;
+}
+
+export interface MusicRuntimeOptions {
+  readonly createAudio?: (src: string) => MusicAudioElementLike | null;
+  readonly nowSeconds?: () => number;
+  readonly baseGain?: number;
+  readonly fadeSeconds?: number;
+}
+
+interface Channel {
+  readonly cue: MusicCue;
+  readonly element: MusicAudioElementLike;
+  readonly startedAt: number;
+  readonly fromVolume: number;
+}
+
+const SILENT_AUDIO: AudioSettings = Object.freeze({
+  master: 0,
+  music: 0,
+  sfx: 0,
+});
+
+const DEFAULT_INTENSITY: MusicIntensity = Object.freeze({
+  volumeScale: 1,
+  playbackRate: 1,
+});
+
+const DEFAULT_BASE_GAIN = 0.34;
+const DEFAULT_FADE_SECONDS = 0.35;
+
+export const MUSIC_CUES: Readonly<Record<MusicCueId, MusicCue>> = Object.freeze({
+  title: { id: "title", src: "/audio/music/title.opus" },
+  "velvet-coast": {
+    id: "velvet-coast",
+    src: "/audio/music/velvet-coast.opus",
+  },
+  "iron-borough": {
+    id: "iron-borough",
+    src: "/audio/music/iron-borough.opus",
+  },
+  "ember-steppe": {
+    id: "ember-steppe",
+    src: "/audio/music/ember-steppe.opus",
+  },
+  "breakwater-isles": {
+    id: "breakwater-isles",
+    src: "/audio/music/breakwater-isles.opus",
+  },
+  "glass-ridge": {
+    id: "glass-ridge",
+    src: "/audio/music/glass-ridge.opus",
+  },
+  "neon-meridian": {
+    id: "neon-meridian",
+    src: "/audio/music/neon-meridian.opus",
+  },
+  "moss-frontier": {
+    id: "moss-frontier",
+    src: "/audio/music/moss-frontier.opus",
+  },
+  "crown-circuit": {
+    id: "crown-circuit",
+    src: "/audio/music/crown-circuit.opus",
+  },
+});
+
+export function titleMusicCue(): MusicCue {
+  return MUSIC_CUES.title;
+}
+
+export function raceMusicCue(input: RaceMusicInput): MusicCue {
+  const region = regionMusicCueId(input.tourId ?? input.trackId);
+  return MUSIC_CUES[region];
+}
+
+export function raceMusicIntensity(input: RaceMusicIntensityInput): MusicIntensity {
+  const speedScalar = clampUnit(input.speed / Math.max(1, input.topSpeed));
+  const nitro = input.nitroActive ? 1 : 0;
+  const finalLap = input.finalLap ? 1 : 0;
+  const timeTrialTrim = input.nitroActive === undefined ? -0.04 : 0;
+  return {
+    volumeScale: clamp(0.76 + speedScalar * 0.2 + nitro * 0.07 + finalLap * 0.06, 0, 1.12),
+    playbackRate: clamp(0.98 + speedScalar * 0.035 + nitro * 0.025 + finalLap * 0.015 + timeTrialTrim, 0.92, 1.08),
+  };
+}
+
+export class MusicRuntime {
+  private active: Channel | null = null;
+  private fadingOut: Channel | null = null;
+  private readonly createAudio: (src: string) => MusicAudioElementLike | null;
+  private readonly nowSeconds: () => number;
+  private readonly baseGain: number;
+  private readonly fadeSeconds: number;
+
+  constructor(options: MusicRuntimeOptions = {}) {
+    this.createAudio = options.createAudio ?? browserAudioElementFactory;
+    this.nowSeconds = options.nowSeconds ?? defaultNowSeconds;
+    this.baseGain = nonNegativeOr(options.baseGain, DEFAULT_BASE_GAIN);
+    this.fadeSeconds = nonNegativeOr(options.fadeSeconds, DEFAULT_FADE_SECONDS);
+  }
+
+  currentCueId(): MusicCueId | null {
+    return this.active?.cue.id ?? null;
+  }
+
+  isPlaying(): boolean {
+    return this.active !== null;
+  }
+
+  play(
+    cue: MusicCue,
+    audio: AudioSettings | undefined,
+    intensity: MusicIntensity = DEFAULT_INTENSITY,
+  ): boolean {
+    const targetVolume = this.effectiveGain(audio, intensity);
+    if (targetVolume === 0) {
+      this.stop();
+      return false;
+    }
+
+    if (this.active?.cue.id === cue.id) {
+      this.update(audio, intensity);
+      return true;
+    }
+
+    const element = this.createAudio(cue.src);
+    if (element === null) return false;
+
+    const now = this.nowSeconds();
+    if (this.active !== null) {
+      this.fadingOut = {
+        ...this.active,
+        startedAt: now,
+        fromVolume: this.active.element.volume,
+      };
+    }
+
+    element.src = cue.src;
+    element.loop = true;
+    element.preload = "auto";
+    element.currentTime = 0;
+    element.volume = 0;
+    element.playbackRate = intensity.playbackRate;
+    this.active = { cue, element, startedAt: now, fromVolume: 0 };
+    void Promise.resolve(element.play()).catch(() => {
+      if (this.active?.element === element) this.active = null;
+      this.stopChannel({ cue, element, startedAt: now, fromVolume: 0 });
+    });
+    this.update(audio, intensity);
+    return true;
+  }
+
+  update(
+    audio: AudioSettings | undefined,
+    intensity: MusicIntensity = DEFAULT_INTENSITY,
+  ): void {
+    const now = this.nowSeconds();
+    const targetVolume = this.effectiveGain(audio, intensity);
+
+    if (targetVolume === 0) {
+      this.stop();
+      return;
+    }
+
+    if (this.active !== null) {
+      const fade = fadeProgress(now, this.active.startedAt, this.fadeSeconds);
+      this.active.element.volume = targetVolume * fade;
+      this.active.element.playbackRate = intensity.playbackRate;
+    }
+
+    if (this.fadingOut !== null) {
+      const fade = fadeProgress(now, this.fadingOut.startedAt, this.fadeSeconds);
+      this.fadingOut.element.volume = this.fadingOut.fromVolume * (1 - fade);
+      if (fade >= 1) {
+        this.stopChannel(this.fadingOut);
+        this.fadingOut = null;
+      }
+    }
+  }
+
+  stop(): void {
+    this.stopChannel(this.active);
+    this.stopChannel(this.fadingOut);
+    this.active = null;
+    this.fadingOut = null;
+  }
+
+  private stopChannel(channel: Channel | null): void {
+    if (channel === null) return;
+    channel.element.pause();
+    channel.element.volume = 0;
+  }
+
+  private effectiveGain(
+    audio: AudioSettings | undefined,
+    intensity: MusicIntensity,
+  ): number {
+    const gains = resolveMixerGains(audio ?? SILENT_AUDIO);
+    if (gains === null || isMixerSilent(gains) || gains.music === 0) return 0;
+    return clamp01(gains.master * gains.music * this.baseGain * intensity.volumeScale);
+  }
+}
+
+function regionMusicCueId(value: string): MusicCueId {
+  if (value.startsWith("iron-borough")) return "iron-borough";
+  if (value.startsWith("ember-steppe")) return "ember-steppe";
+  if (value.startsWith("breakwater-isles")) return "breakwater-isles";
+  if (value.startsWith("glass-ridge")) return "glass-ridge";
+  if (value.startsWith("neon-meridian")) return "neon-meridian";
+  if (value.startsWith("moss-frontier")) return "moss-frontier";
+  if (value.startsWith("crown-circuit")) return "crown-circuit";
+  return "velvet-coast";
+}
+
+function browserAudioElementFactory(src: string): MusicAudioElementLike | null {
+  if (typeof Audio === "undefined") return null;
+  return new Audio(src);
+}
+
+function defaultNowSeconds(): number {
+  if (typeof performance === "undefined") return 0;
+  return performance.now() / 1000;
+}
+
+function fadeProgress(now: number, start: number, duration: number): number {
+  if (duration <= 0) return 1;
+  return clampUnit((now - start) / duration);
+}
+
+function nonNegativeOr(value: number | undefined, fallback: number): number {
+  return value === undefined || !Number.isFinite(value) || value < 0
+    ? fallback
+    : value;
+}
+
+function clamp01(value: number): number {
+  return clamp(value, 0, 1);
+}
+
+function clampUnit(value: number): number {
+  return clamp(value, 0, 1);
+}
+
+function clamp(value: number, min: number, max: number): number {
+  if (!Number.isFinite(value)) return min;
+  return Math.min(max, Math.max(min, value));
+}

--- a/src/components/audio/MenuMusicDirector.tsx
+++ b/src/components/audio/MenuMusicDirector.tsx
@@ -50,13 +50,17 @@ export function MenuMusicDirector(): null {
 
     const update = (): void => {
       runtime.update(audioRef.current);
-      animationFrame = window.requestAnimationFrame(update);
+      if (runtime.isPlaying()) {
+        animationFrame = window.requestAnimationFrame(update);
+        return;
+      }
+      animationFrame = null;
     };
 
     const play = (): void => {
       armedRef.current = true;
-      runtime.play(titleMusicCue(), audioRef.current);
-      if (animationFrame === null) {
+      const started = runtime.play(titleMusicCue(), audioRef.current);
+      if (started && animationFrame === null) {
         animationFrame = window.requestAnimationFrame(update);
       }
     };

--- a/src/components/audio/MenuMusicDirector.tsx
+++ b/src/components/audio/MenuMusicDirector.tsx
@@ -1,0 +1,86 @@
+"use client";
+
+import { usePathname } from "next/navigation";
+import { useEffect, useRef } from "react";
+
+import type { AudioSettings } from "@/data/schemas";
+import { titleMusicCue, MusicRuntime } from "@/audio/music";
+import { defaultSave, loadSave } from "@/persistence/save";
+
+const DEFAULT_AUDIO_SETTINGS: AudioSettings = Object.freeze({
+  master: 1,
+  music: 0.8,
+  sfx: 0.9,
+});
+
+const MENU_MUSIC_PATHS = new Set([
+  "/",
+  "/world",
+  "/daily",
+  "/garage",
+  "/garage/cars",
+  "/garage/repair",
+  "/garage/upgrade",
+  "/options",
+]);
+
+export function MenuMusicDirector(): null {
+  const pathname = usePathname();
+  const runtimeRef = useRef<MusicRuntime | null>(null);
+  const armedRef = useRef(false);
+  const audioRef = useRef<AudioSettings>(DEFAULT_AUDIO_SETTINGS);
+
+  if (runtimeRef.current === null) {
+    runtimeRef.current = new MusicRuntime();
+  }
+
+  useEffect(() => {
+    const loaded = loadSave();
+    audioRef.current =
+      loaded.kind === "loaded"
+        ? (loaded.save.settings.audio ?? DEFAULT_AUDIO_SETTINGS)
+        : (defaultSave().settings.audio ?? DEFAULT_AUDIO_SETTINGS);
+  }, [pathname]);
+
+  useEffect(() => {
+    const runtime = runtimeRef.current;
+    if (runtime === null) return;
+    const shouldPlay = pathname === null ? false : MENU_MUSIC_PATHS.has(pathname);
+    let animationFrame: number | null = null;
+
+    const update = (): void => {
+      runtime.update(audioRef.current);
+      animationFrame = window.requestAnimationFrame(update);
+    };
+
+    const play = (): void => {
+      armedRef.current = true;
+      runtime.play(titleMusicCue(), audioRef.current);
+      if (animationFrame === null) {
+        animationFrame = window.requestAnimationFrame(update);
+      }
+    };
+
+    if (!shouldPlay) {
+      runtime.stop();
+      return () => {};
+    }
+
+    if (armedRef.current) {
+      play();
+    } else {
+      window.addEventListener("pointerdown", play, { once: true });
+      window.addEventListener("keydown", play, { once: true });
+    }
+
+    return () => {
+      window.removeEventListener("pointerdown", play);
+      window.removeEventListener("keydown", play);
+      if (animationFrame !== null) {
+        window.cancelAnimationFrame(animationFrame);
+      }
+    };
+  }, [pathname]);
+
+  return null;
+}


### PR DESCRIPTION
## Summary
- Adds a tested music runtime for the generated placeholder music bank.
- Plays title music on menu routes after a user gesture and stops it when leaving menu routes.
- Starts regional race music from the existing race audio gesture path and scales intensity from speed, nitro, and final lap.

## GDD
- `docs/gdd/18-sound-and-music-design.md`
- `docs/gdd/21-technical-design-for-web-implementation.md`
- `docs/gdd/24-content-plan.md`
- Coverage id: `GDD-18-MUSIC-RUNTIME`

## Progress log
- `docs/PROGRESS_LOG.md`: 2026-04-29, Slice: Sound and music runtime

## Test plan
- `npx vitest run src/audio/music.test.ts src/audio/mixer.test.ts src/audio/sfx.test.ts src/audio/engineRuntime.test.ts`
- `npm run typecheck`
- `npm run verify`
- `npm run test:e2e`

## Followups
- True multi-stem music layering, weather stem blending, final-lap stingers, lap-complete SFX, results stingers, surface-specific spray or snow hush SFX, brake scrub, tire squeal, gear shift, and final production music replacement remain for later sound-system slices.