### PR TITLE
feat(audio): add surface sfx cues

### DIFF
--- a/docs/GDD_COVERAGE.json
+++ b/docs/GDD_COVERAGE.json
@@ -297,6 +297,28 @@
       "followupRefs": ["VibeGear2-implement-sound-music-1611f9dd"]
     },
     {
+      "id": "GDD-18-PROCEDURAL-SURFACE-SFX",
+      "gddSections": [
+        "docs/gdd/18-sound-and-music-design.md",
+        "docs/gdd/10-driving-model-and-physics.md",
+        "docs/gdd/14-weather-and-environmental-systems.md",
+        "docs/gdd/21-technical-design-for-web-implementation.md"
+      ],
+      "requirement": "Live races emit gated player brake-scrub, tire-squeal, and wet or snow surface-hush cues from deterministic input, surface, speed, and weather state, then play distinct procedural SFX one-shots through the shared SFX runtime.",
+      "coverage": ["implemented-code", "automated-test"],
+      "implementationRefs": [
+        "src/game/raceSession.ts",
+        "src/audio/sfx.ts",
+        "src/app/race/page.tsx"
+      ],
+      "testRefs": [
+        "src/game/__tests__/raceSession.test.ts",
+        "src/game/__tests__/raceSessionActions.test.ts",
+        "src/audio/sfx.test.ts"
+      ],
+      "followupRefs": ["VibeGear2-implement-sound-music-1611f9dd"]
+    },
+    {
       "id": "GDD-14-OVERCAST-WEATHER-OPTION",
       "gddSections": [
         "docs/gdd/14-weather-and-environmental-systems.md",

--- a/docs/PROGRESS_LOG.md
+++ b/docs/PROGRESS_LOG.md
@@ -23,7 +23,9 @@ runtime.
 ### Done
 - `src/game/raceSession.ts`: added deterministic player audio gates so
   brake scrub, tire squeal, and wet or snow surface hush cues emit only
-  when their qualifying state first becomes active.
+  when their qualifying state first becomes active. The surface hush
+  gate tracks wet versus snow so weather kind changes can emit a fresh
+  cue while the speed gate stays active.
 - `src/audio/sfx.ts`: added procedural one-shot playback methods for
   brake scrub, tire squeal, and wet or snow surface hush.
 - `src/app/race/page.tsx`: routed the new race-session events into the
@@ -32,9 +34,9 @@ runtime.
 
 ### Verified
 - `npx vitest run src/game/__tests__/raceSession.test.ts src/game/__tests__/raceSessionActions.test.ts src/audio/sfx.test.ts`
-  green, 141 passed.
+  green, 142 passed.
 - `npm run typecheck` green.
-- `npm run verify` green, 2505 passed.
+- `npm run verify` green, 2506 passed.
 - `npm run test:e2e` green, 79 passed.
 
 ### Decisions and assumptions

--- a/docs/PROGRESS_LOG.md
+++ b/docs/PROGRESS_LOG.md
@@ -6,6 +6,57 @@ Correct them by adding a new entry that references the old one.
 
 ---
 
+## 2026-04-29: Slice: Surface SFX cues
+
+**GDD sections touched:**
+[§18](gdd/18-sound-and-music-design.md) required vehicle and race
+SFX,
+[§10](gdd/10-driving-model-and-physics.md) braking, steering, and
+surface state,
+[§14](gdd/14-weather-and-environmental-systems.md) weather-aware
+surface effects,
+[§21](gdd/21-technical-design-for-web-implementation.md) audio
+runtime.
+**Branch / PR:** `feat/surface-audio-cues`, PR pending.
+**Status:** Implemented.
+
+### Done
+- `src/game/raceSession.ts`: added deterministic player audio gates so
+  brake scrub, tire squeal, and wet or snow surface hush cues emit only
+  when their qualifying state first becomes active.
+- `src/audio/sfx.ts`: added procedural one-shot playback methods for
+  brake scrub, tire squeal, and wet or snow surface hush.
+- `src/app/race/page.tsx`: routed the new race-session events into the
+  procedural SFX runtime.
+- `docs/GDD_COVERAGE.json`: added GDD-18-PROCEDURAL-SURFACE-SFX.
+
+### Verified
+- `npx vitest run src/game/__tests__/raceSession.test.ts src/game/__tests__/raceSessionActions.test.ts src/audio/sfx.test.ts`
+  green, 141 passed.
+- `npm run typecheck` green.
+- `npm run verify` green, 2505 passed.
+- `npm run test:e2e` green, 79 passed.
+
+### Decisions and assumptions
+- Continuous-feel cues are gated in the pure session state rather than
+  emitted every tick. A cue re-arms only after its condition clears, so
+  live playback avoids per-frame one-shot spam.
+- Wet surface hush is limited to rainy road surfaces. Snow hush follows
+  snow weather on any surface because the road and shoulders are both
+  snow-covered in the current renderer.
+
+### Coverage ledger
+- GDD-18-PROCEDURAL-SURFACE-SFX covers brake scrub, tire squeal, and
+  spray or snow hush entries from the required SFX list.
+- Uncovered adjacent requirements: weather audio stems and true
+  multi-stem music layering remain under the §18 sound parent dot.
+
+### Followups created
+None.
+
+### GDD edits
+None.
+
 ## 2026-04-29: Slice: Race milestone SFX events
 
 **GDD sections touched:**

--- a/docs/PROGRESS_LOG.md
+++ b/docs/PROGRESS_LOG.md
@@ -17,7 +17,7 @@ surface state,
 surface effects,
 [§21](gdd/21-technical-design-for-web-implementation.md) audio
 runtime.
-**Branch / PR:** `feat/surface-audio-cues`, PR pending.
+**Branch / PR:** `feat/surface-audio-cues`, PR #87.
 **Status:** Implemented.
 
 ### Done

--- a/src/app/race/page.tsx
+++ b/src/app/race/page.tsx
@@ -253,6 +253,16 @@ function playRaceSfxEvents(
       runtime.playLapComplete({ audio });
     } else if (event.kind === "raceFinish") {
       runtime.playResultsStinger({ audio });
+    } else if (event.kind === "brakeScrub") {
+      runtime.playBrakeScrub({ speedFactor: event.speedFactor, audio });
+    } else if (event.kind === "tireSqueal") {
+      runtime.playTireSqueal({ speedFactor: event.speedFactor, audio });
+    } else if (event.kind === "surfaceHush") {
+      runtime.playSurfaceHush({
+        surface: event.surface,
+        speedFactor: event.speedFactor,
+        audio,
+      });
     }
   }
 }

--- a/src/audio/sfx.test.ts
+++ b/src/audio/sfx.test.ts
@@ -229,6 +229,52 @@ describe("ProceduralSfxRuntime", () => {
     expect(context.oscillators[1]?.stop).toHaveBeenCalledWith(0.34);
   });
 
+  it("plays surface cues with speed-scaled ramps", () => {
+    const context = new FakeAudioContext();
+    const runtime = new ProceduralSfxRuntime({
+      context: () => context,
+      baseGain: 0.2,
+    });
+
+    expect(runtime.playBrakeScrub({ speedFactor: 0.5, audio: AUDIO })).toBe(
+      true,
+    );
+    expect(runtime.playTireSqueal({ speedFactor: 0.5, audio: AUDIO })).toBe(
+      true,
+    );
+    expect(
+      runtime.playSurfaceHush({
+        surface: "snow",
+        speedFactor: 0.5,
+        audio: AUDIO,
+      }),
+    ).toBe(true);
+
+    expect(context.oscillators[0]?.type).toBe("sawtooth");
+    expect(context.oscillators[0]?.frequency.setValueAtTime).toHaveBeenCalledWith(
+      215,
+      0,
+    );
+    expect(
+      context.oscillators[0]?.frequency.linearRampToValueAtTime,
+    ).toHaveBeenCalledWith(165, 0.14);
+    expect(context.oscillators[1]?.type).toBe("triangle");
+    expect(context.oscillators[1]?.frequency.setValueAtTime).toHaveBeenCalledWith(
+      1070,
+      0,
+    );
+    expect(
+      context.oscillators[1]?.frequency.linearRampToValueAtTime,
+    ).toHaveBeenCalledWith(1240, 0.16);
+    expect(context.oscillators[2]?.frequency.setValueAtTime).toHaveBeenCalledWith(
+      300,
+      0,
+    );
+    expect(
+      context.oscillators[2]?.frequency.linearRampToValueAtTime,
+    ).toHaveBeenCalledWith(245, 0.24);
+  });
+
   it("disconnects finished one-shots", () => {
     const context = new FakeAudioContext();
     const runtime = new ProceduralSfxRuntime({ context: () => context });

--- a/src/audio/sfx.ts
+++ b/src/audio/sfx.ts
@@ -67,6 +67,22 @@ export interface ResultsStingerSfxInput {
   readonly audio: AudioSettings | undefined;
 }
 
+export interface BrakeScrubSfxInput {
+  readonly speedFactor: number;
+  readonly audio: AudioSettings | undefined;
+}
+
+export interface TireSquealSfxInput {
+  readonly speedFactor: number;
+  readonly audio: AudioSettings | undefined;
+}
+
+export interface SurfaceHushSfxInput {
+  readonly surface: "wet" | "snow";
+  readonly speedFactor: number;
+  readonly audio: AudioSettings | undefined;
+}
+
 export interface ProceduralSfxRuntimeOptions {
   readonly context: () => SfxAudioContextLike | null;
   readonly baseGain?: number;
@@ -165,6 +181,43 @@ export class ProceduralSfxRuntime {
       gainScale: 0.8,
       durationSeconds: 0.34,
       endFrequency: 1320,
+    });
+  }
+
+  playBrakeScrub(input: BrakeScrubSfxInput): boolean {
+    const speed = clampUnit(input.speedFactor);
+    return this.playTone({
+      audio: input.audio,
+      frequency: Math.round(170 + speed * 90),
+      oscillatorType: "sawtooth",
+      gainScale: 0.35 + speed * 0.25,
+      durationSeconds: 0.14,
+      endFrequency: Math.round(130 + speed * 70),
+    });
+  }
+
+  playTireSqueal(input: TireSquealSfxInput): boolean {
+    const speed = clampUnit(input.speedFactor);
+    return this.playTone({
+      audio: input.audio,
+      frequency: Math.round(860 + speed * 420),
+      oscillatorType: "triangle",
+      gainScale: 0.4 + speed * 0.3,
+      durationSeconds: 0.16,
+      endFrequency: Math.round(980 + speed * 520),
+    });
+  }
+
+  playSurfaceHush(input: SurfaceHushSfxInput): boolean {
+    const speed = clampUnit(input.speedFactor);
+    const snow = input.surface === "snow";
+    return this.playTone({
+      audio: input.audio,
+      frequency: Math.round((snow ? 260 : 360) + speed * (snow ? 80 : 140)),
+      oscillatorType: "sawtooth",
+      gainScale: 0.28 + speed * 0.22,
+      durationSeconds: snow ? 0.24 : 0.18,
+      endFrequency: Math.round((snow ? 210 : 290) + speed * (snow ? 70 : 110)),
     });
   }
 

--- a/src/game/__tests__/raceSession.test.ts
+++ b/src/game/__tests__/raceSession.test.ts
@@ -1166,6 +1166,37 @@ describe("stepRaceSession (surface audio)", () => {
       speedFactor: expect.any(Number),
     });
   });
+
+  it("re-arms surface hush when the hush kind changes", () => {
+    const config = buildConfig({
+      countdownSec: 0,
+      ai: [],
+      track: trackWithWeather(["rain", "snow"]),
+      weather: "snow",
+    });
+    let session = createRaceSession(config);
+    session = {
+      ...session,
+      player: {
+        ...session.player,
+        audioGates: {
+          ...session.player.audioGates,
+          surfaceHushActive: "wet",
+        },
+        car: { ...session.player.car, speed: 18 },
+      },
+    };
+
+    session = stepRaceSession(session, fullThrottle(), config, DT);
+
+    expect(session.audioEvents).toContainEqual({
+      kind: "surfaceHush",
+      carId: "player",
+      surface: "snow",
+      speedFactor: expect.any(Number),
+    });
+    expect(session.player.audioGates.surfaceHushActive).toBe("snow");
+  });
 });
 
 describe("stepRaceSession (drafting)", () => {

--- a/src/game/__tests__/raceSession.test.ts
+++ b/src/game/__tests__/raceSession.test.ts
@@ -1043,6 +1043,131 @@ describe("stepRaceSession (transmission)", () => {
   });
 });
 
+describe("stepRaceSession (surface audio)", () => {
+  it("emits brake scrub once until braking clears", () => {
+    const config = buildConfig({ countdownSec: 0, ai: [] });
+    let session = createRaceSession(config);
+    session = {
+      ...session,
+      player: {
+        ...session.player,
+        car: { ...session.player.car, speed: 24 },
+      },
+    };
+
+    session = stepRaceSession(
+      session,
+      { ...NEUTRAL_INPUT, brake: 1 },
+      config,
+      DT,
+    );
+    expect(session.audioEvents).toEqual([
+      { kind: "brakeScrub", carId: "player", speedFactor: expect.any(Number) },
+    ]);
+
+    session = stepRaceSession(
+      session,
+      { ...NEUTRAL_INPUT, brake: 1 },
+      config,
+      DT,
+    );
+    expect(session.audioEvents).toEqual([]);
+
+    session = stepRaceSession(session, NEUTRAL_INPUT, config, DT);
+    session = {
+      ...session,
+      player: {
+        ...session.player,
+        car: { ...session.player.car, speed: 24 },
+      },
+    };
+    session = stepRaceSession(
+      session,
+      { ...NEUTRAL_INPUT, brake: 1 },
+      config,
+      DT,
+    );
+    expect(session.audioEvents[0]?.kind).toBe("brakeScrub");
+  });
+
+  it("emits tire squeal once for high-speed steering until it clears", () => {
+    const config = buildConfig({ countdownSec: 0, ai: [] });
+    let session = createRaceSession(config);
+    session = {
+      ...session,
+      player: {
+        ...session.player,
+        car: { ...session.player.car, speed: 28 },
+      },
+    };
+
+    session = stepRaceSession(
+      session,
+      { ...NEUTRAL_INPUT, throttle: 1, steer: 1 },
+      config,
+      DT,
+    );
+    expect(session.audioEvents).toEqual([
+      { kind: "tireSqueal", carId: "player", speedFactor: expect.any(Number) },
+    ]);
+    session = stepRaceSession(
+      session,
+      { ...NEUTRAL_INPUT, throttle: 1, steer: 1 },
+      config,
+      DT,
+    );
+    expect(session.audioEvents).toEqual([]);
+  });
+
+  it("emits wet and snow surface hush once per weather surface", () => {
+    const rainConfig = buildConfig({
+      countdownSec: 0,
+      ai: [],
+      track: trackWithWeather(["rain"]),
+      weather: "rain",
+    });
+    let rainSession = createRaceSession(rainConfig);
+    rainSession = {
+      ...rainSession,
+      player: {
+        ...rainSession.player,
+        car: { ...rainSession.player.car, speed: 18 },
+      },
+    };
+    rainSession = stepRaceSession(rainSession, fullThrottle(), rainConfig, DT);
+    expect(rainSession.audioEvents).toContainEqual({
+      kind: "surfaceHush",
+      carId: "player",
+      surface: "wet",
+      speedFactor: expect.any(Number),
+    });
+    rainSession = stepRaceSession(rainSession, fullThrottle(), rainConfig, DT);
+    expect(rainSession.audioEvents).toEqual([]);
+
+    const snowConfig = buildConfig({
+      countdownSec: 0,
+      ai: [],
+      track: trackWithWeather(["snow"]),
+      weather: "snow",
+    });
+    let snowSession = createRaceSession(snowConfig);
+    snowSession = {
+      ...snowSession,
+      player: {
+        ...snowSession.player,
+        car: { ...snowSession.player.car, speed: 18 },
+      },
+    };
+    snowSession = stepRaceSession(snowSession, fullThrottle(), snowConfig, DT);
+    expect(snowSession.audioEvents).toContainEqual({
+      kind: "surfaceHush",
+      carId: "player",
+      surface: "snow",
+      speedFactor: expect.any(Number),
+    });
+  });
+});
+
 describe("stepRaceSession (drafting)", () => {
   const FAST = DRAFT_MIN_SPEED_M_PER_S + 30;
 

--- a/src/game/raceSession.ts
+++ b/src/game/raceSession.ts
@@ -117,6 +117,7 @@ import {
   isOffRoad,
   step,
   type CarState,
+  type Surface,
   type TrackContext,
 } from "./physics";
 import { EMPTY_PASSED_SET } from "./raceCheckpoints";
@@ -243,6 +244,27 @@ export interface RaceSessionRaceFinishAudioEvent {
   readonly carId: string;
 }
 
+export interface RaceSessionBrakeScrubAudioEvent {
+  readonly kind: "brakeScrub";
+  readonly carId: string;
+  readonly speedFactor: number;
+}
+
+export interface RaceSessionTireSquealAudioEvent {
+  readonly kind: "tireSqueal";
+  readonly carId: string;
+  readonly speedFactor: number;
+}
+
+export type RaceSessionSurfaceHushKind = "wet" | "snow";
+
+export interface RaceSessionSurfaceHushAudioEvent {
+  readonly kind: "surfaceHush";
+  readonly carId: string;
+  readonly surface: RaceSessionSurfaceHushKind;
+  readonly speedFactor: number;
+}
+
 type RaceSessionLapMilestoneAudioEvent =
   | RaceSessionLapCompleteAudioEvent
   | RaceSessionRaceFinishAudioEvent;
@@ -252,7 +274,10 @@ export type RaceSessionAudioEvent =
   | RaceSessionNitroAudioEvent
   | RaceSessionGearShiftAudioEvent
   | RaceSessionLapCompleteAudioEvent
-  | RaceSessionRaceFinishAudioEvent;
+  | RaceSessionRaceFinishAudioEvent
+  | RaceSessionBrakeScrubAudioEvent
+  | RaceSessionTireSquealAudioEvent
+  | RaceSessionSurfaceHushAudioEvent;
 
 export interface RaceSessionConfig {
   /** Compiled track to drive on. Frozen output of `compileTrack`. */
@@ -420,6 +445,12 @@ export interface RaceSessionPlayerCar {
   /** Edge-detection mirror of the prior tick's `shiftDown` input. */
   lastShiftDownPressed: boolean;
   /**
+   * Per-player audio gates for continuous-feel SFX. The session emits
+   * brake, tire, and surface hush cues only when a qualifying condition
+   * first becomes active, then re-arms the cue after the condition clears.
+   */
+  audioGates: RaceSessionAudioGates;
+  /**
    * Per-session §19 accessibility assist memory, threaded across ticks
    * by `applyAssists`. Initialised at session creation to
    * `INITIAL_ASSIST_MEMORY` and reset back to it the same tick the
@@ -514,6 +545,18 @@ export interface RaceSessionPlayerCar {
  */
 export type RaceCarStatus = "racing" | "finished" | "dnf";
 
+export interface RaceSessionAudioGates {
+  readonly brakeScrubActive: boolean;
+  readonly tireSquealActive: boolean;
+  readonly surfaceHushActive: boolean;
+}
+
+const INITIAL_AUDIO_GATES: RaceSessionAudioGates = Object.freeze({
+  brakeScrubActive: false,
+  tireSquealActive: false,
+  surfaceHushActive: false,
+});
+
 export interface RaceSessionState {
   race: RaceState;
   player: RaceSessionPlayerCar;
@@ -594,6 +637,10 @@ export const AI_GRID_SPACING_M = 5;
  */
 export const CAR_LENGTH_M = 4;
 export const CAR_WIDTH_M = 1.8;
+const BRAKE_SCRUB_SPEED_M_PER_S = 8;
+const TIRE_SQUEAL_SPEED_M_PER_S = 18;
+const TIRE_SQUEAL_STEER_THRESHOLD = 0.65;
+const SURFACE_HUSH_SPEED_M_PER_S = 10;
 
 /**
  * Reference top speed (m/s) used to normalise the §13 `speedFactor`
@@ -686,6 +733,7 @@ export function createRaceSession(config: RaceSessionConfig): RaceSessionState {
     }),
     lastShiftUpPressed: false,
     lastShiftDownPressed: false,
+    audioGates: { ...INITIAL_AUDIO_GATES },
     assistMemory: { ...INITIAL_ASSIST_MEMORY },
     assistBadge: null,
     weatherVisualReductionActive:
@@ -1728,16 +1776,26 @@ export function stepRaceSession(
     SEGMENT_LENGTH,
     nextTick,
   );
+  const playerSurfaceAudio = buildPlayerSurfaceAudioEvents({
+    gates: state.player.audioGates,
+    input: effectivePlayerInput,
+    car: nextPlayerCar,
+    status: nextPlayerStatus,
+    weather: trackWeather,
+    topSpeed: playerStats.topSpeed,
+  });
   const hasPlayerNonImpactAudioEvents =
     playerNitroEvents.length > 0 ||
     playerShiftEvents.length > 0 ||
-    playerLapEvents.length > 0;
+    playerLapEvents.length > 0 ||
+    playerSurfaceAudio.events.length > 0;
   const nextAudioEvents: ReadonlyArray<RaceSessionAudioEvent> =
     hasPlayerNonImpactAudioEvents
       ? [
           ...playerNitroEvents,
           ...playerShiftEvents,
           ...playerLapEvents,
+          ...playerSurfaceAudio.events,
           ...playerImpactEvents,
         ]
       : playerImpactEvents;
@@ -1765,6 +1823,7 @@ export function stepRaceSession(
       transmission: playerTransmission,
       lastShiftUpPressed: effectivePlayerInput.shiftUp,
       lastShiftDownPressed: effectivePlayerInput.shiftDown,
+      audioGates: playerSurfaceAudio.gates,
       assistMemory: assistResult.memory,
       assistBadge: assistResult.badge,
       weatherVisualReductionActive: assistResult.weatherVisualReductionActive,
@@ -1788,6 +1847,92 @@ export function stepRaceSession(
     weatherRngState: nextWeatherRngState,
     audioEvents: nextAudioEvents,
   };
+}
+
+function buildPlayerSurfaceAudioEvents(input: {
+  readonly gates: RaceSessionAudioGates;
+  readonly input: Input;
+  readonly car: Readonly<CarState>;
+  readonly status: RaceCarStatus;
+  readonly weather: WeatherOption;
+  readonly topSpeed: number;
+}): {
+  readonly gates: RaceSessionAudioGates;
+  readonly events: ReadonlyArray<RaceSessionAudioEvent>;
+} {
+  if (input.status !== "racing") {
+    return { gates: { ...INITIAL_AUDIO_GATES }, events: [] };
+  }
+
+  const speedFactor = speedFactorForAudio(input.car.speed, input.topSpeed);
+  const brakeScrubNow =
+    input.input.brake > 0 &&
+    input.car.speed >= BRAKE_SCRUB_SPEED_M_PER_S &&
+    input.car.surface !== "grass";
+  const tireSquealNow =
+    input.car.speed >= TIRE_SQUEAL_SPEED_M_PER_S &&
+    input.car.surface !== "grass" &&
+    (Math.abs(input.input.steer) >= TIRE_SQUEAL_STEER_THRESHOLD ||
+      input.input.handbrake);
+  const hushKind = surfaceHushKindForWeather(input.weather, input.car.surface);
+  const surfaceHushNow =
+    hushKind !== null && input.car.speed >= SURFACE_HUSH_SPEED_M_PER_S;
+
+  const events: RaceSessionAudioEvent[] = [];
+  if (brakeScrubNow && !input.gates.brakeScrubActive) {
+    events.push({
+      kind: "brakeScrub",
+      carId: PLAYER_CAR_ID,
+      speedFactor,
+    });
+  }
+  if (tireSquealNow && !input.gates.tireSquealActive) {
+    events.push({
+      kind: "tireSqueal",
+      carId: PLAYER_CAR_ID,
+      speedFactor,
+    });
+  }
+  if (surfaceHushNow && !input.gates.surfaceHushActive && hushKind !== null) {
+    events.push({
+      kind: "surfaceHush",
+      carId: PLAYER_CAR_ID,
+      surface: hushKind,
+      speedFactor,
+    });
+  }
+
+  return {
+    gates: {
+      brakeScrubActive: brakeScrubNow,
+      tireSquealActive: tireSquealNow,
+      surfaceHushActive: surfaceHushNow,
+    },
+    events,
+  };
+}
+
+function speedFactorForAudio(speed: number, topSpeed: number): number {
+  if (!Number.isFinite(speed) || !Number.isFinite(topSpeed) || topSpeed <= 0) {
+    return 0;
+  }
+  return Math.min(1, Math.max(0, speed / topSpeed));
+}
+
+function surfaceHushKindForWeather(
+  weather: WeatherOption,
+  surface: Surface,
+): RaceSessionSurfaceHushKind | null {
+  if (weather === "snow") return "snow";
+  if (
+    surface === "road" &&
+    (weather === "light_rain" ||
+      weather === "rain" ||
+      weather === "heavy_rain")
+  ) {
+    return "wet";
+  }
+  return null;
 }
 
 /**
@@ -1893,6 +2038,7 @@ function clonePlayerCar(
     transmission: { ...player.transmission },
     lastShiftUpPressed: player.lastShiftUpPressed,
     lastShiftDownPressed: player.lastShiftDownPressed,
+    audioGates: { ...player.audioGates },
     assistMemory: { ...player.assistMemory },
     assistBadge: player.assistBadge,
     weatherVisualReductionActive: player.weatherVisualReductionActive,

--- a/src/game/raceSession.ts
+++ b/src/game/raceSession.ts
@@ -548,13 +548,13 @@ export type RaceCarStatus = "racing" | "finished" | "dnf";
 export interface RaceSessionAudioGates {
   readonly brakeScrubActive: boolean;
   readonly tireSquealActive: boolean;
-  readonly surfaceHushActive: boolean;
+  readonly surfaceHushActive: RaceSessionSurfaceHushKind | null;
 }
 
 const INITIAL_AUDIO_GATES: RaceSessionAudioGates = Object.freeze({
   brakeScrubActive: false,
   tireSquealActive: false,
-  surfaceHushActive: false,
+  surfaceHushActive: null,
 });
 
 export interface RaceSessionState {
@@ -1893,7 +1893,11 @@ function buildPlayerSurfaceAudioEvents(input: {
       speedFactor,
     });
   }
-  if (surfaceHushNow && !input.gates.surfaceHushActive && hushKind !== null) {
+  if (
+    surfaceHushNow &&
+    hushKind !== null &&
+    input.gates.surfaceHushActive !== hushKind
+  ) {
     events.push({
       kind: "surfaceHush",
       carId: PLAYER_CAR_ID,
@@ -1906,7 +1910,7 @@ function buildPlayerSurfaceAudioEvents(input: {
     gates: {
       brakeScrubActive: brakeScrubNow,
       tireSquealActive: tireSquealNow,
-      surfaceHushActive: surfaceHushNow,
+      surfaceHushActive: surfaceHushNow ? hushKind : null,
     },
     events,
   };

--- a/src/game/raceSessionActions.ts
+++ b/src/game/raceSessionActions.ts
@@ -187,6 +187,7 @@ function clonePlayerPure(
     car: { ...player.car },
     nitro: { ...player.nitro },
     transmission: { ...player.transmission },
+    audioGates: { ...player.audioGates },
     assistMemory: { ...player.assistMemory },
     dnfTimers: { ...player.dnfTimers },
     lapTimes: player.lapTimes.slice(),


### PR DESCRIPTION
## Summary

Adds gated live-race SFX cues for brake scrub, tire squeal, and wet or snow surface hush. The pure race session emits each cue when its qualifying state first becomes active, then re-arms it after the condition clears.

## GDD sections

- docs/gdd/18-sound-and-music-design.md: required vehicle and race SFX.
- docs/gdd/10-driving-model-and-physics.md: braking, steering, speed, and surface state.
- docs/gdd/14-weather-and-environmental-systems.md: weather-aware surface effects.
- docs/gdd/21-technical-design-for-web-implementation.md: shared audio runtime.

## Requirement inventory

Handled in this PR:

- Brake scrub cue on qualifying player braking.
- Tire squeal cue on qualifying high-speed steering or handbrake input.
- Wet road hush for rainy road driving.
- Snow hush for snow-weather driving.
- Procedural runtime playback through persisted SFX gain.
- GDD coverage ledger record GDD-18-PROCEDURAL-SURFACE-SFX.

Left under the sound parent dot:

- Weather audio stems.
- True multi-stem music layering.

## Progress log

- docs/PROGRESS_LOG.md: 2026-04-29 Slice: Surface SFX cues.

## Test plan

- [x] npx vitest run src/game/__tests__/raceSession.test.ts src/game/__tests__/raceSessionActions.test.ts src/audio/sfx.test.ts
- [x] npm run typecheck
- [x] npm run verify
- [x] npm run test:e2e
- [x] git diff --check
- [x] grep -rn forbidden dash codepoints in changed files

## Followups

None.