### PR TITLE
Gate leaderboard storage provider

### DIFF
--- a/docs/FOLLOWUPS.md
+++ b/docs/FOLLOWUPS.md
@@ -1024,7 +1024,7 @@ strict literal replace, not a path rewrite.
 ## F-030: Provision Vercel KV and swap LEADERBOARD_BACKEND in production
 **Created:** 2026-04-26
 **Priority:** nice-to-have
-**Status:** open
+**Status:** obsolete (2026-04-29)
 **Notes:** The `feat/leaderboard-client` slice ships
 `src/leaderboard/client.ts` (gated by `NEXT_PUBLIC_LEADERBOARD_ENABLED`)
 and `src/leaderboard/store-vercel-kv.ts` (loaded dynamically via
@@ -1042,6 +1042,23 @@ deploy continues to use the noop store and `submitLap` short-circuits
 to the `disabled` sentinel client-side. The `KvLike` interface in
 `store-vercel-kv.ts` is narrow enough that an Upstash Redis swap is a
 one-line change if the KV pricing tier shifts before launch.
+
+Obsoleted by 2026-04-29 storage-provider review. Current Vercel docs say
+Vercel KV is no longer available for new projects and Redis should be
+provisioned through Marketplace integrations instead. The replacement
+decision is tracked by Q-011 and the implementation followup is F-069.
+
+## F-069: Select Marketplace Redis provider and wire production leaderboard backend
+**Created:** 2026-04-29
+**Priority:** nice-to-have
+**Status:** open
+**Notes:** Replaces F-030 after the Vercel KV sunset. Once Q-011 is answered,
+provision the selected Redis provider through Vercel Marketplace, install the
+matching SDK or REST client, update the current `store-vercel-kv` naming if
+the provider is not Vercel KV-compatible, set the production env vars, and
+verify one signed lap roundtrip through `/api/leaderboard/test%2Fstraight`.
+Do not start this slice until the dev approves the provider, pricing plan,
+and production environment changes.
 
 ## F-029: Playwright e2e race-finish spec
 **Created:** 2026-04-26

--- a/docs/GDD_COVERAGE.json
+++ b/docs/GDD_COVERAGE.json
@@ -986,12 +986,13 @@
         "docs/gdd/24-content-plan.md"
       ],
       "requirement": "Online leaderboard production storage must use a currently available provider and must not be provisioned until the dev approves the provider, pricing plan, and production environment changes.",
-      "coverage": ["implemented-code"],
+      "coverage": ["implemented-code", "open-question", "open-followup"],
       "implementationRefs": [
         "docs/OPEN_QUESTIONS.md",
         "docs/FOLLOWUPS.md",
         "docs/PROGRESS_LOG.md"
       ],
+      "questionRefs": ["Q-011"],
       "followupRefs": ["F-069"]
     },
     {

--- a/docs/GDD_COVERAGE.json
+++ b/docs/GDD_COVERAGE.json
@@ -980,6 +980,21 @@
       "followupRefs": []
     },
     {
+      "id": "GDD-21-LEADERBOARD-STORAGE-GATE",
+      "gddSections": [
+        "docs/gdd/21-technical-design-for-web-implementation.md",
+        "docs/gdd/24-content-plan.md"
+      ],
+      "requirement": "Online leaderboard production storage must use a currently available provider and must not be provisioned until the dev approves the provider, pricing plan, and production environment changes.",
+      "coverage": ["implemented-code"],
+      "implementationRefs": [
+        "docs/OPEN_QUESTIONS.md",
+        "docs/FOLLOWUPS.md",
+        "docs/PROGRESS_LOG.md"
+      ],
+      "followupRefs": ["F-069"]
+    },
+    {
       "id": "GDD-05-GARAGE-SUMMARY",
       "gddSections": [
         "docs/gdd/05-core-gameplay-loop.md",

--- a/docs/OPEN_QUESTIONS.md
+++ b/docs/OPEN_QUESTIONS.md
@@ -9,6 +9,44 @@ they are part of the design history.
 
 ---
 
+## Q-011: Leaderboard storage provider after Vercel KV sunset
+
+**GDD reference:** [§21](gdd/21-technical-design-for-web-implementation.md)
+"leaderboard back end concept", [§24](gdd/24-content-plan.md) "Online
+leaderboard".
+**Status:** open
+**Asked in loop:** 2026-04-29
+
+**Question.** F-030 asked the agent to provision Vercel KV and flip
+`LEADERBOARD_BACKEND=vercel-kv` in production. Current Vercel docs say
+Vercel KV is no longer available for new projects, and Redis storage now
+comes through Marketplace integrations that inject env vars into the
+project. Which backend should the leaderboard use?
+
+- **(a) Upstash Redis through Vercel Marketplace (recommended).** Closest
+  successor to the old Vercel KV path. Vercel docs say old Vercel KV stores
+  were moved to Upstash Redis, and Marketplace storage docs name Upstash
+  Redis for key-value use cases. Requires dev approval for provider,
+  pricing plan, env injection, and production env flips.
+- **(b) Redis Cloud through Vercel Marketplace.** Also listed as a Vercel
+  Marketplace Redis option. Requires choosing a Redis provider and adapting
+  any env names or SDK calls that differ from the current `KvLike` adapter.
+- **(c) Keep the noop backend for v1.0.** No external service, no paid
+  integration, and no env change. Leaves online leaderboard as a later
+  post-v1.0 feature.
+- **(d) Use a non-Marketplace Redis or serverless data store.** Flexible,
+  but adds more manual credential handling and more docs work than the
+  Marketplace path.
+
+**Recommended default.** (a), but do not proceed without dev confirmation.
+This crosses the working-agreement gate for paid services and production
+environment changes. Once approved, create a replacement followup for the
+chosen provider and update the current `vercel-kv` adapter name if needed.
+
+**Blocking?** Yes for replacing F-030. It is not blocking local gameplay
+because the noop leaderboard path still deploys and the client remains
+feature-flagged off.
+
 ## Q-010: `tourTierScale` table for the §12 repair-cost formula
 
 **GDD reference:** [§12](gdd/12-upgrade-and-economy-system.md) "Repair

--- a/docs/PROGRESS_LOG.md
+++ b/docs/PROGRESS_LOG.md
@@ -11,7 +11,7 @@ Correct them by adding a new entry that references the old one.
 **GDD sections touched:**
 [§21](gdd/21-technical-design-for-web-implementation.md) leaderboard back end
 concept, [§24](gdd/24-content-plan.md) online leaderboard.
-**Branch / PR:** `docs/leaderboard-storage-gate`, PR pending.
+**Branch / PR:** `docs/leaderboard-storage-gate`, PR #109.
 **Status:** Partial.
 
 ### Done

--- a/docs/PROGRESS_LOG.md
+++ b/docs/PROGRESS_LOG.md
@@ -6,6 +6,47 @@ Correct them by adding a new entry that references the old one.
 
 ---
 
+## 2026-04-29: Slice: Leaderboard storage provider gate
+
+**GDD sections touched:**
+[§21](gdd/21-technical-design-for-web-implementation.md) leaderboard back end
+concept, [§24](gdd/24-content-plan.md) online leaderboard.
+**Branch / PR:** `docs/leaderboard-storage-gate`, PR pending.
+**Status:** Partial.
+
+### Done
+- Reviewed F-030 against current Vercel docs and found the requested Vercel
+  KV provisioning path is obsolete for new projects.
+- Marked F-030 obsolete and created F-069 for the replacement Marketplace
+  Redis implementation after dev approval.
+- Added Q-011 so the dev can choose the Redis provider or keep the noop
+  leaderboard backend for v1.0.
+
+### Verified
+- Vercel CLI is available locally as `vercel` 50.34.2.
+- Official Vercel docs reviewed:
+  https://vercel.com/docs/redis,
+  https://vercel.com/docs/marketplace-storage,
+  https://vercel.com/docs/environment-variables.
+- `npm run verify` green, 2593 passed.
+
+### Decisions and assumptions
+- No paid service was provisioned and no production env vars were changed.
+  The working agreement requires dev confirmation before those actions.
+
+### Coverage ledger
+- GDD-21-LEADERBOARD-STORAGE-GATE records the provider-selection gate for
+  production leaderboard storage.
+- Uncovered adjacent requirements: online leaderboard production storage is
+  blocked on Q-011 and tracked by F-069.
+
+### Followups created
+- F-069: Select Marketplace Redis provider and wire production leaderboard
+  backend.
+
+### GDD edits
+None.
+
 ## 2026-04-29: Slice: GitHub issue labels and starter tasks
 
 **GDD sections touched:**


### PR DESCRIPTION
## GDD sections

- §21 Technical design: leaderboard back end concept
- §24 Content plan: online leaderboard

## Requirement inventory

- Marks the old Vercel KV provisioning followup obsolete because Vercel KV is no longer available for new projects.
- Adds Q-011 to choose Upstash Redis, Redis Cloud, noop for v1.0, or another backend before any paid service or production env change.
- Adds F-069 as the replacement implementation followup once the provider is approved.
- Adds GDD-21-LEADERBOARD-STORAGE-GATE coverage ledger entry.

Adjacent work left for later: production online leaderboard storage remains blocked on Q-011 and F-069.

## Progress log

- docs/PROGRESS_LOG.md: Leaderboard storage provider gate

## Test plan

- [x] Vercel docs reviewed: https://vercel.com/docs/redis, https://vercel.com/docs/marketplace-storage, https://vercel.com/docs/environment-variables
- [x] vercel --version
- [x] npm run content-lint
- [x] npm run verify
- [x] No-dash scan and git diff --check

## Followups

- F-069: Select Marketplace Redis provider and wire production leaderboard backend
- Q-011: Leaderboard storage provider after Vercel KV sunset