### PR TITLE
Mod loader review fixes

### DIFF
--- a/docs/PROGRESS_LOG.md
+++ b/docs/PROGRESS_LOG.md
@@ -34,7 +34,7 @@ Correct them by adding a new entry that references the old one.
 - `npx vitest run src/mods/__tests__/manifest.test.ts src/data/schemas.test.ts`
   green, 60 passed.
 - `npm run typecheck` green.
-- `npm run verify` green, 2580 passed.
+- `npm run verify` green, 2582 passed.
 
 ### Decisions and assumptions
 - The first loader is a pure data loader. It validates mod packs but does not

--- a/docs/PROGRESS_LOG.md
+++ b/docs/PROGRESS_LOG.md
@@ -34,7 +34,7 @@ Correct them by adding a new entry that references the old one.
 - `npx vitest run src/mods/__tests__/manifest.test.ts src/data/schemas.test.ts`
   green, 60 passed.
 - `npm run typecheck` green.
-- `npm run verify` green, 2582 passed.
+- `npm run verify` green, 2583 passed.
 
 ### Decisions and assumptions
 - The first loader is a pure data loader. It validates mod packs but does not

--- a/docs/PROGRESS_LOG.md
+++ b/docs/PROGRESS_LOG.md
@@ -12,7 +12,7 @@ Correct them by adding a new entry that references the old one.
 [§21](gdd/21-technical-design-for-web-implementation.md) mod layer,
 [§22](gdd/22-data-schemas.md) mod manifest schema,
 [§26](gdd/26-open-source-project-guidance.md) data-only mod rules.
-**Branch / PR:** `feat/mod-loader`, PR #98.
+**Branch / PR:** `feat/mod-loader`, PR #98; `fix/mod-loader-review`, PR pending.
 **Status:** Implemented.
 
 ### Done

--- a/docs/PROGRESS_LOG.md
+++ b/docs/PROGRESS_LOG.md
@@ -12,7 +12,7 @@ Correct them by adding a new entry that references the old one.
 [§21](gdd/21-technical-design-for-web-implementation.md) mod layer,
 [§22](gdd/22-data-schemas.md) mod manifest schema,
 [§26](gdd/26-open-source-project-guidance.md) data-only mod rules.
-**Branch / PR:** `feat/mod-loader`, PR #98; `fix/mod-loader-review`, PR pending.
+**Branch / PR:** `feat/mod-loader`, PR #98; `fix/mod-loader-review`, PR #99.
 **Status:** Implemented.
 
 ### Done

--- a/scripts/__tests__/content-lint.test.ts
+++ b/scripts/__tests__/content-lint.test.ts
@@ -18,7 +18,7 @@
 
 import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { dirname, join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
 import {
@@ -54,8 +54,7 @@ afterEach(() => {
 
 function writeFile(relPath: string, contents: string): void {
   const abs = join(repoRoot, relPath);
-  const dir = abs.substring(0, abs.lastIndexOf("/"));
-  mkdirSync(dir, { recursive: true });
+  mkdirSync(dirname(abs), { recursive: true });
   writeFileSync(abs, contents, "utf8");
 }
 

--- a/scripts/__tests__/content-lint.test.ts
+++ b/scripts/__tests__/content-lint.test.ts
@@ -442,6 +442,19 @@ describe("lintPublicModManifests", () => {
     expect(lintPublicModManifests({ repoRoot })).toEqual([]);
   });
 
+  it("accepts safe in-folder paths whose segment starts with two dots", () => {
+    writeFile(
+      "public/mods/community-pack/manifest.json",
+      JSON.stringify({
+        ...MOD_MANIFEST,
+        data: { tracks: ["..foo/harbor-day.json"] },
+      }),
+    );
+    writeFile("public/mods/community-pack/..foo/harbor-day.json", JSON.stringify(MOD_TRACK));
+
+    expect(lintPublicModManifests({ repoRoot })).toEqual([]);
+  });
+
   it("rejects a manifest whose id does not match its folder", () => {
     writeFile(
       "public/mods/community-pack/manifest.json",

--- a/scripts/content-lint.ts
+++ b/scripts/content-lint.ts
@@ -48,7 +48,15 @@
  */
 
 import { existsSync, readFileSync, readdirSync, statSync } from "node:fs";
-import { basename, dirname, extname, join, relative, resolve } from "node:path";
+import {
+  basename,
+  dirname,
+  extname,
+  isAbsolute,
+  join,
+  relative,
+  resolve,
+} from "node:path";
 import {
   AIDriverSchema,
   CarSchema,
@@ -428,7 +436,8 @@ function lintReferencedModFiles(
 ): void {
   for (const ref of refs ?? []) {
     const abs = resolve(modDir, ref);
-    if (!abs.startsWith(`${modDir}/`)) {
+    const relFromMod = relative(modDir, abs);
+    if (relFromMod.startsWith("..") || isAbsolute(relFromMod)) {
       hits.push({
         path: relative(input.repoRoot, manifestAbs),
         rule: "mod-manifest",
@@ -477,7 +486,7 @@ export function lintPublicModManifests(input: LintInput): LintHit[] {
 
   const hits: LintHit[] = [];
   for (const manifestAbs of walkFiles(modsDir, (p) =>
-    p.endsWith(`/${MOD_MANIFEST_FILENAME}`),
+    basename(p) === MOD_MANIFEST_FILENAME,
   )) {
     const modDir = dirname(manifestAbs);
     const raw = parseJson(manifestAbs);

--- a/scripts/content-lint.ts
+++ b/scripts/content-lint.ts
@@ -437,7 +437,12 @@ function lintReferencedModFiles(
   for (const ref of refs ?? []) {
     const abs = resolve(modDir, ref);
     const relFromMod = relative(modDir, abs);
-    if (relFromMod.startsWith("..") || isAbsolute(relFromMod)) {
+    const firstRelSegment = relFromMod.split(/[\\/]/, 1)[0];
+    if (
+      relFromMod === ".." ||
+      firstRelSegment === ".." ||
+      isAbsolute(relFromMod)
+    ) {
       hits.push({
         path: relative(input.repoRoot, manifestAbs),
         rule: "mod-manifest",

--- a/src/data/schemas.ts
+++ b/src/data/schemas.ts
@@ -28,6 +28,13 @@ const slug = z
     message: "id must be a slug or slug/slug path (lowercase, digits, hyphens, underscores)",
   });
 
+const singleSegmentSlug = z
+  .string()
+  .min(1)
+  .regex(/^[a-z0-9][a-z0-9_-]*$/u, {
+    message: "id must be a single slug segment (lowercase, digits, hyphens, underscores)",
+  });
+
 const nonNegInt = z.number().int().nonnegative();
 const positiveInt = z.number().int().positive();
 const positiveNumber = z.number().positive();
@@ -486,7 +493,7 @@ export type ModAssetRefs = z.infer<typeof ModAssetRefsSchema>;
 
 export const ModManifestSchema = z
   .object({
-    id: slug,
+    id: singleSegmentSlug,
     name: z.string().min(1),
     version: positiveInt,
     author: z.string().min(1),

--- a/src/mods/__tests__/manifest.test.ts
+++ b/src/mods/__tests__/manifest.test.ts
@@ -2,7 +2,13 @@ import { describe, expect, it } from "vitest";
 
 import { ModManifestSchema } from "@/data/schemas";
 
-import { isSafeModPath, loadModContent, loadModManifest, modFileUrl } from "../manifest";
+import {
+  isSafeModId,
+  isSafeModPath,
+  loadModContent,
+  loadModManifest,
+  modFileUrl,
+} from "../manifest";
 
 const track = {
   id: "community/harbor-day",
@@ -72,6 +78,15 @@ describe("ModManifestSchema", () => {
     expect(result.success).toBe(false);
   });
 
+  it("rejects path-like mod ids", () => {
+    const result = ModManifestSchema.safeParse({
+      ...manifest,
+      id: "community/pack",
+    });
+
+    expect(result.success).toBe(false);
+  });
+
   it("rejects manifests without content references", () => {
     const result = ModManifestSchema.safeParse({
       ...manifest,
@@ -83,6 +98,14 @@ describe("ModManifestSchema", () => {
 });
 
 describe("mod loader", () => {
+  it("rejects path-like mod ids before building a URL", () => {
+    expect(isSafeModId("community-pack")).toBe(true);
+    expect(isSafeModId("community/pack")).toBe(false);
+    expect(() => modFileUrl("/mods", "community/pack", "manifest.json")).toThrow(
+      /unsafe mod id/u,
+    );
+  });
+
   it("normalizes safe mod file URLs under the mod folder", () => {
     expect(modFileUrl("/mods", "community-pack", "tracks/harbor-day.json")).toBe(
       "/mods/community-pack/tracks/harbor-day.json",

--- a/src/mods/index.ts
+++ b/src/mods/index.ts
@@ -1,6 +1,7 @@
 export {
   MOD_MANIFEST_FILE,
   MODS_BASE_PATH,
+  isSafeModId,
   isSafeModPath,
   loadModContent,
   loadModManifest,

--- a/src/mods/manifest.ts
+++ b/src/mods/manifest.ts
@@ -37,10 +37,10 @@ export interface LoadModOptions {
 }
 
 const EXECUTABLE_EXT_RE = /\.(?:js|mjs|cjs|ts|tsx|jsx|wasm|html?)$/iu;
-const MOD_ID_RE = /^[a-z0-9][a-z0-9_-]*$/u;
+const ModIdSchema = ModManifestSchema.shape.id;
 
 export function isSafeModId(modId: string): boolean {
-  return MOD_ID_RE.test(modId);
+  return ModIdSchema.safeParse(modId).success;
 }
 
 export function isSafeModPath(path: string): boolean {

--- a/src/mods/manifest.ts
+++ b/src/mods/manifest.ts
@@ -37,6 +37,11 @@ export interface LoadModOptions {
 }
 
 const EXECUTABLE_EXT_RE = /\.(?:js|mjs|cjs|ts|tsx|jsx|wasm|html?)$/iu;
+const MOD_ID_RE = /^[a-z0-9][a-z0-9_-]*$/u;
+
+export function isSafeModId(modId: string): boolean {
+  return MOD_ID_RE.test(modId);
+}
 
 export function isSafeModPath(path: string): boolean {
   if (!path || path.startsWith("/") || path.includes("\\")) return false;
@@ -46,6 +51,9 @@ export function isSafeModPath(path: string): boolean {
 }
 
 export function modFileUrl(basePath: string, modId: string, path: string): string {
+  if (!isSafeModId(modId)) {
+    throw new Error(`modFileUrl: unsafe mod id "${modId}"`);
+  }
   if (!isSafeModPath(path)) {
     throw new Error(`modFileUrl: unsafe mod path "${path}"`);
   }


### PR DESCRIPTION
## GDD sections
- docs/gdd/22-data-schemas.md mod manifest schema
- docs/gdd/26-open-source-project-guidance.md data-only mod rules

## Requirement inventory
- Carries the review fixes that missed PR #98 because that PR merged before the follow-up commit landed.
- Restricts mod manifest ids and loader ids to single-segment slugs.
- Makes public mod manifest discovery and containment checks portable with basename and path.relative.
- Makes the content-lint test helper use dirname instead of POSIX slash slicing.

Nearby requirements left for later: public mod browser submission and legal review UI.

## Progress log
- docs/PROGRESS_LOG.md: Data mod loader

## Coverage
- GDD-26-DATA-MOD-LOADER

## Test plan
- [x] npx vitest run src/mods/__tests__/manifest.test.ts scripts/__tests__/content-lint.test.ts src/data/schemas.test.ts
- [x] npm run typecheck
- [x] npm run verify
- [x] grep -rn $'\\u2014\\|\\u2013' src/data/schemas.ts src/mods scripts/content-lint.ts scripts/__tests__/content-lint.test.ts docs/PROGRESS_LOG.md || true\n- [x] git diff --check\n\n## Followups\nNone.