### PR TITLE
Starter mod sample pack

### DIFF
--- a/docs/GDD_COVERAGE.json
+++ b/docs/GDD_COVERAGE.json
@@ -900,6 +900,28 @@
       "followupRefs": []
     },
     {
+      "id": "GDD-26-STARTER-MOD-SAMPLE",
+      "gddSections": [
+        "docs/gdd/21-technical-design-for-web-implementation.md",
+        "docs/gdd/22-data-schemas.md",
+        "docs/gdd/26-open-source-project-guidance.md"
+      ],
+      "requirement": "The repo ships a small starter data mod under public/mods with a schema-valid manifest and track JSON, plus a browser smoke that loads the pack through the official data-only mod loader.",
+      "coverage": ["implemented-code", "automated-test"],
+      "implementationRefs": [
+        "public/mods/starter-sample/manifest.json",
+        "public/mods/starter-sample/README.md",
+        "public/mods/starter-sample/tracks/sample-loop.json",
+        "src/app/dev/mods/page.tsx",
+        "docs/MODDING.md"
+      ],
+      "testRefs": [
+        "e2e/mod-loader.spec.ts",
+        "scripts/__tests__/content-lint.test.ts"
+      ],
+      "followupRefs": []
+    },
+    {
       "id": "GDD-26-DEV-TRACK-EDITOR",
       "gddSections": [
         "docs/gdd/09-track-design.md",

--- a/docs/MODDING.md
+++ b/docs/MODDING.md
@@ -21,6 +21,10 @@ public/mods/<mod-id>/
 
 The `<mod-id>` folder name must match `manifest.json` `id`.
 
+The repository includes a tiny starter pack at
+`public/mods/starter-sample/`. Use it as the reference for file layout,
+manifest fields, and schema-valid track JSON.
+
 ## Manifest
 
 Each mod must include `manifest.json`:

--- a/docs/PROGRESS_LOG.md
+++ b/docs/PROGRESS_LOG.md
@@ -6,6 +6,47 @@ Correct them by adding a new entry that references the old one.
 
 ---
 
+## 2026-04-29: Slice: Starter mod sample pack
+
+**GDD sections touched:**
+[§21](gdd/21-technical-design-for-web-implementation.md) mod layer,
+[§22](gdd/22-data-schemas.md) mod manifest schema,
+[§26](gdd/26-open-source-project-guidance.md) data-only mod rules.
+**Branch / PR:** `feat/starter-mod-sample`, PR pending.
+**Status:** Implemented.
+
+### Done
+- `public/mods/starter-sample/`: added a schema-valid data-only starter mod
+  with manifest provenance fields, a README, and one original sample track.
+- `src/app/dev/mods/`: added a browser smoke page that loads the starter
+  pack through `loadModContent`.
+- `e2e/mod-loader.spec.ts`: added a Playwright smoke that verifies the
+  browser loader reaches ready state and exposes the starter track id.
+- `docs/MODDING.md`: linked the starter sample as the reference layout.
+
+### Verified
+- `npm run typecheck` green.
+- `npm run content-lint` green.
+- `npx playwright test e2e/mod-loader.spec.ts` green, 1 passed.
+- `npm run verify` green, 2583 passed.
+- No-dash scan and `git diff --check` green.
+
+### Decisions and assumptions
+- The starter pack stays intentionally tiny and data-only. It proves the
+  loader contract without adding a public mod-browser UI.
+
+### Coverage ledger
+- GDD-26-STARTER-MOD-SAMPLE covers the starter mod sample pack and browser
+  mod-loader smoke.
+- Uncovered adjacent requirements: public mod browser submission and legal
+  review UI remain future slices.
+
+### Followups created
+None.
+
+### GDD edits
+None.
+
 ## 2026-04-29: Slice: Data mod loader
 
 **GDD sections touched:**

--- a/docs/PROGRESS_LOG.md
+++ b/docs/PROGRESS_LOG.md
@@ -12,7 +12,7 @@ Correct them by adding a new entry that references the old one.
 [§21](gdd/21-technical-design-for-web-implementation.md) mod layer,
 [§22](gdd/22-data-schemas.md) mod manifest schema,
 [§26](gdd/26-open-source-project-guidance.md) data-only mod rules.
-**Branch / PR:** `feat/starter-mod-sample`, PR pending.
+**Branch / PR:** `feat/starter-mod-sample`, PR #100.
 **Status:** Implemented.
 
 ### Done

--- a/e2e/mod-loader.spec.ts
+++ b/e2e/mod-loader.spec.ts
@@ -1,0 +1,13 @@
+import { expect, test } from "@playwright/test";
+
+test("loads the starter sample mod through the browser loader", async ({ page }) => {
+  await page.goto("/dev/mods");
+
+  await expect(page.getByTestId("mod-loader-page")).toBeVisible();
+  await expect(page.getByTestId("mod-loader-status")).toHaveText("ready");
+  await expect(page.getByTestId("mod-id")).toHaveText("starter-sample");
+  await expect(page.getByTestId("mod-track-count")).toHaveText("1");
+  await expect(page.getByTestId("mod-track-id")).toHaveText(
+    "starter-sample/sample-loop",
+  );
+});

--- a/public/mods/starter-sample/README.md
+++ b/public/mods/starter-sample/README.md
@@ -1,0 +1,21 @@
+# Starter Sample Pack
+
+`starter-sample` is a tiny data-only reference mod for VibeGear2. It exists so
+contributors can copy the folder shape, manifest fields, and track JSON layout
+without relying on any external assets.
+
+## Contents
+
+- `manifest.json`: required mod metadata, licence, originality statement, and
+  data file list.
+- `tracks/sample-loop.json`: one short original track that validates against the
+  project track schema.
+
+## Licence And Provenance
+
+The sample data is original project-authored content. It does not derive from
+Top Gear 2 or any other commercial racing game.
+
+The manifest declares `CC-BY-SA-4.0` so the loader can exercise an approved
+licence value. There are no bundled raster, audio, or third-party assets in
+this sample pack.

--- a/public/mods/starter-sample/manifest.json
+++ b/public/mods/starter-sample/manifest.json
@@ -1,0 +1,12 @@
+{
+  "id": "starter-sample",
+  "name": "Starter Sample Pack",
+  "version": 1,
+  "author": "VibeGear2 Maintainers",
+  "license": "CC-BY-SA-4.0",
+  "originality": "Original sample data authored from scratch for VibeGear2.",
+  "description": "Small data-only sample pack for validating the mod loader.",
+  "data": {
+    "tracks": ["tracks/sample-loop.json"]
+  }
+}

--- a/public/mods/starter-sample/tracks/sample-loop.json
+++ b/public/mods/starter-sample/tracks/sample-loop.json
@@ -1,0 +1,53 @@
+{
+  "id": "starter-sample/sample-loop",
+  "name": "Sample Loop",
+  "tourId": "starter-sample",
+  "author": "VibeGear2 Maintainers",
+  "version": 1,
+  "lengthMeters": 640,
+  "laps": 1,
+  "laneCount": 3,
+  "weatherOptions": ["clear", "overcast"],
+  "difficulty": 1,
+  "segments": [
+    {
+      "len": 160,
+      "curve": 0,
+      "grade": 0,
+      "roadsideLeft": "grass",
+      "roadsideRight": "grass",
+      "hazards": []
+    },
+    {
+      "len": 160,
+      "curve": 0.22,
+      "grade": 0.02,
+      "roadsideLeft": "tree",
+      "roadsideRight": "sign",
+      "hazards": []
+    },
+    {
+      "len": 160,
+      "curve": -0.18,
+      "grade": -0.02,
+      "roadsideLeft": "rock",
+      "roadsideRight": "fence",
+      "hazards": ["traffic_cone"]
+    },
+    {
+      "len": 160,
+      "curve": 0,
+      "grade": 0,
+      "roadsideLeft": "grass",
+      "roadsideRight": "grass",
+      "hazards": []
+    }
+  ],
+  "checkpoints": [
+    { "segmentIndex": 0, "label": "start" },
+    { "segmentIndex": 2, "label": "split-a" }
+  ],
+  "spawn": {
+    "gridSlots": 4
+  }
+}

--- a/public/mods/starter-sample/tracks/sample-loop.json
+++ b/public/mods/starter-sample/tracks/sample-loop.json
@@ -14,32 +14,32 @@
       "len": 160,
       "curve": 0,
       "grade": 0,
-      "roadsideLeft": "grass",
-      "roadsideRight": "grass",
+      "roadsideLeft": "default",
+      "roadsideRight": "default",
       "hazards": []
     },
     {
       "len": 160,
       "curve": 0.22,
       "grade": 0.02,
-      "roadsideLeft": "tree",
-      "roadsideRight": "sign",
+      "roadsideLeft": "tree_pine",
+      "roadsideRight": "sign_marker",
       "hazards": []
     },
     {
       "len": 160,
       "curve": -0.18,
       "grade": -0.02,
-      "roadsideLeft": "rock",
-      "roadsideRight": "fence",
+      "roadsideLeft": "rock_boulder",
+      "roadsideRight": "fence_post",
       "hazards": ["traffic_cone"]
     },
     {
       "len": 160,
       "curve": 0,
       "grade": 0,
-      "roadsideLeft": "grass",
-      "roadsideRight": "grass",
+      "roadsideLeft": "default",
+      "roadsideRight": "default",
       "hazards": []
     }
   ],

--- a/src/app/dev/mods/ModLoaderSmoke.tsx
+++ b/src/app/dev/mods/ModLoaderSmoke.tsx
@@ -1,0 +1,58 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+import { loadModContent } from "@/mods";
+
+type SmokeState =
+  | { status: "loading" }
+  | { status: "ready"; modId: string; trackId: string; trackCount: number }
+  | { status: "error"; message: string };
+
+export function ModLoaderSmoke(): JSX.Element {
+  const [state, setState] = useState<SmokeState>({ status: "loading" });
+
+  useEffect(() => {
+    let cancelled = false;
+    loadModContent({ modId: "starter-sample" })
+      .then((content) => {
+        if (cancelled) return;
+        setState({
+          status: "ready",
+          modId: content.manifest.id,
+          trackId: content.tracks[0]?.id ?? "none",
+          trackCount: content.tracks.length,
+        });
+      })
+      .catch((error: unknown) => {
+        if (cancelled) return;
+        setState({
+          status: "error",
+          message: error instanceof Error ? error.message : String(error),
+        });
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  return (
+    <main data-testid="mod-loader-page">
+      <h1>Mod Loader Smoke</h1>
+      <p data-testid="mod-loader-status">{state.status}</p>
+      {state.status === "ready" ? (
+        <dl>
+          <dt>Mod</dt>
+          <dd data-testid="mod-id">{state.modId}</dd>
+          <dt>Tracks</dt>
+          <dd data-testid="mod-track-count">{state.trackCount}</dd>
+          <dt>First track</dt>
+          <dd data-testid="mod-track-id">{state.trackId}</dd>
+        </dl>
+      ) : null}
+      {state.status === "error" ? (
+        <pre data-testid="mod-loader-error">{state.message}</pre>
+      ) : null}
+    </main>
+  );
+}

--- a/src/app/dev/mods/ModLoaderSmoke.tsx
+++ b/src/app/dev/mods/ModLoaderSmoke.tsx
@@ -4,6 +4,10 @@ import { useEffect, useState } from "react";
 
 import { loadModContent } from "@/mods";
 
+/**
+ * Dev-only mod-loader smoke for `/dev/mods`, exercised by
+ * `e2e/mod-loader.spec.ts` and intentionally not linked from user-facing UI.
+ */
 type SmokeState =
   | { status: "loading" }
   | { status: "ready"; modId: string; trackId: string; trackCount: number }

--- a/src/app/dev/mods/page.tsx
+++ b/src/app/dev/mods/page.tsx
@@ -1,0 +1,5 @@
+import { ModLoaderSmoke } from "./ModLoaderSmoke";
+
+export default function DevModsPage(): JSX.Element {
+  return <ModLoaderSmoke />;
+}


### PR DESCRIPTION
## Summary
- Add `public/mods/starter-sample` with a schema-valid manifest, provenance README, and one original sample track.
- Add `/dev/mods` browser smoke coverage for the official data-only mod loader.
- Link the starter sample from `docs/MODDING.md` and record coverage in `docs/GDD_COVERAGE.json`.

## GDD Sections
- `docs/gdd/21-technical-design-for-web-implementation.md`
- `docs/gdd/22-data-schemas.md`
- `docs/gdd/26-open-source-project-guidance.md`

## Progress Log
- `docs/PROGRESS_LOG.md`: `2026-04-29: Slice: Starter mod sample pack`

## Test Plan
- `npm run typecheck`
- `npm run content-lint`
- `npx playwright test e2e/mod-loader.spec.ts`
- `npm run verify`
- no-dash scan over touched files
- `git diff --check`

## Followups
- None
