### PR TITLE
Data mod loader

### DIFF
--- a/docs/GDD_COVERAGE.json
+++ b/docs/GDD_COVERAGE.json
@@ -879,6 +879,27 @@
       ]
     },
     {
+      "id": "GDD-26-DATA-MOD-LOADER",
+      "gddSections": [
+        "docs/gdd/21-technical-design-for-web-implementation.md",
+        "docs/gdd/22-data-schemas.md",
+        "docs/gdd/26-open-source-project-guidance.md"
+      ],
+      "requirement": "Official builds support data-only mods under /mods/<mod-id>/ through a strict manifest schema, provenance fields, safe relative paths, no executable plugin references, and schema validation for referenced track, car, upgrade, AI driver, and championship JSON.",
+      "coverage": ["implemented-code", "automated-test"],
+      "implementationRefs": [
+        "src/data/schemas.ts",
+        "src/mods/manifest.ts",
+        "scripts/content-lint.ts",
+        "docs/MODDING.md"
+      ],
+      "testRefs": [
+        "src/mods/__tests__/manifest.test.ts",
+        "scripts/__tests__/content-lint.test.ts"
+      ],
+      "followupRefs": []
+    },
+    {
       "id": "GDD-26-DEV-TRACK-EDITOR",
       "gddSections": [
         "docs/gdd/09-track-design.md",

--- a/docs/MODDING.md
+++ b/docs/MODDING.md
@@ -1,12 +1,67 @@
 # Modding
 
-This file is intentionally a placeholder summary. The expanded modding guide is
-tracked in a separate followup. Until that lands, the binding rules are:
+VibeGear2 v1.0 supports data-only mods. Mods can add or replace structured
+content such as tracks, cars, upgrades, AI drivers, and championships. Mods
+cannot run code, inject scripts, ship WebAssembly, or bypass the project data
+schemas.
 
-- Data mods only for v1.0.
-- No executable plugins.
-- All mod manifests require author, licence, and originality statement.
-- Public mod-browser submissions must pass legal review before inclusion.
+## Folder Layout
+
+Official mod loading expects this shape:
+
+```text
+public/mods/<mod-id>/
+  manifest.json
+  tracks/*.json
+  cars/*.json
+  upgrades/*.json
+  ai/*.json
+  championships/*.json
+```
+
+The `<mod-id>` folder name must match `manifest.json` `id`.
+
+## Manifest
+
+Each mod must include `manifest.json`:
+
+```json
+{
+  "id": "community-pack",
+  "name": "Community Pack",
+  "version": 1,
+  "author": "A. Contributor",
+  "license": "CC-BY-SA-4.0",
+  "originality": "Original data authored from scratch for this project.",
+  "data": {
+    "tracks": ["tracks/harbor-day.json"]
+  }
+}
+```
+
+Allowed manifest licenses are `CC-BY-SA-4.0`, `CC-BY-4.0`, `CC0-1.0`, and
+`public-domain`. Track, championship, balancing, and other community data
+should use `CC-BY-SA-4.0` unless a maintainer approves another compatible
+license.
+
+## Validation
+
+The loader and content lint enforce these rules:
+
+- Manifest paths are relative to the mod folder.
+- Paths cannot use URL schemes, absolute paths, backslashes, or `..`.
+- Paths cannot reference executable file types such as JavaScript,
+  TypeScript, HTML, or WebAssembly.
+- Every referenced data file must exist.
+- Track, car, upgrade, AI driver, and championship JSON must validate
+  against `src/data/schemas.ts`.
+- Data must pass the legal denylist checks in `scripts/content-lint.ts`.
+
+## Legal Safety
+
+Do not include copied game assets, real car badges, real track branding,
+ripped audio, ROM data, unclear sample packs, or trademark-risk names. Public
+mod-browser submissions must pass legal review before inclusion.
 
 See [`docs/gdd/26-open-source-project-guidance.md`](gdd/26-open-source-project-guidance.md)
 and [`LEGAL_SAFETY.md`](LEGAL_SAFETY.md) for the current source of truth.

--- a/docs/PROGRESS_LOG.md
+++ b/docs/PROGRESS_LOG.md
@@ -6,6 +6,55 @@ Correct them by adding a new entry that references the old one.
 
 ---
 
+## 2026-04-29: Slice: Data mod loader
+
+**GDD sections touched:**
+[§21](gdd/21-technical-design-for-web-implementation.md) mod layer,
+[§22](gdd/22-data-schemas.md) mod manifest schema,
+[§26](gdd/26-open-source-project-guidance.md) data-only mod rules.
+**Branch / PR:** `feat/mod-loader`, PR pending.
+**Status:** Implemented.
+
+### Done
+- `src/data/schemas.ts`: added the strict mod manifest schema with author,
+  license, originality, data refs, optional asset refs, safe relative paths,
+  and executable-reference rejection.
+- `src/mods/manifest.ts`: added a browser-safe data mod loader for
+  `/mods/<mod-id>/manifest.json` and referenced track, car, upgrade, AI
+  driver, and championship JSON.
+- `scripts/content-lint.ts`: added a public mod manifest pass that validates
+  manifests, folder-id matches, referenced file existence, and referenced data
+  schemas.
+- `docs/MODDING.md` and §22: documented the official data-only manifest shape
+  and validation rules.
+
+### Verified
+- `npx vitest run src/mods/__tests__/manifest.test.ts scripts/__tests__/content-lint.test.ts`
+  green, 72 passed.
+- `npx vitest run src/mods/__tests__/manifest.test.ts src/data/schemas.test.ts`
+  green, 60 passed.
+- `npm run typecheck` green.
+- `npm run verify` green, 2580 passed.
+
+### Decisions and assumptions
+- The first loader is a pure data loader. It validates mod packs but does not
+  mount a public mod browser or let mods run executable code.
+- Manifest `id` must match the folder name. That keeps `/mods/<id>/` URLs and
+  manifest identity aligned for future public listings.
+
+### Coverage ledger
+- GDD-26-DATA-MOD-LOADER covers the data-only mod manifest schema, safe path
+  validation, loader, docs, and content-lint enforcement.
+- Uncovered adjacent requirements: public mod browser submission and legal
+  review UI remain future slices.
+
+### Followups created
+None.
+
+### GDD edits
+- `docs/gdd/22-data-schemas.md`: added the mod manifest JSON schema and
+  loader validation contract.
+
 ## 2026-04-29: Slice: Vercel Git deploy check hotfix
 
 **GDD sections touched:**

--- a/docs/PROGRESS_LOG.md
+++ b/docs/PROGRESS_LOG.md
@@ -12,7 +12,7 @@ Correct them by adding a new entry that references the old one.
 [§21](gdd/21-technical-design-for-web-implementation.md) mod layer,
 [§22](gdd/22-data-schemas.md) mod manifest schema,
 [§26](gdd/26-open-source-project-guidance.md) data-only mod rules.
-**Branch / PR:** `feat/mod-loader`, PR pending.
+**Branch / PR:** `feat/mod-loader`, PR #98.
 **Status:** Implemented.
 
 ### Done

--- a/docs/gdd/22-data-schemas.md
+++ b/docs/gdd/22-data-schemas.md
@@ -171,6 +171,41 @@
 entries are valid registry metadata but their light and audio transition
 effects are owned by the tunnel segment slice.
 
+## Mod manifest JSON schema
+
+Data mods live under `/mods/<mod-id>/` and load through a manifest file:
+
+```
+{
+  "id": "community-pack",
+  "name": "Community Pack",
+  "version": 1,
+  "author": "A. Contributor",
+  "license": "CC-BY-SA-4.0",
+  "originality": "Original data authored from scratch for this project.",
+  "description": "Optional player-facing summary.",
+  "data": {
+    "tracks": ["tracks/harbor-day.json"],
+    "cars": ["cars/local-starter.json"],
+    "upgrades": ["upgrades/local-upgrades.json"],
+    "aiDrivers": ["ai/local-rivals.json"],
+    "championships": ["championships/local-cup.json"]
+  },
+  "assets": {
+    "art": ["art/roadside.local.manifest.json"],
+    "audio": ["audio/weather.local.manifest.json"]
+  }
+}
+```
+
+`id` must match the folder name in `/mods/<mod-id>/`. Mod manifests are
+strict data: no executable plugin files, no URL schemes, no absolute paths,
+and no `..` path escapes. The loader accepts the approved project data
+licenses (`CC-BY-SA-4.0`, `CC-BY-4.0`, `CC0-1.0`, and `public-domain`) and
+requires an originality statement for legal review. The `data` object must
+reference at least one JSON file, and every referenced file validates against
+the matching schema in this section.
+
 ## Save-game JSON schema
 
 Current schema major: **v3**. v1 saves migrate forward additively via

--- a/scripts/__tests__/content-lint.test.ts
+++ b/scripts/__tests__/content-lint.test.ts
@@ -2,9 +2,9 @@
  * Unit tests for `scripts/content-lint.ts`.
  *
  * The script is the automated enforcement of `docs/LEGAL_SAFETY.md`
- * section 9. These tests cover the four rules that live in the script
+ * section 9. These tests cover the rules that live in the script
  * (binary-without-manifest, track-real-circuit-name,
- * car-manufacturer-name, topgear-text) plus the pure helpers
+ * car-manufacturer-name, topgear-text, mod-manifest) plus the pure helpers
  * (`buildDenylistRegex`, `findDenylistHit`, `formatHit`,
  * `isBinaryAssetPath`) so adding a future rule does not have to relearn
  * the matcher semantics.
@@ -34,6 +34,7 @@ import {
   lintLatestProgressLogCoverage,
   lintBinaryManifest,
   lintCarNames,
+  lintPublicModManifests,
   lintTopGearText,
   lintTrackNames,
   runContentLint,
@@ -388,6 +389,105 @@ describe("lintTopGearText", () => {
     const hits = lintTopGearText({ repoRoot });
     expect(hits).toHaveLength(1);
     expect(hits[0]?.detail).toContain("Snowblind");
+  });
+});
+
+// lintPublicModManifests ----------------------------------------------------
+
+const MOD_TRACK = {
+  id: "community/harbor-day",
+  name: "Harbor Day",
+  tourId: "community",
+  author: "modder",
+  version: 1,
+  lengthMeters: 180,
+  laps: 1,
+  laneCount: 3,
+  weatherOptions: ["clear"],
+  difficulty: 1,
+  segments: [
+    {
+      len: 180,
+      curve: 0,
+      grade: 0,
+      roadsideLeft: "grass",
+      roadsideRight: "grass",
+      hazards: [],
+    },
+  ],
+  checkpoints: [{ segmentIndex: 0, label: "start" }],
+  spawn: { gridSlots: 2 },
+};
+
+const MOD_MANIFEST = {
+  id: "community-pack",
+  name: "Community Pack",
+  version: 1,
+  author: "A. Contributor",
+  license: "CC-BY-SA-4.0",
+  originality: "Original data authored from scratch for this project.",
+  data: {
+    tracks: ["tracks/harbor-day.json"],
+  },
+};
+
+describe("lintPublicModManifests", () => {
+  it("returns no hits when public/mods does not exist", () => {
+    expect(lintPublicModManifests({ repoRoot })).toEqual([]);
+  });
+
+  it("accepts a valid data-only public mod", () => {
+    writeFile("public/mods/community-pack/manifest.json", JSON.stringify(MOD_MANIFEST));
+    writeFile("public/mods/community-pack/tracks/harbor-day.json", JSON.stringify(MOD_TRACK));
+
+    expect(lintPublicModManifests({ repoRoot })).toEqual([]);
+  });
+
+  it("rejects a manifest whose id does not match its folder", () => {
+    writeFile(
+      "public/mods/community-pack/manifest.json",
+      JSON.stringify({ ...MOD_MANIFEST, id: "other-pack" }),
+    );
+    writeFile("public/mods/community-pack/tracks/harbor-day.json", JSON.stringify(MOD_TRACK));
+
+    const hits = lintPublicModManifests({ repoRoot });
+    expect(hits).toHaveLength(1);
+    expect(hits[0]?.rule).toBe("mod-manifest");
+    expect(hits[0]?.detail).toContain("does not match folder");
+  });
+
+  it("rejects missing referenced data files", () => {
+    writeFile("public/mods/community-pack/manifest.json", JSON.stringify(MOD_MANIFEST));
+
+    const hits = lintPublicModManifests({ repoRoot });
+    expect(hits).toHaveLength(1);
+    expect(hits[0]?.detail).toContain("does not exist");
+  });
+
+  it("rejects referenced data that fails its schema", () => {
+    writeFile("public/mods/community-pack/manifest.json", JSON.stringify(MOD_MANIFEST));
+    writeFile(
+      "public/mods/community-pack/tracks/harbor-day.json",
+      JSON.stringify({ ...MOD_TRACK, segments: [] }),
+    );
+
+    const hits = lintPublicModManifests({ repoRoot });
+    expect(hits).toHaveLength(1);
+    expect(hits[0]?.detail).toContain("track schema validation failed");
+  });
+
+  it("rejects executable references through manifest validation", () => {
+    writeFile(
+      "public/mods/community-pack/manifest.json",
+      JSON.stringify({
+        ...MOD_MANIFEST,
+        data: { tracks: ["tracks/run.js"] },
+      }),
+    );
+
+    const hits = lintPublicModManifests({ repoRoot });
+    expect(hits).toHaveLength(1);
+    expect(hits[0]?.detail).toContain("manifest schema validation failed");
   });
 });
 

--- a/scripts/content-lint.ts
+++ b/scripts/content-lint.ts
@@ -32,6 +32,9 @@
  *    to data JSON only because the README, the page title, and source
  *    comments legitimately describe the project as a spiritual successor
  *    to Top Gear 2 per `docs/gdd/01-title-and-high-concept.md`.
+ * 5. `mod-manifest`: Any public data mod under `public/mods/<mod-id>/`
+ *    must ship a valid manifest, match its folder id, and reference
+ *    schema-valid data files without executable plugin paths.
  *
  * Exit code:
  * - 0 when no hits.
@@ -45,7 +48,15 @@
  */
 
 import { existsSync, readFileSync, readdirSync, statSync } from "node:fs";
-import { join, relative, resolve, extname } from "node:path";
+import { basename, dirname, extname, join, relative, resolve } from "node:path";
+import {
+  AIDriverSchema,
+  CarSchema,
+  ChampionshipSchema,
+  ModManifestSchema,
+  TrackSchema,
+  UpgradeSchema,
+} from "../src/data/schemas";
 
 // Denylists -----------------------------------------------------------------
 
@@ -129,6 +140,7 @@ export interface LintHit {
     | "track-real-circuit-name"
     | "car-manufacturer-name"
     | "topgear-text"
+    | "mod-manifest"
     | "gdd-coverage-ledger"
     | "progress-log-coverage";
   detail: string;
@@ -386,6 +398,165 @@ function safeRead(abs: string): string | null {
     return null;
   }
 }
+
+// Public mod manifests ------------------------------------------------------
+
+function parseJson(abs: string): unknown | Error {
+  const text = safeRead(abs);
+  if (text === null) return new Error("file cannot be read");
+  try {
+    return JSON.parse(text);
+  } catch (error) {
+    return error as Error;
+  }
+}
+
+type SchemaLike = {
+  safeParse: (
+    value: unknown,
+  ) => { success: true; data: unknown } | { success: false; error: Error };
+};
+
+function lintReferencedModFiles(
+  input: LintInput,
+  hits: LintHit[],
+  manifestAbs: string,
+  modDir: string,
+  refs: readonly string[] | undefined,
+  label: string,
+  schema: SchemaLike,
+): void {
+  for (const ref of refs ?? []) {
+    const abs = resolve(modDir, ref);
+    if (!abs.startsWith(`${modDir}/`)) {
+      hits.push({
+        path: relative(input.repoRoot, manifestAbs),
+        rule: "mod-manifest",
+        detail: `${label} ref escapes mod folder: ${ref}`,
+      });
+      continue;
+    }
+    if (!existsSync(abs)) {
+      hits.push({
+        path: relative(input.repoRoot, manifestAbs),
+        rule: "mod-manifest",
+        detail: `${label} ref does not exist: ${ref}`,
+      });
+      continue;
+    }
+    const raw = parseJson(abs);
+    if (raw instanceof Error) {
+      hits.push({
+        path: relative(input.repoRoot, abs),
+        rule: "mod-manifest",
+        detail: `${label} JSON parse failed: ${raw.message}`,
+      });
+      continue;
+    }
+    const parsed = schema.safeParse(raw);
+    if (!parsed.success) {
+      hits.push({
+        path: relative(input.repoRoot, abs),
+        rule: "mod-manifest",
+        detail: `${label} schema validation failed: ${parsed.error.message}`,
+      });
+    }
+  }
+}
+
+/**
+ * Validate public data-only mods. Each `public/mods/<mod-id>/manifest.json`
+ * must match the mod manifest schema, match its folder id, and every
+ * referenced data file must exist and validate against the matching content
+ * schema. Binary asset provenance still runs through the existing manifest
+ * pass; this pass owns the data-pack contract.
+ */
+export function lintPublicModManifests(input: LintInput): LintHit[] {
+  const modsDir = resolve(input.repoRoot, "public/mods");
+  if (!existsSync(modsDir)) return [];
+
+  const hits: LintHit[] = [];
+  for (const manifestAbs of walkFiles(modsDir, (p) =>
+    p.endsWith(`/${MOD_MANIFEST_FILENAME}`),
+  )) {
+    const modDir = dirname(manifestAbs);
+    const raw = parseJson(manifestAbs);
+    if (raw instanceof Error) {
+      hits.push({
+        path: relative(input.repoRoot, manifestAbs),
+        rule: "mod-manifest",
+        detail: `manifest JSON parse failed: ${raw.message}`,
+      });
+      continue;
+    }
+    const parsed = ModManifestSchema.safeParse(raw);
+    if (!parsed.success) {
+      hits.push({
+        path: relative(input.repoRoot, manifestAbs),
+        rule: "mod-manifest",
+        detail: `manifest schema validation failed: ${parsed.error.message}`,
+      });
+      continue;
+    }
+    const expectedId = basename(modDir);
+    if (parsed.data.id !== expectedId) {
+      hits.push({
+        path: relative(input.repoRoot, manifestAbs),
+        rule: "mod-manifest",
+        detail: `manifest id "${parsed.data.id}" does not match folder "${expectedId}"`,
+      });
+    }
+
+    lintReferencedModFiles(
+      input,
+      hits,
+      manifestAbs,
+      modDir,
+      parsed.data.data.tracks,
+      "track",
+      TrackSchema,
+    );
+    lintReferencedModFiles(
+      input,
+      hits,
+      manifestAbs,
+      modDir,
+      parsed.data.data.cars,
+      "car",
+      CarSchema,
+    );
+    lintReferencedModFiles(
+      input,
+      hits,
+      manifestAbs,
+      modDir,
+      parsed.data.data.upgrades,
+      "upgrade",
+      UpgradeSchema,
+    );
+    lintReferencedModFiles(
+      input,
+      hits,
+      manifestAbs,
+      modDir,
+      parsed.data.data.aiDrivers,
+      "AI driver",
+      AIDriverSchema,
+    );
+    lintReferencedModFiles(
+      input,
+      hits,
+      manifestAbs,
+      modDir,
+      parsed.data.data.championships,
+      "championship",
+      ChampionshipSchema,
+    );
+  }
+  return hits;
+}
+
+const MOD_MANIFEST_FILENAME = "manifest.json";
 
 // GDD coverage ledger -------------------------------------------------------
 
@@ -722,8 +893,8 @@ export function lintLatestProgressLogCoverage(input: LintInput): LintHit[] {
 
 /**
  * Run every pass and return the concatenated hit list. Order is stable:
- * binary-without-manifest first, then track / car / topgear. Tests rely
- * on this ordering for assertion stability.
+ * binary-without-manifest first, then track / car / topgear / mod
+ * manifest checks. Tests rely on this ordering for assertion stability.
  */
 export function runContentLint(input: LintInput): LintHit[] {
   return [
@@ -731,6 +902,7 @@ export function runContentLint(input: LintInput): LintHit[] {
     ...lintTrackNames(input),
     ...lintCarNames(input),
     ...lintTopGearText(input),
+    ...lintPublicModManifests(input),
     ...lintGddCoverageLedger(input),
     ...lintLatestProgressLogCoverage(input),
   ];

--- a/src/data/schemas.ts
+++ b/src/data/schemas.ts
@@ -435,6 +435,70 @@ export const SponsorObjectiveSchema = z.object({
 });
 export type SponsorObjective = z.infer<typeof SponsorObjectiveSchema>;
 
+// Mod manifest --------------------------------------------------------------
+
+export const ModLicenseSchema = z.enum([
+  "CC-BY-SA-4.0",
+  "CC-BY-4.0",
+  "CC0-1.0",
+  "public-domain",
+]);
+export type ModLicense = z.infer<typeof ModLicenseSchema>;
+
+const modPath = z
+  .string()
+  .min(1)
+  .regex(/^(?!\/)(?!.*(?:^|\/)\.\.(?:\/|$))(?!.*\\)[A-Za-z0-9._/-]+$/u, {
+    message: "mod paths must be relative, stay inside the mod folder, and use forward slashes",
+  })
+  .refine((value) => !/^[A-Za-z][A-Za-z0-9+.-]*:/u.test(value), {
+    message: "mod paths must not include a URL scheme",
+  })
+  .refine((value) => !/\.(?:js|mjs|cjs|ts|tsx|jsx|wasm|html?)$/iu.test(value), {
+    message: "data-only mods cannot reference executable files",
+  })
+  .refine((value) => value.split("/").every((part) => part.length > 0 && part !== "."), {
+    message: "mod paths must not contain empty or current-directory segments",
+  });
+
+export const ModDataRefsSchema = z
+  .object({
+    tracks: z.array(modPath).optional(),
+    cars: z.array(modPath).optional(),
+    upgrades: z.array(modPath).optional(),
+    aiDrivers: z.array(modPath).optional(),
+    championships: z.array(modPath).optional(),
+  })
+  .strict()
+  .refine((refs) => Object.values(refs).some((list) => list && list.length > 0), {
+    message: "mod manifest must reference at least one data file",
+  });
+export type ModDataRefs = z.infer<typeof ModDataRefsSchema>;
+
+export const ModAssetRefsSchema = z
+  .object({
+    art: z.array(modPath).optional(),
+    audio: z.array(modPath).optional(),
+  })
+  .strict()
+  .optional();
+export type ModAssetRefs = z.infer<typeof ModAssetRefsSchema>;
+
+export const ModManifestSchema = z
+  .object({
+    id: slug,
+    name: z.string().min(1),
+    version: positiveInt,
+    author: z.string().min(1),
+    license: ModLicenseSchema,
+    originality: z.string().min(20),
+    description: z.string().min(1).optional(),
+    data: ModDataRefsSchema,
+    assets: ModAssetRefsSchema,
+  })
+  .strict();
+export type ModManifest = z.infer<typeof ModManifestSchema>;
+
 // Save-game -----------------------------------------------------------------
 
 export const SpeedUnitSchema = z.enum(["kph", "mph"]);

--- a/src/mods/__tests__/manifest.test.ts
+++ b/src/mods/__tests__/manifest.test.ts
@@ -1,0 +1,142 @@
+import { describe, expect, it } from "vitest";
+
+import { ModManifestSchema } from "@/data/schemas";
+
+import { isSafeModPath, loadModContent, loadModManifest, modFileUrl } from "../manifest";
+
+const track = {
+  id: "community/harbor-day",
+  name: "Harbor Day",
+  tourId: "community",
+  author: "modder",
+  version: 1,
+  lengthMeters: 180,
+  laps: 1,
+  laneCount: 3,
+  weatherOptions: ["clear"],
+  difficulty: 1,
+  segments: [
+    {
+      len: 180,
+      curve: 0,
+      grade: 0,
+      roadsideLeft: "grass",
+      roadsideRight: "grass",
+      hazards: [],
+    },
+  ],
+  checkpoints: [{ segmentIndex: 0, label: "start" }],
+  spawn: { gridSlots: 2 },
+};
+
+const manifest = {
+  id: "community-pack",
+  name: "Community Pack",
+  version: 1,
+  author: "A. Contributor",
+  license: "CC-BY-SA-4.0",
+  originality: "Original data authored from scratch for this project.",
+  data: {
+    tracks: ["tracks/harbor-day.json"],
+  },
+};
+
+function fetcher(files: Record<string, unknown>) {
+  return async (url: string) => ({
+    ok: Object.prototype.hasOwnProperty.call(files, url),
+    status: Object.prototype.hasOwnProperty.call(files, url) ? 200 : 404,
+    json: async () => files[url],
+  });
+}
+
+describe("ModManifestSchema", () => {
+  it("accepts a data-only manifest with provenance fields", () => {
+    expect(ModManifestSchema.parse(manifest).id).toBe("community-pack");
+  });
+
+  it("rejects executable data references", () => {
+    const result = ModManifestSchema.safeParse({
+      ...manifest,
+      data: { tracks: ["tracks/evil.js"] },
+    });
+
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects non-normal relative data paths", () => {
+    const result = ModManifestSchema.safeParse({
+      ...manifest,
+      data: { tracks: ["tracks/./harbor-day.json"] },
+    });
+
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects manifests without content references", () => {
+    const result = ModManifestSchema.safeParse({
+      ...manifest,
+      data: {},
+    });
+
+    expect(result.success).toBe(false);
+  });
+});
+
+describe("mod loader", () => {
+  it("normalizes safe mod file URLs under the mod folder", () => {
+    expect(modFileUrl("/mods", "community-pack", "tracks/harbor-day.json")).toBe(
+      "/mods/community-pack/tracks/harbor-day.json",
+    );
+  });
+
+  it.each([
+    "../manifest.json",
+    "/tracks/a.json",
+    "https://x.test/a.json",
+    "track\\a.json",
+    "run.wasm",
+    "tracks/",
+    ".",
+    "tracks/./a.json",
+  ])("rejects unsafe path %s", (path) => {
+    expect(isSafeModPath(path)).toBe(false);
+    expect(() => modFileUrl("/mods", "community-pack", path)).toThrow(/unsafe/u);
+  });
+
+  it("loads manifest and validates referenced track JSON", async () => {
+    const loaded = await loadModContent({
+      modId: "community-pack",
+      fetcher: fetcher({
+        "/mods/community-pack/manifest.json": manifest,
+        "/mods/community-pack/tracks/harbor-day.json": track,
+      }),
+    });
+
+    expect(loaded.manifest.id).toBe("community-pack");
+    expect(loaded.tracks).toHaveLength(1);
+    expect(loaded.tracks[0]?.id).toBe("community/harbor-day");
+  });
+
+  it("rejects a manifest id mismatch", async () => {
+    await expect(
+      loadModManifest({
+        modId: "expected-pack",
+        fetcher: fetcher({
+          "/mods/expected-pack/manifest.json": manifest,
+        }),
+      }),
+    ).rejects.toThrow(/does not match/u);
+  });
+
+  it("rejects invalid referenced data", async () => {
+    await expect(
+      loadModContent({
+        modId: "community-pack",
+        fetcher: fetcher({
+          "/mods/community-pack/manifest.json": manifest,
+          "/mods/community-pack/tracks/harbor-day.json": { ...track, segments: [] },
+        }),
+      }),
+    ).rejects.toThrow(/track file/u);
+  });
+});

--- a/src/mods/index.ts
+++ b/src/mods/index.ts
@@ -1,0 +1,10 @@
+export {
+  MOD_MANIFEST_FILE,
+  MODS_BASE_PATH,
+  isSafeModPath,
+  loadModContent,
+  loadModManifest,
+  modFileUrl,
+  type LoadModOptions,
+  type LoadedModContent,
+} from "./manifest";

--- a/src/mods/manifest.ts
+++ b/src/mods/manifest.ts
@@ -1,0 +1,122 @@
+import {
+  AIDriverSchema,
+  CarSchema,
+  ChampionshipSchema,
+  ModManifestSchema,
+  TrackSchema,
+  UpgradeSchema,
+  type AIDriver,
+  type Car,
+  type Championship,
+  type ModManifest,
+  type Track,
+  type Upgrade,
+} from "@/data/schemas";
+
+type FetchLike = (
+  input: string,
+  init?: { cache?: RequestCache },
+) => Promise<{ ok: boolean; status: number; json: () => Promise<unknown> }>;
+
+export const MODS_BASE_PATH = "/mods";
+export const MOD_MANIFEST_FILE = "manifest.json";
+
+export interface LoadedModContent {
+  manifest: ModManifest;
+  tracks: Track[];
+  cars: Car[];
+  upgrades: Upgrade[];
+  aiDrivers: AIDriver[];
+  championships: Championship[];
+}
+
+export interface LoadModOptions {
+  modId: string;
+  basePath?: string;
+  fetcher?: FetchLike;
+}
+
+const EXECUTABLE_EXT_RE = /\.(?:js|mjs|cjs|ts|tsx|jsx|wasm|html?)$/iu;
+
+export function isSafeModPath(path: string): boolean {
+  if (!path || path.startsWith("/") || path.includes("\\")) return false;
+  if (/^[A-Za-z][A-Za-z0-9+.-]*:/u.test(path)) return false;
+  if (EXECUTABLE_EXT_RE.test(path)) return false;
+  return path.split("/").every((part) => part.length > 0 && part !== ".." && part !== ".");
+}
+
+export function modFileUrl(basePath: string, modId: string, path: string): string {
+  if (!isSafeModPath(path)) {
+    throw new Error(`modFileUrl: unsafe mod path "${path}"`);
+  }
+  const cleanBase = basePath.replace(/\/+$/u, "");
+  const encodedId = encodeURIComponent(modId);
+  return `${cleanBase}/${encodedId}/${path}`;
+}
+
+async function fetchJson(fetcher: FetchLike, url: string): Promise<unknown> {
+  const response = await fetcher(url, { cache: "no-store" });
+  if (!response.ok) {
+    throw new Error(`mod loader: ${url} returned HTTP ${response.status}`);
+  }
+  return response.json();
+}
+
+export async function loadModManifest(options: LoadModOptions): Promise<ModManifest> {
+  const fetcher = options.fetcher ?? fetch;
+  const basePath = options.basePath ?? MODS_BASE_PATH;
+  const url = modFileUrl(basePath, options.modId, MOD_MANIFEST_FILE);
+  const parsed = ModManifestSchema.safeParse(await fetchJson(fetcher, url));
+  if (!parsed.success) {
+    throw new Error(`mod loader: ${url} failed manifest validation: ${parsed.error.message}`);
+  }
+  if (parsed.data.id !== options.modId) {
+    throw new Error(
+      `mod loader: manifest id "${parsed.data.id}" does not match requested mod "${options.modId}"`,
+    );
+  }
+  return parsed.data;
+}
+
+async function loadList<T>(
+  fetcher: FetchLike,
+  basePath: string,
+  modId: string,
+  paths: readonly string[] | undefined,
+  label: string,
+  schema: { safeParse: (value: unknown) => { success: true; data: T } | { success: false; error: Error } },
+): Promise<T[]> {
+  const output: T[] = [];
+  for (const path of paths ?? []) {
+    const url = modFileUrl(basePath, modId, path);
+    const parsed = schema.safeParse(await fetchJson(fetcher, url));
+    if (!parsed.success) {
+      throw new Error(`mod loader: ${label} file ${url} failed schema validation: ${parsed.error.message}`);
+    }
+    output.push(parsed.data);
+  }
+  return output;
+}
+
+export async function loadModContent(options: LoadModOptions): Promise<LoadedModContent> {
+  const fetcher = options.fetcher ?? fetch;
+  const basePath = options.basePath ?? MODS_BASE_PATH;
+  const manifest = await loadModManifest({ ...options, basePath, fetcher });
+
+  const [tracks, cars, upgrades, aiDrivers, championships] = await Promise.all([
+    loadList(fetcher, basePath, options.modId, manifest.data.tracks, "track", TrackSchema),
+    loadList(fetcher, basePath, options.modId, manifest.data.cars, "car", CarSchema),
+    loadList(fetcher, basePath, options.modId, manifest.data.upgrades, "upgrade", UpgradeSchema),
+    loadList(fetcher, basePath, options.modId, manifest.data.aiDrivers, "AI driver", AIDriverSchema),
+    loadList(
+      fetcher,
+      basePath,
+      options.modId,
+      manifest.data.championships,
+      "championship",
+      ChampionshipSchema,
+    ),
+  ]);
+
+  return { manifest, tracks, cars, upgrades, aiDrivers, championships };
+}


### PR DESCRIPTION
## GDD sections
- docs/gdd/21-technical-design-for-web-implementation.md mod layer
- docs/gdd/22-data-schemas.md mod manifest schema
- docs/gdd/26-open-source-project-guidance.md data-only mod rules

## Requirement inventory
- Adds a strict mod manifest schema with author, license, originality, data refs, optional asset refs, and safe path validation.
- Adds a browser-safe data loader for /mods/<mod-id>/manifest.json plus referenced track, car, upgrade, AI driver, and championship JSON.
- Adds content-lint validation for public mod manifests, folder-id matches, referenced file existence, and referenced data schemas.
- Expands MODDING.md and §22 with the official data-only mod shape.

Nearby requirements left for later: public mod browser submission and legal review UI.

## Progress log
- docs/PROGRESS_LOG.md: Data mod loader

## Coverage
- GDD-26-DATA-MOD-LOADER

## Test plan
- [x] npx vitest run src/mods/__tests__/manifest.test.ts src/data/schemas.test.ts scripts/__tests__/content-lint.test.ts
- [x] npm run content-lint
- [x] npm run typecheck
- [x] npm run verify
- [x] grep -rn $'\\u2014\\|\\u2013' src/data/schemas.ts src/mods scripts/content-lint.ts scripts/__tests__/content-lint.test.ts docs/MODDING.md docs/gdd/22-data-schemas.md docs/GDD_COVERAGE.json docs/PROGRESS_LOG.md || true\n- [x] git diff --check\n\n## Followups\nNone.