### PR TITLE
GitHub issue labels and starter tasks

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -1,0 +1,35 @@
+---
+name: Bug report
+about: Report broken behavior or a regression
+title: "[Bug]: "
+labels: bug
+assignees: ""
+---
+
+## What happened?
+
+Describe the broken behavior.
+
+## Expected behavior
+
+Describe what should have happened instead.
+
+## Reproduction steps
+
+1. Open ...
+2. Click ...
+3. Observe ...
+
+## Environment
+
+- Browser:
+- Device:
+- Build or commit:
+
+## Relevant labels
+
+Add area labels such as `physics`, `renderer`, `ui-ux`, `audio`, `modding`, `content`, `performance`, or `legal-review` if they apply.
+
+## Screenshots or clips
+
+Attach only original screenshots or recordings from VibeGear2. Do not attach copyrighted assets or reference screenshots from other games.

--- a/.github/ISSUE_TEMPLATE/design-discussion.md
+++ b/.github/ISSUE_TEMPLATE/design-discussion.md
@@ -1,0 +1,28 @@
+---
+name: Design discussion
+about: Propose or clarify a GDD-grounded design decision
+title: "[Design]: "
+labels: design
+assignees: ""
+---
+
+## GDD reference
+
+Link the relevant section under `docs/gdd/`.
+
+## Question or proposal
+
+State the design question or proposed change.
+
+## Options considered
+
+- Option A:
+- Option B:
+
+## Recommended direction
+
+State the preferred option and why it fits the design pillars.
+
+## Impacted areas
+
+Add labels such as `physics`, `renderer`, `ai`, `ui-ux`, `audio`, `modding`, `content`, `performance`, or `legal-review` if they apply.

--- a/.github/ISSUE_TEMPLATE/good-first-issue.md
+++ b/.github/ISSUE_TEMPLATE/good-first-issue.md
@@ -1,0 +1,30 @@
+---
+name: Good first issue
+about: Small contributor-friendly task tied to a specific GDD section
+title: "[Good first issue]: "
+labels: good-first-issue, help-wanted
+assignees: ""
+---
+
+## GDD reference
+
+Link the relevant GDD section, for example `docs/gdd/26-open-source-project-guidance.md`.
+
+## Task
+
+Describe the smallest useful change that would close this issue.
+
+## Suggested files
+
+- `path/to/file`
+
+## Acceptance criteria
+
+- [ ] The change matches the linked GDD section.
+- [ ] Tests or docs are updated if needed.
+- [ ] `npm run verify` passes.
+- [ ] No em-dashes or en-dashes are introduced.
+
+## Notes
+
+Do not paste copyrighted assets, ROM data, ripped audio, or reference screenshots from other games.

--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -1,0 +1,51 @@
+- name: physics
+  color: "1f77b4"
+  description: Driving model, collisions, traction, damage, and race simulation.
+
+- name: renderer
+  color: "5319e7"
+  description: Canvas road rendering, sprite atlases, HUD drawing, and visual effects.
+
+- name: ai
+  color: "0e8a16"
+  description: CPU opponents, racing lines, difficulty tuning, and traffic behavior.
+
+- name: ui-ux
+  color: "c5def5"
+  description: Screens, flows, controls, accessibility, and player-facing copy.
+
+- name: audio
+  color: "fbca04"
+  description: Music, sound effects, mixing, audio manifests, and playback bugs.
+
+- name: modding
+  color: "5319e7"
+  description: Data mods, schemas, loader behavior, starter packs, and community content.
+
+- name: content
+  color: "fef2c0"
+  description: Tracks, tours, cars, balance data, manifests, and authored game data.
+
+- name: legal-review
+  color: "b60205"
+  description: Originality, license, trademark, source provenance, or IP-safety review.
+
+- name: good-first-issue
+  color: "7057ff"
+  description: Small, well-scoped task suitable for first-time contributors.
+
+- name: help-wanted
+  color: "008672"
+  description: Maintainers would welcome outside contribution on this task.
+
+- name: performance
+  color: "006b75"
+  description: Frame time, bundle size, memory, loading, and profiling work.
+
+- name: bug
+  color: "d73a4a"
+  description: Broken behavior, regression, crash, or incorrect output.
+
+- name: design
+  color: "d876e3"
+  description: GDD, balance, UX, rule, roadmap, or game-design discussion.

--- a/.github/workflows/labels.yml
+++ b/.github/workflows/labels.yml
@@ -1,0 +1,27 @@
+name: Sync labels
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - .github/labels.yml
+      - .github/workflows/labels.yml
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
+
+jobs:
+  labels:
+    name: Sync GitHub issue labels
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Sync labels
+        uses: crazy-max/ghaction-github-labeler@v5
+        with:
+          yaml-file: .github/labels.yml
+          skip-delete: true

--- a/.github/workflows/labels.yml
+++ b/.github/workflows/labels.yml
@@ -11,7 +11,6 @@ on:
 permissions:
   contents: read
   issues: write
-  pull-requests: write
 
 jobs:
   labels:

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -140,6 +140,12 @@ Use `legal-review` for originality, licence, trademark, or source-provenance
 questions. Maintainers may block merge until the legal-review question is
 resolved.
 
+The canonical label definitions live in [`.github/labels.yml`](../.github/labels.yml)
+and are synced on pushes to `main` by [`.github/workflows/labels.yml`](../.github/workflows/labels.yml).
+Use the issue templates under [`.github/ISSUE_TEMPLATE/`](../.github/ISSUE_TEMPLATE/)
+for bug reports, GDD-grounded design discussions, and contributor-friendly
+starter tasks.
+
 ## 12. First-Time Contributor Walkthrough
 
 1. Clone the repo and install dependencies:

--- a/docs/GDD_COVERAGE.json
+++ b/docs/GDD_COVERAGE.json
@@ -879,6 +879,25 @@
       ]
     },
     {
+      "id": "GDD-26-ISSUE-LABELS-STARTERS",
+      "gddSections": [
+        "docs/gdd/25-development-roadmap.md",
+        "docs/gdd/26-open-source-project-guidance.md"
+      ],
+      "requirement": "The GitHub repo has the §26 issue-label set, issue templates for bugs, design discussion, and starter tasks, plus seeded good-first-issue tasks for v1.0 contributor onboarding.",
+      "coverage": ["implemented-code"],
+      "implementationRefs": [
+        ".github/labels.yml",
+        ".github/workflows/labels.yml",
+        ".github/ISSUE_TEMPLATE/good-first-issue.md",
+        ".github/ISSUE_TEMPLATE/bug-report.md",
+        ".github/ISSUE_TEMPLATE/design-discussion.md",
+        "scripts/seed-good-first-issues.sh",
+        "docs/CONTRIBUTING.md"
+      ],
+      "followupRefs": []
+    },
+    {
       "id": "GDD-26-DATA-MOD-LOADER",
       "gddSections": [
         "docs/gdd/21-technical-design-for-web-implementation.md",

--- a/docs/PROGRESS_LOG.md
+++ b/docs/PROGRESS_LOG.md
@@ -12,7 +12,7 @@ Correct them by adding a new entry that references the old one.
 [§25](gdd/25-development-roadmap.md) v1.0 contributor starter tasks,
 [§26](gdd/26-open-source-project-guidance.md) suggested issue labels and
 contribution rules.
-**Branch / PR:** `chore/github-issue-starters`, PR pending.
+**Branch / PR:** `chore/github-issue-starters`, PR #108.
 **Status:** Implemented.
 
 ### Done

--- a/docs/PROGRESS_LOG.md
+++ b/docs/PROGRESS_LOG.md
@@ -6,6 +6,51 @@ Correct them by adding a new entry that references the old one.
 
 ---
 
+## 2026-04-29: Slice: GitHub issue labels and starter tasks
+
+**GDD sections touched:**
+[§25](gdd/25-development-roadmap.md) v1.0 contributor starter tasks,
+[§26](gdd/26-open-source-project-guidance.md) suggested issue labels and
+contribution rules.
+**Branch / PR:** `chore/github-issue-starters`, PR pending.
+**Status:** Implemented.
+
+### Done
+- `.github/labels.yml` and `.github/workflows/labels.yml`: added the §26
+  issue-label set and an on-main label sync workflow.
+- `.github/ISSUE_TEMPLATE/`: added bug, design discussion, and good first
+  issue templates tied to GDD and originality expectations.
+- `scripts/seed-good-first-issues.sh`: added a repeat-safe `gh` seeding script
+  for contributor-friendly starter issues.
+- `docs/CONTRIBUTING.md` and `docs/GDD_COVERAGE.json`: linked the label
+  registry, templates, and starter-task coverage.
+
+### Verified
+- `bash -n scripts/seed-good-first-issues.sh` green.
+- `actionlint .github/workflows/labels.yml` green.
+- No-dash scan and `git diff --check` green.
+- `npm run verify` green, 2593 passed.
+- `scripts/seed-good-first-issues.sh` created or confirmed six
+  `good-first-issue` issues: #102, #103, #104, #105, #106, and #107.
+
+### Decisions and assumptions
+- The seed script keeps default GitHub labels intact and only manages the
+  project-specific §26 label set.
+- Seeded issues are skipped if their title already exists, including closed
+  issues, so the script does not recreate completed starter tasks.
+
+### Coverage ledger
+- GDD-26-ISSUE-LABELS-STARTERS covers the §26 label set and §25 v1.0
+  contributor starter-task deliverable.
+- Uncovered adjacent requirements: public mod browser submission and
+  community curation tools remain future post-v1.0 work.
+
+### Followups created
+None.
+
+### GDD edits
+None.
+
 ## 2026-04-29: Slice: Car FX sprite compositor
 
 **GDD sections touched:**

--- a/scripts/seed-good-first-issues.sh
+++ b/scripts/seed-good-first-issues.sh
@@ -1,0 +1,211 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo="${GITHUB_REPOSITORY:-Randroids-Dojo/VibeGear2}"
+
+require_gh() {
+  if ! command -v gh >/dev/null 2>&1; then
+    echo "gh CLI is required" >&2
+    exit 1
+  fi
+}
+
+ensure_label() {
+  local name="$1"
+  local color="$2"
+  local description="$3"
+  local exists
+
+  exists="$(gh label list --repo "$repo" --limit 200 --json name --jq '.[].name' | grep -Fx "$name" || true)"
+  if [ -n "$exists" ]; then
+    gh label edit "$name" --repo "$repo" --color "$color" --description "$description" >/dev/null
+  else
+    gh label create "$name" --repo "$repo" --color "$color" --description "$description" >/dev/null
+  fi
+}
+
+issue_exists() {
+  local title="$1"
+  local matches
+
+  matches="$(gh issue list --repo "$repo" --state all --limit 200 --search "\"$title\" in:title" --json title --jq '.[].title')"
+  if printf '%s\n' "$matches" | grep -Fxq "$title"; then
+    echo 1
+  else
+    echo 0
+  fi
+}
+
+create_issue_if_missing() {
+  local title="$1"
+  local labels="$2"
+  local body="$3"
+
+  if [ "$(issue_exists "$title")" != "0" ]; then
+    echo "skip existing: $title"
+    return 0
+  fi
+
+  gh issue create --repo "$repo" --title "$title" --label "$labels" --body "$body"
+}
+
+require_gh
+
+ensure_label "physics" "1f77b4" "Driving model, collisions, traction, damage, and race simulation."
+ensure_label "renderer" "5319e7" "Canvas road rendering, sprite atlases, HUD drawing, and visual effects."
+ensure_label "ai" "0e8a16" "CPU opponents, racing lines, difficulty tuning, and traffic behavior."
+ensure_label "ui-ux" "c5def5" "Screens, flows, controls, accessibility, and player-facing copy."
+ensure_label "audio" "fbca04" "Music, sound effects, mixing, audio manifests, and playback bugs."
+ensure_label "modding" "5319e7" "Data mods, schemas, loader behavior, starter packs, and community content."
+ensure_label "content" "fef2c0" "Tracks, tours, cars, balance data, manifests, and authored game data."
+ensure_label "legal-review" "b60205" "Originality, license, trademark, source provenance, or IP-safety review."
+ensure_label "good-first-issue" "7057ff" "Small, well-scoped task suitable for first-time contributors."
+ensure_label "help-wanted" "008672" "Maintainers would welcome outside contribution on this task."
+ensure_label "performance" "006b75" "Frame time, bundle size, memory, loading, and profiling work."
+ensure_label "bug" "d73a4a" "Broken behavior, regression, crash, or incorrect output."
+ensure_label "design" "d876e3" "GDD, balance, UX, rule, roadmap, or game-design discussion."
+
+create_issue_if_missing \
+  "Add a schema-valid starter track variation" \
+  "good-first-issue,help-wanted,content,modding" \
+  "## GDD reference
+
+- docs/gdd/22-data-schemas.md
+- docs/gdd/26-open-source-project-guidance.md
+
+## Task
+
+Add a small original track JSON variation under the starter mod sample and make sure content lint accepts it.
+
+## Suggested files
+
+- public/mods/starter-sample/tracks/
+- public/mods/starter-sample/manifest.json
+- public/mods/starter-sample/README.md
+
+## Acceptance criteria
+
+- The new track validates against the track schema.
+- The starter mod manifest references the new file.
+- The README briefly describes the new sample track.
+- npm run content-lint passes.
+"
+
+create_issue_if_missing \
+  "Document one safe original roadside prop pattern" \
+  "good-first-issue,help-wanted,legal-review,content" \
+  "## GDD reference
+
+- docs/gdd/17-art-direction.md
+- docs/gdd/26-open-source-project-guidance.md
+- docs/LEGAL_SAFETY.md
+
+## Task
+
+Add one concise safe-pattern example for an original roadside prop, including what to avoid.
+
+## Suggested files
+
+- docs/LEGAL_SAFETY.md
+- docs/gdd/17-art-direction.md
+
+## Acceptance criteria
+
+- The example is original and does not reference copied commercial assets.
+- The guidance names one safe source pattern and one unsafe source pattern.
+- No em-dashes or en-dashes are introduced.
+"
+
+create_issue_if_missing \
+  "Add a small renderer regression for HUD text placement" \
+  "good-first-issue,help-wanted,renderer,ui-ux" \
+  "## GDD reference
+
+- docs/gdd/16-rendering-and-visual-design.md
+- docs/gdd/20-hud-and-ui-ux.md
+
+## Task
+
+Add a focused renderer test that pins one HUD text placement or sizing rule.
+
+## Suggested files
+
+- src/render/__tests__/
+- src/render/pseudoRoadCanvas.ts
+
+## Acceptance criteria
+
+- The test uses the existing mock canvas helpers.
+- The assertion covers a visible HUD placement rule.
+- npm run test passes.
+"
+
+create_issue_if_missing \
+  "Add contributor docs for choosing issue labels" \
+  "good-first-issue,help-wanted,documentation,design" \
+  "## GDD reference
+
+- docs/gdd/26-open-source-project-guidance.md
+
+## Task
+
+Expand the contributing guide with one sentence per project-specific issue label, focused on when contributors should choose it.
+
+## Suggested files
+
+- docs/CONTRIBUTING.md
+
+## Acceptance criteria
+
+- Every §26 label is mentioned.
+- The guidance stays concise and does not duplicate the issue template text.
+- No em-dashes or en-dashes are introduced.
+"
+
+create_issue_if_missing \
+  "Add a mod manifest negative-case fixture" \
+  "good-first-issue,help-wanted,modding,content" \
+  "## GDD reference
+
+- docs/gdd/22-data-schemas.md
+- docs/gdd/26-open-source-project-guidance.md
+
+## Task
+
+Add one small test fixture or unit test that proves the mod loader rejects an unsafe manifest path.
+
+## Suggested files
+
+- src/mods/__tests__/manifest.test.ts
+- src/mods/manifest.ts
+
+## Acceptance criteria
+
+- The test fails before the unsafe path is rejected.
+- The test passes with the existing loader rules or a narrow fix.
+- npm run test passes.
+"
+
+create_issue_if_missing \
+  "Add a basic audio manifest provenance example" \
+  "good-first-issue,help-wanted,audio,legal-review" \
+  "## GDD reference
+
+- docs/gdd/18-sound-and-music-design.md
+- docs/gdd/26-open-source-project-guidance.md
+
+## Task
+
+Add a short docs example showing how an original SFX or music contribution should document provenance.
+
+## Suggested files
+
+- docs/CONTRIBUTING.md
+- docs/LEGAL_SAFETY.md
+
+## Acceptance criteria
+
+- The example explains source, license, originality, and date fields.
+- The example does not point contributors at unclear sample packs.
+- No em-dashes or en-dashes are introduced.
+"

--- a/scripts/seed-good-first-issues.sh
+++ b/scripts/seed-good-first-issues.sh
@@ -1,14 +1,23 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-repo="${GITHUB_REPOSITORY:-Randroids-Dojo/VibeGear2}"
-
 require_gh() {
   if ! command -v gh >/dev/null 2>&1; then
     echo "gh CLI is required" >&2
     exit 1
   fi
 }
+
+require_gh
+
+repo="${GITHUB_REPOSITORY:-}"
+if [ -z "$repo" ]; then
+  repo="$(gh repo view --json nameWithOwner --jq .nameWithOwner 2>/dev/null || true)"
+fi
+if [ -z "$repo" ]; then
+  echo "Could not determine GitHub repo. Set GITHUB_REPOSITORY=owner/name." >&2
+  exit 1
+fi
 
 ensure_label() {
   local name="$1"
@@ -22,6 +31,51 @@ ensure_label() {
   else
     gh label create "$name" --repo "$repo" --color "$color" --description "$description" >/dev/null
   fi
+}
+
+sync_labels_from_yaml() {
+  node - .github/labels.yml <<'NODE'
+const fs = require("fs");
+
+const yamlPath = process.argv[2];
+const input = fs.readFileSync(yamlPath, "utf8");
+const labels = [];
+let current = null;
+
+function unquote(value) {
+  const trimmed = value.trim();
+  if (trimmed.startsWith('"') && trimmed.endsWith('"')) {
+    return trimmed.slice(1, -1);
+  }
+  return trimmed;
+}
+
+for (const line of input.split(/\r?\n/)) {
+  let match = line.match(/^- name: (.+)$/);
+  if (match) {
+    if (current) labels.push(current);
+    current = { name: unquote(match[1]) };
+    continue;
+  }
+  match = line.match(/^  color: (.+)$/);
+  if (match && current) {
+    current.color = unquote(match[1]);
+    continue;
+  }
+  match = line.match(/^  description: (.+)$/);
+  if (match && current) {
+    current.description = unquote(match[1]);
+  }
+}
+if (current) labels.push(current);
+
+for (const label of labels) {
+  if (!label.name || !label.color || !label.description) {
+    throw new Error(`Incomplete label entry in ${yamlPath}`);
+  }
+  console.log(`${label.name}\t${label.color}\t${label.description}`);
+}
+NODE
 }
 
 issue_exists() {
@@ -49,21 +103,9 @@ create_issue_if_missing() {
   gh issue create --repo "$repo" --title "$title" --label "$labels" --body "$body"
 }
 
-require_gh
-
-ensure_label "physics" "1f77b4" "Driving model, collisions, traction, damage, and race simulation."
-ensure_label "renderer" "5319e7" "Canvas road rendering, sprite atlases, HUD drawing, and visual effects."
-ensure_label "ai" "0e8a16" "CPU opponents, racing lines, difficulty tuning, and traffic behavior."
-ensure_label "ui-ux" "c5def5" "Screens, flows, controls, accessibility, and player-facing copy."
-ensure_label "audio" "fbca04" "Music, sound effects, mixing, audio manifests, and playback bugs."
-ensure_label "modding" "5319e7" "Data mods, schemas, loader behavior, starter packs, and community content."
-ensure_label "content" "fef2c0" "Tracks, tours, cars, balance data, manifests, and authored game data."
-ensure_label "legal-review" "b60205" "Originality, license, trademark, source provenance, or IP-safety review."
-ensure_label "good-first-issue" "7057ff" "Small, well-scoped task suitable for first-time contributors."
-ensure_label "help-wanted" "008672" "Maintainers would welcome outside contribution on this task."
-ensure_label "performance" "006b75" "Frame time, bundle size, memory, loading, and profiling work."
-ensure_label "bug" "d73a4a" "Broken behavior, regression, crash, or incorrect output."
-ensure_label "design" "d876e3" "GDD, balance, UX, rule, roadmap, or game-design discussion."
+while IFS=$'\t' read -r name color description; do
+  ensure_label "$name" "$color" "$description"
+done < <(sync_labels_from_yaml)
 
 create_issue_if_missing \
   "Add a schema-valid starter track variation" \


### PR DESCRIPTION
## GDD sections

- §25 Development roadmap: v1.0 contributor starter tasks
- §26 Open source project guidance: suggested issue labels and contribution rules

## Requirement inventory

- Adds the §26 GitHub issue-label set in .github/labels.yml.
- Adds a main-branch label sync workflow.
- Adds bug, design discussion, and good first issue templates.
- Adds a repeat-safe gh seeding script for starter issues.
- Seeds six contributor starter issues: #102, #103, #104, #105, #106, and #107.

Adjacent work left for later: public mod browser submission and community curation tools remain future post-v1.0 work.

## Progress log

- docs/PROGRESS_LOG.md: GitHub issue labels and starter tasks

## Test plan

- [x] bash -n scripts/seed-good-first-issues.sh
- [x] actionlint .github/workflows/labels.yml
- [x] No-dash scan and git diff --check
- [x] scripts/seed-good-first-issues.sh creates issues once and skips existing titles on rerun
- [x] npm run verify

## Followups

None.