### PR TITLE
feat(options): add display speed unit pane

### DIFF
--- a/docs/GDD_COVERAGE.json
+++ b/docs/GDD_COVERAGE.json
@@ -1193,7 +1193,7 @@
         "docs/gdd/20-hud-and-ui-ux.md",
         "docs/gdd/22-data-schemas.md"
       ],
-      "requirement": "The options screen can reset shipped settings panes to defaults without overwriting settings owned by placeholder panes or profile data.",
+      "requirement": "The options screen can reset shipped settings panes to defaults without overwriting settings owned by unshipped panes or profile data.",
       "coverage": ["implemented-code", "automated-test"],
       "implementationRefs": [
         "src/app/options/page.tsx",
@@ -1206,6 +1206,29 @@
         "e2e/options-screen.spec.ts"
       ],
       "followupRefs": ["F-049"]
+    },
+    {
+      "id": "GDD-20-DISPLAY-OPTIONS-PANE",
+      "gddSections": [
+        "docs/gdd/20-hud-and-ui-ux.md",
+        "docs/gdd/22-data-schemas.md"
+      ],
+      "requirement": "The options screen exposes persisted speed-unit display settings backed by save settings and consumed by race HUD state.",
+      "coverage": ["implemented-code", "automated-test"],
+      "implementationRefs": [
+        "src/app/options/page.tsx",
+        "src/components/options/DisplayPane.tsx",
+        "src/components/options/displayPaneState.ts",
+        "src/components/options/optionsResetState.ts",
+        "src/app/race/page.tsx"
+      ],
+      "testRefs": [
+        "src/components/options/__tests__/displayPaneState.test.ts",
+        "src/components/options/__tests__/optionsResetState.test.ts",
+        "src/app/options/__tests__/page.test.tsx",
+        "e2e/options-screen.spec.ts"
+      ],
+      "followupRefs": ["VibeGear2-implement-hud-ui-6c1b130d"]
     },
     {
       "id": "GDD-20-AUDIO-OPTIONS-PANE",

--- a/docs/PROGRESS_LOG.md
+++ b/docs/PROGRESS_LOG.md
@@ -11,7 +11,7 @@ Correct them by adding a new entry that references the old one.
 **GDD sections touched:**
 [§20](gdd/20-hud-and-ui-ux.md) Settings,
 [§22](gdd/22-data-schemas.md) save settings schema.
-**Branch / PR:** `feat/display-options-pane`, PR pending.
+**Branch / PR:** `feat/display-options-pane`, PR #92.
 **Status:** Implemented.
 
 ### Done

--- a/docs/PROGRESS_LOG.md
+++ b/docs/PROGRESS_LOG.md
@@ -6,6 +6,52 @@ Correct them by adding a new entry that references the old one.
 
 ---
 
+## 2026-04-29: Slice: Display options pane
+
+**GDD sections touched:**
+[§20](gdd/20-hud-and-ui-ux.md) Settings,
+[§22](gdd/22-data-schemas.md) save settings schema.
+**Branch / PR:** `feat/display-options-pane`, PR pending.
+**Status:** Implemented.
+
+### Done
+- `src/components/options/DisplayPane.tsx`: added a shipped Display
+  pane that reads and persists the `displaySpeedUnit` save setting.
+- `src/components/options/displayPaneState.ts`: added pure display
+  pane helpers and schema-backed unit options.
+- `src/app/options/page.tsx`: replaced the Display placeholder with
+  the shipped pane.
+- `src/components/options/optionsResetState.ts`: reset now treats
+  speed unit as a shipped option and keeps unshipped settings intact.
+- `docs/GDD_COVERAGE.json`: added GDD-20-DISPLAY-OPTIONS-PANE and
+  updated the reset wording now that Display is shipped.
+
+### Verified
+- `npx vitest run src/components/options/__tests__/displayPaneState.test.ts src/components/options/__tests__/optionsResetState.test.ts src/app/options/__tests__/page.test.tsx scripts/__tests__/content-lint.test.ts`
+  green, 71 passed.
+- `npm run typecheck` green.
+- `npx playwright test e2e/options-screen.spec.ts` green, 10
+  passed.
+- `npm run verify` green, 2520 passed.
+
+### Decisions and assumptions
+- The first Display pane ships speed unit because the save schema and
+  race HUD already support it. Resolution, frame cap, pixel ratio, and
+  HUD scale remain under the performance and visual polish backlog.
+
+### Coverage ledger
+- GDD-20-DISPLAY-OPTIONS-PANE covers the §20 display settings entry
+  for persisted speed units.
+- Uncovered adjacent requirements: resolution, frame cap, pixel ratio,
+  HUD scale, and additional visual readability controls remain under
+  the performance, visual polish, and accessibility backlog slices.
+
+### Followups created
+None.
+
+### GDD edits
+None.
+
 ## 2026-04-29: Slice: Visual polish coverage closeout
 
 **GDD sections touched:**

--- a/e2e/options-screen.spec.ts
+++ b/e2e/options-screen.spec.ts
@@ -25,9 +25,8 @@ test.describe("options screen", () => {
       "true",
     );
     await expect(page.getByTestId("options-panel-display")).toBeVisible();
-    await expect(page.getByTestId("options-panel-display-dot")).toContainText(
-      "VibeGear2-implement-visual-polish-7d31d112",
-    );
+    await expect(page.getByTestId("display-pane")).toBeVisible();
+    await expect(page.getByTestId("display-speed-unit-kph")).toBeChecked();
   });
 
   test("ArrowRight cycles through tabs and wraps", async ({ page }) => {
@@ -69,7 +68,7 @@ test.describe("options screen", () => {
     );
   });
 
-  test("Reset to defaults restores shipped settings and preserves placeholder-owned settings", async ({ page }) => {
+  test("Reset to defaults restores shipped settings and preserves unshipped settings", async ({ page }) => {
     await page.goto("/options");
 
     const reset = page.getByTestId("options-reset-defaults");
@@ -111,13 +110,35 @@ test.describe("options screen", () => {
     expect(persisted?.settings?.assists?.autoAccelerate).toBe(false);
     expect(persisted?.settings?.difficultyPreset).toBe("normal");
     expect(persisted?.profileName).toBe("Reset Proof");
-    expect(persisted?.settings?.displaySpeedUnit).toBe("mph");
+    expect(persisted?.settings?.displaySpeedUnit).toBe("kph");
     expect(persisted?.settings?.transmissionMode).toBe("manual");
     expect(persisted?.settings?.audio).toEqual({
       master: 1,
       music: 0.8,
       sfx: 0.9,
     });
+  });
+
+  test("Display speed unit persists and reloads", async ({ page }) => {
+    await page.goto("/options");
+
+    await expect(page.getByTestId("display-pane")).toBeVisible();
+    await expect(page.getByTestId("display-speed-unit-kph")).toBeChecked();
+
+    await page.getByTestId("display-speed-unit-mph").check();
+    await expect(page.getByTestId("display-status")).toContainText(
+      "Speed unit set",
+    );
+
+    const persisted = await page.evaluate((key) => {
+      const raw = window.localStorage.getItem(key);
+      return raw ? JSON.parse(raw) : null;
+    }, "vibegear2:save:v3");
+    expect(persisted?.settings?.displaySpeedUnit).toBe("mph");
+
+    await page.reload();
+    await expect(page.getByTestId("display-pane")).toBeVisible();
+    await expect(page.getByTestId("display-speed-unit-mph")).toBeChecked();
   });
 
   test("Audio mix sliders persist master, music, and SFX settings", async ({

--- a/src/app/options/__tests__/page.test.tsx
+++ b/src/app/options/__tests__/page.test.tsx
@@ -11,8 +11,8 @@ import { TAB_ORDER } from "../tabNav";
  * tab navigation is exercised by the Playwright spec
  * `e2e/options-screen.spec.ts`; the pure model is unit-tested in
  * `tabNav.test.ts`. This file pins the contract that the page emits the
- * test ids and dot-id placeholders that downstream slices and the e2e
- * suite key off.
+ * test ids, shipped panes, and placeholder dot ids that downstream
+ * slices and the e2e suite key off.
  */
 describe("OptionsPage", () => {
   const html = renderToStaticMarkup(createElement(OptionsPage));
@@ -50,17 +50,14 @@ describe("OptionsPage", () => {
     expect(audioTab?.[0]).toContain('aria-selected="false"');
   });
 
-  it("renders the Display panel with the polish dot id placeholder", () => {
+  it("renders the shipped Display panel shell", () => {
     expect(html).toContain('data-testid="options-panel-display"');
-    expect(html).toContain("VibeGear2-implement-visual-polish-7d31d112");
+    expect(html).toContain('data-testid="display-pane-loading"');
+    expect(html).not.toContain("VibeGear2-implement-visual-polish-7d31d112");
   });
 
-  it("cites every implementing dot id for the matching tab placeholder", () => {
-    // The active tab is Display, so only its dot id is in the rendered
-    // markup. The other dot ids live in TABS and are emitted when the
-    // pane is selected. We assert the constants exist in the bundle by
-    // checking the tab labels render and the Display dot id is present.
-    expect(html).toContain("VibeGear2-implement-visual-polish-7d31d112");
+  it("keeps the active placeholder dot id out of the shipped Display pane", () => {
+    expect(html).not.toContain("VibeGear2-implement-visual-polish-7d31d112");
   });
 
   it("enables the Reset to defaults button now that reset persistence has landed", () => {

--- a/src/app/options/page.tsx
+++ b/src/app/options/page.tsx
@@ -3,11 +3,10 @@
 /**
  * Options screen scaffold (GDD §20 Settings, §19 Controls and input).
  *
- * Tabbed shell with six panes (Display, Audio, Controls, Accessibility,
- * Difficulty, Performance) per §20. Each pane renders a "Coming soon"
- * placeholder citing the dot id of the slice that lands its real
- * content, so the next agent can grep its dot id and find the exact
- * insertion point.
+ * Tabbed shell for the §20 settings categories. Shipped panes own
+ * their settings directly; placeholder panes cite the dot id of the
+ * slice that lands their real content, so the next agent can grep its
+ * dot id and find the exact insertion point.
  *
  * - The Reset to defaults button resets only fields owned by shipped
  *   panes. Placeholder-pane fields stay untouched until those panes land.
@@ -30,6 +29,7 @@ import { AccessibilityPane } from "@/components/options/AccessibilityPane";
 import { AudioPane } from "@/components/options/AudioPane";
 import { ControlsPane } from "@/components/options/ControlsPane";
 import { DifficultyPane } from "@/components/options/DifficultyPane";
+import { DisplayPane } from "@/components/options/DisplayPane";
 import { ProfileSection } from "@/components/options/ProfileSection";
 import { resetShippedOptionsToDefaults } from "@/components/options/optionsResetState";
 import { defaultSave, loadSave, saveSave } from "@/persistence";
@@ -64,9 +64,7 @@ const TABS: ReadonlyArray<TabSpec> = [
   {
     key: "display",
     label: "Display",
-    headline: "Display options coming soon",
-    body: "Resolution, frame cap, viewport scaling, and HUD scale will land alongside the visual polish slice.",
-    dotId: "VibeGear2-implement-visual-polish-7d31d112",
+    pane: () => <DisplayPane />,
   },
   {
     key: "audio",

--- a/src/components/options/DisplayPane.tsx
+++ b/src/components/options/DisplayPane.tsx
@@ -213,6 +213,6 @@ const descStyle: CSSProperties = {
 function statusStyle(kind: PaneStatus["kind"]): CSSProperties {
   return {
     margin: 0,
-    color: kind === "error" ? "#ff9c9c" : "var(--accent, #8cf)",
+    color: kind === "error" ? "var(--danger, #f88)" : "var(--accent, #8cf)",
   };
 }

--- a/src/components/options/DisplayPane.tsx
+++ b/src/components/options/DisplayPane.tsx
@@ -1,0 +1,218 @@
+"use client";
+
+import type { CSSProperties, ReactElement } from "react";
+import { useCallback, useEffect, useState } from "react";
+
+import type { SaveGame, SpeedUnit } from "@/data/schemas";
+import { defaultSave, loadSave, saveSave } from "@/persistence";
+
+import {
+  DISPLAY_PANE_HEADLINE,
+  DISPLAY_PANE_SUBTITLE,
+  DISPLAY_SPEED_UNIT_OPTIONS,
+  applyDisplaySpeedUnit,
+  readDisplaySpeedUnit,
+} from "./displayPaneState";
+
+interface PaneStatus {
+  kind: "idle" | "info" | "error";
+  message: string;
+}
+
+export function DisplayPane(): ReactElement {
+  const [save, setSave] = useState<SaveGame | null>(null);
+  const [status, setStatus] = useState<PaneStatus>({
+    kind: "idle",
+    message: "",
+  });
+
+  useEffect(() => {
+    const outcome = loadSave();
+    if (outcome.kind === "loaded") {
+      setSave(outcome.save);
+      return;
+    }
+
+    setSave(defaultSave());
+    if (outcome.reason !== "missing" && outcome.reason !== "no-storage") {
+      setStatus({
+        kind: "info",
+        message: `Loaded default save (reason: ${outcome.reason}).`,
+      });
+    }
+  }, []);
+
+  const persist = useCallback((next: SaveGame, successMessage: string) => {
+    const writeResult = saveSave(next);
+    if (writeResult.kind === "ok") {
+      setSave({
+        ...next,
+        writeCounter: (next.writeCounter ?? 0) + 1,
+      });
+      setStatus({ kind: "info", message: successMessage });
+      return;
+    }
+
+    setSave(next);
+    setStatus({
+      kind: "error",
+      message: `Save failed (${writeResult.reason}); change kept in memory only.`,
+    });
+  }, []);
+
+  const onSpeedUnit = useCallback(
+    (unit: SpeedUnit) => {
+      if (!save) return;
+      const result = applyDisplaySpeedUnit(save, unit);
+      if (result.kind === "noop") return;
+      const option = DISPLAY_SPEED_UNIT_OPTIONS.find((item) => item.value === unit);
+      persist(result.save, `Speed unit set to ${option?.label ?? unit}.`);
+    },
+    [persist, save],
+  );
+
+  if (!save) {
+    return (
+      <div data-testid="display-pane-loading" style={loadingStyle}>
+        Loading display settings.
+      </div>
+    );
+  }
+
+  const speedUnit = readDisplaySpeedUnit(save);
+
+  return (
+    <div data-testid="display-pane" style={paneStyle}>
+      <header style={headerStyle}>
+        <h2 style={headlineStyle}>{DISPLAY_PANE_HEADLINE}</h2>
+        <p style={subtitleStyle}>{DISPLAY_PANE_SUBTITLE}</p>
+      </header>
+
+      <fieldset style={fieldsetStyle} aria-label="Speed unit">
+        <legend style={legendStyle}>Speed unit</legend>
+        <ul style={listStyle}>
+          {DISPLAY_SPEED_UNIT_OPTIONS.map((option) => {
+            const checked = speedUnit === option.value;
+            const id = `display-speed-unit-${option.value}`;
+            return (
+              <li
+                key={option.value}
+                style={itemStyle(checked)}
+                data-testid={`display-speed-unit-row-${option.value}`}
+                data-active={checked ? "true" : "false"}
+              >
+                <label htmlFor={id} style={labelStyle}>
+                  <input
+                    id={id}
+                    type="radio"
+                    name="display-speed-unit"
+                    value={option.value}
+                    checked={checked}
+                    onChange={() => onSpeedUnit(option.value)}
+                    data-testid={`display-speed-unit-${option.value}`}
+                  />
+                  <span style={textStyle}>
+                    <span style={titleStyle}>{option.label}</span>
+                    <span style={descStyle}>{option.description}</span>
+                  </span>
+                </label>
+              </li>
+            );
+          })}
+        </ul>
+      </fieldset>
+
+      {status.kind !== "idle" ? (
+        <p data-testid="display-status" style={statusStyle(status.kind)}>
+          {status.message}
+        </p>
+      ) : null}
+    </div>
+  );
+}
+
+const paneStyle: CSSProperties = {
+  display: "grid",
+  gap: "1rem",
+};
+
+const loadingStyle: CSSProperties = {
+  color: "var(--muted, #aaa)",
+};
+
+const headerStyle: CSSProperties = {
+  display: "grid",
+  gap: "0.35rem",
+};
+
+const headlineStyle: CSSProperties = {
+  margin: 0,
+  color: "var(--fg, #ddd)",
+  fontSize: "1.2rem",
+};
+
+const subtitleStyle: CSSProperties = {
+  margin: 0,
+  maxWidth: "44rem",
+  color: "var(--muted, #aaa)",
+  lineHeight: 1.45,
+};
+
+const fieldsetStyle: CSSProperties = {
+  border: "1px solid var(--muted, #444)",
+  borderRadius: "8px",
+  padding: "1rem",
+};
+
+const legendStyle: CSSProperties = {
+  padding: "0 0.4rem",
+  color: "var(--accent, #8cf)",
+  fontWeight: 700,
+};
+
+const listStyle: CSSProperties = {
+  display: "grid",
+  gap: "0.75rem",
+  listStyle: "none",
+  margin: 0,
+  padding: 0,
+};
+
+function itemStyle(active: boolean): CSSProperties {
+  return {
+    border: `1px solid ${active ? "var(--accent, #8cf)" : "var(--muted, #444)"}`,
+    borderRadius: "8px",
+    padding: "0.75rem",
+    background: active ? "rgba(111, 170, 255, 0.12)" : "rgba(255, 255, 255, 0.03)",
+  };
+}
+
+const labelStyle: CSSProperties = {
+  display: "grid",
+  gridTemplateColumns: "auto minmax(0, 1fr)",
+  gap: "0.75rem",
+  alignItems: "start",
+  cursor: "pointer",
+};
+
+const textStyle: CSSProperties = {
+  display: "grid",
+  gap: "0.25rem",
+};
+
+const titleStyle: CSSProperties = {
+  color: "var(--fg, #ddd)",
+  fontWeight: 700,
+};
+
+const descStyle: CSSProperties = {
+  color: "var(--muted, #aaa)",
+  lineHeight: 1.35,
+};
+
+function statusStyle(kind: PaneStatus["kind"]): CSSProperties {
+  return {
+    margin: 0,
+    color: kind === "error" ? "#ff9c9c" : "var(--accent, #8cf)",
+  };
+}

--- a/src/components/options/__tests__/displayPaneState.test.ts
+++ b/src/components/options/__tests__/displayPaneState.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vitest";
+
+import { defaultSave } from "@/persistence";
+
+import {
+  DISPLAY_SPEED_UNIT_OPTIONS,
+  applyDisplaySpeedUnit,
+  readDisplaySpeedUnit,
+} from "../displayPaneState";
+
+describe("displayPaneState", () => {
+  it("reads the default speed unit from the save settings", () => {
+    expect(readDisplaySpeedUnit(defaultSave())).toBe("kph");
+  });
+
+  it("applies a speed unit without mutating the input save", () => {
+    const save = defaultSave();
+    const before = JSON.stringify(save);
+
+    const result = applyDisplaySpeedUnit(save, "mph");
+
+    expect(result.kind).toBe("applied");
+    expect(JSON.stringify(save)).toBe(before);
+    if (result.kind === "applied") {
+      expect(result.save.settings.displaySpeedUnit).toBe("mph");
+      expect(result.save.settings.audio).toBe(save.settings.audio);
+      expect(result.save.profileName).toBe(save.profileName);
+    }
+  });
+
+  it("returns noop when applying the active unit", () => {
+    expect(applyDisplaySpeedUnit(defaultSave(), "kph")).toEqual({
+      kind: "noop",
+      reason: "same-value",
+    });
+  });
+
+  it("defines the two schema-backed speed unit options", () => {
+    expect(DISPLAY_SPEED_UNIT_OPTIONS.map((option) => option.value)).toEqual([
+      "kph",
+      "mph",
+    ]);
+  });
+});

--- a/src/components/options/__tests__/optionsResetState.test.ts
+++ b/src/components/options/__tests__/optionsResetState.test.ts
@@ -5,7 +5,7 @@ import { defaultSave } from "@/persistence";
 import { resetShippedOptionsToDefaults } from "../optionsResetState";
 
 describe("resetShippedOptionsToDefaults", () => {
-  it("resets assists, audio, and difficulty to defaults", () => {
+  it("resets assists, audio, display, and difficulty to defaults", () => {
     const save = defaultSave();
     const customised = {
       ...save,
@@ -18,6 +18,7 @@ describe("resetShippedOptionsToDefaults", () => {
         },
         audio: { master: 0.25, music: 0.35, sfx: 0.45 },
         difficultyPreset: "hard" as const,
+        displaySpeedUnit: "mph" as const,
       },
     };
 
@@ -28,10 +29,11 @@ describe("resetShippedOptionsToDefaults", () => {
       expect(result.save.settings.assists).toEqual(defaultSave().settings.assists);
       expect(result.save.settings.audio).toEqual(defaultSave().settings.audio);
       expect(result.save.settings.difficultyPreset).toBe("normal");
+      expect(result.save.settings.displaySpeedUnit).toBe("kph");
     }
   });
 
-  it("preserves placeholder-owned settings and profile data", () => {
+  it("preserves unshipped settings and profile data", () => {
     const save = defaultSave();
     const customised = {
       ...save,
@@ -69,7 +71,7 @@ describe("resetShippedOptionsToDefaults", () => {
     if (result.kind === "applied") {
       expect(result.save.profileName).toBe("Reset Proof");
       expect(result.save.garage.credits).toBe(1234);
-      expect(result.save.settings.displaySpeedUnit).toBe("mph");
+      expect(result.save.settings.displaySpeedUnit).toBe("kph");
       expect(result.save.settings.transmissionMode).toBe("manual");
       expect(result.save.settings.audio).toEqual(defaultSave().settings.audio);
       expect(result.save.settings.accessibility).toEqual(

--- a/src/components/options/displayPaneState.ts
+++ b/src/components/options/displayPaneState.ts
@@ -1,0 +1,51 @@
+import type { SaveGame, SpeedUnit } from "@/data/schemas";
+
+export interface DisplaySpeedUnitOption {
+  readonly value: SpeedUnit;
+  readonly label: string;
+  readonly description: string;
+}
+
+export const DISPLAY_PANE_HEADLINE = "Display";
+export const DISPLAY_PANE_SUBTITLE =
+  "Speed unit display for the race HUD. This setting applies immediately to new HUD snapshots.";
+
+export const DISPLAY_SPEED_UNIT_OPTIONS: ReadonlyArray<DisplaySpeedUnitOption> = [
+  {
+    value: "kph",
+    label: "Kilometers per hour",
+    description: "Use KM/H in the race HUD speed readout.",
+  },
+  {
+    value: "mph",
+    label: "Miles per hour",
+    description: "Use MPH in the race HUD speed readout.",
+  },
+];
+
+export type ApplyDisplaySpeedUnitResult =
+  | { kind: "applied"; save: SaveGame }
+  | { kind: "noop"; reason: "same-value" };
+
+export function readDisplaySpeedUnit(save: SaveGame): SpeedUnit {
+  return save.settings.displaySpeedUnit;
+}
+
+export function applyDisplaySpeedUnit(
+  save: SaveGame,
+  unit: SpeedUnit,
+): ApplyDisplaySpeedUnitResult {
+  if (save.settings.displaySpeedUnit === unit) {
+    return { kind: "noop", reason: "same-value" };
+  }
+  return {
+    kind: "applied",
+    save: {
+      ...save,
+      settings: {
+        ...save.settings,
+        displaySpeedUnit: unit,
+      },
+    },
+  };
+}

--- a/src/components/options/optionsResetState.ts
+++ b/src/components/options/optionsResetState.ts
@@ -21,6 +21,7 @@ export function resetShippedOptionsToDefaults(
       assists: { ...defaults.settings.assists },
       audio: defaults.settings.audio,
       difficultyPreset: defaults.settings.difficultyPreset,
+      displaySpeedUnit: defaults.settings.displaySpeedUnit,
       keyBindings: defaults.settings.keyBindings,
     },
   };
@@ -30,6 +31,7 @@ export function resetShippedOptionsToDefaults(
       JSON.stringify(save.settings.assists) &&
     JSON.stringify(next.settings.audio) === JSON.stringify(save.settings.audio) &&
     next.settings.difficultyPreset === save.settings.difficultyPreset &&
+    next.settings.displaySpeedUnit === save.settings.displaySpeedUnit &&
     JSON.stringify(next.settings.keyBindings) ===
       JSON.stringify(save.settings.keyBindings)
   ) {


### PR DESCRIPTION
## Summary

- ship the Display options pane for the saved speed unit setting
- include display speed unit in Reset to defaults because the pane is now shipped
- add GDD coverage and progress log entries for the §20 display settings path

## GDD sections

- docs/gdd/20-hud-and-ui-ux.md Settings
- docs/gdd/22-data-schemas.md save settings schema

## Requirement inventory

Handled:
- Display settings exposes the persisted `displaySpeedUnit` value.
- The setting persists to `vibegear2:save:v3` and reloads on `/options`.
- Reset to defaults resets speed unit with the other shipped panes while preserving unshipped settings and profile data.

Left to followups or existing backlog:
- Resolution, frame cap, pixel ratio, HUD scale, and additional visual readability controls remain in performance, visual polish, and accessibility backlog slices.

## Progress log

- `docs/PROGRESS_LOG.md`: `2026-04-29: Slice: Display options pane`

## Test plan

- [x] `npx vitest run src/components/options/__tests__/displayPaneState.test.ts src/components/options/__tests__/optionsResetState.test.ts src/app/options/__tests__/page.test.tsx scripts/__tests__/content-lint.test.ts`
- [x] `npm run typecheck`
- [x] `npx playwright test e2e/options-screen.spec.ts`
- [x] `npm run verify`
- [x] `grep -rn $'\u2014\|\u2013' src/components/options src/app/options e2e/options-screen.spec.ts docs/PROGRESS_LOG.md docs/GDD_COVERAGE.json || true`
- [x] `git diff --check`

## Followups created

None.
