### PR TITLE
feat(modes): add practice mode

### DIFF
--- a/docs/GDD_COVERAGE.json
+++ b/docs/GDD_COVERAGE.json
@@ -230,6 +230,27 @@
       "followupRefs": ["VibeGear2-implement-practice-quick-ad3ba399"]
     },
     {
+      "id": "GDD-06-PRACTICE-MODE",
+      "gddSections": [
+        "docs/gdd/06-game-modes.md",
+        "docs/gdd/20-hud-and-ui-ux.md",
+        "docs/gdd/21-technical-design-for-web-implementation.md"
+      ],
+      "requirement": "Practice mode starts a no-stakes test session with restart, checkpoint reset, visible grip telemetry, and instant weather swap controls.",
+      "coverage": ["implemented-code", "automated-test"],
+      "implementationRefs": [
+        "src/app/race/page.tsx",
+        "src/game/raceSessionActions.ts",
+        "src/app/page.tsx"
+      ],
+      "testRefs": [
+        "src/game/__tests__/raceSessionActions.test.ts",
+        "e2e/title-screen.spec.ts",
+        "e2e/practice-mode.spec.ts"
+      ],
+      "followupRefs": ["VibeGear2-implement-practice-quick-ad3ba399"]
+    },
+    {
       "id": "GDD-10-GRASS-RESTART-PHYSICS",
       "gddSections": [
         "docs/gdd/10-driving-model-and-physics.md",

--- a/docs/PROGRESS_LOG.md
+++ b/docs/PROGRESS_LOG.md
@@ -12,7 +12,7 @@ Correct them by adding a new entry that references the old one.
 [§6](gdd/06-game-modes.md) Practice,
 [§20](gdd/20-hud-and-ui-ux.md) title menu and race controls,
 [§21](gdd/21-technical-design-for-web-implementation.md) runtime reuse.
-**Branch / PR:** `feat/practice-mode`, PR pending.
+**Branch / PR:** `feat/practice-mode`, PR #94.
 **Status:** Implemented.
 
 ### Done

--- a/docs/PROGRESS_LOG.md
+++ b/docs/PROGRESS_LOG.md
@@ -6,6 +6,56 @@ Correct them by adding a new entry that references the old one.
 
 ---
 
+## 2026-04-29: Slice: Practice mode
+
+**GDD sections touched:**
+[§6](gdd/06-game-modes.md) Practice,
+[§20](gdd/20-hud-and-ui-ux.md) title menu and race controls,
+[§21](gdd/21-technical-design-for-web-implementation.md) runtime reuse.
+**Branch / PR:** `feat/practice-mode`, PR pending.
+**Status:** Implemented.
+
+### Done
+- `src/app/race/page.tsx`: added `mode=practice` with no AI grid,
+  no campaign economy, no damage persistence, no PB writes, and no
+  countdown delay.
+- `src/app/race/page.tsx`: added a Practice control panel with restart,
+  checkpoint reset, weather swap, and grip telemetry.
+- `src/game/raceSessionActions.ts`: added pure helpers for checkpoint
+  rewind and instant weather swaps.
+- `src/app/page.tsx`: added Practice to the title menu.
+- `docs/GDD_COVERAGE.json`: added GDD-06-PRACTICE-MODE.
+
+### Verified
+- `npm run typecheck` green.
+- `npx vitest run src/game/__tests__/raceSessionActions.test.ts src/app/__tests__/page.test.tsx`
+  green, 22 passed.
+- `npx playwright test e2e/title-screen.spec.ts --grep "Practice|main menu" e2e/practice-mode.spec.ts`
+  green, 3 passed.
+- `npm run verify` green, 2526 passed.
+- `npm run test:e2e` green, 84 passed.
+
+### Decisions and assumptions
+- Practice sessions use the normal race renderer and physics but disable
+  all persistent result writes. Results can still be staged in session
+  storage if the player finishes or retires.
+- Checkpoint reset is pinned with pure unit coverage. The browser smoke
+  verifies the shipped control surface and weather swap because reaching
+  a mid-track checkpoint in e2e is slow and already covered by the
+  checkpoint detector tests.
+
+### Coverage ledger
+- GDD-06-PRACTICE-MODE covers the §6 Practice requirement for restart,
+  checkpoint reset, grip telemetry, and instant weather swap.
+- Uncovered adjacent requirements: none for the Practice and Quick Race
+  parent dot after this slice.
+
+### Followups created
+None.
+
+### GDD edits
+None.
+
 ## 2026-04-29: Slice: Quick Race mode
 
 **GDD sections touched:**

--- a/docs/PROGRESS_LOG.md
+++ b/docs/PROGRESS_LOG.md
@@ -30,9 +30,11 @@ Correct them by adding a new entry that references the old one.
 - `npm run typecheck` green.
 - `npx vitest run src/game/__tests__/raceSessionActions.test.ts src/app/__tests__/page.test.tsx`
   green, 22 passed.
+- `npx vitest run src/game/__tests__/raceSession.test.ts src/game/__tests__/raceSessionActions.test.ts src/app/__tests__/page.test.tsx`
+  green, 141 passed after PR review fixes.
 - `npx playwright test e2e/title-screen.spec.ts --grep "Practice|main menu" e2e/practice-mode.spec.ts`
   green, 3 passed.
-- `npm run verify` green, 2526 passed.
+- `npm run verify` green, 2528 passed.
 - `npm run test:e2e` green, 84 passed.
 
 ### Decisions and assumptions

--- a/e2e/practice-mode.spec.ts
+++ b/e2e/practice-mode.spec.ts
@@ -1,0 +1,34 @@
+import { expect, test } from "@playwright/test";
+
+test.describe("practice mode", () => {
+  test("starts without stakes and swaps weather in-session", async ({ page }) => {
+    await page.goto(
+      "/race?mode=practice&track=velvet-coast%2Fharbor-run&weather=clear",
+    );
+
+    await expect(page.getByTestId("race-canvas")).toHaveAttribute(
+      "data-mode",
+      "practice",
+    );
+    await expect(page.getByTestId("race-phase")).toHaveText("racing", {
+      timeout: 10_000,
+    });
+    await expect(page.getByTestId("race-field-size")).toHaveText("1");
+    await expect(page.getByTestId("practice-panel")).toBeVisible();
+    await expect(page.getByTestId("practice-weather-select")).toHaveValue(
+      "clear",
+    );
+    await expect(page.getByTestId("practice-grip")).toHaveText("108%");
+    await expect(page.getByTestId("practice-checkpoint-reset")).toBeDisabled();
+
+    await page.getByTestId("practice-weather-select").selectOption("rain");
+
+    await expect(page.getByTestId("practice-weather-select")).toHaveValue(
+      "rain",
+    );
+    await expect(page.getByTestId("practice-grip")).toHaveText("88%");
+
+    await page.getByTestId("practice-restart").click();
+    await expect(page.getByTestId("race-phase")).toHaveText("racing");
+  });
+});

--- a/e2e/practice-mode.spec.ts
+++ b/e2e/practice-mode.spec.ts
@@ -18,7 +18,10 @@ test.describe("practice mode", () => {
     await expect(page.getByTestId("practice-weather-select")).toHaveValue(
       "clear",
     );
-    await expect(page.getByTestId("practice-grip")).toHaveText("108%");
+    await expect(page.getByTestId("practice-grip")).toHaveText(/^\d+%$/);
+    const clearGripText = await page.getByTestId("practice-grip").textContent();
+    const clearGrip = Number(clearGripText?.replace("%", ""));
+    expect(clearGrip).toBeGreaterThan(0);
     await expect(page.getByTestId("practice-checkpoint-reset")).toBeDisabled();
 
     await page.getByTestId("practice-weather-select").selectOption("rain");
@@ -26,7 +29,16 @@ test.describe("practice mode", () => {
     await expect(page.getByTestId("practice-weather-select")).toHaveValue(
       "rain",
     );
-    await expect(page.getByTestId("practice-grip")).toHaveText("88%");
+    await expect
+      .poll(async () =>
+        Number(
+          (await page.getByTestId("practice-grip").textContent())?.replace(
+            "%",
+            "",
+          ),
+        ),
+      )
+      .toBeLessThan(clearGrip);
 
     await page.getByTestId("practice-restart").click();
     await expect(page.getByTestId("race-phase")).toHaveText("racing");

--- a/e2e/title-screen.spec.ts
+++ b/e2e/title-screen.spec.ts
@@ -71,6 +71,11 @@ test.describe("title screen", () => {
     await expect(quickRace).toHaveText("Quick Race");
     await expect(quickRace).toHaveAttribute("href", "/quick-race");
 
+    const practice = page.getByTestId("menu-practice");
+    await expect(practice).toBeVisible();
+    await expect(practice).toHaveText("Practice");
+    await expect(practice).toHaveAttribute("href", "/race?mode=practice");
+
     const daily = page.getByTestId("menu-daily");
     await expect(daily).toBeVisible();
     await expect(daily).toHaveText("Daily Challenge");
@@ -127,6 +132,17 @@ test.describe("title screen", () => {
       "href",
       /\/race\?mode=quickRace&track=.+&weather=.+&car=.+/,
     );
+  });
+
+  test("Practice link navigates to practice race mode", async ({ page }) => {
+    await page.goto("/");
+    await page.getByTestId("menu-practice").click();
+    await expect(page).toHaveURL(/\/race\?mode=practice$/);
+    await expect(page.getByTestId("race-canvas")).toHaveAttribute(
+      "data-mode",
+      "practice",
+    );
+    await expect(page.getByTestId("practice-panel")).toBeVisible();
   });
 
   test("Daily Challenge link navigates to /daily", async ({ page }) => {

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -8,14 +8,15 @@ import styles from "./page.module.css";
  *
  * Renders the top-level main menu items per GDD §5 and §20:
  * Start Race -> `/race`, World Tour -> `/world`, Time Trial ->
- * `/time-trial`, Quick Race -> `/quick-race`, Daily Challenge -> `/daily`,
- * Garage -> `/garage`, Options -> `/options`. The Options entry was a disabled placeholder
- * (`menu-options-pending`) until the `/options` scaffold landed in
+ * `/time-trial`, Quick Race -> `/quick-race`, Practice ->
+ * `/race?mode=practice`, Daily Challenge -> `/daily`, Garage ->
+ * `/garage`, Options -> `/options`. The Options entry was a disabled
+ * placeholder (`menu-options-pending`) until the `/options` scaffold landed in
  * `VibeGear2-implement-options-screen-a9379c4a`. Its replacement keeps
  * the original `menu-options` test id that the e2e suite asserts on.
  *
  * Keyboard order is Start Race -> World Tour -> Time Trial -> Quick Race
- * -> Daily Challenge -> Garage -> Options (DOM order).
+ * -> Practice -> Daily Challenge -> Garage -> Options (DOM order).
  *
  * The footer carries two pieces of metadata. The pre-existing
  * `build-status` line tracks the design phase (kept verbatim so the
@@ -37,6 +38,7 @@ const MENU: ReadonlyArray<MenuItem> = [
   { label: "World Tour", href: "/world", testId: "menu-world" },
   { label: "Time Trial", href: "/time-trial", testId: "menu-time-trial" },
   { label: "Quick Race", href: "/quick-race", testId: "menu-quick-race" },
+  { label: "Practice", href: "/race?mode=practice", testId: "menu-practice" },
   { label: "Daily Challenge", href: "/daily", testId: "menu-daily" },
   { label: "Garage", href: "/garage", testId: "menu-garage" },
   { label: "Options", href: "/options", testId: "menu-options" },

--- a/src/app/race/page.tsx
+++ b/src/app/race/page.tsx
@@ -788,7 +788,12 @@ function RaceCanvas({
       if (mode !== "practice") return;
       const session = sessionRef.current;
       if (!session) return;
-      sessionRef.current = setRaceSessionWeather(session, nextWeather);
+      if (!track.compiled.weatherOptions.includes(nextWeather)) return;
+      sessionRef.current = setRaceSessionWeather(
+        session,
+        nextWeather,
+        track.compiled.weatherOptions,
+      );
       setPracticeSnapshot((prev) =>
         prev === null
           ? prev
@@ -798,7 +803,7 @@ function RaceCanvas({
             },
       );
     },
-    [mode],
+    [mode, track],
   );
 
   const pauseActions = usePauseActions({

--- a/src/app/race/page.tsx
+++ b/src/app/race/page.tsx
@@ -78,6 +78,8 @@ import {
   applyTourRaceResult,
   rankPosition,
   retireRaceSession,
+  resetRaceSessionToLastCheckpoint,
+  setRaceSessionWeather,
   spawnGrid,
   startLoop,
   stepRaceSession,
@@ -102,6 +104,7 @@ import {
   WeatherOptionSchema,
   type AIDriver,
   type CarBaseStats,
+  type WeatherOption,
 } from "@/data/schemas";
 import {
   CAMERA_DEPTH,
@@ -411,9 +414,10 @@ function resolveTrack(
   return { id, runtimeId, version: parsed.version, compiled: loadTrack(runtimeId) };
 }
 
-type RaceMode = "race" | "timeTrial" | "quickRace";
+type RaceMode = "race" | "timeTrial" | "quickRace" | "practice";
 
 function resolveRaceMode(raw: string | null): RaceMode {
+  if (raw === "practice") return "practice";
   if (raw === "quickRace") return "quickRace";
   return raw === "timeTrial" ? "timeTrial" : "race";
 }
@@ -429,6 +433,13 @@ function resolveRaceWeather(
 
 function resolvePlayerTire(raw: string | null): TireKind | undefined {
   return raw === "wet" || raw === "dry" ? raw : undefined;
+}
+
+function weatherOptionLabel(weather: WeatherOption): string {
+  return weather
+    .split("_")
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+    .join(" ");
 }
 
 function resolveSessionCar(
@@ -725,6 +736,14 @@ function RaceCanvas({
     steer: number;
     touchActive: boolean;
   }>(() => ({ steer: 0, touchActive: false }));
+  const [practiceSnapshot, setPracticeSnapshot] = useState<{
+    weather: WeatherOption;
+    weatherGripPercent: number;
+    tire: TireKind;
+    surface: string;
+    checkpointLabel: string | null;
+    checkpointReady: boolean;
+  } | null>(null);
   const [fieldSize, setFieldSize] = useState<number>(1);
   const [touchLayout, setTouchLayout] = useState<TouchLayout>(() =>
     touchLayoutFor({ width: VIEWPORT_WIDTH, height: VIEWPORT_HEIGHT }),
@@ -758,6 +777,29 @@ function RaceCanvas({
   const onExitToTitleImpl = useCallback(() => {
     exitFnRef.current?.();
   }, []);
+  const onPracticeCheckpointReset = useCallback(() => {
+    if (mode !== "practice") return;
+    const session = sessionRef.current;
+    if (!session) return;
+    sessionRef.current = resetRaceSessionToLastCheckpoint(session);
+  }, [mode]);
+  const onPracticeWeatherChange = useCallback(
+    (nextWeather: WeatherOption) => {
+      if (mode !== "practice") return;
+      const session = sessionRef.current;
+      if (!session) return;
+      sessionRef.current = setRaceSessionWeather(session, nextWeather);
+      setPracticeSnapshot((prev) =>
+        prev === null
+          ? prev
+          : {
+              ...prev,
+              weather: nextWeather,
+            },
+      );
+    },
+    [mode],
+  );
 
   const pauseActions = usePauseActions({
     closeMenu: pause.closeMenu,
@@ -791,17 +833,19 @@ function RaceCanvas({
     const persistedAssists = persistedSettings.assists;
     const persistedDifficulty = persistedSettings.difficultyPreset;
     const persistedKeyBindings = readKeyBindings(sessionSave);
+    const practiceMode = mode === "practice";
     const ghostEnabled = mode === "timeTrial";
     const recordsOnlyMode = mode === "timeTrial" || mode === "quickRace";
+    const noCampaignMode = recordsOnlyMode || practiceMode;
     const economyEnabled = mode === "race";
     const sessionCar = resolveSessionCar(sessionSave, selectedCarId);
     const playerStats = sessionCar.stats;
-    const initialPlayerDamage = recordsOnlyMode
+    const initialPlayerDamage = noCampaignMode
       ? PRISTINE_DAMAGE_STATE
       : pendingDamageForActiveCar(sessionSave);
     const raceSeed = 1;
     let timeTrialSaveSnapshot = sessionSave;
-    const spawnedAi = ghostEnabled
+    const spawnedAi = ghostEnabled || practiceMode
       ? []
       : spawnGrid({
           trackSpawn: track.compiled.spawn,
@@ -826,6 +870,7 @@ function RaceCanvas({
       seed: raceSeed,
       ...(weather ? { weather } : {}),
       ...(playerTire ? { playerTire } : {}),
+      ...(practiceMode ? { countdownSec: 0 } : {}),
       ...(lapsOverride !== null ? { totalLaps: lapsOverride } : {}),
     };
     setFieldSize(1 + config.ai.length);
@@ -932,7 +977,7 @@ function RaceCanvas({
     const raceMusicCueForSession = raceMusicCue({
       trackId: track.id,
       tourId: tourContext?.tourId,
-      mode: mode === "quickRace" ? "race" : mode,
+      mode: mode === "quickRace" || mode === "practice" ? "race" : mode,
     });
     let latestEngineInput: EngineRuntimeInput = {
       speed: 0,
@@ -1017,7 +1062,7 @@ function RaceCanvas({
       // the dl below re-renders the countdown immediately rather than
       // showing the racing phase momentarily until the next render
       // tick fires.
-      setPhase("countdown");
+      setPhase((config.countdownSec ?? 3) > 0 ? "countdown" : "racing");
       setCountdownSecondsLeft(Math.ceil(config.countdownSec ?? 3));
       setResultMs(null);
       lastCountdownSfxStep = null;
@@ -1081,26 +1126,30 @@ function RaceCanvas({
       }
       const committed = recordsOnlyCommit
         ? recordsOnlyCommit.result
-        : commitRaceCredits({
-            result,
-            save,
-            // §15 default per `SaveGameSettingsSchema`: a v1 save without
-            // a `difficultyPreset` field reads as `'normal'`.
-            difficulty: persistedDifficulty ?? "normal",
-            baseTrackReward: baseRewardForTrackDifficulty(track.compiled.difficulty),
-            damageAfter: retired.player.damage,
-            activeCarId: save.garage.activeCarId,
-            transformCommit:
-              tourContext === null
-                ? undefined
-                : (nextSave, nextResult) =>
-                    applyTourRaceResult({
-                      save: nextSave,
-                      result: nextResult,
-                      championship: tourContext.championship,
-                      playerCarId: save.garage.activeCarId,
-                    }),
-          });
+        : practiceMode
+          ? { ...result, creditsAwarded: 0 }
+          : commitRaceCredits({
+              result,
+              save,
+              // §15 default per `SaveGameSettingsSchema`: a v1 save without
+              // a `difficultyPreset` field reads as `'normal'`.
+              difficulty: persistedDifficulty ?? "normal",
+              baseTrackReward: baseRewardForTrackDifficulty(
+                track.compiled.difficulty,
+              ),
+              damageAfter: retired.player.damage,
+              activeCarId: save.garage.activeCarId,
+              transformCommit:
+                tourContext === null
+                  ? undefined
+                  : (nextSave, nextResult) =>
+                      applyTourRaceResult({
+                        save: nextSave,
+                        result: nextResult,
+                        championship: tourContext.championship,
+                        playerCarId: save.garage.activeCarId,
+                      }),
+            });
       saveRaceResult(committed);
       // Flip the natural-finish guard so the render callback's finish
       // wiring cannot also fire on the next frame (the loop tear-down
@@ -1367,7 +1416,8 @@ function RaceCanvas({
               playerStartPosition: 1,
               damageBefore: damageDeltaFromState(initialPlayerDamage),
               damageAfter: damageDeltaFromState(session.player.damage),
-              recordPBs: session.player.status === "finished",
+              recordPBs:
+                !practiceMode && session.player.status === "finished",
               championship: tourContext?.championship,
               tourId: tourContext?.tourId,
               currentTrackIndex: tourContext?.raceIndex,
@@ -1384,28 +1434,30 @@ function RaceCanvas({
             }
             const committed = recordsOnlyCommit
               ? recordsOnlyCommit.result
-              : commitRaceCredits({
-                  result,
-                  save,
-                  // §15 default per `SaveGameSettingsSchema`: a v1 save
-                  // without a `difficultyPreset` reads as `'normal'`.
-                  difficulty: persistedDifficulty ?? "normal",
-                  baseTrackReward: baseRewardForTrackDifficulty(
-                    track.compiled.difficulty,
-                  ),
-                  damageAfter: session.player.damage,
-                  activeCarId: save.garage.activeCarId,
-                  transformCommit:
-                    tourContext === null
-                      ? undefined
-                      : (nextSave, nextResult) =>
-                          applyTourRaceResult({
-                            save: nextSave,
-                            result: nextResult,
-                            championship: tourContext.championship,
-                            playerCarId: save.garage.activeCarId,
-                          }),
-                });
+              : practiceMode
+                ? { ...result, creditsAwarded: 0 }
+                : commitRaceCredits({
+                    result,
+                    save,
+                    // §15 default per `SaveGameSettingsSchema`: a v1 save
+                    // without a `difficultyPreset` reads as `'normal'`.
+                    difficulty: persistedDifficulty ?? "normal",
+                    baseTrackReward: baseRewardForTrackDifficulty(
+                      track.compiled.difficulty,
+                    ),
+                    damageAfter: session.player.damage,
+                    activeCarId: save.garage.activeCarId,
+                    transformCommit:
+                      tourContext === null
+                        ? undefined
+                        : (nextSave, nextResult) =>
+                            applyTourRaceResult({
+                              save: nextSave,
+                              result: nextResult,
+                              championship: tourContext.championship,
+                              playerCarId: save.garage.activeCarId,
+                            }),
+                  });
             saveRaceResult(committed);
             // Tear down the loop, input, and audio bindings before the
             // route hop. Mirrors the retire branch tear-down ordering.
@@ -1429,6 +1481,22 @@ function RaceCanvas({
           steer: lastSteerRef.current,
           touchActive: inputManager.hasTouch(),
         });
+        if (practiceMode) {
+          setPracticeSnapshot({
+            weather: renderWeather,
+            weatherGripPercent: Math.round(
+              weatherGripScalarForState(
+                playerStats,
+                session.weather,
+                config.playerTire ?? "dry",
+              ) * 100,
+            ),
+            tire: config.playerTire ?? "dry",
+            surface: session.player.car.surface,
+            checkpointLabel: session.race.lastCheckpoint?.label ?? null,
+            checkpointReady: session.race.lastCheckpoint !== null,
+          });
+        }
       },
     });
 
@@ -1501,6 +1569,67 @@ function RaceCanvas({
           Race finished. Total time: {(resultMs / 1000).toFixed(2)} s
         </div>
       ) : null}
+      {mode === "practice" && practiceSnapshot !== null ? (
+        <section
+          aria-label="Practice controls"
+          data-testid="practice-panel"
+          style={practicePanelStyle}
+        >
+          <div style={practiceToolbarStyle}>
+            <button
+              type="button"
+              data-testid="practice-restart"
+              style={practiceButtonStyle}
+              onClick={onRestartImpl}
+            >
+              Restart
+            </button>
+            <button
+              type="button"
+              data-testid="practice-checkpoint-reset"
+              style={practiceButtonStyle}
+              onClick={onPracticeCheckpointReset}
+              disabled={!practiceSnapshot.checkpointReady}
+            >
+              Checkpoint
+            </button>
+            <label style={practiceSelectLabelStyle}>
+              Weather
+              <select
+                data-testid="practice-weather-select"
+                value={practiceSnapshot.weather}
+                onChange={(event) => {
+                  const parsed = WeatherOptionSchema.safeParse(
+                    event.currentTarget.value,
+                  );
+                  if (parsed.success) onPracticeWeatherChange(parsed.data);
+                }}
+                style={practiceSelectStyle}
+              >
+                {track.compiled.weatherOptions.map((option) => (
+                  <option key={option} value={option}>
+                    {weatherOptionLabel(option)}
+                  </option>
+                ))}
+              </select>
+            </label>
+          </div>
+          <dl style={practiceTelemetryStyle}>
+            <dt>Grip</dt>
+            <dd data-testid="practice-grip">
+              {practiceSnapshot.weatherGripPercent}%
+            </dd>
+            <dt>Tire</dt>
+            <dd data-testid="practice-tire">{practiceSnapshot.tire}</dd>
+            <dt>Surface</dt>
+            <dd data-testid="practice-surface">{practiceSnapshot.surface}</dd>
+            <dt>Checkpoint</dt>
+            <dd data-testid="practice-checkpoint">
+              {practiceSnapshot.checkpointLabel ?? "none"}
+            </dd>
+          </dl>
+        </section>
+      ) : null}
       <PauseOverlay open={pause.open} {...pauseActions} />
     </main>
   );
@@ -1544,4 +1673,61 @@ const resultStyle: CSSProperties = {
   border: "1px solid var(--muted, #888)",
   borderRadius: "6px",
   background: "rgba(255,255,255,0.05)",
+};
+
+const practicePanelStyle: CSSProperties = {
+  position: "absolute",
+  left: "50%",
+  bottom: "1rem",
+  transform: "translateX(-50%)",
+  display: "grid",
+  gap: "0.5rem",
+  minWidth: "min(42rem, calc(100vw - 2rem))",
+  padding: "0.75rem",
+  border: "1px solid rgba(160, 200, 255, 0.72)",
+  borderRadius: "6px",
+  background: "rgba(8, 14, 25, 0.86)",
+  color: "#f4f7ff",
+  pointerEvents: "auto",
+};
+
+const practiceToolbarStyle: CSSProperties = {
+  display: "flex",
+  flexWrap: "wrap",
+  gap: "0.5rem",
+  alignItems: "center",
+};
+
+const practiceButtonStyle: CSSProperties = {
+  minHeight: "2.25rem",
+  padding: "0 0.75rem",
+  border: "1px solid rgba(240, 245, 255, 0.7)",
+  borderRadius: "4px",
+  background: "rgba(245, 248, 255, 0.12)",
+  color: "inherit",
+  font: "inherit",
+  cursor: "pointer",
+};
+
+const practiceSelectLabelStyle: CSSProperties = {
+  display: "flex",
+  gap: "0.5rem",
+  alignItems: "center",
+};
+
+const practiceSelectStyle: CSSProperties = {
+  minHeight: "2.25rem",
+  border: "1px solid rgba(240, 245, 255, 0.7)",
+  borderRadius: "4px",
+  background: "#0e1727",
+  color: "inherit",
+  font: "inherit",
+};
+
+const practiceTelemetryStyle: CSSProperties = {
+  display: "grid",
+  gridTemplateColumns: "repeat(4, auto)",
+  gap: "0.25rem 0.75rem",
+  margin: 0,
+  fontSize: "0.86rem",
 };

--- a/src/game/__tests__/raceSession.test.ts
+++ b/src/game/__tests__/raceSession.test.ts
@@ -635,6 +635,24 @@ describe("stepRaceSession (sector timer)", () => {
     expect(session.sectorTimer.sectors[1]!.tickEntered).toBe(session.tick);
   });
 
+  it("stamps the most recent checkpoint for practice reset", () => {
+    const config = buildConfig({ countdownSec: 0 });
+    let session = createRaceSession(config);
+    session = {
+      ...session,
+      player: {
+        ...session.player,
+        car: { ...session.player.car, z: 407, speed: 60 },
+      },
+    };
+
+    session = stepRaceSession(session, fullThrottle(), config, DT);
+
+    expect(session.race.lastCheckpoint?.label).toBe("sector-1");
+    expect(session.race.lastCheckpoint?.carState.z).toBeGreaterThan(408);
+    expect(session.race.passedCheckpointsThisLap.has(68)).toBe(true);
+  });
+
   it("captures the previous lap as the baseline for the next lap", () => {
     const track = loadTrack("test/curve");
     const config: RaceSessionConfig = {

--- a/src/game/__tests__/raceSessionActions.test.ts
+++ b/src/game/__tests__/raceSessionActions.test.ts
@@ -31,9 +31,12 @@ import {
 import {
   DNF_REASON_RETIRED,
   buildFinalCarInputsFromSession,
+  resetRaceSessionToLastCheckpoint,
   retireRaceSession,
+  setRaceSessionWeather,
 } from "@/game/raceSessionActions";
 import { NEUTRAL_INPUT } from "@/game/input";
+import { applyCheckpointPass } from "@/game/raceCheckpoints";
 import type { AIDriver, CarBaseStats } from "@/data/schemas";
 
 const STARTER_STATS: CarBaseStats = Object.freeze({
@@ -138,6 +141,70 @@ describe("retireRaceSession", () => {
     expect(retired.ai).toHaveLength(session.ai.length);
     expect(retired.ai[0]?.status).toBe(session.ai[0]?.status);
     expect(retired.ai[0]?.car.z).toBe(session.ai[0]?.car.z);
+  });
+});
+
+describe("resetRaceSessionToLastCheckpoint", () => {
+  it("rewinds the player car to the most recent checkpoint snapshot", () => {
+    const config = buildConfig();
+    const session = createRaceSession(config);
+    const checkpointCar = {
+      ...session.player.car,
+      x: 0.35,
+      z: 410,
+      speed: 23,
+    };
+    const withCheckpoint = {
+      ...session,
+      race: applyCheckpointPass(
+        session.race,
+        { segmentIndex: 68, label: "sector-1" },
+        22,
+        checkpointCar,
+      ),
+      player: {
+        ...session.player,
+        car: { ...session.player.car, x: -0.8, z: 700, speed: 55 },
+      },
+    };
+
+    const reset = resetRaceSessionToLastCheckpoint(withCheckpoint);
+
+    expect(reset.player.car).toEqual(checkpointCar);
+    expect(reset.player.car).not.toBe(checkpointCar);
+    expect(withCheckpoint.player.car.z).toBe(700);
+  });
+
+  it("returns a fresh no-op clone when no checkpoint has been passed", () => {
+    const session = createRaceSession(buildConfig());
+    const reset = resetRaceSessionToLastCheckpoint(session);
+    expect(reset.player.car).toEqual(session.player.car);
+    expect(reset.player.car).not.toBe(session.player.car);
+  });
+});
+
+describe("setRaceSessionWeather", () => {
+  it("switches the live weather immediately and clears any transition", () => {
+    const session = createRaceSession({
+      ...buildConfig(),
+      weather: "clear",
+    });
+    const withTransition = {
+      ...session,
+      weather: {
+        current: "clear" as const,
+        transitioning: {
+          from: "clear" as const,
+          to: "rain" as const,
+          progress: 0.4,
+        },
+      },
+    };
+
+    const swapped = setRaceSessionWeather(withTransition, "snow");
+
+    expect(swapped.weather).toEqual({ current: "snow", transitioning: null });
+    expect(withTransition.weather.transitioning).not.toBeNull();
   });
 });
 

--- a/src/game/__tests__/raceSessionActions.test.ts
+++ b/src/game/__tests__/raceSessionActions.test.ts
@@ -201,10 +201,25 @@ describe("setRaceSessionWeather", () => {
       },
     };
 
-    const swapped = setRaceSessionWeather(withTransition, "snow");
+    const swapped = setRaceSessionWeather(withTransition, "snow", [
+      "clear",
+      "snow",
+    ]);
 
     expect(swapped.weather).toEqual({ current: "snow", transitioning: null });
     expect(withTransition.weather.transitioning).not.toBeNull();
+  });
+
+  it("ignores weather that is not allowed by the active track", () => {
+    const session = createRaceSession({
+      ...buildConfig(),
+      weather: "clear",
+    });
+
+    const swapped = setRaceSessionWeather(session, "snow", ["clear"]);
+
+    expect(swapped.weather).toEqual(session.weather);
+    expect(swapped.weather).not.toBe(session.weather);
   });
 });
 

--- a/src/game/raceSession.ts
+++ b/src/game/raceSession.ts
@@ -120,7 +120,12 @@ import {
   type Surface,
   type TrackContext,
 } from "./physics";
-import { EMPTY_PASSED_SET } from "./raceCheckpoints";
+import {
+  EMPTY_PASSED_SET,
+  applyCheckpointPass,
+  detectCheckpointPass,
+  resetCheckpointsForNewLap,
+} from "./raceCheckpoints";
 import {
   exceedsRaceTimeLimit,
   INITIAL_DNF_TIMERS,
@@ -1760,6 +1765,35 @@ export function stepRaceSession(
     trackLength > 0
       ? ((nextPlayerCar.z % trackLength) + trackLength) % trackLength
       : nextPlayerCar.z;
+  const prevLapPos =
+    trackLength > 0
+      ? ((state.player.car.z % trackLength) + trackLength) % trackLength
+      : state.player.car.z;
+  const checkpointInputs = config.track.checkpoints.map((checkpoint) => ({
+    segmentIndex: checkpoint.compiledStart,
+    label: checkpoint.label,
+  }));
+  const checkpointPass = detectCheckpointPass(
+    prevLapPos,
+    lapPos,
+    trackLength,
+    SEGMENT_LENGTH,
+    checkpointInputs,
+  );
+  let nextRaceCheckpointState =
+    checkpointPass === null
+      ? state.race
+      : applyCheckpointPass(
+          state.race,
+          checkpointPass,
+          nextTick,
+          nextPlayerCar,
+        );
+  if (nextLap > state.race.lap) {
+    nextRaceCheckpointState = resetCheckpointsForNewLap(
+      nextRaceCheckpointState,
+    );
+  }
   let nextBaseline = state.baselineSplitsMs;
   if (nextLap > state.race.lap) {
     // Close the final sector of the just-finished lap so its split lands in
@@ -1803,6 +1837,9 @@ export function stepRaceSession(
   return {
     race: {
       ...state.race,
+      lastCheckpoint: nextRaceCheckpointState.lastCheckpoint,
+      passedCheckpointsThisLap:
+        nextRaceCheckpointState.passedCheckpointsThisLap,
       phase: nextPhase,
       elapsed: nextElapsed,
       lap: nextLap,

--- a/src/game/raceSessionActions.ts
+++ b/src/game/raceSessionActions.ts
@@ -36,6 +36,7 @@ import {
   type RaceSessionPlayerCar,
   type RaceSessionState,
 } from "./raceSession";
+import type { WeatherOption } from "@/data/schemas";
 
 /**
  * `DnfReason` value pinned for user-initiated retirement. Re-exported here
@@ -110,6 +111,35 @@ export function retireRaceSession(
     brokenHazards: state.brokenHazards.slice(),
     weather: cloneWeatherPure(state.weather),
     weatherRngState: state.weatherRngState,
+    audioEvents: [],
+  };
+}
+
+export function resetRaceSessionToLastCheckpoint(
+  state: Readonly<RaceSessionState>,
+): RaceSessionState {
+  const checkpoint = state.race.lastCheckpoint;
+  if (checkpoint === null || state.race.phase === "finished") {
+    return clonePure(state);
+  }
+
+  return {
+    ...clonePure(state),
+    player: {
+      ...clonePlayerPure(state.player),
+      car: { ...checkpoint.carState },
+    },
+    audioEvents: [],
+  };
+}
+
+export function setRaceSessionWeather(
+  state: Readonly<RaceSessionState>,
+  weather: WeatherOption,
+): RaceSessionState {
+  return {
+    ...clonePure(state),
+    weather: { current: weather, transitioning: null },
     audioEvents: [],
   };
 }

--- a/src/game/raceSessionActions.ts
+++ b/src/game/raceSessionActions.ts
@@ -136,7 +136,11 @@ export function resetRaceSessionToLastCheckpoint(
 export function setRaceSessionWeather(
   state: Readonly<RaceSessionState>,
   weather: WeatherOption,
+  allowedWeather: ReadonlyArray<WeatherOption>,
 ): RaceSessionState {
+  if (!allowedWeather.includes(weather)) {
+    return clonePure(state);
+  }
   return {
     ...clonePure(state),
     weather: { current: weather, transitioning: null },


### PR DESCRIPTION
## GDD sections
- §6 Practice mode
- §20 title menu and race controls
- §21 runtime reuse

## Requirement inventory
- Adds `mode=practice` as a no-stakes race runtime mode.
- Practice starts without AI, campaign economy, campaign damage persistence, PB writes, or countdown delay.
- Adds restart, checkpoint reset, grip telemetry, and instant weather swap controls.
- Adds Practice to the title menu.
- Leaves no adjacent Practice or Quick Race requirements uncovered.

## Progress log
- `docs/PROGRESS_LOG.md`: `2026-04-29: Slice: Practice mode`

## Test plan
- [x] `npm run typecheck`
- [x] `npx vitest run src/game/__tests__/raceSessionActions.test.ts src/app/__tests__/page.test.tsx`
- [x] `npx playwright test e2e/title-screen.spec.ts --grep "Practice|main menu" e2e/practice-mode.spec.ts`
- [x] `npm run verify`
- [x] `npm run test:e2e`

## Followups
- None.