### PR TITLE
feat(audio): add race milestone sfx

### DIFF
--- a/docs/GDD_COVERAGE.json
+++ b/docs/GDD_COVERAGE.json
@@ -278,6 +278,25 @@
       "followupRefs": ["VibeGear2-implement-sound-music-1611f9dd"]
     },
     {
+      "id": "GDD-18-PROCEDURAL-RACE-MILESTONE-SFX",
+      "gddSections": [
+        "docs/gdd/18-sound-and-music-design.md",
+        "docs/gdd/21-technical-design-for-web-implementation.md"
+      ],
+      "requirement": "Live races emit player gear-shift, lap-complete, and race-finish cues from deterministic race-session state and play distinct procedural SFX one-shots through the shared SFX runtime.",
+      "coverage": ["implemented-code", "automated-test"],
+      "implementationRefs": [
+        "src/game/raceSession.ts",
+        "src/audio/sfx.ts",
+        "src/app/race/page.tsx"
+      ],
+      "testRefs": [
+        "src/game/__tests__/raceSession.test.ts",
+        "src/audio/sfx.test.ts"
+      ],
+      "followupRefs": ["VibeGear2-implement-sound-music-1611f9dd"]
+    },
+    {
       "id": "GDD-14-OVERCAST-WEATHER-OPTION",
       "gddSections": [
         "docs/gdd/14-weather-and-environmental-systems.md",

--- a/docs/PROGRESS_LOG.md
+++ b/docs/PROGRESS_LOG.md
@@ -6,6 +6,55 @@ Correct them by adding a new entry that references the old one.
 
 ---
 
+## 2026-04-29: Slice: Race milestone SFX events
+
+**GDD sections touched:**
+[§18](gdd/18-sound-and-music-design.md) required vehicle and race
+SFX,
+[§21](gdd/21-technical-design-for-web-implementation.md) audio
+runtime.
+**Branch / PR:** `feat/race-sfx-events`, PR pending.
+**Status:** Implemented.
+
+### Done
+- `src/game/raceSession.ts`: added deterministic player audio events
+  for explicit manual gear shifts, lap completion before the final lap,
+  and race finish.
+- `src/audio/sfx.ts`: added procedural one-shot playback methods for
+  gear shift, lap complete, and results stinger cues through the shared
+  SFX mixer path.
+- `src/app/race/page.tsx`: routed the new race-session events into the
+  procedural SFX runtime.
+- `docs/GDD_COVERAGE.json`: added
+  GDD-18-PROCEDURAL-RACE-MILESTONE-SFX.
+
+### Verified
+- `npx vitest run src/audio/sfx.test.ts src/game/__tests__/raceSession.test.ts`
+  green, 128 passed.
+- `npm run typecheck` green.
+- `npm run verify` green, 2501 passed.
+- `npm run test:e2e` green, 79 passed.
+
+### Decisions and assumptions
+- Gear-shift SFX fire for explicit manual shift input only. Automatic
+  transmission changes stay silent for this slice so routine auto shifts
+  do not spam event output every time the reducer crosses a threshold.
+- The results stinger is triggered by the player crossing the final line.
+  The later results screen can add a screen-enter stinger if needed.
+
+### Coverage ledger
+- GDD-18-PROCEDURAL-RACE-MILESTONE-SFX covers gear shift, lap complete,
+  and results stinger events from the required SFX list.
+- Uncovered adjacent requirements: brake scrub, tire squeal, spray or
+  snow hush SFX, weather audio stems, and true multi-stem music layering
+  remain under the §18 sound parent dot.
+
+### Followups created
+None.
+
+### GDD edits
+None.
+
 ## 2026-04-29: Slice: Sound and music runtime
 
 **GDD sections touched:**

--- a/docs/PROGRESS_LOG.md
+++ b/docs/PROGRESS_LOG.md
@@ -13,7 +13,7 @@ Correct them by adding a new entry that references the old one.
 SFX,
 [§21](gdd/21-technical-design-for-web-implementation.md) audio
 runtime.
-**Branch / PR:** `feat/race-sfx-events`, PR pending.
+**Branch / PR:** `feat/race-sfx-events`, PR #86.
 **Status:** Implemented.
 
 ### Done

--- a/src/app/race/page.tsx
+++ b/src/app/race/page.tsx
@@ -243,6 +243,16 @@ function playRaceSfxEvents(
       });
     } else if (event.kind === "nitroEngage") {
       runtime.playNitroEngage({ audio });
+    } else if (event.kind === "gearShift") {
+      runtime.playGearShift({
+        fromGear: event.fromGear,
+        toGear: event.toGear,
+        audio,
+      });
+    } else if (event.kind === "lapComplete") {
+      runtime.playLapComplete({ audio });
+    } else if (event.kind === "raceFinish") {
+      runtime.playResultsStinger({ audio });
     }
   }
 }

--- a/src/audio/sfx.test.ts
+++ b/src/audio/sfx.test.ts
@@ -170,6 +170,65 @@ describe("ProceduralSfxRuntime", () => {
     expect(context.oscillators[0]?.stop).toHaveBeenCalledWith(0.18);
   });
 
+  it("plays gear shifts with direction-specific pitch movement", () => {
+    const context = new FakeAudioContext();
+    const runtime = new ProceduralSfxRuntime({
+      context: () => context,
+      baseGain: 0.2,
+    });
+
+    expect(
+      runtime.playGearShift({ fromGear: 2, toGear: 3, audio: AUDIO }),
+    ).toBe(true);
+    expect(
+      runtime.playGearShift({ fromGear: 4, toGear: 3, audio: AUDIO }),
+    ).toBe(true);
+
+    expect(context.oscillators[0]?.type).toBe("triangle");
+    expect(context.oscillators[0]?.frequency.setValueAtTime).toHaveBeenCalledWith(
+      420,
+      0,
+    );
+    expect(
+      context.oscillators[0]?.frequency.linearRampToValueAtTime,
+    ).toHaveBeenCalledWith(660, 0.09);
+    expect(context.oscillators[1]?.frequency.setValueAtTime).toHaveBeenCalledWith(
+      560,
+      0,
+    );
+    expect(
+      context.oscillators[1]?.frequency.linearRampToValueAtTime,
+    ).toHaveBeenCalledWith(320, 0.09);
+  });
+
+  it("plays lap and results stingers as longer rising cues", () => {
+    const context = new FakeAudioContext();
+    const runtime = new ProceduralSfxRuntime({
+      context: () => context,
+      baseGain: 0.2,
+    });
+
+    expect(runtime.playLapComplete({ audio: AUDIO })).toBe(true);
+    expect(runtime.playResultsStinger({ audio: AUDIO })).toBe(true);
+
+    expect(context.oscillators[0]?.frequency.setValueAtTime).toHaveBeenCalledWith(
+      740,
+      0,
+    );
+    expect(
+      context.oscillators[0]?.frequency.linearRampToValueAtTime,
+    ).toHaveBeenCalledWith(1110, 0.24);
+    expect(context.oscillators[0]?.stop).toHaveBeenCalledWith(0.24);
+    expect(context.oscillators[1]?.frequency.setValueAtTime).toHaveBeenCalledWith(
+      880,
+      0,
+    );
+    expect(
+      context.oscillators[1]?.frequency.linearRampToValueAtTime,
+    ).toHaveBeenCalledWith(1320, 0.34);
+    expect(context.oscillators[1]?.stop).toHaveBeenCalledWith(0.34);
+  });
+
   it("disconnects finished one-shots", () => {
     const context = new FakeAudioContext();
     const runtime = new ProceduralSfxRuntime({ context: () => context });

--- a/src/audio/sfx.ts
+++ b/src/audio/sfx.ts
@@ -53,6 +53,20 @@ export interface NitroEngageSfxInput {
   readonly audio: AudioSettings | undefined;
 }
 
+export interface GearShiftSfxInput {
+  readonly fromGear: number;
+  readonly toGear: number;
+  readonly audio: AudioSettings | undefined;
+}
+
+export interface LapCompleteSfxInput {
+  readonly audio: AudioSettings | undefined;
+}
+
+export interface ResultsStingerSfxInput {
+  readonly audio: AudioSettings | undefined;
+}
+
 export interface ProceduralSfxRuntimeOptions {
   readonly context: () => SfxAudioContextLike | null;
   readonly baseGain?: number;
@@ -117,6 +131,40 @@ export class ProceduralSfxRuntime {
       gainScale: 0.75,
       durationSeconds: 0.18,
       endFrequency: 1460,
+    });
+  }
+
+  playGearShift(input: GearShiftSfxInput): boolean {
+    const shiftingUp = input.toGear >= input.fromGear;
+    return this.playTone({
+      audio: input.audio,
+      frequency: shiftingUp ? 420 : 560,
+      oscillatorType: "triangle",
+      gainScale: 0.45,
+      durationSeconds: 0.09,
+      endFrequency: shiftingUp ? 660 : 320,
+    });
+  }
+
+  playLapComplete(input: LapCompleteSfxInput): boolean {
+    return this.playTone({
+      audio: input.audio,
+      frequency: 740,
+      oscillatorType: "square",
+      gainScale: 0.7,
+      durationSeconds: 0.24,
+      endFrequency: 1110,
+    });
+  }
+
+  playResultsStinger(input: ResultsStingerSfxInput): boolean {
+    return this.playTone({
+      audio: input.audio,
+      frequency: 880,
+      oscillatorType: "square",
+      gainScale: 0.8,
+      durationSeconds: 0.34,
+      endFrequency: 1320,
     });
   }
 

--- a/src/game/__tests__/raceSession.test.ts
+++ b/src/game/__tests__/raceSession.test.ts
@@ -876,6 +876,9 @@ describe("stepRaceSession (transmission)", () => {
     session = stepRaceSession(session, shiftUpInput(), config, DT);
     expect(session.player.transmission.gear).toBe(3);
     expect(session.player.lastShiftUpPressed).toBe(true);
+    expect(session.audioEvents).toEqual([
+      { kind: "gearShift", carId: "player", fromGear: 2, toGear: 3 },
+    ]);
   });
 
   it("manual shiftUp held across ticks only fires once (no cascade)", () => {
@@ -897,6 +900,7 @@ describe("stepRaceSession (transmission)", () => {
     expect(session.player.transmission.gear).toBe(3);
     for (let i = 0; i < 10; i += 1) {
       session = stepRaceSession(session, shiftUpInput(), config, DT);
+      expect(session.audioEvents).toEqual([]);
     }
     expect(session.player.transmission.gear).toBe(3);
   });
@@ -940,6 +944,9 @@ describe("stepRaceSession (transmission)", () => {
     };
     session = stepRaceSession(session, shiftDownInput(), config, DT);
     expect(session.player.transmission.gear).toBe(3);
+    expect(session.audioEvents).toEqual([
+      { kind: "gearShift", carId: "player", fromGear: 4, toGear: 3 },
+    ]);
   });
 
   it("respects the gearbox upgrade tier when capping max gear", () => {
@@ -1673,8 +1680,42 @@ describe("stepRaceSession (§7 per-car DNF tracking + finishing order, F-028)", 
     expect(session.player.lapTimes.length).toBe(1);
     expect(session.player.lapTimes[0]).toBeGreaterThan(0);
     expect(session.player.finishedAtMs).not.toBeNull();
+    expect(session.audioEvents).toEqual([
+      { kind: "raceFinish", carId: "player" },
+    ]);
     // Race phase mirrors the player flip (existing behaviour).
     expect(session.race.phase).toBe("finished");
+  });
+
+  it("emits lap-complete SFX before the final lap", () => {
+    const track = loadTrack("test/straight");
+    const config: RaceSessionConfig = {
+      track,
+      player: { stats: STARTER_STATS },
+      ai: [],
+      countdownSec: 0,
+      totalLaps: 2,
+    };
+    let session = createRaceSession(config);
+    session = {
+      ...session,
+      player: {
+        ...session.player,
+        car: {
+          ...session.player.car,
+          z: track.totalLengthMeters - 0.1,
+          speed: 60,
+        },
+      },
+    };
+
+    session = stepRaceSession(session, fullThrottle(), config, DT);
+
+    expect(session.race.phase).toBe("racing");
+    expect(session.race.lap).toBe(2);
+    expect(session.audioEvents).toEqual([
+      { kind: "lapComplete", carId: "player", lap: 1 },
+    ]);
   });
 
   it("appends per-lap durations across multi-lap races (cumulative-aware)", () => {

--- a/src/game/raceSession.ts
+++ b/src/game/raceSession.ts
@@ -243,6 +243,10 @@ export interface RaceSessionRaceFinishAudioEvent {
   readonly carId: string;
 }
 
+type RaceSessionLapMilestoneAudioEvent =
+  | RaceSessionLapCompleteAudioEvent
+  | RaceSessionRaceFinishAudioEvent;
+
 export type RaceSessionAudioEvent =
   | RaceSessionImpactAudioEvent
   | RaceSessionNitroAudioEvent
@@ -1535,7 +1539,7 @@ export function stepRaceSession(
   let bestLapTimeMs = state.race.bestLapTimeMs;
   let nextPhase: RaceState["phase"] = state.race.phase;
   let nextPlayerLapTimes: ReadonlyArray<number> = state.player.lapTimes;
-  const playerLapEvents: RaceSessionAudioEvent[] = [];
+  const playerLapEvents: RaceSessionLapMilestoneAudioEvent[] = [];
   // Apply the §13 wreck flip before the lap-completion check so a car
   // that wrecked this tick cannot also pick up a finish (would-be lap
   // crossings on the wrecked tick are ignored, mirroring the §7 DNF
@@ -1724,6 +1728,19 @@ export function stepRaceSession(
     SEGMENT_LENGTH,
     nextTick,
   );
+  const hasPlayerNonImpactAudioEvents =
+    playerNitroEvents.length > 0 ||
+    playerShiftEvents.length > 0 ||
+    playerLapEvents.length > 0;
+  const nextAudioEvents: ReadonlyArray<RaceSessionAudioEvent> =
+    hasPlayerNonImpactAudioEvents
+      ? [
+          ...playerNitroEvents,
+          ...playerShiftEvents,
+          ...playerLapEvents,
+          ...playerImpactEvents,
+        ]
+      : playerImpactEvents;
 
   return {
     race: {
@@ -1769,12 +1786,7 @@ export function stepRaceSession(
         : Array.from(nextBrokenHazards),
     weather: nextWeather,
     weatherRngState: nextWeatherRngState,
-    audioEvents: [
-      ...playerNitroEvents,
-      ...playerShiftEvents,
-      ...playerLapEvents,
-      ...playerImpactEvents,
-    ],
+    audioEvents: nextAudioEvents,
   };
 }
 

--- a/src/game/raceSession.ts
+++ b/src/game/raceSession.ts
@@ -225,9 +225,30 @@ export interface RaceSessionNitroAudioEvent {
   readonly carId: string;
 }
 
+export interface RaceSessionGearShiftAudioEvent {
+  readonly kind: "gearShift";
+  readonly carId: string;
+  readonly fromGear: number;
+  readonly toGear: number;
+}
+
+export interface RaceSessionLapCompleteAudioEvent {
+  readonly kind: "lapComplete";
+  readonly carId: string;
+  readonly lap: number;
+}
+
+export interface RaceSessionRaceFinishAudioEvent {
+  readonly kind: "raceFinish";
+  readonly carId: string;
+}
+
 export type RaceSessionAudioEvent =
   | RaceSessionImpactAudioEvent
-  | RaceSessionNitroAudioEvent;
+  | RaceSessionNitroAudioEvent
+  | RaceSessionGearShiftAudioEvent
+  | RaceSessionLapCompleteAudioEvent
+  | RaceSessionRaceFinishAudioEvent;
 
 export interface RaceSessionConfig {
   /** Compiled track to drive on. Frozen output of `compileTrack`. */
@@ -1086,6 +1107,20 @@ export function stepRaceSession(
         dt,
       )
     : { ...state.player.transmission };
+  const playerShiftEvents: RaceSessionGearShiftAudioEvent[] =
+    playerIsRacing &&
+    state.player.transmission.mode === "manual" &&
+    (playerShiftUpEdge || playerShiftDownEdge) &&
+    playerTransmission.gear !== state.player.transmission.gear
+      ? [
+          {
+            kind: "gearShift",
+            carId: PLAYER_CAR_ID,
+            fromGear: state.player.transmission.gear,
+            toGear: playerTransmission.gear,
+          },
+        ]
+      : [];
   const playerGearMultiplier = gearAccelMultiplier(playerTransmission);
   const playerAccelMultiplier = playerNitroMultiplier * playerGearMultiplier;
 
@@ -1500,6 +1535,7 @@ export function stepRaceSession(
   let bestLapTimeMs = state.race.bestLapTimeMs;
   let nextPhase: RaceState["phase"] = state.race.phase;
   let nextPlayerLapTimes: ReadonlyArray<number> = state.player.lapTimes;
+  const playerLapEvents: RaceSessionAudioEvent[] = [];
   // Apply the §13 wreck flip before the lap-completion check so a car
   // that wrecked this tick cannot also pick up a finish (would-be lap
   // crossings on the wrecked tick are ignored, mirroring the §7 DNF
@@ -1540,6 +1576,16 @@ export function stepRaceSession(
         nextLap = state.race.totalLaps;
         nextPlayerStatus = "finished";
         nextPlayerFinishedAtMs = nextElapsedMs;
+        playerLapEvents.push({
+          kind: "raceFinish",
+          carId: PLAYER_CAR_ID,
+        });
+      } else {
+        playerLapEvents.push({
+          kind: "lapComplete",
+          carId: PLAYER_CAR_ID,
+          lap: nextLap - 1,
+        });
       }
     }
   }
@@ -1723,10 +1769,12 @@ export function stepRaceSession(
         : Array.from(nextBrokenHazards),
     weather: nextWeather,
     weatherRngState: nextWeatherRngState,
-    audioEvents:
-      playerNitroEvents.length === 0
-        ? playerImpactEvents
-        : [...playerNitroEvents, ...playerImpactEvents],
+    audioEvents: [
+      ...playerNitroEvents,
+      ...playerShiftEvents,
+      ...playerLapEvents,
+      ...playerImpactEvents,
+    ],
   };
 }
 


### PR DESCRIPTION
## Summary

Adds deterministic player race audio events for explicit manual gear shifts, lap-complete cues, and race-finish stingers, then routes them through the procedural SFX runtime.

## GDD sections

- docs/gdd/18-sound-and-music-design.md: required vehicle and race SFX.
- docs/gdd/21-technical-design-for-web-implementation.md: shared audio runtime.

## Requirement inventory

Handled in this PR:

- Player manual gear shifts emit deterministic SFX events.
- Player lap completion before the final lap emits a lap cue.
- Player final finish emits a results stinger cue.
- Live race playback maps those events to procedural one-shots through persisted SFX gain.
- GDD coverage ledger records GDD-18-PROCEDURAL-RACE-MILESTONE-SFX.

Left under the sound parent dot:

- Brake scrub.
- Tire squeal.
- Spray or snow hush.
- Weather audio stems.
- True multi-stem music layering.

## Progress log

- docs/PROGRESS_LOG.md: 2026-04-29 Slice: Race milestone SFX events.

## Test plan

- [x] npx vitest run src/audio/sfx.test.ts src/game/__tests__/raceSession.test.ts
- [x] npm run typecheck
- [x] npm run verify
- [x] npm run test:e2e
- [x] git diff --check
- [x] grep -rn forbidden dash codepoints in changed files

## Followups

None.