### PR TITLE
feat(audio): mix music intensity stems

### DIFF
--- a/docs/GDD_COVERAGE.json
+++ b/docs/GDD_COVERAGE.json
@@ -154,6 +154,18 @@
       "followupRefs": ["VibeGear2-implement-sound-music-1611f9dd"]
     },
     {
+      "id": "GDD-18-MUSIC-INTENSITY-STEM-RUNTIME",
+      "gddSections": [
+        "docs/gdd/18-sound-and-music-design.md",
+        "docs/gdd/21-technical-design-for-web-implementation.md"
+      ],
+      "requirement": "Race music runtime mixes the regional base groove with drive and lead intensity stem loops, fading those stems from speed, nitro, and final-lap race pressure.",
+      "coverage": ["implemented-code", "automated-test"],
+      "implementationRefs": ["src/audio/music.ts", "src/app/race/page.tsx"],
+      "testRefs": ["src/audio/music.test.ts"],
+      "followupRefs": ["VibeGear2-implement-sound-music-1611f9dd"]
+    },
+    {
       "id": "GDD-06-DAILY-CHALLENGE-SELECTION",
       "gddSections": [
         "docs/gdd/06-game-modes.md",

--- a/docs/PROGRESS_LOG.md
+++ b/docs/PROGRESS_LOG.md
@@ -6,6 +6,54 @@ Correct them by adding a new entry that references the old one.
 
 ---
 
+## 2026-04-29: Slice: Music intensity stem runtime
+
+**GDD sections touched:**
+[§18](gdd/18-sound-and-music-design.md) race music intensity layers,
+[§21](gdd/21-technical-design-for-web-implementation.md) audio
+runtime.
+**Branch / PR:** `feat/music-intensity-stem-runtime`, PR pending.
+**Status:** Implemented.
+
+### Done
+- `src/audio/music.ts`: added drive and lead stem metadata for every
+  race cue and extended race music intensity with per-layer mix values
+  driven by speed, nitro, and final-lap pressure.
+- `src/audio/music.ts`: extended `MusicRuntime` to start, update, fade,
+  and stop the regional drive and lead stems alongside the base race
+  music cue.
+- `src/audio/music.test.ts`: covers intensity stem mapping, mix
+  pressure, playback volumes, playback rate sync, and fade-out.
+- `docs/GDD_COVERAGE.json`: added
+  GDD-18-MUSIC-INTENSITY-STEM-RUNTIME.
+
+### Verified
+- `npx vitest run src/audio/music.test.ts` green, 16 passed.
+- `npm run typecheck` green.
+- `npx vitest run src/audio/music.test.ts scripts/__tests__/content-lint.test.ts`
+  green, 70 passed.
+- `npm run verify` green, 2514 passed.
+- `npm run test:e2e` green, 79 passed.
+
+### Decisions and assumptions
+- The shipped regional loop is the base groove. Drive and lead are the
+  second and third layers, which satisfies the §18 2 to 3 intensity
+  layer requirement without adding a fourth live race music bus.
+- Intensity stems follow the base race cue playback rate so nitro and
+  final-lap pressure stay phase-compatible with the main loop.
+
+### Coverage ledger
+- GDD-18-MUSIC-INTENSITY-STEM-RUNTIME covers runtime mixing for the
+  required 2 to 3 race music intensity layers.
+- Uncovered adjacent requirements: none for §18 sound and music known
+  after this slice.
+
+### Followups created
+None.
+
+### GDD edits
+None.
+
 ## 2026-04-29: Slice: Music intensity stem assets
 
 **GDD sections touched:**

--- a/docs/PROGRESS_LOG.md
+++ b/docs/PROGRESS_LOG.md
@@ -12,7 +12,7 @@ Correct them by adding a new entry that references the old one.
 [§18](gdd/18-sound-and-music-design.md) race music intensity layers,
 [§21](gdd/21-technical-design-for-web-implementation.md) audio
 runtime.
-**Branch / PR:** `feat/music-intensity-stem-runtime`, PR pending.
+**Branch / PR:** `feat/music-intensity-stem-runtime`, PR #90.
 **Status:** Implemented.
 
 ### Done

--- a/docs/PROGRESS_LOG.md
+++ b/docs/PROGRESS_LOG.md
@@ -23,16 +23,17 @@ runtime.
   and stop the regional drive and lead stems alongside the base race
   music cue.
 - `src/audio/music.test.ts`: covers intensity stem mapping, mix
-  pressure, playback volumes, playback rate sync, and fade-out.
+  pressure, playback volumes, playback rate sync, phase alignment,
+  base-cue failure cleanup, and fade-out.
 - `docs/GDD_COVERAGE.json`: added
   GDD-18-MUSIC-INTENSITY-STEM-RUNTIME.
 
 ### Verified
-- `npx vitest run src/audio/music.test.ts` green, 16 passed.
+- `npx vitest run src/audio/music.test.ts` green, 18 passed.
 - `npm run typecheck` green.
 - `npx vitest run src/audio/music.test.ts scripts/__tests__/content-lint.test.ts`
-  green, 70 passed.
-- `npm run verify` green, 2514 passed.
+  green, 72 passed.
+- `npm run verify` green, 2516 passed.
 - `npm run test:e2e` green, 79 passed.
 
 ### Decisions and assumptions
@@ -41,6 +42,9 @@ runtime.
   layer requirement without adding a fourth live race music bus.
 - Intensity stems follow the base race cue playback rate so nitro and
   final-lap pressure stay phase-compatible with the main loop.
+- New stems start at the active base cue playback time and resync if
+  drift exceeds a small threshold. If the base cue fails to play, all
+  intensity stems stop with it so no orphaned loop remains.
 
 ### Coverage ledger
 - GDD-18-MUSIC-INTENSITY-STEM-RUNTIME covers runtime mixing for the

--- a/src/audio/music.test.ts
+++ b/src/audio/music.test.ts
@@ -322,6 +322,65 @@ describe("MusicRuntime", () => {
     expect(elements[2]?.playbackRate).toBe(1.03);
   });
 
+  it("aligns new intensity stems to the active base cue time", () => {
+    let now = 0;
+    const elements: FakeMusicElement[] = [];
+    const runtime = new MusicRuntime({
+      nowSeconds: () => now,
+      fadeSeconds: 1,
+      createAudio: (src) => {
+        const element = new FakeMusicElement();
+        element.src = src;
+        elements.push(element);
+        return element;
+      },
+    });
+    const quiet = {
+      volumeScale: 1,
+      playbackRate: 1,
+      layerMix: { drive: 0, lead: 0 },
+    };
+    const active = {
+      volumeScale: 1,
+      playbackRate: 1,
+      layerMix: { drive: 1, lead: 0 },
+    };
+
+    runtime.play(MUSIC_CUES["velvet-coast"], AUDIO, quiet);
+    elements[0]!.currentTime = 12.5;
+    now = 1;
+    runtime.update(AUDIO, active);
+
+    expect(elements[1]?.currentTime).toBe(12.5);
+  });
+
+  it("stops intensity stems when the base cue play fails", async () => {
+    const elements: FakeMusicElement[] = [];
+    const runtime = new MusicRuntime({
+      createAudio: (src) => {
+        const element =
+          elements.length === 0
+            ? new FakeMusicElement(() => Promise.reject(new Error("play failed")))
+            : new FakeMusicElement();
+        element.src = src;
+        elements.push(element);
+        return element;
+      },
+    });
+    const intensity = {
+      volumeScale: 1,
+      playbackRate: 1,
+      layerMix: { drive: 1, lead: 1 },
+    };
+
+    expect(runtime.play(MUSIC_CUES["velvet-coast"], AUDIO, intensity)).toBe(true);
+    await vi.waitFor(() => expect(runtime.currentCueId()).toBeNull());
+
+    expect(runtime.currentIntensityStemIds()).toEqual([]);
+    expect(elements[1]?.pause).toHaveBeenCalledTimes(1);
+    expect(elements[2]?.pause).toHaveBeenCalledTimes(1);
+  });
+
   it("fades intensity stems out when the mix clears", () => {
     let now = 0;
     const elements: FakeMusicElement[] = [];
@@ -362,12 +421,14 @@ describe("MusicRuntime", () => {
 });
 
 class FakeMusicElement implements MusicAudioElementLike {
+  constructor(private readonly playImpl = () => Promise.resolve()) {}
+
   src = "";
   loop = false;
   preload = "";
   volume = 0;
   playbackRate = 1;
   currentTime = 0;
-  readonly play = vi.fn(() => Promise.resolve());
+  readonly play = vi.fn(() => this.playImpl());
   readonly pause = vi.fn(() => undefined);
 }

--- a/src/audio/music.test.ts
+++ b/src/audio/music.test.ts
@@ -2,8 +2,10 @@ import { describe, expect, it, vi } from "vitest";
 
 import {
   MUSIC_CUES,
+  MUSIC_INTENSITY_STEMS,
   MusicRuntime,
   WEATHER_MUSIC_STEMS,
+  musicIntensityStemsFor,
   raceMusicCue,
   raceMusicIntensity,
   titleMusicCue,
@@ -42,6 +44,14 @@ describe("music cues", () => {
     expect(weatherMusicStem("fog")).toEqual(WEATHER_MUSIC_STEMS.fog);
     expect(weatherMusicStem("snow")).toEqual(WEATHER_MUSIC_STEMS.snow);
   });
+
+  it("maps race cues to drive and lead intensity stems", () => {
+    expect(musicIntensityStemsFor("title")).toEqual([]);
+    expect(musicIntensityStemsFor("velvet-coast")).toEqual([
+      MUSIC_INTENSITY_STEMS["velvet-coast"].drive,
+      MUSIC_INTENSITY_STEMS["velvet-coast"].lead,
+    ]);
+  });
 });
 
 describe("raceMusicIntensity", () => {
@@ -64,6 +74,22 @@ describe("raceMusicIntensity", () => {
 
     expect(escalated.volumeScale).toBeGreaterThan(baseline.volumeScale);
     expect(escalated.playbackRate).toBeGreaterThan(baseline.playbackRate);
+  });
+
+  it("raises intensity stem mix as race pressure increases", () => {
+    const idle = raceMusicIntensity({ speed: 0, topSpeed: 60 });
+    const fast = raceMusicIntensity({ speed: 55, topSpeed: 60 });
+    const finalLap = raceMusicIntensity({
+      speed: 55,
+      topSpeed: 60,
+      finalLap: true,
+    });
+
+    expect(idle.layerMix.drive).toBe(0);
+    expect(idle.layerMix.lead).toBe(0);
+    expect(fast.layerMix.drive).toBeGreaterThan(0);
+    expect(fast.layerMix.lead).toBeGreaterThan(0);
+    expect(finalLap.layerMix.lead).toBeGreaterThanOrEqual(fast.layerMix.lead);
   });
 });
 
@@ -180,6 +206,7 @@ describe("MusicRuntime", () => {
     runtime.play(MUSIC_CUES.title, AUDIO, {
       volumeScale: 1,
       playbackRate: 1.04,
+      layerMix: { drive: 0, lead: 0 },
     });
 
     expect(element.playbackRate).toBe(1.04);
@@ -256,6 +283,81 @@ describe("MusicRuntime", () => {
     expect(runtime.currentWeatherStemId()).toBeNull();
     expect(elements[1]?.pause).toHaveBeenCalledTimes(1);
     expect(elements[1]?.volume).toBe(0);
+  });
+
+  it("layers race intensity stems through the music bus", () => {
+    let now = 0;
+    const elements: FakeMusicElement[] = [];
+    const runtime = new MusicRuntime({
+      nowSeconds: () => now,
+      fadeSeconds: 1,
+      baseGain: 0.5,
+      createAudio: (src) => {
+        const element = new FakeMusicElement();
+        element.src = src;
+        elements.push(element);
+        return element;
+      },
+    });
+    const intensity = {
+      volumeScale: 1,
+      playbackRate: 1.03,
+      layerMix: { drive: 0.75, lead: 0.5 },
+    };
+
+    expect(runtime.play(MUSIC_CUES["velvet-coast"], AUDIO, intensity)).toBe(true);
+    expect(elements).toHaveLength(3);
+    expect(elements[1]?.src).toBe("/audio/music/stems/velvet-coast-drive.opus");
+    expect(elements[2]?.src).toBe("/audio/music/stems/velvet-coast-lead.opus");
+    expect(runtime.currentIntensityStemIds()).toEqual([
+      "velvet-coast:drive",
+      "velvet-coast:lead",
+    ]);
+
+    now = 1;
+    runtime.update(AUDIO, intensity);
+    expect(elements[1]?.volume).toBeCloseTo(1 * 0.8 * 0.5 * 0.58 * 0.75);
+    expect(elements[2]?.volume).toBeCloseTo(1 * 0.8 * 0.5 * 0.5 * 0.5);
+    expect(elements[1]?.playbackRate).toBe(1.03);
+    expect(elements[2]?.playbackRate).toBe(1.03);
+  });
+
+  it("fades intensity stems out when the mix clears", () => {
+    let now = 0;
+    const elements: FakeMusicElement[] = [];
+    const runtime = new MusicRuntime({
+      nowSeconds: () => now,
+      fadeSeconds: 1,
+      baseGain: 0.5,
+      createAudio: (src) => {
+        const element = new FakeMusicElement();
+        element.src = src;
+        elements.push(element);
+        return element;
+      },
+    });
+    const active = {
+      volumeScale: 1,
+      playbackRate: 1,
+      layerMix: { drive: 1, lead: 1 },
+    };
+    const quiet = {
+      volumeScale: 1,
+      playbackRate: 1,
+      layerMix: { drive: 0, lead: 0 },
+    };
+
+    runtime.play(MUSIC_CUES["velvet-coast"], AUDIO, active);
+    now = 1;
+    runtime.update(AUDIO, active);
+    runtime.update(AUDIO, quiet);
+    expect(runtime.currentIntensityStemIds()).toEqual([]);
+    expect(elements[1]?.volume).toBeCloseTo(1 * 0.8 * 0.5 * 0.58);
+
+    now = 2;
+    runtime.update(AUDIO, quiet);
+    expect(elements[1]?.pause).toHaveBeenCalledTimes(1);
+    expect(elements[2]?.pause).toHaveBeenCalledTimes(1);
   });
 });
 

--- a/src/audio/music.ts
+++ b/src/audio/music.ts
@@ -322,7 +322,10 @@ export class MusicRuntime {
     element.playbackRate = intensity.playbackRate;
     this.active = { cue, element, startedAt: now, fromVolume: 0 };
     void Promise.resolve(element.play()).catch(() => {
-      if (this.active?.element === element) this.active = null;
+      if (this.active?.element === element) {
+        this.active = null;
+        this.stopIntensityStems();
+      }
       this.stopChannel({ cue, element, startedAt: now, fromVolume: 0 });
     });
     this.update(audio, intensity);
@@ -515,7 +518,7 @@ export class MusicRuntime {
           element.src = stem.src;
           element.loop = true;
           element.preload = "auto";
-          element.currentTime = 0;
+          element.currentTime = this.active?.element.currentTime ?? 0;
           element.volume = 0;
           element.playbackRate = intensity.playbackRate;
           this.activeIntensityStems[layer] = {
@@ -536,6 +539,7 @@ export class MusicRuntime {
       const nextActive = this.activeIntensityStems[layer];
       if (nextActive !== undefined) {
         const fade = fadeProgress(now, nextActive.startedAt, this.fadeSeconds);
+        this.syncIntensityStemPlayback(nextActive);
         nextActive.element.volume = targetVolume * fade;
         nextActive.element.playbackRate = intensity.playbackRate;
       }
@@ -549,6 +553,14 @@ export class MusicRuntime {
           delete this.fadingIntensityStems[layer];
         }
       }
+    }
+  }
+
+  private syncIntensityStemPlayback(channel: Channel<MusicIntensityStem>): void {
+    const baseTime = this.active?.element.currentTime;
+    if (baseTime === undefined) return;
+    if (Math.abs(channel.element.currentTime - baseTime) > 0.08) {
+      channel.element.currentTime = baseTime;
     }
   }
 

--- a/src/audio/music.ts
+++ b/src/audio/music.ts
@@ -26,9 +26,22 @@ export interface WeatherMusicStem {
   readonly volumeScale: number;
 }
 
+export type MusicIntensityLayerId = "drive" | "lead";
+
+export type RaceMusicCueId = Exclude<MusicCueId, "title">;
+
+export interface MusicIntensityStem {
+  readonly id: string;
+  readonly cueId: RaceMusicCueId;
+  readonly layer: MusicIntensityLayerId;
+  readonly src: string;
+  readonly volumeScale: number;
+}
+
 export interface MusicIntensity {
   readonly volumeScale: number;
   readonly playbackRate: number;
+  readonly layerMix: Readonly<Record<MusicIntensityLayerId, number>>;
 }
 
 export interface RaceMusicInput {
@@ -63,7 +76,7 @@ export interface MusicRuntimeOptions {
   readonly fadeSeconds?: number;
 }
 
-interface Channel<Cue extends MusicCue | WeatherMusicStem> {
+interface Channel<Cue extends MusicCue | WeatherMusicStem | MusicIntensityStem> {
   readonly cue: Cue;
   readonly element: MusicAudioElementLike;
   readonly startedAt: number;
@@ -79,11 +92,19 @@ const SILENT_AUDIO: AudioSettings = Object.freeze({
 const DEFAULT_INTENSITY: MusicIntensity = Object.freeze({
   volumeScale: 1,
   playbackRate: 1,
+  layerMix: Object.freeze({
+    drive: 0,
+    lead: 0,
+  }),
 });
 
 const DEFAULT_BASE_GAIN = 0.34;
 const DEFAULT_WEATHER_STEM_GAIN = 0.16;
 const DEFAULT_FADE_SECONDS = 0.35;
+const MUSIC_INTENSITY_LAYER_IDS: readonly MusicIntensityLayerId[] = [
+  "drive",
+  "lead",
+];
 
 export const MUSIC_CUES: Readonly<Record<MusicCueId, MusicCue>> = Object.freeze({
   title: { id: "title", src: "/audio/music/title.opus" },
@@ -146,6 +167,19 @@ export const WEATHER_MUSIC_STEMS: Readonly<
   },
 });
 
+export const MUSIC_INTENSITY_STEMS: Readonly<
+  Record<RaceMusicCueId, Readonly<Record<MusicIntensityLayerId, MusicIntensityStem>>>
+> = Object.freeze({
+  "velvet-coast": musicIntensityStemSet("velvet-coast"),
+  "iron-borough": musicIntensityStemSet("iron-borough"),
+  "ember-steppe": musicIntensityStemSet("ember-steppe"),
+  "breakwater-isles": musicIntensityStemSet("breakwater-isles"),
+  "glass-ridge": musicIntensityStemSet("glass-ridge"),
+  "neon-meridian": musicIntensityStemSet("neon-meridian"),
+  "moss-frontier": musicIntensityStemSet("moss-frontier"),
+  "crown-circuit": musicIntensityStemSet("crown-circuit"),
+});
+
 export function titleMusicCue(): MusicCue {
   return MUSIC_CUES.title;
 }
@@ -173,14 +207,27 @@ export function weatherMusicStem(
   }
 }
 
+export function musicIntensityStemsFor(
+  cueId: MusicCueId,
+): readonly MusicIntensityStem[] {
+  if (cueId === "title") return [];
+  return MUSIC_INTENSITY_LAYER_IDS.map((layer) => MUSIC_INTENSITY_STEMS[cueId][layer]);
+}
+
 export function raceMusicIntensity(input: RaceMusicIntensityInput): MusicIntensity {
   const speedScalar = clampUnit(input.speed / Math.max(1, input.topSpeed));
   const nitro = input.nitroActive ? 1 : 0;
   const finalLap = input.finalLap ? 1 : 0;
   const timeTrialTrim = input.nitroActive === undefined ? -0.04 : 0;
+  const driveMix = clamp01((speedScalar - 0.28) / 0.42 + nitro * 0.24 + finalLap * 0.1);
+  const leadMix = clamp01((speedScalar - 0.68) / 0.32 + nitro * 0.36 + finalLap * 0.24);
   return {
     volumeScale: clamp(0.76 + speedScalar * 0.2 + nitro * 0.07 + finalLap * 0.06, 0, 1.12),
     playbackRate: clamp(0.98 + speedScalar * 0.035 + nitro * 0.025 + finalLap * 0.015 + timeTrialTrim, 0.92, 1.08),
+    layerMix: {
+      drive: driveMix,
+      lead: leadMix,
+    },
   };
 }
 
@@ -189,6 +236,12 @@ export class MusicRuntime {
   private fadingOut: Channel<MusicCue> | null = null;
   private activeWeatherStem: Channel<WeatherMusicStem> | null = null;
   private fadingWeatherStem: Channel<WeatherMusicStem> | null = null;
+  private activeIntensityStems: Partial<
+    Record<MusicIntensityLayerId, Channel<MusicIntensityStem>>
+  > = {};
+  private fadingIntensityStems: Partial<
+    Record<MusicIntensityLayerId, Channel<MusicIntensityStem>>
+  > = {};
   private readonly createAudio: (src: string) => MusicAudioElementLike | null;
   private readonly nowSeconds: () => number;
   private readonly baseGain: number;
@@ -215,12 +268,21 @@ export class MusicRuntime {
       this.active !== null ||
       this.fadingOut !== null ||
       this.activeWeatherStem !== null ||
-      this.fadingWeatherStem !== null
+      this.fadingWeatherStem !== null ||
+      hasAnyStem(this.activeIntensityStems) ||
+      hasAnyStem(this.fadingIntensityStems)
     );
   }
 
   currentWeatherStemId(): WeatherMusicStemId | null {
     return this.activeWeatherStem?.cue.id ?? null;
+  }
+
+  currentIntensityStemIds(): readonly string[] {
+    return MUSIC_INTENSITY_LAYER_IDS.flatMap((layer) => {
+      const stem = this.activeIntensityStems[layer];
+      return stem === undefined ? [] : [stem.cue.id];
+    });
   }
 
   play(
@@ -292,6 +354,10 @@ export class MusicRuntime {
         this.stopChannel(this.fadingOut);
         this.fadingOut = null;
       }
+    }
+
+    if (this.active !== null) {
+      this.updateIntensityStems(this.active.cue.id, audio, intensity);
     }
   }
 
@@ -385,6 +451,7 @@ export class MusicRuntime {
     this.stopChannel(this.fadingOut);
     this.stopChannel(this.activeWeatherStem);
     this.stopChannel(this.fadingWeatherStem);
+    this.stopIntensityStems();
     this.active = null;
     this.fadingOut = null;
     this.activeWeatherStem = null;
@@ -398,12 +465,91 @@ export class MusicRuntime {
     this.fadingWeatherStem = null;
   }
 
-  private stopChannel<Cue extends MusicCue | WeatherMusicStem>(
+  private stopChannel<Cue extends MusicCue | WeatherMusicStem | MusicIntensityStem>(
     channel: Channel<Cue> | null,
   ): void {
     if (channel === null) return;
     channel.element.pause();
     channel.element.volume = 0;
+  }
+
+  private stopIntensityStems(): void {
+    for (const layer of MUSIC_INTENSITY_LAYER_IDS) {
+      this.stopChannel(this.activeIntensityStems[layer] ?? null);
+      this.stopChannel(this.fadingIntensityStems[layer] ?? null);
+    }
+    this.activeIntensityStems = {};
+    this.fadingIntensityStems = {};
+  }
+
+  private fadeOutIntensityStem(layer: MusicIntensityLayerId, now: number): void {
+    const active = this.activeIntensityStems[layer];
+    if (active === undefined) return;
+    this.stopChannel(this.fadingIntensityStems[layer] ?? null);
+    this.fadingIntensityStems[layer] = {
+      ...active,
+      startedAt: now,
+      fromVolume: active.element.volume,
+    };
+    delete this.activeIntensityStems[layer];
+  }
+
+  private updateIntensityStems(
+    cueId: MusicCueId,
+    audio: AudioSettings | undefined,
+    intensity: MusicIntensity,
+  ): void {
+    const now = this.nowSeconds();
+    const stems = musicIntensityStemsFor(cueId);
+    for (const layer of MUSIC_INTENSITY_LAYER_IDS) {
+      const stem = stems.find((item) => item.layer === layer) ?? null;
+      const targetVolume = this.effectiveIntensityStemGain(audio, stem, intensity);
+      const active = this.activeIntensityStems[layer];
+
+      if (stem === null || targetVolume === 0) {
+        this.fadeOutIntensityStem(layer, now);
+      } else if (active === undefined || active.cue.id !== stem.id) {
+        const element = this.createAudio(stem.src);
+        if (element !== null) {
+          this.fadeOutIntensityStem(layer, now);
+          element.src = stem.src;
+          element.loop = true;
+          element.preload = "auto";
+          element.currentTime = 0;
+          element.volume = 0;
+          element.playbackRate = intensity.playbackRate;
+          this.activeIntensityStems[layer] = {
+            cue: stem,
+            element,
+            startedAt: now,
+            fromVolume: 0,
+          };
+          void Promise.resolve(element.play()).catch(() => {
+            if (this.activeIntensityStems[layer]?.element === element) {
+              delete this.activeIntensityStems[layer];
+            }
+            this.stopChannel({ cue: stem, element, startedAt: now, fromVolume: 0 });
+          });
+        }
+      }
+
+      const nextActive = this.activeIntensityStems[layer];
+      if (nextActive !== undefined) {
+        const fade = fadeProgress(now, nextActive.startedAt, this.fadeSeconds);
+        nextActive.element.volume = targetVolume * fade;
+        nextActive.element.playbackRate = intensity.playbackRate;
+      }
+
+      const fading = this.fadingIntensityStems[layer];
+      if (fading !== undefined) {
+        const fade = fadeProgress(now, fading.startedAt, this.fadeSeconds);
+        fading.element.volume = fading.fromVolume * (1 - fade);
+        if (fade >= 1) {
+          this.stopChannel(fading);
+          delete this.fadingIntensityStems[layer];
+        }
+      }
+    }
   }
 
   private effectiveGain(
@@ -426,6 +572,50 @@ export class MusicRuntime {
       gains.master * gains.music * this.weatherStemGain * stem.volumeScale,
     );
   }
+
+  private effectiveIntensityStemGain(
+    audio: AudioSettings | undefined,
+    stem: MusicIntensityStem | null,
+    intensity: MusicIntensity,
+  ): number {
+    if (stem === null) return 0;
+    const gains = resolveMixerGains(audio ?? SILENT_AUDIO);
+    if (gains === null || isMixerSilent(gains) || gains.music === 0) return 0;
+    return clamp01(
+      gains.master *
+        gains.music *
+        this.baseGain *
+        stem.volumeScale *
+        intensity.layerMix[stem.layer],
+    );
+  }
+}
+
+function musicIntensityStemSet(
+  cueId: RaceMusicCueId,
+): Readonly<Record<MusicIntensityLayerId, MusicIntensityStem>> {
+  return Object.freeze({
+    drive: {
+      id: `${cueId}:drive`,
+      cueId,
+      layer: "drive",
+      src: `/audio/music/stems/${cueId}-drive.opus`,
+      volumeScale: 0.58,
+    },
+    lead: {
+      id: `${cueId}:lead`,
+      cueId,
+      layer: "lead",
+      src: `/audio/music/stems/${cueId}-lead.opus`,
+      volumeScale: 0.5,
+    },
+  });
+}
+
+function hasAnyStem(
+  stems: Partial<Record<MusicIntensityLayerId, Channel<MusicIntensityStem>>>,
+): boolean {
+  return MUSIC_INTENSITY_LAYER_IDS.some((layer) => stems[layer] !== undefined);
 }
 
 function regionMusicCueId(value: string): MusicCueId {


### PR DESCRIPTION
## Summary
- maps each race cue to generated drive and lead stem assets
- extends race music intensity with drive and lead mix levels from speed, nitro, and final lap pressure
- updates `MusicRuntime` to start, update, fade, and stop regional intensity stems with the base cue

## GDD
- §18 Sound and music design: race music 2 to 3 intensity layers
- §21 Technical design for web implementation: audio runtime

## Progress log
- `docs/PROGRESS_LOG.md`: 2026-04-29 Slice: Music intensity stem runtime

## Test plan
- `npx vitest run src/audio/music.test.ts`
- `npm run typecheck`
- `npx vitest run src/audio/music.test.ts scripts/__tests__/content-lint.test.ts`
- `npm run verify`
- `npm run test:e2e`

## Followups
- None.
