### PR TITLE
feat(modes): add quick race mode

### DIFF
--- a/docs/GDD_COVERAGE.json
+++ b/docs/GDD_COVERAGE.json
@@ -207,6 +207,29 @@
       "followupRefs": []
     },
     {
+      "id": "GDD-06-QUICK-RACE-MODE",
+      "gddSections": [
+        "docs/gdd/06-game-modes.md",
+        "docs/gdd/20-hud-and-ui-ux.md",
+        "docs/gdd/21-technical-design-for-web-implementation.md",
+        "docs/gdd/22-data-schemas.md"
+      ],
+      "requirement": "Quick Race lets the player choose an unlocked track, authored weather option, and owned car, then runs a single race with AI present, personal records enabled, and campaign economy and damage persistence disabled.",
+      "coverage": ["implemented-code", "automated-test"],
+      "implementationRefs": [
+        "src/game/modes/quickRace.ts",
+        "src/app/quick-race/page.tsx",
+        "src/app/race/page.tsx",
+        "src/app/page.tsx"
+      ],
+      "testRefs": [
+        "src/game/modes/__tests__/quickRace.test.ts",
+        "e2e/title-screen.spec.ts",
+        "e2e/race-finish.spec.ts"
+      ],
+      "followupRefs": ["VibeGear2-implement-practice-quick-ad3ba399"]
+    },
+    {
       "id": "GDD-10-GRASS-RESTART-PHYSICS",
       "gddSections": [
         "docs/gdd/10-driving-model-and-physics.md",

--- a/docs/PROGRESS_LOG.md
+++ b/docs/PROGRESS_LOG.md
@@ -6,6 +6,53 @@ Correct them by adding a new entry that references the old one.
 
 ---
 
+## 2026-04-29: Slice: Quick Race mode
+
+**GDD sections touched:**
+[§6](gdd/06-game-modes.md) Quick race,
+[§20](gdd/20-hud-and-ui-ux.md) title menu and results,
+[§21](gdd/21-technical-design-for-web-implementation.md) runtime reuse,
+[§22](gdd/22-data-schemas.md) save records.
+**Branch / PR:** `feat/quick-race-mode`, PR pending.
+**Status:** Implemented.
+
+### Done
+- `src/game/modes/quickRace.ts`: added pure Quick Race view and
+  race-href builders for unlocked tracks, authored weather, and owned
+  cars.
+- `src/app/quick-race/page.tsx`: added the Quick Race picker route.
+- `src/app/race/page.tsx`: added `mode=quickRace`, kept AI enabled,
+  applied the selected owned car stats, and reused the records-only
+  persistence path so campaign cash and damage are not written.
+- `src/app/page.tsx`: added the title-menu Quick Race entry.
+- `docs/GDD_COVERAGE.json`: added GDD-06-QUICK-RACE-MODE.
+
+### Verified
+- `npm run typecheck` green.
+- `npx vitest run src/game/modes/__tests__/quickRace.test.ts src/app/__tests__/page.test.tsx scripts/__tests__/content-lint.test.ts`
+  green, 67 passed.
+- `npx playwright test e2e/title-screen.spec.ts e2e/race-finish.spec.ts`
+  green, 14 passed.
+- `npm run verify` green, 2523 passed.
+
+### Decisions and assumptions
+- Quick Race uses the same records-only persistence path as Time Trial
+  but does not enable ghost recording. This keeps PB records while
+  preserving the no-campaign-economy rule from §6.
+
+### Coverage ledger
+- GDD-06-QUICK-RACE-MODE covers the first Quick Race picker and runtime
+  path.
+- Uncovered adjacent requirements: Practice mode restart, checkpoint
+  reset, telemetry overlay, and instant weather swap remain under the
+  same parent dot.
+
+### Followups created
+None.
+
+### GDD edits
+None.
+
 ## 2026-04-29: Slice: Display options pane
 
 **GDD sections touched:**

--- a/docs/PROGRESS_LOG.md
+++ b/docs/PROGRESS_LOG.md
@@ -13,7 +13,7 @@ Correct them by adding a new entry that references the old one.
 [§20](gdd/20-hud-and-ui-ux.md) title menu and results,
 [§21](gdd/21-technical-design-for-web-implementation.md) runtime reuse,
 [§22](gdd/22-data-schemas.md) save records.
-**Branch / PR:** `feat/quick-race-mode`, PR pending.
+**Branch / PR:** `feat/quick-race-mode`, PR #93.
 **Status:** Implemented.
 
 ### Done

--- a/e2e/race-finish.spec.ts
+++ b/e2e/race-finish.spec.ts
@@ -274,6 +274,64 @@ test.describe("time trial PB persistence", () => {
   });
 });
 
+test.describe("quick race result persistence", () => {
+  test("finished quick race keeps economy and damage out of the save", async ({
+    page,
+  }) => {
+    test.setTimeout(70_000);
+
+    await page.goto("/");
+    await page.evaluate(
+      ({ key, save }) => window.localStorage.setItem(key, JSON.stringify(save)),
+      { key: SAVE_KEY, save: buildRaceDamageSave() },
+    );
+
+    await page.goto(
+      "/race?mode=quickRace&track=test/straight&weather=clear&car=sparrow-gt",
+    );
+    await expect(page.getByTestId("race-canvas")).toHaveAttribute(
+      "data-mode",
+      "quickRace",
+    );
+    await expect(page.getByTestId("race-field-size")).not.toHaveText("1");
+    const canvas = page.getByTestId("race-canvas-element");
+    await expect(canvas).toBeVisible();
+    await expect(page.getByTestId("race-phase")).toHaveText("racing", {
+      timeout: 10_000,
+    });
+
+    await canvas.focus();
+    await page.keyboard.down("ArrowUp");
+    await expect(page).toHaveURL(/\/race\/results/, { timeout: 45_000 });
+    await page.keyboard.up("ArrowUp");
+
+    await expect(page.getByTestId("results-credits-awarded")).toHaveText("0 cr");
+
+    const persisted = await page.evaluate((key) => {
+      const raw = window.localStorage.getItem(key);
+      return raw
+        ? (JSON.parse(raw) as {
+            garage?: {
+              credits?: number;
+              pendingDamage?: Record<
+                string,
+                { zones?: { body?: number }; total?: number }
+              >;
+            };
+            records?: Record<string, { bestLapMs?: number; bestRaceMs?: number }>;
+          })
+        : null;
+    }, SAVE_KEY);
+
+    expect(persisted?.garage?.credits).toBe(1000);
+    expect(
+      persisted?.garage?.pendingDamage?.["sparrow-gt"]?.zones?.body ?? 0,
+    ).toBe(0.33);
+    expect(persisted?.records?.["test/straight"]?.bestLapMs).toBeGreaterThan(0);
+    expect(persisted?.records?.["test/straight"]?.bestRaceMs).toBeGreaterThan(0);
+  });
+});
+
 function buildRaceDamageSave() {
   return {
     version: 3,

--- a/e2e/title-screen.spec.ts
+++ b/e2e/title-screen.spec.ts
@@ -66,6 +66,11 @@ test.describe("title screen", () => {
     await expect(timeTrial).toHaveText("Time Trial");
     await expect(timeTrial).toHaveAttribute("href", "/time-trial");
 
+    const quickRace = page.getByTestId("menu-quick-race");
+    await expect(quickRace).toBeVisible();
+    await expect(quickRace).toHaveText("Quick Race");
+    await expect(quickRace).toHaveAttribute("href", "/quick-race");
+
     const daily = page.getByTestId("menu-daily");
     await expect(daily).toBeVisible();
     await expect(daily).toHaveText("Daily Challenge");
@@ -110,6 +115,17 @@ test.describe("title screen", () => {
     await expect(page.getByTestId("race-canvas")).toHaveAttribute(
       "data-mode",
       "timeTrial",
+    );
+  });
+
+  test("Quick Race link navigates to quick-race picker", async ({ page }) => {
+    await page.goto("/");
+    await page.getByTestId("menu-quick-race").click();
+    await expect(page).toHaveURL(/\/quick-race$/);
+    await expect(page.getByTestId("quick-race-page")).toBeVisible();
+    await expect(page.getByTestId("quick-race-start")).toHaveAttribute(
+      "href",
+      /\/race\?mode=quickRace&track=.+&weather=.+&car=.+/,
     );
   });
 

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -8,14 +8,14 @@ import styles from "./page.module.css";
  *
  * Renders the top-level main menu items per GDD §5 and §20:
  * Start Race -> `/race`, World Tour -> `/world`, Time Trial ->
- * `/time-trial`, Daily Challenge -> `/daily`, Garage -> `/garage`,
- * Options -> `/options`. The Options entry was a disabled placeholder
+ * `/time-trial`, Quick Race -> `/quick-race`, Daily Challenge -> `/daily`,
+ * Garage -> `/garage`, Options -> `/options`. The Options entry was a disabled placeholder
  * (`menu-options-pending`) until the `/options` scaffold landed in
  * `VibeGear2-implement-options-screen-a9379c4a`. Its replacement keeps
  * the original `menu-options` test id that the e2e suite asserts on.
  *
- * Keyboard order is Start Race -> World Tour -> Time Trial -> Daily
- * Challenge -> Garage -> Options (DOM order).
+ * Keyboard order is Start Race -> World Tour -> Time Trial -> Quick Race
+ * -> Daily Challenge -> Garage -> Options (DOM order).
  *
  * The footer carries two pieces of metadata. The pre-existing
  * `build-status` line tracks the design phase (kept verbatim so the
@@ -36,6 +36,7 @@ const MENU: ReadonlyArray<MenuItem> = [
   { label: "Start Race", href: "/race", testId: "menu-start-race" },
   { label: "World Tour", href: "/world", testId: "menu-world" },
   { label: "Time Trial", href: "/time-trial", testId: "menu-time-trial" },
+  { label: "Quick Race", href: "/quick-race", testId: "menu-quick-race" },
   { label: "Daily Challenge", href: "/daily", testId: "menu-daily" },
   { label: "Garage", href: "/garage", testId: "menu-garage" },
   { label: "Options", href: "/options", testId: "menu-options" },

--- a/src/app/quick-race/page.tsx
+++ b/src/app/quick-race/page.tsx
@@ -152,14 +152,20 @@ export default function QuickRacePage(): ReactElement {
               </select>
             </label>
 
-            <Link
-              href={href}
-              aria-disabled={!ready}
-              data-testid="quick-race-start"
-              style={startStyle}
-            >
-              Start quick race
-            </Link>
+            {ready ? (
+              <Link href={href} data-testid="quick-race-start" style={startStyle}>
+                Start quick race
+              </Link>
+            ) : (
+              <button
+                type="button"
+                disabled
+                data-testid="quick-race-start"
+                style={startStyle}
+              >
+                Start quick race
+              </button>
+            )}
           </div>
         )}
 

--- a/src/app/quick-race/page.tsx
+++ b/src/app/quick-race/page.tsx
@@ -1,0 +1,237 @@
+"use client";
+
+import Link from "next/link";
+import {
+  useEffect,
+  useMemo,
+  useState,
+  type CSSProperties,
+  type ReactElement,
+} from "react";
+
+import {
+  CARS_BY_ID,
+  TRACK_RAW,
+  TrackSchema,
+  getChampionship,
+  type SaveGame,
+  type Track,
+  type WeatherOption,
+} from "@/data";
+import { buildQuickRaceView, quickRaceHref } from "@/game/modes/quickRace";
+import { defaultSave, loadSave } from "@/persistence";
+
+const CHAMPIONSHIP_ID = "world-tour-standard";
+const TRACKS_BY_ID = buildTrackMap();
+
+export default function QuickRacePage(): ReactElement {
+  const [save, setSave] = useState<SaveGame | null>(null);
+  const [trackId, setTrackId] = useState<string>("");
+  const [weather, setWeather] = useState<WeatherOption | "">("");
+  const [carId, setCarId] = useState<string>("");
+
+  useEffect(() => {
+    const loaded = loadSave();
+    setSave(loaded.kind === "loaded" ? loaded.save : defaultSave());
+  }, []);
+
+  const view = useMemo(() => {
+    if (!save) return null;
+    return buildQuickRaceView({
+      save,
+      championship: getChampionship(CHAMPIONSHIP_ID),
+      tracksById: TRACKS_BY_ID,
+      carsById: CARS_BY_ID,
+    });
+  }, [save]);
+
+  const selectedTrack =
+    view?.tracks.find((option) => option.id === trackId) ?? view?.tracks[0];
+  const selectedWeather =
+    weather !== "" && selectedTrack?.weatherOptions.includes(weather)
+      ? weather
+      : selectedTrack?.weatherOptions[0];
+  const selectedCar =
+    view?.cars.find((option) => option.id === carId) ?? view?.cars[0];
+
+  useEffect(() => {
+    if (!view) return;
+    const firstTrack = view.tracks[0];
+    const firstCar = view.cars[0];
+    if (firstTrack && !trackId) {
+      setTrackId(firstTrack.id);
+      setWeather(firstTrack.weatherOptions[0] ?? "clear");
+    }
+    if (firstCar && !carId) {
+      setCarId(firstCar.id);
+    }
+  }, [carId, trackId, view]);
+
+  useEffect(() => {
+    if (!selectedTrack) return;
+    if (selectedWeather === undefined) {
+      setWeather(selectedTrack.weatherOptions[0] ?? "clear");
+    }
+  }, [selectedTrack, selectedWeather]);
+
+  const ready =
+    selectedTrack !== undefined &&
+    selectedWeather !== undefined &&
+    selectedCar !== undefined;
+  const href = ready
+    ? quickRaceHref({
+        trackId: selectedTrack.id,
+        weather: selectedWeather,
+        carId: selectedCar.id,
+      })
+    : "/";
+
+  return (
+    <main data-testid="quick-race-page" style={pageStyle}>
+      <section style={shellStyle}>
+        <header>
+          <h1 style={titleStyle}>Quick Race</h1>
+          <p style={subtitleStyle}>
+            Pick an unlocked track, weather, and owned car for a no-economy
+            race.
+          </p>
+        </header>
+
+        {!view ? (
+          <p data-testid="quick-race-loading">Loading quick race options.</p>
+        ) : (
+          <div style={formStyle}>
+            <label style={fieldStyle}>
+              <span>Track</span>
+              <select
+                value={selectedTrack?.id ?? ""}
+                onChange={(event) => {
+                  const nextTrack = view.tracks.find(
+                    (option) => option.id === event.target.value,
+                  );
+                  setTrackId(event.target.value);
+                  setWeather(nextTrack?.weatherOptions[0] ?? "clear");
+                }}
+                data-testid="quick-race-track"
+              >
+                {view.tracks.map((option) => (
+                  <option key={option.id} value={option.id}>
+                    {option.name}
+                  </option>
+                ))}
+              </select>
+            </label>
+
+            <label style={fieldStyle}>
+              <span>Weather</span>
+              <select
+                value={selectedWeather ?? ""}
+                onChange={(event) => setWeather(event.target.value as WeatherOption)}
+                data-testid="quick-race-weather"
+              >
+                {(selectedTrack?.weatherOptions ?? []).map((option) => (
+                  <option key={option} value={option}>
+                    {formatWeather(option)}
+                  </option>
+                ))}
+              </select>
+            </label>
+
+            <label style={fieldStyle}>
+              <span>Car</span>
+              <select
+                value={selectedCar?.id ?? ""}
+                onChange={(event) => setCarId(event.target.value)}
+                data-testid="quick-race-car"
+              >
+                {view.cars.map((option) => (
+                  <option key={option.id} value={option.id}>
+                    {option.name}
+                  </option>
+                ))}
+              </select>
+            </label>
+
+            <Link
+              href={href}
+              aria-disabled={!ready}
+              data-testid="quick-race-start"
+              style={startStyle}
+            >
+              Start quick race
+            </Link>
+          </div>
+        )}
+
+        <Link href="/" data-testid="quick-race-back" style={backStyle}>
+          Back to title
+        </Link>
+      </section>
+    </main>
+  );
+}
+
+function buildTrackMap(): ReadonlyMap<string, Track> {
+  const entries = Object.values(TRACK_RAW).map((raw) => {
+    const track = TrackSchema.parse(raw);
+    return [track.id, track] as const;
+  });
+  return new Map(entries);
+}
+
+function formatWeather(weather: WeatherOption): string {
+  return weather
+    .split("_")
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+    .join(" ");
+}
+
+const pageStyle: CSSProperties = {
+  minHeight: "100vh",
+  display: "grid",
+  placeItems: "center",
+  background: "var(--bg, #111)",
+  color: "var(--fg, #ddd)",
+  fontFamily: "system-ui, sans-serif",
+  padding: "2rem",
+};
+
+const shellStyle: CSSProperties = {
+  width: "min(42rem, 100%)",
+  display: "grid",
+  gap: "1.25rem",
+};
+
+const titleStyle: CSSProperties = {
+  margin: 0,
+  fontSize: "2rem",
+};
+
+const subtitleStyle: CSSProperties = {
+  margin: "0.25rem 0 0",
+  color: "var(--muted, #aaa)",
+  lineHeight: 1.45,
+};
+
+const formStyle: CSSProperties = {
+  display: "grid",
+  gap: "1rem",
+};
+
+const fieldStyle: CSSProperties = {
+  display: "grid",
+  gap: "0.35rem",
+};
+
+const startStyle: CSSProperties = {
+  justifySelf: "start",
+  padding: "0.75rem 1rem",
+  border: "1px solid var(--accent, #8cf)",
+  borderRadius: "8px",
+  color: "var(--fg, #ddd)",
+  textDecoration: "none",
+};
+
+const backStyle: CSSProperties = {
+  color: "var(--muted, #aaa)",
+};

--- a/src/app/race/page.tsx
+++ b/src/app/race/page.tsx
@@ -839,10 +839,17 @@ function RaceCanvas({
         return;
       }
       const currentGhost = timeTrialSaveSnapshot.ghosts?.[track.id] ?? null;
-      ghostDriverRef.current = createGhostDriver({
-        replay: currentGhost,
-        stats: playerStats,
-      });
+      const ghostCarStats =
+        currentGhost === null
+          ? playerStats
+          : getCar(currentGhost.carId)?.baseStats;
+      ghostDriverRef.current =
+        ghostCarStats === undefined
+          ? null
+          : createGhostDriver({
+              replay: currentGhost,
+              stats: ghostCarStats,
+            });
       timeTrialRecorderRef.current = createTimeTrialRecorder({
         trackId: track.id,
         trackVersion: track.version,

--- a/src/app/race/page.tsx
+++ b/src/app/race/page.tsx
@@ -44,10 +44,12 @@ import { usePauseToggle } from "@/components/pause/usePauseToggle";
 import { saveRaceResult } from "@/components/results/raceResultStorage";
 import {
   AI_DRIVERS,
+  CARS,
   HAZARDS_BY_ID,
   TRACK_IDS,
   TRACK_RAW,
   getAIDriver,
+  getCar,
   getChampionship,
   loadTrack,
 } from "@/data";
@@ -409,9 +411,10 @@ function resolveTrack(
   return { id, runtimeId, version: parsed.version, compiled: loadTrack(runtimeId) };
 }
 
-type RaceMode = "race" | "timeTrial";
+type RaceMode = "race" | "timeTrial" | "quickRace";
 
 function resolveRaceMode(raw: string | null): RaceMode {
+  if (raw === "quickRace") return "quickRace";
   return raw === "timeTrial" ? "timeTrial" : "race";
 }
 
@@ -426,6 +429,21 @@ function resolveRaceWeather(
 
 function resolvePlayerTire(raw: string | null): TireKind | undefined {
   return raw === "wet" || raw === "dry" ? raw : undefined;
+}
+
+function resolveSessionCar(
+  save: SaveGame,
+  requestedCarId: string | null,
+): { id: string; stats: CarBaseStats } {
+  const fallbackId = save.garage.activeCarId;
+  const requestedIsOwned =
+    requestedCarId !== null && save.garage.ownedCars.includes(requestedCarId);
+  const carId = requestedIsOwned ? requestedCarId : fallbackId;
+  const car = getCar(carId) ?? getCar(fallbackId) ?? CARS[0];
+  if (car === undefined) {
+    return { id: fallbackId, stats: STARTER_STATS };
+  }
+  return { id: car.id, stats: car.baseStats };
 }
 
 /**
@@ -616,6 +634,7 @@ function RaceShell(): ReactElement {
   const modeRaw = search?.get("mode") ?? null;
   const weatherRaw = search?.get("weather") ?? null;
   const tireRaw = search?.get("tire") ?? null;
+  const carRaw = search?.get("car") ?? null;
   const tourId = search?.get("tour") ?? null;
   const raceIndexRaw = search?.get("raceIndex") ?? null;
   const tourContext = useMemo(
@@ -641,6 +660,7 @@ function RaceShell(): ReactElement {
       tourContext={tourContext}
       weather={weather}
       playerTire={playerTire}
+      selectedCarId={carRaw}
     />
   );
 }
@@ -652,6 +672,7 @@ interface RaceCanvasProps {
   tourContext: TourRaceContext | null;
   weather: RaceSessionConfig["weather"];
   playerTire: TireKind | undefined;
+  selectedCarId: string | null;
 }
 
 function RaceCanvas({
@@ -661,6 +682,7 @@ function RaceCanvas({
   tourContext,
   weather,
   playerTire,
+  selectedCarId,
 }: RaceCanvasProps): ReactElement {
   const router = useRouter();
   const canvasRef = useRef<HTMLCanvasElement | null>(null);
@@ -769,20 +791,24 @@ function RaceCanvas({
     const persistedAssists = persistedSettings.assists;
     const persistedDifficulty = persistedSettings.difficultyPreset;
     const persistedKeyBindings = readKeyBindings(sessionSave);
-    const timeTrialEnabled = mode === "timeTrial";
-    const initialPlayerDamage = timeTrialEnabled
+    const ghostEnabled = mode === "timeTrial";
+    const recordsOnlyMode = mode === "timeTrial" || mode === "quickRace";
+    const economyEnabled = mode === "race";
+    const sessionCar = resolveSessionCar(sessionSave, selectedCarId);
+    const playerStats = sessionCar.stats;
+    const initialPlayerDamage = recordsOnlyMode
       ? PRISTINE_DAMAGE_STATE
       : pendingDamageForActiveCar(sessionSave);
     const raceSeed = 1;
     let timeTrialSaveSnapshot = sessionSave;
-    const spawnedAi = timeTrialEnabled
+    const spawnedAi = ghostEnabled
       ? []
       : spawnGrid({
           trackSpawn: track.compiled.spawn,
           laneCount: track.compiled.laneCount,
           aiDrivers: resolveRaceAIDrivers(tourContext).map((driver) => ({
             driver,
-            stats: STARTER_STATS,
+            stats: playerStats,
           })),
           seed: raceSeed,
         });
@@ -790,7 +816,7 @@ function RaceCanvas({
     const config: RaceSessionConfig = {
       track: track.compiled,
       player: {
-        stats: STARTER_STATS,
+        stats: playerStats,
         assists: persistedAssists,
         difficultyPreset: persistedDifficulty,
         initialDamage: initialPlayerDamage,
@@ -807,7 +833,7 @@ function RaceCanvas({
     const resetTimeTrialRuntime = (): void => {
       ghostOverlayRef.current = null;
       ghostOverlayTickRef.current = null;
-      if (!timeTrialEnabled) {
+      if (!ghostEnabled) {
         ghostDriverRef.current = null;
         timeTrialRecorderRef.current = null;
         return;
@@ -815,12 +841,12 @@ function RaceCanvas({
       const currentGhost = timeTrialSaveSnapshot.ghosts?.[track.id] ?? null;
       ghostDriverRef.current = createGhostDriver({
         replay: currentGhost,
-        stats: STARTER_STATS,
+        stats: playerStats,
       });
       timeTrialRecorderRef.current = createTimeTrialRecorder({
         trackId: track.id,
         trackVersion: track.version,
-        carId: timeTrialSaveSnapshot.garage.activeCarId,
+        carId: sessionCar.id,
         seed: raceSeed,
         onFinalize: (replay) => {
           const latest = loadSave();
@@ -899,16 +925,16 @@ function RaceCanvas({
     const raceMusicCueForSession = raceMusicCue({
       trackId: track.id,
       tourId: tourContext?.tourId,
-      mode,
+      mode: mode === "quickRace" ? "race" : mode,
     });
     let latestEngineInput: EngineRuntimeInput = {
       speed: 0,
-      topSpeed: STARTER_STATS.topSpeed,
+      topSpeed: playerStats.topSpeed,
       audio: persistedSettings.audio,
     };
     let latestRaceMusicIntensity = raceMusicIntensity({
       speed: 0,
-      topSpeed: STARTER_STATS.topSpeed,
+      topSpeed: playerStats.topSpeed,
     });
     let latestWeatherMusicStem = weatherMusicStem(weather);
     let engineStartPending = false;
@@ -1040,14 +1066,14 @@ function RaceCanvas({
       // F-034: credit the wallet (DNF cars receive the §12 participation
       // cash) and mirror the delta onto `RaceResult.creditsAwarded` so
       // the §20 results screen renders the actual wallet change.
-      const timeTrialCommit = timeTrialEnabled
+      const recordsOnlyCommit = recordsOnlyMode
         ? commitTimeTrialRecords({ result, fallbackSave: save })
         : null;
-      if (timeTrialCommit !== null) {
-        timeTrialSaveSnapshot = timeTrialCommit.save;
+      if (recordsOnlyCommit !== null) {
+        timeTrialSaveSnapshot = recordsOnlyCommit.save;
       }
-      const committed = timeTrialCommit
-        ? timeTrialCommit.result
+      const committed = recordsOnlyCommit
+        ? recordsOnlyCommit.result
         : commitRaceCredits({
             result,
             save,
@@ -1109,12 +1135,12 @@ function RaceCanvas({
         camera.x = session.player.car.x;
         latestEngineInput = {
           speed: session.player.car.speed,
-          topSpeed: STARTER_STATS.topSpeed,
+          topSpeed: playerStats.topSpeed,
           audio: persistedSettings.audio,
         };
         latestRaceMusicIntensity = raceMusicIntensity({
           speed: session.player.car.speed,
-          topSpeed: STARTER_STATS.topSpeed,
+          topSpeed: playerStats.topSpeed,
           nitroActive: session.player.nitro.activeRemainingSec > 0,
           finalLap: session.race.lap >= session.race.totalLaps,
         });
@@ -1140,7 +1166,7 @@ function RaceCanvas({
           upcomingCurvature(track.compiled.segments, camera.z, SEGMENT_LENGTH * 5),
         );
         if (
-          timeTrialEnabled &&
+          ghostEnabled &&
           session.race.phase === "racing" &&
           ghostDriverRef.current !== null &&
           ghostOverlayTickRef.current !== session.tick
@@ -1153,7 +1179,7 @@ function RaceCanvas({
             segments: track.compiled.segments,
           });
           ghostOverlayTickRef.current = session.tick;
-        } else if (!timeTrialEnabled || session.race.phase === "countdown") {
+        } else if (!ghostEnabled || session.race.phase === "countdown") {
           ghostOverlayRef.current = null;
           ghostOverlayTickRef.current = null;
         }
@@ -1217,16 +1243,16 @@ function RaceCanvas({
         const nitroUpgradeTier = nitroUpgradeTierForUpgrades(
           config.player.upgrades ?? null,
         );
-        const projectedCashDelta = timeTrialEnabled
-          ? undefined
-          : computeRaceReward({
+        const projectedCashDelta = economyEnabled
+          ? computeRaceReward({
               place: rankPosition(PLAYER_ID, cars),
               status: "finished",
               baseTrackReward: baseRewardForTrackDifficulty(
                 track.compiled.difficulty,
               ),
               difficulty: persistedDifficulty ?? "normal",
-            });
+            })
+          : undefined;
         const hud = deriveHudState({
           race: session.race,
           playerSpeedMetersPerSecond: session.player.car.speed,
@@ -1237,7 +1263,7 @@ function RaceCanvas({
           damage: session.player.damage,
           weather: renderWeather,
           weatherGripScalar: weatherGripScalarForState(
-            STARTER_STATS,
+            playerStats,
             session.weather,
             config.playerTire ?? "dry",
           ),
@@ -1343,14 +1369,14 @@ function RaceCanvas({
             // results screen will render. The `commitRaceCredits`
             // helper persists the merged save and mirrors the
             // wallet delta onto `RaceResult.creditsAwarded`.
-            const timeTrialCommit = timeTrialEnabled
+            const recordsOnlyCommit = recordsOnlyMode
               ? commitTimeTrialRecords({ result, fallbackSave: save })
               : null;
-            if (timeTrialCommit !== null) {
-              timeTrialSaveSnapshot = timeTrialCommit.save;
+            if (recordsOnlyCommit !== null) {
+              timeTrialSaveSnapshot = recordsOnlyCommit.save;
             }
-            const committed = timeTrialCommit
-              ? timeTrialCommit.result
+            const committed = recordsOnlyCommit
+              ? recordsOnlyCommit.result
               : commitRaceCredits({
                   result,
                   save,
@@ -1414,6 +1440,7 @@ function RaceCanvas({
     openPauseMenu,
     weather,
     playerTire,
+    selectedCarId,
   ]);
 
   return (

--- a/src/game/index.ts
+++ b/src/game/index.ts
@@ -21,6 +21,7 @@ export * from "./rng";
 export * from "./ghost";
 export * from "./ghostDriver";
 export * from "./timeTrial";
+export * from "./modes/quickRace";
 export * from "./assists";
 export * from "./difficultyPresets";
 export * from "./raceDamagePersistence";

--- a/src/game/modes/__tests__/quickRace.test.ts
+++ b/src/game/modes/__tests__/quickRace.test.ts
@@ -1,0 +1,155 @@
+import { describe, expect, it } from "vitest";
+
+import type { Car, Championship, Track } from "@/data/schemas";
+import { defaultSave } from "@/persistence";
+
+import { buildQuickRaceView, quickRaceHref } from "../quickRace";
+
+const CHAMPIONSHIP: Championship = {
+  id: "world-tour-standard",
+  name: "World Tour",
+  difficultyPreset: "normal",
+  tours: [
+    {
+      id: "velvet-coast",
+      requiredStanding: 4,
+      tracks: ["velvet-coast/harbor-run", "velvet-coast/sunpier-loop"],
+    },
+    {
+      id: "iron-borough",
+      requiredStanding: 4,
+      tracks: ["iron-borough/freightline-ring"],
+    },
+  ],
+};
+
+const TRACKS = new Map<string, Track>(
+  [
+    track("velvet-coast/harbor-run", "Harbor Run", ["clear", "rain"]),
+    track("velvet-coast/sunpier-loop", "Sunpier Loop", ["clear"]),
+    track("iron-borough/freightline-ring", "Freightline Ring", ["fog"]),
+  ].map((entry) => [entry.id, entry]),
+);
+
+const CARS = new Map<string, Car>([
+  [
+    "sparrow-gt",
+    {
+      id: "sparrow-gt",
+      name: "Sparrow GT",
+      class: "balance",
+      purchasePrice: 0,
+      repairFactor: 1,
+      baseStats: {
+        topSpeed: 61,
+        accel: 16,
+        brake: 28,
+        gripDry: 1,
+        gripWet: 0.82,
+        stability: 1,
+        durability: 0.95,
+        nitroEfficiency: 1,
+      },
+      upgradeCaps: {
+        engine: 4,
+        gearbox: 4,
+        dryTires: 4,
+        wetTires: 4,
+        nitro: 4,
+        armor: 4,
+        cooling: 4,
+        aero: 3,
+      },
+      visualProfile: {
+        spriteSet: "sparrow_gt",
+        paletteSet: "starter_a",
+      },
+    },
+  ],
+]);
+
+describe("buildQuickRaceView", () => {
+  it("lists the first tour tracks for a fresh save", () => {
+    const view = buildQuickRaceView({
+      save: defaultSave(),
+      championship: CHAMPIONSHIP,
+      tracksById: TRACKS,
+      carsById: CARS,
+    });
+
+    expect(view.tracks.map((option) => option.id)).toEqual([
+      "velvet-coast/harbor-run",
+      "velvet-coast/sunpier-loop",
+    ]);
+    expect(view.cars.map((option) => option.id)).toEqual(["sparrow-gt"]);
+  });
+
+  it("includes tracks from later unlocked tours without duplicates", () => {
+    const save = defaultSave();
+    const unlocked = {
+      ...save,
+      progress: {
+        ...save.progress,
+        unlockedTours: ["velvet-coast", "iron-borough"],
+      },
+    };
+
+    const view = buildQuickRaceView({
+      save: unlocked,
+      championship: CHAMPIONSHIP,
+      tracksById: TRACKS,
+      carsById: CARS,
+    });
+
+    expect(view.tracks.map((option) => option.id)).toEqual([
+      "velvet-coast/harbor-run",
+      "velvet-coast/sunpier-loop",
+      "iron-borough/freightline-ring",
+    ]);
+  });
+});
+
+describe("quickRaceHref", () => {
+  it("builds the race URL with mode, track, weather, and car", () => {
+    expect(
+      quickRaceHref({
+        trackId: "velvet-coast/harbor-run",
+        weather: "rain",
+        carId: "sparrow-gt",
+      }),
+    ).toBe(
+      "/race?mode=quickRace&track=velvet-coast%2Fharbor-run&weather=rain&car=sparrow-gt",
+    );
+  });
+});
+
+function track(
+  id: string,
+  name: string,
+  weatherOptions: Track["weatherOptions"],
+): Track {
+  return {
+    id,
+    name,
+    tourId: id.split("/")[0] ?? "test",
+    author: "test",
+    version: 1,
+    lengthMeters: 1000,
+    laps: 1,
+    laneCount: 2,
+    weatherOptions,
+    difficulty: 1,
+    segments: [
+      {
+        len: 100,
+        curve: 0,
+        grade: 0,
+        roadsideLeft: "none",
+        roadsideRight: "none",
+        hazards: [],
+      },
+    ],
+    checkpoints: [],
+    spawn: { gridSlots: 2 },
+  };
+}

--- a/src/game/modes/quickRace.ts
+++ b/src/game/modes/quickRace.ts
@@ -1,0 +1,89 @@
+import type {
+  Car,
+  Championship,
+  SaveGame,
+  Track,
+  WeatherOption,
+} from "@/data/schemas";
+
+export interface QuickRaceTrackOption {
+  readonly id: string;
+  readonly name: string;
+  readonly weatherOptions: readonly WeatherOption[];
+}
+
+export interface QuickRaceCarOption {
+  readonly id: string;
+  readonly name: string;
+}
+
+export interface QuickRaceView {
+  readonly tracks: readonly QuickRaceTrackOption[];
+  readonly cars: readonly QuickRaceCarOption[];
+}
+
+export interface QuickRaceHrefInput {
+  readonly trackId: string;
+  readonly weather: WeatherOption;
+  readonly carId: string;
+}
+
+export function buildQuickRaceView(input: {
+  readonly save: SaveGame;
+  readonly championship: Championship;
+  readonly tracksById: ReadonlyMap<string, Track>;
+  readonly carsById: ReadonlyMap<string, Car>;
+}): QuickRaceView {
+  const unlockedTrackIds = unlockedQuickRaceTrackIds(
+    input.save,
+    input.championship,
+  );
+  return {
+    tracks: unlockedTrackIds.flatMap((trackId) => {
+      const track = input.tracksById.get(trackId);
+      if (!track) return [];
+      return [
+        {
+          id: track.id,
+          name: track.name,
+          weatherOptions: track.weatherOptions,
+        },
+      ];
+    }),
+    cars: input.save.garage.ownedCars.flatMap((carId) => {
+      const car = input.carsById.get(carId);
+      if (!car) return [];
+      return [{ id: car.id, name: car.name }];
+    }),
+  };
+}
+
+export function quickRaceHref(input: QuickRaceHrefInput): string {
+  const params = new URLSearchParams({
+    mode: "quickRace",
+    track: input.trackId,
+    weather: input.weather,
+    car: input.carId,
+  });
+  return `/race?${params.toString()}`;
+}
+
+function unlockedQuickRaceTrackIds(
+  save: SaveGame,
+  championship: Championship,
+): readonly string[] {
+  const firstTourId = championship.tours[0]?.id;
+  const unlocked = new Set(save.progress.unlockedTours);
+  if (firstTourId) unlocked.add(firstTourId);
+  const seen = new Set<string>();
+  const ids: string[] = [];
+  for (const tour of championship.tours) {
+    if (!unlocked.has(tour.id)) continue;
+    for (const trackId of tour.tracks) {
+      if (seen.has(trackId)) continue;
+      seen.add(trackId);
+      ids.push(trackId);
+    }
+  }
+  return ids;
+}


### PR DESCRIPTION
## Summary

- add a Quick Race picker route for unlocked tracks, authored weather, and owned cars
- add `mode=quickRace` to the race runtime with AI enabled and selected-car stats
- keep Quick Race records while disabling campaign credits and damage persistence

## GDD sections

- docs/gdd/06-game-modes.md Quick race
- docs/gdd/20-hud-and-ui-ux.md title menu and results
- docs/gdd/21-technical-design-for-web-implementation.md runtime reuse
- docs/gdd/22-data-schemas.md save records

## Requirement inventory

Handled:
- Quick Race appears from the title menu.
- Quick Race lets the player choose an unlocked track, authored weather option, and owned car.
- Quick Race starts `/race?mode=quickRace` with AI present.
- Finished Quick Race runs write PB records but do not award campaign credits or persist race damage.

Left to followups or existing backlog:
- Practice mode restart, checkpoint reset, telemetry overlay, and weather swap remain under `VibeGear2-implement-practice-quick-ad3ba399`.

## Progress log

- `docs/PROGRESS_LOG.md`: `2026-04-29: Slice: Quick Race mode`

## Test plan

- [x] `npm run typecheck`
- [x] `npx vitest run src/game/modes/__tests__/quickRace.test.ts src/app/__tests__/page.test.tsx scripts/__tests__/content-lint.test.ts`
- [x] `npx playwright test e2e/title-screen.spec.ts e2e/race-finish.spec.ts`
- [x] `npm run verify`
- [x] `npx vitest run scripts/__tests__/content-lint.test.ts`
- [x] `grep -rn $'\u2014\|\u2013' src/app/quick-race src/app/race/page.tsx src/app/page.tsx src/game/modes/quickRace.ts src/game/modes/__tests__/quickRace.test.ts e2e/title-screen.spec.ts e2e/race-finish.spec.ts docs/PROGRESS_LOG.md docs/GDD_COVERAGE.json || true`
- [x] `git diff --check`

## Followups created

None.
