### PR TITLE
feat(audio): add weather music stems

### DIFF
--- a/docs/GDD_COVERAGE.json
+++ b/docs/GDD_COVERAGE.json
@@ -126,7 +126,7 @@
         "docs/gdd/14-weather-and-environmental-systems.md",
         "docs/gdd/21-technical-design-for-web-implementation.md"
       ],
-      "requirement": "Race music supports optional weather stem loops for rainy, heavy rainy, foggy, and snowy races through the persisted music mixer bus, with smooth fades as weather state changes.",
+      "requirement": "Race music supports optional weather stem loops for rainy, heavy rain, foggy, and snowy races through the persisted music mixer bus, with smooth fades as weather state changes.",
       "coverage": ["implemented-code", "automated-test"],
       "implementationRefs": [
         "src/audio/music.ts",

--- a/docs/GDD_COVERAGE.json
+++ b/docs/GDD_COVERAGE.json
@@ -120,6 +120,23 @@
       "followupRefs": ["VibeGear2-implement-sound-music-1611f9dd"]
     },
     {
+      "id": "GDD-18-WEATHER-MUSIC-STEMS",
+      "gddSections": [
+        "docs/gdd/18-sound-and-music-design.md",
+        "docs/gdd/14-weather-and-environmental-systems.md",
+        "docs/gdd/21-technical-design-for-web-implementation.md"
+      ],
+      "requirement": "Race music supports optional weather stem loops for rainy, heavy rainy, foggy, and snowy races through the persisted music mixer bus, with smooth fades as weather state changes.",
+      "coverage": ["implemented-code", "automated-test"],
+      "implementationRefs": [
+        "src/audio/music.ts",
+        "src/app/race/page.tsx",
+        "public/audio/weather/"
+      ],
+      "testRefs": ["src/audio/music.test.ts"],
+      "followupRefs": ["VibeGear2-implement-sound-music-1611f9dd"]
+    },
+    {
       "id": "GDD-06-DAILY-CHALLENGE-SELECTION",
       "gddSections": [
         "docs/gdd/06-game-modes.md",

--- a/docs/PROGRESS_LOG.md
+++ b/docs/PROGRESS_LOG.md
@@ -14,7 +14,7 @@ weather stem option,
 [§14](gdd/14-weather-and-environmental-systems.md) weather states,
 [§21](gdd/21-technical-design-for-web-implementation.md) audio
 runtime.
-**Branch / PR:** `feat/weather-music-stems`, PR pending.
+**Branch / PR:** `feat/weather-music-stems`, PR #88.
 **Status:** Implemented.
 
 ### Done

--- a/docs/PROGRESS_LOG.md
+++ b/docs/PROGRESS_LOG.md
@@ -6,6 +6,49 @@ Correct them by adding a new entry that references the old one.
 
 ---
 
+## 2026-04-29: Slice: Weather music stems
+
+**GDD sections touched:**
+[§18](gdd/18-sound-and-music-design.md) dynamic audio layers and region
+weather stem option,
+[§14](gdd/14-weather-and-environmental-systems.md) weather states,
+[§21](gdd/21-technical-design-for-web-implementation.md) audio
+runtime.
+**Branch / PR:** `feat/weather-music-stems`, PR pending.
+**Status:** Implemented.
+
+### Done
+- `src/audio/music.ts`: added weather stem metadata, weather-to-stem
+  selection, and a second fading music-runtime channel for rainy, heavy
+  rainy, foggy, and snowy ambient loops.
+- `src/app/race/page.tsx`: wired the race music runtime to start and
+  update the active weather stem from the session weather state.
+- `docs/GDD_COVERAGE.json`: added GDD-18-WEATHER-MUSIC-STEMS.
+
+### Verified
+- `npx vitest run src/audio/music.test.ts` green, 12 passed.
+- `npm run typecheck` green.
+- `npm run verify` green, 2509 passed.
+- `npm run test:e2e` green, 79 passed.
+
+### Decisions and assumptions
+- Weather stems ride the music bus instead of the SFX bus because §18
+  describes them as dynamic music layers and ambient pads.
+- Clear, overcast, and dusk races do not play a weather stem. Light
+  rain reuses the rain loop.
+
+### Coverage ledger
+- GDD-18-WEATHER-MUSIC-STEMS covers weather ambient pad or noise layer
+  and region weather stem option runtime support.
+- Uncovered adjacent requirements: true 2 to 3 intensity stem layering
+  remains under the §18 sound parent dot.
+
+### Followups created
+None.
+
+### GDD edits
+None.
+
 ## 2026-04-29: Slice: Surface SFX cues
 
 **GDD sections touched:**

--- a/src/app/race/page.tsx
+++ b/src/app/race/page.tsx
@@ -153,6 +153,7 @@ import {
   MusicRuntime,
   raceMusicCue,
   raceMusicIntensity,
+  weatherMusicStem,
 } from "@/audio/music";
 
 const VIEWPORT_WIDTH = 800;
@@ -909,6 +910,7 @@ function RaceCanvas({
       speed: 0,
       topSpeed: STARTER_STATS.topSpeed,
     });
+    let latestWeatherMusicStem = weatherMusicStem(weather);
     let engineStartPending = false;
     let engineAudioTeardown = false;
     let lastEngineAudioUpdateMs = 0;
@@ -927,6 +929,10 @@ function RaceCanvas({
             raceMusicCueForSession,
             persistedSettings.audio,
             latestRaceMusicIntensity,
+          );
+          raceMusic.playWeatherStem(
+            latestWeatherMusicStem,
+            persistedSettings.audio,
           );
         })
         .finally(() => {
@@ -1112,18 +1118,22 @@ function RaceCanvas({
           nitroActive: session.player.nitro.activeRemainingSec > 0,
           finalLap: session.race.lap >= session.race.totalLaps,
         });
+        const renderWeather = activeWeatherForState(session.weather);
+        latestWeatherMusicStem = weatherMusicStem(renderWeather);
         const audioUpdateMs = performance.now();
         if (audioUpdateMs - lastEngineAudioUpdateMs >= 50) {
           lastEngineAudioUpdateMs = audioUpdateMs;
           engineAudio.update(latestEngineInput);
           raceMusic.update(persistedSettings.audio, latestRaceMusicIntensity);
+          raceMusic.updateWeatherStem(
+            latestWeatherMusicStem,
+            persistedSettings.audio,
+          );
         }
         if (lastRaceSfxTick !== session.tick) {
           lastRaceSfxTick = session.tick;
           playRaceSfxEvents(raceSfx, session.audioEvents, persistedSettings.audio);
         }
-        const renderWeather = activeWeatherForState(session.weather);
-
         const strips = project(track.compiled.segments, camera, viewport);
         const playerFrameIndex = playerCarFrameIndex(
           lastSteerRef.current,

--- a/src/audio/music.test.ts
+++ b/src/audio/music.test.ts
@@ -201,6 +201,7 @@ describe("MusicRuntime", () => {
     });
 
     expect(runtime.playWeatherStem(WEATHER_MUSIC_STEMS.rain, AUDIO)).toBe(true);
+    expect(runtime.isPlaying()).toBe(true);
     expect(runtime.currentWeatherStemId()).toBe("rain");
     expect(elements).toHaveLength(1);
     expect(elements[0]?.src).toBe("/audio/weather/rain-loop.opus");

--- a/src/audio/music.test.ts
+++ b/src/audio/music.test.ts
@@ -3,9 +3,11 @@ import { describe, expect, it, vi } from "vitest";
 import {
   MUSIC_CUES,
   MusicRuntime,
+  WEATHER_MUSIC_STEMS,
   raceMusicCue,
   raceMusicIntensity,
   titleMusicCue,
+  weatherMusicStem,
   type MusicAudioElementLike,
 } from "./music";
 
@@ -26,6 +28,19 @@ describe("music cues", () => {
     expect(raceMusicCue({ trackId: "neon-meridian/night-loop" }).id).toBe(
       "neon-meridian",
     );
+  });
+
+  it("maps weather states to optional weather stems", () => {
+    expect(weatherMusicStem("clear")).toBeNull();
+    expect(weatherMusicStem("overcast")).toBeNull();
+    expect(weatherMusicStem("dusk")).toBeNull();
+    expect(weatherMusicStem("light_rain")).toEqual(WEATHER_MUSIC_STEMS.rain);
+    expect(weatherMusicStem("rain")).toEqual(WEATHER_MUSIC_STEMS.rain);
+    expect(weatherMusicStem("heavy_rain")).toEqual(
+      WEATHER_MUSIC_STEMS.heavy_rain,
+    );
+    expect(weatherMusicStem("fog")).toEqual(WEATHER_MUSIC_STEMS.fog);
+    expect(weatherMusicStem("snow")).toEqual(WEATHER_MUSIC_STEMS.snow);
   });
 });
 
@@ -168,6 +183,78 @@ describe("MusicRuntime", () => {
     });
 
     expect(element.playbackRate).toBe(1.04);
+  });
+
+  it("plays a weather stem through the music bus", () => {
+    let now = 0;
+    const elements: FakeMusicElement[] = [];
+    const runtime = new MusicRuntime({
+      nowSeconds: () => now,
+      fadeSeconds: 1,
+      weatherStemGain: 0.25,
+      createAudio: (src) => {
+        const element = new FakeMusicElement();
+        element.src = src;
+        elements.push(element);
+        return element;
+      },
+    });
+
+    expect(runtime.playWeatherStem(WEATHER_MUSIC_STEMS.rain, AUDIO)).toBe(true);
+    expect(runtime.currentWeatherStemId()).toBe("rain");
+    expect(elements).toHaveLength(1);
+    expect(elements[0]?.src).toBe("/audio/weather/rain-loop.opus");
+    expect(elements[0]?.loop).toBe(true);
+    expect(elements[0]?.preload).toBe("auto");
+    expect(elements[0]?.play).toHaveBeenCalledTimes(1);
+    expect(elements[0]?.volume).toBe(0);
+
+    now = 1;
+    runtime.updateWeatherStem(WEATHER_MUSIC_STEMS.rain, AUDIO);
+    expect(elements[0]?.volume).toBeCloseTo(
+      1 * 0.8 * 0.25 * WEATHER_MUSIC_STEMS.rain.volumeScale,
+    );
+  });
+
+  it("crossfades between weather stems and stops cleared weather", () => {
+    let now = 0;
+    const elements: FakeMusicElement[] = [];
+    const runtime = new MusicRuntime({
+      nowSeconds: () => now,
+      fadeSeconds: 1,
+      weatherStemGain: 0.25,
+      createAudio: (src) => {
+        const element = new FakeMusicElement();
+        element.src = src;
+        elements.push(element);
+        return element;
+      },
+    });
+
+    runtime.playWeatherStem(WEATHER_MUSIC_STEMS.rain, AUDIO);
+    now = 1;
+    runtime.updateWeatherStem(WEATHER_MUSIC_STEMS.rain, AUDIO);
+    runtime.playWeatherStem(WEATHER_MUSIC_STEMS.snow, AUDIO);
+
+    expect(elements).toHaveLength(2);
+    expect(runtime.currentWeatherStemId()).toBe("snow");
+    expect(elements[0]?.volume).toBeCloseTo(
+      1 * 0.8 * 0.25 * WEATHER_MUSIC_STEMS.rain.volumeScale,
+    );
+    expect(elements[1]?.volume).toBe(0);
+
+    now = 2;
+    runtime.updateWeatherStem(WEATHER_MUSIC_STEMS.snow, AUDIO);
+    expect(elements[0]?.pause).toHaveBeenCalledTimes(1);
+    expect(elements[0]?.volume).toBe(0);
+    expect(elements[1]?.volume).toBeCloseTo(
+      1 * 0.8 * 0.25 * WEATHER_MUSIC_STEMS.snow.volumeScale,
+    );
+
+    runtime.updateWeatherStem(null, AUDIO);
+    expect(runtime.currentWeatherStemId()).toBeNull();
+    expect(elements[1]?.pause).toHaveBeenCalledTimes(1);
+    expect(elements[1]?.volume).toBe(0);
   });
 });
 

--- a/src/audio/music.ts
+++ b/src/audio/music.ts
@@ -63,8 +63,8 @@ export interface MusicRuntimeOptions {
   readonly fadeSeconds?: number;
 }
 
-interface Channel {
-  readonly cue: MusicCue | WeatherMusicStem;
+interface Channel<Cue extends MusicCue | WeatherMusicStem> {
+  readonly cue: Cue;
   readonly element: MusicAudioElementLike;
   readonly startedAt: number;
   readonly fromVolume: number;
@@ -185,10 +185,10 @@ export function raceMusicIntensity(input: RaceMusicIntensityInput): MusicIntensi
 }
 
 export class MusicRuntime {
-  private active: Channel | null = null;
-  private fadingOut: Channel | null = null;
-  private activeWeatherStem: Channel | null = null;
-  private fadingWeatherStem: Channel | null = null;
+  private active: Channel<MusicCue> | null = null;
+  private fadingOut: Channel<MusicCue> | null = null;
+  private activeWeatherStem: Channel<WeatherMusicStem> | null = null;
+  private fadingWeatherStem: Channel<WeatherMusicStem> | null = null;
   private readonly createAudio: (src: string) => MusicAudioElementLike | null;
   private readonly nowSeconds: () => number;
   private readonly baseGain: number;
@@ -207,17 +207,20 @@ export class MusicRuntime {
   }
 
   currentCueId(): MusicCueId | null {
-    const id = this.active?.cue.id;
-    return isMusicCueId(id) ? id : null;
+    return this.active?.cue.id ?? null;
   }
 
   isPlaying(): boolean {
-    return this.active !== null;
+    return (
+      this.active !== null ||
+      this.fadingOut !== null ||
+      this.activeWeatherStem !== null ||
+      this.fadingWeatherStem !== null
+    );
   }
 
   currentWeatherStemId(): WeatherMusicStemId | null {
-    const id = this.activeWeatherStem?.cue.id;
-    return isWeatherMusicStemId(id) ? id : null;
+    return this.activeWeatherStem?.cue.id ?? null;
   }
 
   play(
@@ -395,7 +398,9 @@ export class MusicRuntime {
     this.fadingWeatherStem = null;
   }
 
-  private stopChannel(channel: Channel | null): void {
+  private stopChannel<Cue extends MusicCue | WeatherMusicStem>(
+    channel: Channel<Cue> | null,
+  ): void {
     if (channel === null) return;
     channel.element.pause();
     channel.element.volume = 0;
@@ -421,29 +426,6 @@ export class MusicRuntime {
       gains.master * gains.music * this.weatherStemGain * stem.volumeScale,
     );
   }
-}
-
-function isWeatherMusicStemId(value: string | undefined): value is WeatherMusicStemId {
-  return (
-    value === "rain" ||
-    value === "heavy_rain" ||
-    value === "fog" ||
-    value === "snow"
-  );
-}
-
-function isMusicCueId(value: string | undefined): value is MusicCueId {
-  return (
-    value === "title" ||
-    value === "velvet-coast" ||
-    value === "iron-borough" ||
-    value === "ember-steppe" ||
-    value === "breakwater-isles" ||
-    value === "glass-ridge" ||
-    value === "neon-meridian" ||
-    value === "moss-frontier" ||
-    value === "crown-circuit"
-  );
 }
 
 function regionMusicCueId(value: string): MusicCueId {

--- a/src/audio/music.ts
+++ b/src/audio/music.ts
@@ -1,4 +1,4 @@
-import type { AudioSettings } from "@/data/schemas";
+import type { AudioSettings, WeatherOption } from "@/data/schemas";
 
 import { isMixerSilent, resolveMixerGains } from "./mixer";
 
@@ -16,6 +16,14 @@ export type MusicCueId =
 export interface MusicCue {
   readonly id: MusicCueId;
   readonly src: string;
+}
+
+export type WeatherMusicStemId = "rain" | "heavy_rain" | "fog" | "snow";
+
+export interface WeatherMusicStem {
+  readonly id: WeatherMusicStemId;
+  readonly src: string;
+  readonly volumeScale: number;
 }
 
 export interface MusicIntensity {
@@ -51,11 +59,12 @@ export interface MusicRuntimeOptions {
   readonly createAudio?: (src: string) => MusicAudioElementLike | null;
   readonly nowSeconds?: () => number;
   readonly baseGain?: number;
+  readonly weatherStemGain?: number;
   readonly fadeSeconds?: number;
 }
 
 interface Channel {
-  readonly cue: MusicCue;
+  readonly cue: MusicCue | WeatherMusicStem;
   readonly element: MusicAudioElementLike;
   readonly startedAt: number;
   readonly fromVolume: number;
@@ -73,6 +82,7 @@ const DEFAULT_INTENSITY: MusicIntensity = Object.freeze({
 });
 
 const DEFAULT_BASE_GAIN = 0.34;
+const DEFAULT_WEATHER_STEM_GAIN = 0.16;
 const DEFAULT_FADE_SECONDS = 0.35;
 
 export const MUSIC_CUES: Readonly<Record<MusicCueId, MusicCue>> = Object.freeze({
@@ -111,6 +121,31 @@ export const MUSIC_CUES: Readonly<Record<MusicCueId, MusicCue>> = Object.freeze(
   },
 });
 
+export const WEATHER_MUSIC_STEMS: Readonly<
+  Record<WeatherMusicStemId, WeatherMusicStem>
+> = Object.freeze({
+  rain: {
+    id: "rain",
+    src: "/audio/weather/rain-loop.opus",
+    volumeScale: 0.86,
+  },
+  heavy_rain: {
+    id: "heavy_rain",
+    src: "/audio/weather/heavy-rain-loop.opus",
+    volumeScale: 1,
+  },
+  fog: {
+    id: "fog",
+    src: "/audio/weather/fog-wind-loop.opus",
+    volumeScale: 0.72,
+  },
+  snow: {
+    id: "snow",
+    src: "/audio/weather/snow-loop.opus",
+    volumeScale: 0.78,
+  },
+});
+
 export function titleMusicCue(): MusicCue {
   return MUSIC_CUES.title;
 }
@@ -118,6 +153,24 @@ export function titleMusicCue(): MusicCue {
 export function raceMusicCue(input: RaceMusicInput): MusicCue {
   const region = regionMusicCueId(input.tourId ?? input.trackId);
   return MUSIC_CUES[region];
+}
+
+export function weatherMusicStem(
+  weather: WeatherOption | null | undefined,
+): WeatherMusicStem | null {
+  switch (weather) {
+    case "light_rain":
+    case "rain":
+      return WEATHER_MUSIC_STEMS.rain;
+    case "heavy_rain":
+      return WEATHER_MUSIC_STEMS.heavy_rain;
+    case "fog":
+      return WEATHER_MUSIC_STEMS.fog;
+    case "snow":
+      return WEATHER_MUSIC_STEMS.snow;
+    default:
+      return null;
+  }
 }
 
 export function raceMusicIntensity(input: RaceMusicIntensityInput): MusicIntensity {
@@ -134,24 +187,37 @@ export function raceMusicIntensity(input: RaceMusicIntensityInput): MusicIntensi
 export class MusicRuntime {
   private active: Channel | null = null;
   private fadingOut: Channel | null = null;
+  private activeWeatherStem: Channel | null = null;
+  private fadingWeatherStem: Channel | null = null;
   private readonly createAudio: (src: string) => MusicAudioElementLike | null;
   private readonly nowSeconds: () => number;
   private readonly baseGain: number;
+  private readonly weatherStemGain: number;
   private readonly fadeSeconds: number;
 
   constructor(options: MusicRuntimeOptions = {}) {
     this.createAudio = options.createAudio ?? browserAudioElementFactory;
     this.nowSeconds = options.nowSeconds ?? defaultNowSeconds;
     this.baseGain = nonNegativeOr(options.baseGain, DEFAULT_BASE_GAIN);
+    this.weatherStemGain = nonNegativeOr(
+      options.weatherStemGain,
+      DEFAULT_WEATHER_STEM_GAIN,
+    );
     this.fadeSeconds = nonNegativeOr(options.fadeSeconds, DEFAULT_FADE_SECONDS);
   }
 
   currentCueId(): MusicCueId | null {
-    return this.active?.cue.id ?? null;
+    const id = this.active?.cue.id;
+    return isMusicCueId(id) ? id : null;
   }
 
   isPlaying(): boolean {
     return this.active !== null;
+  }
+
+  currentWeatherStemId(): WeatherMusicStemId | null {
+    const id = this.activeWeatherStem?.cue.id;
+    return isWeatherMusicStemId(id) ? id : null;
   }
 
   play(
@@ -226,11 +292,107 @@ export class MusicRuntime {
     }
   }
 
+  playWeatherStem(
+    stem: WeatherMusicStem | null,
+    audio: AudioSettings | undefined,
+  ): boolean {
+    const targetVolume = this.effectiveWeatherStemGain(audio, stem);
+    if (stem === null || targetVolume === 0) {
+      this.stopWeatherStem();
+      return false;
+    }
+
+    if (this.activeWeatherStem?.cue.id === stem.id) {
+      this.updateWeatherStem(stem, audio);
+      return true;
+    }
+
+    const element = this.createAudio(stem.src);
+    if (element === null) return false;
+
+    const now = this.nowSeconds();
+    if (this.activeWeatherStem !== null) {
+      this.stopChannel(this.fadingWeatherStem);
+      this.fadingWeatherStem = {
+        ...this.activeWeatherStem,
+        startedAt: now,
+        fromVolume: this.activeWeatherStem.element.volume,
+      };
+    }
+
+    element.src = stem.src;
+    element.loop = true;
+    element.preload = "auto";
+    element.currentTime = 0;
+    element.volume = 0;
+    element.playbackRate = 1;
+    this.activeWeatherStem = { cue: stem, element, startedAt: now, fromVolume: 0 };
+    void Promise.resolve(element.play()).catch(() => {
+      if (this.activeWeatherStem?.element === element) {
+        this.activeWeatherStem = null;
+      }
+      this.stopChannel({ cue: stem, element, startedAt: now, fromVolume: 0 });
+    });
+    this.updateWeatherStem(stem, audio);
+    return true;
+  }
+
+  updateWeatherStem(
+    stem: WeatherMusicStem | null,
+    audio: AudioSettings | undefined,
+  ): void {
+    const now = this.nowSeconds();
+    const targetVolume = this.effectiveWeatherStemGain(audio, stem);
+
+    if (stem === null || targetVolume === 0) {
+      this.stopWeatherStem();
+      return;
+    }
+
+    if (this.activeWeatherStem === null || this.activeWeatherStem.cue.id !== stem.id) {
+      this.playWeatherStem(stem, audio);
+      return;
+    }
+
+    const fade = fadeProgress(
+      now,
+      this.activeWeatherStem.startedAt,
+      this.fadeSeconds,
+    );
+    this.activeWeatherStem.element.volume = targetVolume * fade;
+    this.activeWeatherStem.element.playbackRate = 1;
+
+    if (this.fadingWeatherStem !== null) {
+      const fadeOut = fadeProgress(
+        now,
+        this.fadingWeatherStem.startedAt,
+        this.fadeSeconds,
+      );
+      this.fadingWeatherStem.element.volume =
+        this.fadingWeatherStem.fromVolume * (1 - fadeOut);
+      if (fadeOut >= 1) {
+        this.stopChannel(this.fadingWeatherStem);
+        this.fadingWeatherStem = null;
+      }
+    }
+  }
+
   stop(): void {
     this.stopChannel(this.active);
     this.stopChannel(this.fadingOut);
+    this.stopChannel(this.activeWeatherStem);
+    this.stopChannel(this.fadingWeatherStem);
     this.active = null;
     this.fadingOut = null;
+    this.activeWeatherStem = null;
+    this.fadingWeatherStem = null;
+  }
+
+  stopWeatherStem(): void {
+    this.stopChannel(this.activeWeatherStem);
+    this.stopChannel(this.fadingWeatherStem);
+    this.activeWeatherStem = null;
+    this.fadingWeatherStem = null;
   }
 
   private stopChannel(channel: Channel | null): void {
@@ -247,6 +409,41 @@ export class MusicRuntime {
     if (gains === null || isMixerSilent(gains) || gains.music === 0) return 0;
     return clamp01(gains.master * gains.music * this.baseGain * intensity.volumeScale);
   }
+
+  private effectiveWeatherStemGain(
+    audio: AudioSettings | undefined,
+    stem: WeatherMusicStem | null,
+  ): number {
+    if (stem === null) return 0;
+    const gains = resolveMixerGains(audio ?? SILENT_AUDIO);
+    if (gains === null || isMixerSilent(gains) || gains.music === 0) return 0;
+    return clamp01(
+      gains.master * gains.music * this.weatherStemGain * stem.volumeScale,
+    );
+  }
+}
+
+function isWeatherMusicStemId(value: string | undefined): value is WeatherMusicStemId {
+  return (
+    value === "rain" ||
+    value === "heavy_rain" ||
+    value === "fog" ||
+    value === "snow"
+  );
+}
+
+function isMusicCueId(value: string | undefined): value is MusicCueId {
+  return (
+    value === "title" ||
+    value === "velvet-coast" ||
+    value === "iron-borough" ||
+    value === "ember-steppe" ||
+    value === "breakwater-isles" ||
+    value === "glass-ridge" ||
+    value === "neon-meridian" ||
+    value === "moss-frontier" ||
+    value === "crown-circuit"
+  );
 }
 
 function regionMusicCueId(value: string): MusicCueId {


### PR DESCRIPTION
## Summary
- maps race weather to the shipped rain, heavy rain, fog, and snow audio loops
- adds a second fading channel in `MusicRuntime` for weather stems on the music bus
- updates the race page to start and update weather stems from live session weather

## GDD
- §18 Sound and music design: dynamic audio layers and region weather stem option
- §14 Weather and environmental systems: weather states
- §21 Technical design for web implementation: audio runtime

## Progress log
- `docs/PROGRESS_LOG.md`: 2026-04-29 Slice: Weather music stems

## Test plan
- `npx vitest run src/audio/music.test.ts`
- `npm run typecheck`
- `npm run verify`
- `npm run test:e2e`

## Followups
- True 2 to 3 intensity stem layering remains under `VibeGear2-implement-sound-music-1611f9dd`.
