### PR TITLE
feat(tunnel): add authored tunnel segments

### DIFF
--- a/docs/GDD_COVERAGE.json
+++ b/docs/GDD_COVERAGE.json
@@ -670,20 +670,30 @@
         "docs/gdd/09-track-design.md",
         "docs/gdd/14-weather-and-environmental-systems.md",
         "docs/gdd/16-rendering-and-visual-design.md",
+        "docs/gdd/18-sound-and-music-design.md",
         "docs/gdd/22-data-schemas.md"
       ],
-      "requirement": "Projected tunnel hazard metadata drives a visual light-adaptation shift in the live road renderer without making tunnel hazards collide with the car.",
+      "requirement": "Authored tunnel segment metadata survives track compilation, drives visual light adaptation in the live road renderer, exposes a deterministic audio filter spec, and remains non-colliding for hazard physics.",
       "coverage": ["implemented-code", "automated-test"],
       "implementationRefs": [
-        "src/render/pseudoRoadCanvas.ts"
+        "src/data/schemas.ts",
+        "src/road/trackCompiler.ts",
+        "src/game/tunnelState.ts",
+        "src/render/tunnelRenderer.ts",
+        "src/render/pseudoRoadCanvas.ts",
+        "src/audio/tunnelBus.ts",
+        "src/app/race/page.tsx",
+        "src/data/tracks/iron-borough-rivet-tunnel.json"
       ],
       "testRefs": [
+        "src/road/__tests__/trackCompiler.test.ts",
+        "src/game/__tests__/tunnelState.test.ts",
+        "src/render/__tests__/tunnelRenderer.test.ts",
         "src/render/__tests__/pseudoRoadCanvas.test.ts",
+        "src/audio/tunnelBus.test.ts",
         "src/game/__tests__/hazards.test.ts"
       ],
-      "followupRefs": [
-        "VibeGear2-implement-sound-music-1611f9dd"
-      ]
+      "followupRefs": []
     },
     {
       "id": "GDD-14-HEAT-SHIMMER",

--- a/docs/PROGRESS_LOG.md
+++ b/docs/PROGRESS_LOG.md
@@ -14,7 +14,7 @@ Correct them by adding a new entry that references the old one.
 [§18](gdd/18-sound-and-music-design.md) tunnel audio shift,
 [§22](gdd/22-data-schemas.md) track segment metadata,
 [§24](gdd/24-content-plan.md) Iron Borough Rivet Tunnel.
-**Branch / PR:** `feat/tunnel-segments`, PR pending.
+**Branch / PR:** `feat/tunnel-segments`, PR #95.
 **Status:** Implemented.
 
 ### Done

--- a/docs/PROGRESS_LOG.md
+++ b/docs/PROGRESS_LOG.md
@@ -6,6 +6,65 @@ Correct them by adding a new entry that references the old one.
 
 ---
 
+## 2026-04-29: Slice: Tunnel segments
+
+**GDD sections touched:**
+[§9](gdd/09-track-design.md) tunnel hazards and roadside scenery,
+[§16](gdd/16-rendering-and-visual-design.md) tunnel mouths and visual contrast,
+[§18](gdd/18-sound-and-music-design.md) tunnel audio shift,
+[§22](gdd/22-data-schemas.md) track segment metadata,
+[§24](gdd/24-content-plan.md) Iron Borough Rivet Tunnel.
+**Branch / PR:** `feat/tunnel-segments`, PR pending.
+**Status:** Implemented.
+
+### Done
+- `src/data/schemas.ts` and `src/road/trackCompiler.ts`: added optional
+  `inTunnel` and `tunnelMaterial` authored segment fields and preserved them
+  on compiled segments.
+- `src/game/tunnelState.ts`: added a deterministic tunnel phase state
+  machine and segment detector.
+- `src/render/tunnelRenderer.ts`: extracted tunnel light-adaptation drawing
+  from the road drawer and made it prefer compiled tunnel metadata while
+  keeping legacy `tunnel` hazards compatible.
+- `src/audio/tunnelBus.ts`: added the pure tunnel low-pass and reverb send
+  spec for the future Web Audio wiring layer.
+- `src/app/race/page.tsx`: drives tunnel light adaptation from the player's
+  current tunnel phase instead of only from far visible road strips.
+- `src/data/tracks/iron-borough-rivet-tunnel.json`: marked the authored
+  tunnel segment with `inTunnel` and its material id.
+- `docs/GDD_COVERAGE.json`: expanded GDD-14-TUNNEL-LIGHT-ADAPTATION to
+  cover the segment metadata, renderer, audio spec, and non-colliding
+  hazard contract.
+
+### Verified
+- `npx vitest run src/game/__tests__/tunnelState.test.ts src/audio/tunnelBus.test.ts src/render/__tests__/tunnelRenderer.test.ts src/road/__tests__/trackCompiler.test.ts src/render/__tests__/pseudoRoadCanvas.test.ts`
+  green, 90 passed.
+- `npx vitest run scripts/__tests__/content-lint.test.ts src/road/__tests__/trackCompiler.golden.test.ts src/game/__tests__/hazards.test.ts`
+  green, 74 passed.
+- `npm run typecheck` green.
+- `npm run verify` green, 2541 passed.
+- `npm run test:e2e` green, 84 passed.
+
+### Decisions and assumptions
+- Existing `hazards: ["tunnel"]` content remains compatible, but new content
+  should use `inTunnel` for the render and audio contract.
+- The Web Audio graph mutation is represented as a pure spec in this slice.
+  That keeps the tunnel audio behavior testable and avoids adding a second
+  runtime audio graph before the mixer grows a filter bus.
+
+### Coverage ledger
+- GDD-14-TUNNEL-LIGHT-ADAPTATION covers authored tunnel metadata,
+  non-colliding hazard behavior, live render light adaptation, and the
+  deterministic tunnel audio filter spec.
+- Uncovered adjacent requirements: authored tunnel-mouth sprite art remains
+  part of the broader roadside prop and region art backlog.
+
+### Followups created
+None.
+
+### GDD edits
+None.
+
 ## 2026-04-29: Slice: Practice mode
 
 **GDD sections touched:**

--- a/src/app/race/page.tsx
+++ b/src/app/race/page.tsx
@@ -81,6 +81,7 @@ import {
   resetRaceSessionToLastCheckpoint,
   setRaceSessionWeather,
   OPEN_TUNNEL_STATE,
+  segmentAt,
   segmentIsTunnel,
   spawnGrid,
   startLoop,
@@ -508,18 +509,6 @@ function toMinimapCar(
   const progress = continuousIndex - Math.floor(continuousIndex);
   const { x, y } = projectCar(points, segmentIndex, progress);
   return { x, y, isPlayer };
-}
-
-function compiledSegmentAtZ(
-  track: CompiledTrack,
-  carZ: number,
-): CompiledTrack["segments"][number] | undefined {
-  if (track.totalCompiledSegments <= 0 || track.totalLengthMeters <= 0) {
-    return undefined;
-  }
-  const wrappedZ = ((carZ % track.totalLengthMeters) + track.totalLengthMeters) % track.totalLengthMeters;
-  const segmentIndex = Math.floor(wrappedZ / SEGMENT_LENGTH) % track.totalCompiledSegments;
-  return track.segments[segmentIndex];
 }
 
 /**
@@ -1201,7 +1190,7 @@ function RaceCanvas({
         lastSteerRef.current = input.steer;
         const next = stepRaceSession(session, input, config, dt);
         sessionRef.current = next;
-        const playerSegment = compiledSegmentAtZ(track.compiled, next.player.car.z);
+        const playerSegment = segmentAt(track.compiled, next.player.car.z);
         tunnelState = stepTunnelState({
           state: tunnelState,
           dtMs: dt * 1000,

--- a/src/app/race/page.tsx
+++ b/src/app/race/page.tsx
@@ -80,10 +80,14 @@ import {
   retireRaceSession,
   resetRaceSessionToLastCheckpoint,
   setRaceSessionWeather,
+  OPEN_TUNNEL_STATE,
+  segmentIsTunnel,
   spawnGrid,
   startLoop,
   stepRaceSession,
+  stepTunnelState,
   totalProgress,
+  tunnelOcclusion,
   type LoopHandle,
   type RaceSessionAudioEvent,
   type RaceSessionConfig,
@@ -504,6 +508,18 @@ function toMinimapCar(
   const progress = continuousIndex - Math.floor(continuousIndex);
   const { x, y } = projectCar(points, segmentIndex, progress);
   return { x, y, isPlayer };
+}
+
+function compiledSegmentAtZ(
+  track: CompiledTrack,
+  carZ: number,
+): CompiledTrack["segments"][number] | undefined {
+  if (track.totalCompiledSegments <= 0 || track.totalLengthMeters <= 0) {
+    return undefined;
+  }
+  const wrappedZ = ((carZ % track.totalLengthMeters) + track.totalLengthMeters) % track.totalLengthMeters;
+  const segmentIndex = Math.floor(wrappedZ / SEGMENT_LENGTH) % track.totalCompiledSegments;
+  return track.segments[segmentIndex];
 }
 
 /**
@@ -994,6 +1010,7 @@ function RaceCanvas({
       topSpeed: playerStats.topSpeed,
     });
     let latestWeatherMusicStem = weatherMusicStem(weather);
+    let tunnelState = OPEN_TUNNEL_STATE;
     let engineStartPending = false;
     let engineAudioTeardown = false;
     let lastEngineAudioUpdateMs = 0;
@@ -1059,6 +1076,7 @@ function RaceCanvas({
       if (!handle) return;
       sessionRef.current = createRaceSession(config);
       resetTimeTrialRuntime();
+      tunnelState = OPEN_TUNNEL_STATE;
       // Re-arm the natural-finish guard so the restarted race can
       // route on its own finish. Must precede `handle.resume()` so the
       // first render tick after resume sees the fresh `false` latch.
@@ -1183,6 +1201,12 @@ function RaceCanvas({
         lastSteerRef.current = input.steer;
         const next = stepRaceSession(session, input, config, dt);
         sessionRef.current = next;
+        const playerSegment = compiledSegmentAtZ(track.compiled, next.player.car.z);
+        tunnelState = stepTunnelState({
+          state: tunnelState,
+          dtMs: dt * 1000,
+          inTunnel: playerSegment ? segmentIsTunnel(playerSegment) : false,
+        });
         timeTrialRecorderRef.current?.observe({
           phase: next.race.phase,
           tick: next.tick,
@@ -1262,6 +1286,9 @@ function RaceCanvas({
             tourContext?.tourId === "ember-steppe"
               ? { enabled: true, phaseMeters: camera.z }
               : undefined,
+          tunnelAdaptation: {
+            intensityScale: tunnelOcclusion(tunnelState),
+          },
           ghostCar: ghostOverlayRef.current
             ? {
                 ...ghostOverlayRef.current,

--- a/src/audio/tunnelBus.test.ts
+++ b/src/audio/tunnelBus.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vitest";
+
+import { applyTunnelFilter } from "./tunnelBus";
+
+describe("applyTunnelFilter", () => {
+  const audio = { enabled: true, master: 1, music: 0.5, sfx: 0.75 };
+
+  it("low-passes and adds reverb as tunnel occlusion rises", () => {
+    const spec = applyTunnelFilter({ audio, occlusion: 1 });
+    expect(spec).not.toBeNull();
+    expect(spec!.lowPassCutoffHz).toBeLessThanOrEqual(1500);
+    expect(spec!.reverbSend).toBeCloseTo(0.58 * 0.75, 6);
+    expect(spec!.outputGain).toBeCloseTo(0.75, 6);
+  });
+
+  it("returns an open-air bus spec when occlusion is zero", () => {
+    const spec = applyTunnelFilter({ audio, occlusion: 0 });
+    expect(spec).not.toBeNull();
+    expect(spec!.lowPassCutoffHz).toBe(12000);
+    expect(spec!.reverbSend).toBe(0);
+  });
+
+  it("bypasses muted audio", () => {
+    expect(
+      applyTunnelFilter({
+        audio: { enabled: false, master: 1, music: 1, sfx: 1 },
+        occlusion: 1,
+      }),
+    ).toBeNull();
+  });
+});

--- a/src/audio/tunnelBus.ts
+++ b/src/audio/tunnelBus.ts
@@ -1,0 +1,51 @@
+import { isMixerSilent, resolveMixerGains, type MixerSettings } from "./mixer";
+
+export interface TunnelBusSpec {
+  readonly lowPassCutoffHz: number;
+  readonly reverbSend: number;
+  readonly outputGain: number;
+}
+
+export interface ApplyTunnelFilterInput {
+  readonly occlusion: number;
+  readonly audio?: MixerSettings;
+  readonly baseCutoffHz?: number;
+  readonly tunnelCutoffHz?: number;
+  readonly maxReverbSend?: number;
+}
+
+const DEFAULT_BASE_CUTOFF_HZ = 12000;
+const DEFAULT_TUNNEL_CUTOFF_HZ = 1400;
+const DEFAULT_MAX_REVERB_SEND = 0.58;
+
+export function applyTunnelFilter(input: ApplyTunnelFilterInput): TunnelBusSpec | null {
+  const gains = resolveMixerGains(input.audio ?? { master: 0, music: 0, sfx: 0 });
+  if (gains === null || isMixerSilent(gains)) return null;
+
+  const occlusion = clampUnit(input.occlusion);
+  const baseCutoffHz = positiveOr(input.baseCutoffHz, DEFAULT_BASE_CUTOFF_HZ);
+  const tunnelCutoffHz = positiveOr(input.tunnelCutoffHz, DEFAULT_TUNNEL_CUTOFF_HZ);
+  const maxReverbSend = clampUnit(input.maxReverbSend ?? DEFAULT_MAX_REVERB_SEND);
+
+  return {
+    lowPassCutoffHz: lerp(baseCutoffHz, tunnelCutoffHz, occlusion),
+    reverbSend: maxReverbSend * occlusion * gains.sfx,
+    outputGain: gains.master * gains.sfx,
+  };
+}
+
+function lerp(from: number, to: number, t: number): number {
+  return from + (to - from) * t;
+}
+
+function positiveOr(value: number | undefined, fallback: number): number {
+  return value === undefined || !Number.isFinite(value) || value <= 0
+    ? fallback
+    : value;
+}
+
+function clampUnit(value: number): number {
+  if (!Number.isFinite(value) || value <= 0) return 0;
+  if (value >= 1) return 1;
+  return value;
+}

--- a/src/data/schemas.ts
+++ b/src/data/schemas.ts
@@ -80,6 +80,8 @@ export const TrackSegmentSchema = z.object({
   roadsideLeft: z.string().min(1),
   roadsideRight: z.string().min(1),
   hazards: z.array(slug),
+  inTunnel: z.boolean().optional(),
+  tunnelMaterial: slug.optional(),
 });
 export type TrackSegment = z.infer<typeof TrackSegmentSchema>;
 

--- a/src/data/tracks/iron-borough-rivet-tunnel.json
+++ b/src/data/tracks/iron-borough-rivet-tunnel.json
@@ -12,7 +12,7 @@
   "segments": [
     { "len": 240, "curve": 0, "grade": 0, "roadsideLeft": "light_pole", "roadsideRight": "light_pole", "hazards": [] },
     { "len": 240, "curve": -0.1, "grade": 0.02, "roadsideLeft": "fence_post", "roadsideRight": "rock_boulder", "hazards": [] },
-    { "len": 240, "curve": 0, "grade": -0.02, "roadsideLeft": "rock_boulder", "roadsideRight": "rock_boulder", "hazards": ["tunnel"] },
+    { "len": 240, "curve": 0, "grade": -0.02, "roadsideLeft": "rock_boulder", "roadsideRight": "rock_boulder", "hazards": ["tunnel"], "inTunnel": true, "tunnelMaterial": "iron-borough/riveted-steel" },
     { "len": 240, "curve": 0.12, "grade": 0, "roadsideLeft": "sign_marker", "roadsideRight": "fence_post", "hazards": [] },
     { "len": 300, "curve": -0.04, "grade": 0.02, "roadsideLeft": "light_pole", "roadsideRight": "sign_marker", "hazards": ["traffic_cone"] },
     { "len": 360, "curve": 0, "grade": 0, "roadsideLeft": "fence_post", "roadsideRight": "light_pole", "hazards": [] }

--- a/src/game/__tests__/hazards.test.ts
+++ b/src/game/__tests__/hazards.test.ts
@@ -81,7 +81,7 @@ describe("evaluateHazards", () => {
     expect(effect.events[0]?.hit).toBeNull();
   });
 
-  it("ignores tunnel metadata until the tunnel slice consumes it", () => {
+  it("keeps tunnel metadata non-colliding for hazard physics", () => {
     const track = loadTrack("iron-borough/rivet-tunnel");
     const effect = evaluateHazards({
       car: car({ z: 505 }),

--- a/src/game/__tests__/tunnelState.test.ts
+++ b/src/game/__tests__/tunnelState.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  OPEN_TUNNEL_STATE,
+  segmentIsTunnel,
+  stepTunnelState,
+  tunnelOcclusion,
+  type TunnelState,
+} from "../tunnelState";
+
+describe("tunnelState", () => {
+  it("ramps from open to inside when the car enters a tunnel", () => {
+    const entering = stepTunnelState({
+      state: OPEN_TUNNEL_STATE,
+      dtMs: 200,
+      inTunnel: true,
+      transitionMs: 400,
+    });
+    expect(entering).toEqual({ phase: "entering", elapsedMs: 200 });
+    expect(tunnelOcclusion(entering, 400)).toBeCloseTo(0.5, 6);
+
+    const inside = stepTunnelState({
+      state: entering,
+      dtMs: 200,
+      inTunnel: true,
+      transitionMs: 400,
+    });
+    expect(inside).toEqual({ phase: "inside", elapsedMs: 400 });
+    expect(tunnelOcclusion(inside, 400)).toBe(1);
+  });
+
+  it("ramps back to open when the car exits a tunnel", () => {
+    const exiting = stepTunnelState({
+      state: { phase: "inside", elapsedMs: 400 },
+      dtMs: 100,
+      inTunnel: false,
+      transitionMs: 400,
+    });
+    expect(exiting).toEqual({ phase: "exiting", elapsedMs: 100 });
+    expect(tunnelOcclusion(exiting, 400)).toBeCloseTo(0.75, 6);
+
+    const open = stepTunnelState({
+      state: exiting,
+      dtMs: 300,
+      inTunnel: false,
+      transitionMs: 400,
+    });
+    expect(open).toBe(OPEN_TUNNEL_STATE);
+  });
+
+  it("handles reversing out while entering without flicker", () => {
+    const entering: TunnelState = { phase: "entering", elapsedMs: 250 };
+    const exiting = stepTunnelState({
+      state: entering,
+      dtMs: 50,
+      inTunnel: false,
+      transitionMs: 400,
+    });
+    expect(exiting.phase).toBe("exiting");
+    expect(exiting.elapsedMs).toBe(200);
+    expect(tunnelOcclusion(exiting, 400)).toBeCloseTo(0.5, 6);
+  });
+
+  it("detects both segment tunnel metadata and legacy tunnel hazards", () => {
+    expect(segmentIsTunnel({ inTunnel: true, hazardIds: [] })).toBe(true);
+    expect(segmentIsTunnel({ hazardIds: ["tunnel"] })).toBe(true);
+    expect(segmentIsTunnel({ hazardIds: ["puddle"] })).toBe(false);
+  });
+});

--- a/src/game/index.ts
+++ b/src/game/index.ts
@@ -34,3 +34,4 @@ export * from "./preRaceCard";
 // `@/game/raceBonuses` for the tour-completion / sponsor surfaces.
 export * from "./raceResult";
 export * from "./tourProgress";
+export * from "./tunnelState";

--- a/src/game/tunnelState.ts
+++ b/src/game/tunnelState.ts
@@ -1,0 +1,88 @@
+import type { CompiledSegment } from "@/road/types";
+
+export type TunnelPhase = "open" | "entering" | "inside" | "exiting";
+
+export interface TunnelState {
+  readonly phase: TunnelPhase;
+  readonly elapsedMs: number;
+}
+
+export interface StepTunnelStateInput {
+  readonly state: TunnelState;
+  readonly dtMs: number;
+  readonly inTunnel: boolean;
+  readonly transitionMs?: number;
+}
+
+export const DEFAULT_TUNNEL_TRANSITION_MS = 400;
+export const OPEN_TUNNEL_STATE: TunnelState = Object.freeze({
+  phase: "open",
+  elapsedMs: 0,
+});
+
+export function segmentIsTunnel(segment: Pick<CompiledSegment, "inTunnel" | "hazardIds">): boolean {
+  return segment.inTunnel === true || segment.hazardIds.includes("tunnel");
+}
+
+export function stepTunnelState(input: StepTunnelStateInput): TunnelState {
+  const transitionMs = positiveOr(input.transitionMs, DEFAULT_TUNNEL_TRANSITION_MS);
+  const dtMs = Math.max(0, finiteOr(input.dtMs, 0));
+  const state = input.state;
+
+  if (input.inTunnel) {
+    if (state.phase === "inside") return { phase: "inside", elapsedMs: transitionMs };
+    const elapsedMs =
+      state.phase === "entering"
+        ? Math.min(transitionMs, state.elapsedMs + dtMs)
+        : state.phase === "exiting"
+          ? Math.min(transitionMs, transitionMs - state.elapsedMs + dtMs)
+          : Math.min(transitionMs, dtMs);
+    return elapsedMs >= transitionMs
+      ? { phase: "inside", elapsedMs: transitionMs }
+      : { phase: "entering", elapsedMs };
+  }
+
+  if (state.phase === "open") return OPEN_TUNNEL_STATE;
+  const elapsedMs =
+    state.phase === "exiting"
+      ? Math.min(transitionMs, state.elapsedMs + dtMs)
+      : state.phase === "entering"
+        ? Math.min(transitionMs, transitionMs - state.elapsedMs + dtMs)
+        : Math.min(transitionMs, dtMs);
+  return elapsedMs >= transitionMs
+    ? OPEN_TUNNEL_STATE
+    : { phase: "exiting", elapsedMs };
+}
+
+export function tunnelOcclusion(
+  state: TunnelState,
+  transitionMs = DEFAULT_TUNNEL_TRANSITION_MS,
+): number {
+  const duration = positiveOr(transitionMs, DEFAULT_TUNNEL_TRANSITION_MS);
+  switch (state.phase) {
+    case "inside":
+      return 1;
+    case "entering":
+      return clampUnit(state.elapsedMs / duration);
+    case "exiting":
+      return 1 - clampUnit(state.elapsedMs / duration);
+    case "open":
+      return 0;
+  }
+}
+
+function finiteOr(value: number, fallback: number): number {
+  return Number.isFinite(value) ? value : fallback;
+}
+
+function positiveOr(value: number | undefined, fallback: number): number {
+  return value === undefined || !Number.isFinite(value) || value <= 0
+    ? fallback
+    : value;
+}
+
+function clampUnit(value: number): number {
+  if (!Number.isFinite(value) || value <= 0) return 0;
+  if (value >= 1) return 1;
+  return value;
+}

--- a/src/render/__tests__/tunnelRenderer.test.ts
+++ b/src/render/__tests__/tunnelRenderer.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, it } from "vitest";
+
+import type { Strip, Viewport } from "@/road/types";
+import {
+  TUNNEL_ADAPTATION_OVERLAY_FILL,
+  drawTunnelAdaptation,
+  tunnelAdaptationIntensity,
+} from "../tunnelRenderer";
+
+interface FillRectCall {
+  readonly fillStyle: string;
+  readonly globalAlpha: number;
+  readonly x: number;
+  readonly y: number;
+  readonly w: number;
+  readonly h: number;
+}
+
+function strip(overrides: Partial<Strip> = {}): Strip {
+  return {
+    visible: true,
+    screenX: 400,
+    screenY: 300,
+    screenW: 120,
+    scale: 1,
+    worldX: 0,
+    worldY: 0,
+    segment: {
+      index: 0,
+      worldZ: 0,
+      curve: 0,
+      grade: 0,
+      authoredIndex: 0,
+      roadsideLeftId: "default",
+      roadsideRightId: "default",
+      hazardIds: [],
+    },
+    ...overrides,
+  };
+}
+
+function makeCtx(): {
+  readonly ctx: CanvasRenderingContext2D;
+  readonly calls: FillRectCall[];
+} {
+  const calls: FillRectCall[] = [];
+  const target = {
+    fillStyle: "#000",
+    globalAlpha: 1,
+    fillRect(x: number, y: number, w: number, h: number): void {
+      calls.push({
+        fillStyle: String(this.fillStyle),
+        globalAlpha: this.globalAlpha,
+        x,
+        y,
+        w,
+        h,
+      });
+    },
+  };
+  return {
+    ctx: target as unknown as CanvasRenderingContext2D,
+    calls,
+  };
+}
+
+describe("tunnelRenderer", () => {
+  const viewport: Viewport = { width: 800, height: 480 };
+
+  it("computes intensity from visible tunnel segments", () => {
+    const intensity = tunnelAdaptationIntensity([
+      strip({ segment: { ...strip().segment, inTunnel: true } }),
+      strip({ segment: { ...strip().segment, hazardIds: ["tunnel"] } }),
+      strip({ segment: { ...strip().segment, hazardIds: [] } }),
+    ]);
+    expect(intensity).toBe(1);
+  });
+
+  it("draws a deterministic dark overlay scaled by caller intensity", () => {
+    const { ctx, calls } = makeCtx();
+    drawTunnelAdaptation(
+      ctx,
+      [strip({ segment: { ...strip().segment, inTunnel: true } })],
+      viewport,
+      { intensityScale: 0.5 },
+    );
+
+    const overlay = calls.find((call) => call.fillStyle === TUNNEL_ADAPTATION_OVERLAY_FILL);
+    expect(overlay).toBeDefined();
+    expect(overlay!.x).toBe(0);
+    expect(overlay!.y).toBe(0);
+    expect(overlay!.w).toBe(viewport.width);
+    expect(overlay!.h).toBe(viewport.height);
+    expect(overlay!.globalAlpha).toBeCloseTo(0.38 * 0.5, 6);
+    expect(ctx.globalAlpha).toBe(1);
+  });
+
+  it("skips disabled draws", () => {
+    const { ctx, calls } = makeCtx();
+    drawTunnelAdaptation(
+      ctx,
+      [strip({ segment: { ...strip().segment, inTunnel: true } })],
+      viewport,
+      { enabled: false },
+    );
+    expect(calls).toEqual([]);
+  });
+});

--- a/src/render/index.ts
+++ b/src/render/index.ts
@@ -8,5 +8,6 @@ export * from "./hudSplits";
 export * from "./parallax";
 export * from "./pseudoRoadCanvas";
 export * from "./spriteAtlas";
+export * from "./tunnelRenderer";
 export * from "./uiRenderer";
 export * from "./vfx";

--- a/src/render/index.ts
+++ b/src/render/index.ts
@@ -8,6 +8,6 @@ export * from "./hudSplits";
 export * from "./parallax";
 export * from "./pseudoRoadCanvas";
 export * from "./spriteAtlas";
-export * from "./tunnelRenderer";
+export * as tunnelRenderer from "./tunnelRenderer";
 export * from "./uiRenderer";
 export * from "./vfx";

--- a/src/render/pseudoRoadCanvas.ts
+++ b/src/render/pseudoRoadCanvas.ts
@@ -32,6 +32,13 @@ import { visibilityForWeather } from "@/game/weather";
 import { drawDust, type DustState } from "./dust";
 import { drawParallax, type ParallaxLayer } from "./parallax";
 import { frame, type LoadedAtlas } from "./spriteAtlas";
+export {
+  TUNNEL_ADAPTATION_HIGHLIGHT_FILL,
+  TUNNEL_ADAPTATION_HIGHLIGHT_MAX_ALPHA,
+  TUNNEL_ADAPTATION_MAX_ALPHA,
+  TUNNEL_ADAPTATION_OVERLAY_FILL,
+} from "./tunnelRenderer";
+import { drawTunnelAdaptation } from "./tunnelRenderer";
 import { drawVfx, type VfxState } from "./vfx";
 
 /**
@@ -76,10 +83,6 @@ export const PLAYER_CAR_DEFAULT_SPRITE_ID = "sparrow_clean";
 export const ROADSIDE_DRAW_PERIOD = 10;
 export const ROADSIDE_MAX_HEIGHT_FRACTION = 0.22;
 export const WEATHER_EFFECT_REDUCTION_SCALE = 0.35;
-export const TUNNEL_ADAPTATION_OVERLAY_FILL = "#05070d";
-export const TUNNEL_ADAPTATION_HIGHLIGHT_FILL = "#f2e18a";
-export const TUNNEL_ADAPTATION_MAX_ALPHA = 0.38;
-export const TUNNEL_ADAPTATION_HIGHLIGHT_MAX_ALPHA = 0.24;
 export const HEAT_SHIMMER_FILL = "#f4ddb0";
 export const HEAT_SHIMMER_MAX_ALPHA = 0.16;
 export const HEAT_SHIMMER_BAND_COUNT = 6;
@@ -575,46 +578,6 @@ function drawWeatherEffects(
     case "overcast":
       return;
   }
-}
-
-function drawTunnelAdaptation(
-  ctx: CanvasRenderingContext2D,
-  strips: readonly Strip[],
-  viewport: Viewport,
-  options: DrawRoadOptions["tunnelAdaptation"],
-): void {
-  if (options?.enabled === false) return;
-  if (viewport.width <= 0 || viewport.height <= 0) return;
-  const intensity = tunnelAdaptationIntensity(strips) * clampUnit(options?.intensityScale ?? 1);
-  if (intensity <= 0) return;
-
-  const prevFill = ctx.fillStyle;
-  const prevAlpha = ctx.globalAlpha;
-  try {
-    ctx.globalAlpha = TUNNEL_ADAPTATION_MAX_ALPHA * intensity;
-    ctx.fillStyle = TUNNEL_ADAPTATION_OVERLAY_FILL;
-    ctx.fillRect(0, 0, viewport.width, viewport.height);
-
-    ctx.globalAlpha = TUNNEL_ADAPTATION_HIGHLIGHT_MAX_ALPHA * intensity;
-    ctx.fillStyle = TUNNEL_ADAPTATION_HIGHLIGHT_FILL;
-    const bandHeight = Math.max(2, viewport.height * 0.018);
-    ctx.fillRect(0, viewport.height * 0.22, viewport.width, bandHeight);
-  } finally {
-    ctx.fillStyle = prevFill;
-    ctx.globalAlpha = prevAlpha;
-  }
-}
-
-function tunnelAdaptationIntensity(strips: readonly Strip[]): number {
-  let visible = 0;
-  let tunnel = 0;
-  for (const strip of strips) {
-    if (!strip.visible) continue;
-    visible += 1;
-    if (strip.segment.hazardIds.includes("tunnel")) tunnel += 1;
-  }
-  if (visible === 0 || tunnel === 0) return 0;
-  return 0.55 + Math.min(0.45, tunnel / visible);
 }
 
 function drawHeatShimmer(

--- a/src/render/tunnelRenderer.ts
+++ b/src/render/tunnelRenderer.ts
@@ -1,0 +1,58 @@
+import { segmentIsTunnel } from "@/game/tunnelState";
+import type { Strip, Viewport } from "@/road/types";
+
+export const TUNNEL_ADAPTATION_OVERLAY_FILL = "#05070d";
+export const TUNNEL_ADAPTATION_HIGHLIGHT_FILL = "#f2e18a";
+export const TUNNEL_ADAPTATION_MAX_ALPHA = 0.38;
+export const TUNNEL_ADAPTATION_HIGHLIGHT_MAX_ALPHA = 0.24;
+
+export interface TunnelRendererOptions {
+  readonly enabled?: boolean;
+  readonly intensityScale?: number;
+}
+
+export function drawTunnelAdaptation(
+  ctx: CanvasRenderingContext2D,
+  strips: readonly Strip[],
+  viewport: Viewport,
+  options: TunnelRendererOptions | undefined,
+): void {
+  if (options?.enabled === false) return;
+  if (viewport.width <= 0 || viewport.height <= 0) return;
+  const intensity = tunnelAdaptationIntensity(strips) * clampUnit(options?.intensityScale ?? 1);
+  if (intensity <= 0) return;
+
+  const prevFill = ctx.fillStyle;
+  const prevAlpha = ctx.globalAlpha;
+  try {
+    ctx.globalAlpha = TUNNEL_ADAPTATION_MAX_ALPHA * intensity;
+    ctx.fillStyle = TUNNEL_ADAPTATION_OVERLAY_FILL;
+    ctx.fillRect(0, 0, viewport.width, viewport.height);
+
+    ctx.globalAlpha = TUNNEL_ADAPTATION_HIGHLIGHT_MAX_ALPHA * intensity;
+    ctx.fillStyle = TUNNEL_ADAPTATION_HIGHLIGHT_FILL;
+    const bandHeight = Math.max(2, viewport.height * 0.018);
+    ctx.fillRect(0, viewport.height * 0.22, viewport.width, bandHeight);
+  } finally {
+    ctx.fillStyle = prevFill;
+    ctx.globalAlpha = prevAlpha;
+  }
+}
+
+export function tunnelAdaptationIntensity(strips: readonly Strip[]): number {
+  let visible = 0;
+  let tunnel = 0;
+  for (const strip of strips) {
+    if (!strip.visible) continue;
+    visible += 1;
+    if (segmentIsTunnel(strip.segment)) tunnel += 1;
+  }
+  if (visible === 0 || tunnel === 0) return 0;
+  return 0.55 + Math.min(0.45, tunnel / visible);
+}
+
+function clampUnit(value: number): number {
+  if (!Number.isFinite(value) || value <= 0) return 0;
+  if (value >= 1) return 1;
+  return value;
+}

--- a/src/road/__tests__/snapshotHelpers.ts
+++ b/src/road/__tests__/snapshotHelpers.ts
@@ -40,6 +40,8 @@ interface SnapshotSegment {
   roadsideLeftId: string;
   roadsideRightId: string;
   hazardIds: readonly string[];
+  inTunnel?: boolean;
+  tunnelMaterialId?: string;
 }
 
 export interface CompiledTrackSnapshot {
@@ -66,6 +68,8 @@ function projectSegment(s: CompiledSegment): SnapshotSegment {
     roadsideLeftId: s.roadsideLeftId,
     roadsideRightId: s.roadsideRightId,
     hazardIds: [...s.hazardIds],
+    ...(s.inTunnel === true ? { inTunnel: true } : {}),
+    ...(s.tunnelMaterialId ? { tunnelMaterialId: s.tunnelMaterialId } : {}),
   };
 }
 

--- a/src/road/__tests__/trackCompiler.test.ts
+++ b/src/road/__tests__/trackCompiler.test.ts
@@ -117,6 +117,23 @@ describe("compileSegments (lower-level dev-page entry point)", () => {
     // Same array reference avoids per-frame allocation in the renderer.
     expect(compiled.segments[0]!.hazardIds).toBe(hazards);
   });
+
+  it("propagates tunnel segment metadata", () => {
+    const compiled = compileSegments([
+      seg({
+        len: 6,
+        inTunnel: true,
+        tunnelMaterial: "iron-borough/riveted-steel",
+      }),
+    ]);
+    expect(compiled.segments[0]!.inTunnel).toBe(true);
+    expect(compiled.segments[0]!.tunnelMaterialId).toBe("iron-borough/riveted-steel");
+  });
+
+  it("treats legacy tunnel hazards as tunnel segments", () => {
+    const compiled = compileSegments([seg({ len: 6, hazards: ["tunnel"] })]);
+    expect(compiled.segments[0]!.inTunnel).toBe(true);
+  });
 });
 
 describe("compileTrack (full-track entry point)", () => {
@@ -133,6 +150,27 @@ describe("compileTrack (full-track entry point)", () => {
     const compiled = compileTrack(t);
     expect(compiled.totalCompiledSegments).toBe(4);
     expect(compiled.segments[0]!.worldZ).toBe(0);
+  });
+
+  it("accepts authored tunnel fields in TrackSchema and full-track compilation", () => {
+    const t = track({
+      segments: [
+        seg({
+          len: 60,
+          inTunnel: true,
+          tunnelMaterial: "iron-borough/riveted-steel",
+        }),
+        seg({ len: 60 }),
+        seg({ len: 60 }),
+        seg({ len: 60 }),
+      ],
+      lengthMeters: 240,
+    });
+    const parsed = TrackSchema.safeParse(t);
+    expect(parsed.success).toBe(true);
+    const compiled = compileTrack(t);
+    expect(compiled.segments[0]!.inTunnel).toBe(true);
+    expect(compiled.segments[0]!.tunnelMaterialId).toBe("iron-borough/riveted-steel");
   });
 
   it("compiles a 13 m authored segment to 3 compiled segments (ceil(13/6))", () => {

--- a/src/road/trackCompiler.ts
+++ b/src/road/trackCompiler.ts
@@ -135,6 +135,8 @@ export function compileTrack(track: Track): CompiledTrack {
         roadsideLeftId: seg.roadsideLeft,
         roadsideRightId: seg.roadsideRight,
         hazardIds: seg.hazards,
+        inTunnel: seg.inTunnel === true || seg.hazards.includes("tunnel"),
+        tunnelMaterialId: seg.tunnelMaterial,
       });
       cumulativeIndex += 1;
     }
@@ -316,6 +318,8 @@ export function compileSegments(authored: readonly TrackSegment[]): CompiledSegm
         roadsideLeftId: seg.roadsideLeft,
         roadsideRightId: seg.roadsideRight,
         hazardIds: seg.hazards,
+        inTunnel: seg.inTunnel === true || seg.hazards.includes("tunnel"),
+        tunnelMaterialId: seg.tunnelMaterial,
       });
       cumulativeIndex += 1;
     }

--- a/src/road/types.ts
+++ b/src/road/types.ts
@@ -50,6 +50,10 @@ export interface Viewport {
  * decoration ids for the strip. `hazardIds` is the same array reference
  * as the source authored segment's `hazards` array (frozen) to avoid
  * per-segment allocation.
+ *
+ * `inTunnel` and `tunnelMaterialId` are authored visual and audio metadata.
+ * `hazardIds` can still contain `tunnel` for older content, but the
+ * renderer and audio layer should prefer `inTunnel` once present.
  */
 export interface CompiledSegment {
   index: number;
@@ -60,6 +64,8 @@ export interface CompiledSegment {
   roadsideLeftId: string;
   roadsideRightId: string;
   hazardIds: readonly string[];
+  inTunnel?: boolean;
+  tunnelMaterialId?: string;
 }
 
 /**


### PR DESCRIPTION
## GDD sections

- docs/gdd/09-track-design.md: tunnel light adaptation hazard and tunnel segments.
- docs/gdd/16-rendering-and-visual-design.md: tunnel contrast and tunnel-mouth visual hook.
- docs/gdd/18-sound-and-music-design.md: tunnel audio shift.
- docs/gdd/22-data-schemas.md: track segment metadata.
- docs/gdd/24-content-plan.md: Iron Borough Rivet Tunnel content.

## Requirement inventory

- Adds optional `inTunnel` and `tunnelMaterial` fields to authored track segments.
- Preserves tunnel metadata on compiled segments while keeping legacy `hazards: ["tunnel"]` compatible.
- Drives live road light adaptation from the player tunnel phase, not just any far visible tunnel strip.
- Adds a pure tunnel state machine and pure audio filter spec for low-pass and reverb send.
- Confirms tunnel metadata remains non-colliding in hazard physics.

Nearby requirement left for later: authored tunnel-mouth sprite art remains part of the broader roadside prop and region art backlog.

## Progress log

- docs/PROGRESS_LOG.md: 2026-04-29 Slice: Tunnel segments.
- docs/GDD_COVERAGE.json: GDD-14-TUNNEL-LIGHT-ADAPTATION updated.

## Test plan

- [x] `npx vitest run src/game/__tests__/tunnelState.test.ts src/audio/tunnelBus.test.ts src/render/__tests__/tunnelRenderer.test.ts src/road/__tests__/trackCompiler.test.ts src/render/__tests__/pseudoRoadCanvas.test.ts`
- [x] `npx vitest run scripts/__tests__/content-lint.test.ts src/road/__tests__/trackCompiler.golden.test.ts src/game/__tests__/hazards.test.ts`
- [x] `npm run typecheck`
- [x] `npm run verify`
- [x] `npm run test:e2e`

## Followups

None.
