### PR TITLE
docs(render): close visual polish coverage

### DIFF
--- a/docs/GDD_COVERAGE.json
+++ b/docs/GDD_COVERAGE.json
@@ -1094,6 +1094,44 @@
       "followupRefs": ["F-052"]
     },
     {
+      "id": "GDD-16-VFX-FLASH-SHAKE",
+      "gddSections": [
+        "docs/gdd/16-rendering-and-visual-design.md",
+        "docs/gdd/19-controls-and-input.md",
+        "docs/gdd/21-technical-design-for-web-implementation.md"
+      ],
+      "requirement": "Race rendering supports deterministic flash and light camera-shake VFX with a reduced-motion gate for shake.",
+      "coverage": ["implemented-code", "automated-test"],
+      "implementationRefs": [
+        "src/render/vfx.ts",
+        "src/render/pseudoRoadCanvas.ts"
+      ],
+      "testRefs": [
+        "src/render/__tests__/vfx.test.ts",
+        "src/render/__tests__/pseudoRoadCanvas.test.ts"
+      ],
+      "followupRefs": ["VibeGear2-implement-visual-polish-7d31d112"]
+    },
+    {
+      "id": "GDD-16-OFF-ROAD-DUST",
+      "gddSections": [
+        "docs/gdd/10-driving-model-and-physics.md",
+        "docs/gdd/16-rendering-and-visual-design.md",
+        "docs/gdd/21-technical-design-for-web-implementation.md"
+      ],
+      "requirement": "Off-road driving can emit bounded deterministic dust particles from player surface and speed state, and the road renderer can draw the dust pool over road strips.",
+      "coverage": ["implemented-code", "automated-test"],
+      "implementationRefs": [
+        "src/render/dust.ts",
+        "src/render/pseudoRoadCanvas.ts"
+      ],
+      "testRefs": [
+        "src/render/__tests__/dust.test.ts",
+        "src/render/__tests__/pseudoRoadCanvas.test.ts"
+      ],
+      "followupRefs": ["VibeGear2-implement-visual-polish-7d31d112"]
+    },
+    {
       "id": "GDD-25-LOOP-COVERAGE-LEDGER",
       "gddSections": [
         "docs/IMPLEMENTATION_PLAN.md",

--- a/docs/PROGRESS_LOG.md
+++ b/docs/PROGRESS_LOG.md
@@ -22,9 +22,9 @@ rendering.
   already landed deterministic flash and shake renderer path.
 - `docs/GDD_COVERAGE.json`: added GDD-16-OFF-ROAD-DUST for the
   already landed bounded dust particle pool and draw integration.
-- Confirmed the visual-polish parent dot's sprite atlas, parallax,
-  VFX, dust, and render benchmark scope has implementation and tests
-  on `main`.
+- Confirmed `main` already has implementations and tests for the
+  visual-polish parent dot's sprite atlas, parallax, VFX, dust, and
+  render benchmark scope.
 
 ### Verified
 - `npx vitest run scripts/__tests__/content-lint.test.ts` green.

--- a/docs/PROGRESS_LOG.md
+++ b/docs/PROGRESS_LOG.md
@@ -6,6 +6,52 @@ Correct them by adding a new entry that references the old one.
 
 ---
 
+## 2026-04-29: Slice: Visual polish coverage closeout
+
+**GDD sections touched:**
+[§10](gdd/10-driving-model-and-physics.md) off-road feedback,
+[§16](gdd/16-rendering-and-visual-design.md) VFX and dust,
+[§19](gdd/19-controls-and-input.md) reduced motion,
+[§21](gdd/21-technical-design-for-web-implementation.md) deterministic
+rendering.
+**Branch / PR:** `docs/visual-polish-coverage`, PR pending.
+**Status:** Implemented.
+
+### Done
+- `docs/GDD_COVERAGE.json`: added GDD-16-VFX-FLASH-SHAKE for the
+  already landed deterministic flash and shake renderer path.
+- `docs/GDD_COVERAGE.json`: added GDD-16-OFF-ROAD-DUST for the
+  already landed bounded dust particle pool and draw integration.
+- Confirmed the visual-polish parent dot's sprite atlas, parallax,
+  VFX, dust, and render benchmark scope has implementation and tests
+  on `main`.
+
+### Verified
+- `npx vitest run scripts/__tests__/content-lint.test.ts` green.
+- `node -e "JSON.parse(require('fs').readFileSync('docs/GDD_COVERAGE.json','utf8'))"`
+  green.
+
+### Decisions and assumptions
+- This is a docs and task-ledger closeout slice. No runtime code changed
+  because the relevant render modules and tests were already present.
+- Region art theming and car FX sprite variants remain separate ready
+  backlog dots because they are broader than the visual-polish parent
+  slice described here.
+
+### Coverage ledger
+- GDD-16-VFX-FLASH-SHAKE covers deterministic flash and light
+  camera-shake VFX with reduced-motion handling.
+- GDD-16-OFF-ROAD-DUST covers deterministic off-road dust emission and
+  draw support.
+- Uncovered adjacent requirements: region art theme registry and car FX
+  sprite variants remain in separate ready dots.
+
+### Followups created
+None.
+
+### GDD edits
+None.
+
 ## 2026-04-29: Slice: Music intensity stem runtime
 
 **GDD sections touched:**

--- a/docs/PROGRESS_LOG.md
+++ b/docs/PROGRESS_LOG.md
@@ -14,7 +14,7 @@ Correct them by adding a new entry that references the old one.
 [§19](gdd/19-controls-and-input.md) reduced motion,
 [§21](gdd/21-technical-design-for-web-implementation.md) deterministic
 rendering.
-**Branch / PR:** `docs/visual-polish-coverage`, PR pending.
+**Branch / PR:** `docs/visual-polish-coverage`, PR #91.
 **Status:** Implemented.
 
 ### Done


### PR DESCRIPTION
## GDD sections
- docs/gdd/10-driving-model-and-physics.md
- docs/gdd/16-rendering-and-visual-design.md
- docs/gdd/19-controls-and-input.md
- docs/gdd/21-technical-design-for-web-implementation.md

## Requirement inventory
- Records the already implemented deterministic flash and light camera-shake VFX path in the machine-readable coverage ledger.
- Records the already implemented bounded deterministic off-road dust particle pool and draw integration.
- Leaves region art theming and car FX sprite variants to their existing ready backlog dots.

## Progress log
- docs/PROGRESS_LOG.md: Visual polish coverage closeout.

## Test plan
- [x] npx vitest run scripts/__tests__/content-lint.test.ts
- [x] node -e "JSON.parse(require('fs').readFileSync('docs/GDD_COVERAGE.json','utf8'))"
- [x] npm run verify

## Followups
- None created.