### PR TITLE
Verify Vercel Git deploy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,42 +86,39 @@ jobs:
         run: npm run bench:render
 
   deploy:
-    name: Deploy to Vercel (production)
+    name: Verify Vercel production deploy
     needs: verify
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     timeout-minutes: 10
     # Separate concurrency group with cancel-in-progress disabled: a queued
-    # deploy waits its turn instead of killing an in-flight one. Vercel can
-    # leave aliasing in a confused state if a deploy upload is interrupted.
+    # verification waits its turn instead of racing another production smoke.
     concurrency:
       group: deploy-prod
       cancel-in-progress: false
     environment:
       name: production
-      url: ${{ steps.vercel-deploy.outputs.url }}
-    env:
-      VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
-      VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
+      url: https://vibe-gear2.vercel.app
     steps:
       - uses: actions/checkout@v4
 
       - uses: actions/setup-node@v4
         with:
           node-version: 20
-          cache: npm
 
-      - name: Install dependencies
-        run: npm ci
-
-      - name: Pull Vercel environment
-        run: npx vercel pull --yes --environment=production --token=${{ secrets.VERCEL_TOKEN }}
-
-      - name: Build with Vercel CLI
-        run: npx vercel build --prod --token=${{ secrets.VERCEL_TOKEN }}
-
-      - name: Deploy prebuilt artefact
-        id: vercel-deploy
+      - name: Wait for Vercel Git deployment
+        env:
+          PRODUCTION_URL: https://vibe-gear2.vercel.app
         run: |
-          url="$(npx vercel deploy --prebuilt --prod --token=${{ secrets.VERCEL_TOKEN }})"
-          echo "url=$url" >> "$GITHUB_OUTPUT"
+          expected="${GITHUB_SHA::7}"
+          for attempt in {1..60}; do
+            version="$(node -e "fetch(process.env.PRODUCTION_URL + '/api/version', { cache: 'no-store' }).then(async (response) => { if (!response.ok) throw new Error(String(response.status)); const body = await response.json(); console.log(body.version ?? ''); }).catch(() => process.exit(1));" 2>/dev/null || true)"
+            status="$(node -e "fetch(process.env.PRODUCTION_URL, { redirect: 'manual', cache: 'no-store' }).then((response) => console.log(response.status)).catch(() => process.exit(1));" 2>/dev/null || true)"
+            echo "attempt=$attempt status=$status version=$version expected=$expected"
+            if [ "$status" = "200" ] && [ "$version" = "$expected" ]; then
+              exit 0
+            fi
+            sleep 10
+          done
+          echo "Production did not report expected build id $expected" >&2
+          exit 1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,9 @@ concurrency:
   group: ci-verify-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   verify:
     name: Lint, typecheck, unit, e2e

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,9 @@ concurrency:
 permissions:
   contents: read
 
+env:
+  PRODUCTION_URL: https://vibe-gear2.vercel.app
+
 jobs:
   verify:
     name: Lint, typecheck, unit, e2e
@@ -101,7 +104,7 @@ jobs:
       cancel-in-progress: false
     environment:
       name: production
-      url: https://vibe-gear2.vercel.app
+      url: ${{ env.PRODUCTION_URL }}
     steps:
       - uses: actions/checkout@v4
 
@@ -110,13 +113,11 @@ jobs:
           node-version: 20
 
       - name: Wait for Vercel Git deployment
-        env:
-          PRODUCTION_URL: https://vibe-gear2.vercel.app
         run: |
-          expected="${GITHUB_SHA::7}"
+          expected="$(git rev-parse --short HEAD)"
           for attempt in {1..60}; do
-            version="$(node -e "fetch(process.env.PRODUCTION_URL + '/api/version', { cache: 'no-store' }).then(async (response) => { if (!response.ok) throw new Error(String(response.status)); const body = await response.json(); console.log(body.version ?? ''); }).catch(() => process.exit(1));" 2>/dev/null || true)"
-            status="$(node -e "fetch(process.env.PRODUCTION_URL, { redirect: 'manual', cache: 'no-store' }).then((response) => console.log(response.status)).catch(() => process.exit(1));" 2>/dev/null || true)"
+            version="$(curl --fail --silent --show-error --max-time 5 "$PRODUCTION_URL/api/version" | node -e "let raw = ''; process.stdin.on('data', (chunk) => { raw += chunk; }); process.stdin.on('end', () => { try { console.log(JSON.parse(raw).version ?? ''); } catch { process.exit(1); } });" 2>/dev/null || true)"
+            status="$(curl --silent --output /dev/null --write-out "%{http_code}" --max-time 5 "$PRODUCTION_URL" || true)"
             echo "attempt=$attempt status=$status version=$version expected=$expected"
             if [ "$status" = "200" ] && [ "$version" = "$expected" ]; then
               exit 0

--- a/docs/GDD_COVERAGE.json
+++ b/docs/GDD_COVERAGE.json
@@ -905,6 +905,23 @@
       "followupRefs": ["VibeGear2-implement-mod-loader-e9b8b51f"]
     },
     {
+      "id": "GDD-21-CI-DEPLOY-HEALTH",
+      "gddSections": [
+        "docs/gdd/21-technical-design-for-web-implementation.md"
+      ],
+      "requirement": "The CI workflow verifies the production Vercel Git deployment for pushed main commits by checking that the live app serves the expected build id.",
+      "coverage": ["implemented-code", "automated-test"],
+      "implementationRefs": [
+        ".github/workflows/ci.yml",
+        "src/app/api/version/route.ts"
+      ],
+      "testRefs": [
+        "src/app/api/version/__tests__/route.test.ts",
+        "scripts/__tests__/content-lint.test.ts"
+      ],
+      "followupRefs": []
+    },
+    {
       "id": "GDD-05-GARAGE-SUMMARY",
       "gddSections": [
         "docs/gdd/05-core-gameplay-loop.md",

--- a/docs/GDD_COVERAGE.json
+++ b/docs/GDD_COVERAGE.json
@@ -910,14 +910,10 @@
         "docs/gdd/21-technical-design-for-web-implementation.md"
       ],
       "requirement": "The CI workflow verifies the production Vercel Git deployment for pushed main commits by checking that the live app serves the expected build id.",
-      "coverage": ["implemented-code", "automated-test"],
+      "coverage": ["implemented-code"],
       "implementationRefs": [
         ".github/workflows/ci.yml",
         "src/app/api/version/route.ts"
-      ],
-      "testRefs": [
-        "src/app/api/version/__tests__/route.test.ts",
-        "scripts/__tests__/content-lint.test.ts"
       ],
       "followupRefs": []
     },

--- a/docs/PROGRESS_LOG.md
+++ b/docs/PROGRESS_LOG.md
@@ -32,8 +32,10 @@ Correct them by adding a new entry that references the old one.
   CLI deployment with a separate token secret.
 
 ### Coverage ledger
-- This is CI health work for §21. It does not add a new gameplay coverage
-  item.
+- GDD-21-CI-DEPLOY-HEALTH covers the `main` production deploy verification
+  contract for the Vercel Git integration.
+- Uncovered adjacent requirements: none for the CI deploy verification
+  contract.
 
 ### Followups created
 None.

--- a/docs/PROGRESS_LOG.md
+++ b/docs/PROGRESS_LOG.md
@@ -10,7 +10,7 @@ Correct them by adding a new entry that references the old one.
 
 **GDD sections touched:**
 [§21](gdd/21-technical-design-for-web-implementation.md) CI and deploy target.
-**Branch / PR:** `fix/vercel-git-deploy-check`, PR pending.
+**Branch / PR:** `fix/vercel-git-deploy-check`, PR #97.
 **Status:** Implemented.
 
 ### Done

--- a/docs/PROGRESS_LOG.md
+++ b/docs/PROGRESS_LOG.md
@@ -6,6 +6,41 @@ Correct them by adding a new entry that references the old one.
 
 ---
 
+## 2026-04-29: Slice: Vercel Git deploy check hotfix
+
+**GDD sections touched:**
+[§21](gdd/21-technical-design-for-web-implementation.md) CI and deploy target.
+**Branch / PR:** `fix/vercel-git-deploy-check`, PR pending.
+**Status:** Implemented.
+
+### Done
+- `.github/workflows/ci.yml`: replaced the token-based Vercel CLI
+  production deploy job with a production smoke check that waits for the
+  Vercel Git deployment to serve the pushed short SHA from `/api/version`.
+
+### Verified
+- `actionlint .github/workflows/ci.yml` green.
+- Local production smoke of `https://vibe-gear2.vercel.app` returned 200 for
+  `/`, `/world`, `/race`, `/quick-race`, `/race?mode=practice`, `/daily`,
+  `/options`, `/race/results`, and `/garage`, and returned 404 for
+  `/dev/track-editor`.
+- Local shell probe matched `/api/version` to merge commit `ce8448c`.
+
+### Decisions and assumptions
+- Vercel Git integration is the production deployment owner. The GitHub
+  workflow now verifies the deployed build instead of attempting a duplicate
+  CLI deployment with a separate token secret.
+
+### Coverage ledger
+- This is CI health work for §21. It does not add a new gameplay coverage
+  item.
+
+### Followups created
+None.
+
+### GDD edits
+None.
+
 ## 2026-04-29: Slice: Dev track editor
 
 **GDD sections touched:**


### PR DESCRIPTION
## Summary
- Replaces the broken token-based Vercel CLI production deploy job with a production smoke check.
- Waits for the Vercel Git deployment to serve the pushed short SHA from `/api/version`.
- Keeps production deploy verification in GitHub without depending on a separate stale token secret.

## GDD links
- docs/gdd/21-technical-design-for-web-implementation.md

## Requirement inventory
- Covered: `main` CI verifies the production deployment that Vercel Git integration already publishes.
- Left to followup: none.

## Progress log
- docs/PROGRESS_LOG.md: Vercel Git deploy check hotfix

## Test plan
- [x] `actionlint .github/workflows/ci.yml`
- [x] Local shell probe matched `/api/version` to `ce8448c` on production.
- [x] Production smoke returned expected statuses for core routes and `/dev/track-editor` 404.

## Followups
- None.