### PR TITLE
Contributor dev experience checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,9 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Docs check
+        run: npm run docs:check
+
       - name: Lint
         run: npm run lint
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -60,9 +60,11 @@ The Game Design Document is the source of truth for what VibeGear2 is. Before pr
 Implementation work runs the loop in `IMPLEMENTATION_PLAN.md` §4. Each loop iteration is one ship-shaped slice that fits in a single PR.
 
 - Branch off `main` as `feat/<slice>`, `fix/<slice>`, `chore/<slice>`, or `docs/<slice>`. One branch per slice. Delete after merge.
+- Create short-lived branches from `main` named `feat/<slice>`, `fix/<slice>`, `chore/<slice>`, or `docs/<slice>`.
 - Never push directly to `main`. Always go through a PR.
 - Commit messages follow the `<type>(<area>): <imperative summary>` format from `WORKING_AGREEMENT.md` §3. Lead the body with *why*, not *what*.
 - Never `--amend` a pushed commit. Never `--no-verify`. Never force-push `main` or any branch with someone else's commits on it.
+- Do not bypass checks with `--no-verify`.
 - PR title mirrors the slice title. PR body links the GDD section(s) implemented, the matching `PROGRESS_LOG.md` entry, the test plan, and any followups created.
 - Wait for CI green before merging. Squash-merge into `main` unless the slice deliberately benefits from preserving history.
 
@@ -125,6 +127,7 @@ Per `IMPLEMENTATION_PLAN.md` §8 and `WORKING_AGREEMENT.md` §6:
 ## Quick pre-commit checklist
 
 1. No em-dashes. Run `grep -rn $'\u2014' .` (checks for codepoint U+2014). Must return nothing.
+   Do not use em-dashes or en-dashes anywhere.
 2. No AI attribution in the commit message or PR body.
 3. Lint, type-check, unit, integration, and e2e suites all pass locally.
 4. New game-logic, route, and content code has tests per RULE 8.
@@ -132,3 +135,6 @@ Per `IMPLEMENTATION_PLAN.md` §8 and `WORKING_AGREEMENT.md` §6:
 6. `PROGRESS_LOG.md` has a new entry. `OPEN_QUESTIONS.md` and `FOLLOWUPS.md` reflect the new state.
 7. No secrets in the diff.
 8. Branch name and commit messages follow `WORKING_AGREEMENT.md` §2 and §3.
+
+See [`docs/SCRIPTS.md`](docs/SCRIPTS.md) for the full npm script reference.
+See [`docs/LOCAL_DEV.md`](docs/LOCAL_DEV.md) when local setup or test runs fail.

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -118,6 +118,9 @@ championship, save, leaderboard, and future mod-manifest data should be
 schema-first. Lint warnings block merge. Content-lint violations block merge.
 Do not bypass checks with `--no-verify`.
 
+For a complete command reference, read [`SCRIPTS.md`](SCRIPTS.md). For local
+setup and test failures, read [`LOCAL_DEV.md`](LOCAL_DEV.md).
+
 ## 11. Issue Triage and Labels
 
 Use these labels when filing issues or triaging PRs:

--- a/docs/GDD_COVERAGE.json
+++ b/docs/GDD_COVERAGE.json
@@ -898,6 +898,25 @@
       "followupRefs": []
     },
     {
+      "id": "GDD-26-DEVELOPER-ONBOARDING",
+      "gddSections": [
+        "docs/gdd/26-open-source-project-guidance.md"
+      ],
+      "requirement": "Contributor onboarding includes a complete npm script catalogue, local development troubleshooting guide, and automated doc-parity checks for shared workflow rules.",
+      "coverage": ["implemented-code", "automated-test"],
+      "implementationRefs": [
+        "docs/SCRIPTS.md",
+        "docs/LOCAL_DEV.md",
+        "scripts/check-doc-parity.ts",
+        "package.json",
+        ".github/workflows/ci.yml",
+        "AGENTS.md",
+        "docs/CONTRIBUTING.md"
+      ],
+      "testRefs": ["scripts/check-doc-parity.ts"],
+      "followupRefs": []
+    },
+    {
       "id": "GDD-26-DATA-MOD-LOADER",
       "gddSections": [
         "docs/gdd/21-technical-design-for-web-implementation.md",

--- a/docs/LOCAL_DEV.md
+++ b/docs/LOCAL_DEV.md
@@ -1,0 +1,101 @@
+# Local Development Troubleshooting
+
+Use this when a fresh clone or local run refuses to behave. Commands assume
+you are in the repository root.
+
+## Required Node Version
+
+Use Node 20 or newer. The project declares this in `package.json` under
+`engines.node`.
+
+```sh
+node --version
+```
+
+If your shell uses `nvm`, run:
+
+```sh
+nvm install 20
+nvm use 20
+```
+
+## First-Time Clone
+
+Use the lockfile for reproducible installs:
+
+```sh
+npm ci
+npx playwright install chromium
+npm run dev
+```
+
+Use `npm install` only when intentionally changing dependencies.
+
+## Port 3000 Busy
+
+Next.js dev may fall back to port 3001, but production `next start` expects
+port 3000 unless told otherwise.
+
+macOS or Linux:
+
+```sh
+lsof -i :3000
+kill <pid>
+```
+
+Windows PowerShell:
+
+```powershell
+netstat -ano | findstr :3000
+taskkill /PID <pid> /F
+```
+
+## macOS Npm Cache Corruption
+
+If installs fail with cache or tarball errors, clear local install state and
+retry:
+
+```sh
+rm -rf node_modules ~/.npm/_cacache
+npm ci
+```
+
+## Vitest Or Jsdom Install Warning
+
+Vitest may mention optional peers during install. Treat warnings as noise if
+`npm run test` passes. If tests fail because `jsdom` is missing, rerun:
+
+```sh
+npm ci
+```
+
+## Playwright Browsers Missing
+
+If e2e tests fail before launching Chromium, install the browser:
+
+```sh
+npx playwright install chromium
+```
+
+On Linux CI-like hosts, use:
+
+```sh
+npx playwright install --with-deps chromium
+```
+
+## Build Succeeds But The Title Screen Is Blank
+
+Check the browser console first. If `/api/version` or build-id reads as
+`undefined`, rebuild inside a git checkout or provide the same git SHA env
+fallback used by CI. Then run:
+
+```sh
+npm run build
+npm run start
+```
+
+## No-Dash Grep Finds Generated Files
+
+The no-dash rule applies to repo source and authored docs. Do not scan
+`node_modules`, `.next`, Playwright reports, or other generated output.
+For source files, use the targeted command from `AGENTS.md`.

--- a/docs/PROGRESS_LOG.md
+++ b/docs/PROGRESS_LOG.md
@@ -11,7 +11,7 @@ Correct them by adding a new entry that references the old one.
 **GDD sections touched:**
 [§26](gdd/26-open-source-project-guidance.md) contribution guidelines and
 project structure.
-**Branch / PR:** `docs/contributor-dev-experience`, PR pending.
+**Branch / PR:** `docs/contributor-dev-experience`, PR #110.
 **Status:** Implemented.
 
 ### Done

--- a/docs/PROGRESS_LOG.md
+++ b/docs/PROGRESS_LOG.md
@@ -6,6 +6,49 @@ Correct them by adding a new entry that references the old one.
 
 ---
 
+## 2026-04-29: Slice: Contributor dev experience docs
+
+**GDD sections touched:**
+[§26](gdd/26-open-source-project-guidance.md) contribution guidelines and
+project structure.
+**Branch / PR:** `docs/contributor-dev-experience`, PR pending.
+**Status:** Implemented.
+
+### Done
+- `docs/SCRIPTS.md`: added a complete npm script catalogue with run timing
+  and failure meanings.
+- `docs/LOCAL_DEV.md`: added local setup and troubleshooting guidance for
+  Node, installs, port conflicts, Playwright, blank builds, and generated
+  file scans.
+- `scripts/check-doc-parity.ts`: added a docs guard that verifies every
+  package script is documented and shared workflow anchors stay present in
+  `AGENTS.md` and `docs/CONTRIBUTING.md`.
+- `package.json` and `.github/workflows/ci.yml`: wired `npm run docs:check`
+  into local verify and CI.
+- `AGENTS.md` and `docs/CONTRIBUTING.md`: linked the script catalogue and
+  local troubleshooting guide.
+
+### Verified
+- `npm run docs:check` green.
+- `npm run verify` green, 2593 passed.
+
+### Decisions and assumptions
+- The parity check intentionally verifies a small set of exact workflow
+  anchors instead of comparing whole documents, so docs can still explain the
+  same rule in their own surrounding context.
+
+### Coverage ledger
+- GDD-26-DEVELOPER-ONBOARDING covers the script catalogue, troubleshooting
+  guide, and automated workflow-anchor check.
+- Uncovered adjacent requirements: formal code of conduct remains TBD in
+  `docs/CONTRIBUTING.md`.
+
+### Followups created
+None.
+
+### GDD edits
+None.
+
 ## 2026-04-29: Slice: Leaderboard storage provider gate
 
 **GDD sections touched:**

--- a/docs/SCRIPTS.md
+++ b/docs/SCRIPTS.md
@@ -1,0 +1,37 @@
+# Npm Scripts
+
+This page is the quick reference for every script in `package.json`.
+Run commands from the repository root.
+
+| Script | Purpose | When to run | Failure usually means |
+| --- | --- | --- | --- |
+| `dev` | Starts the Next.js dev server. | Local feature work. | Port conflict, invalid environment, or compile error. |
+| `build` | Creates the production Next.js build and then runs `postbuild`. | Before production-like smoke tests. | Type, route, asset, or Next.js build failure. |
+| `postbuild` | Scrubs source maps for workspace-local paths after `next build`. | Automatically after `build`. | Source map layout changed or generated files are missing. |
+| `start` | Serves the built app on port 3000. | Playwright or production build smoke tests. | Run `npm run build` first, or free the port. |
+| `lint` | Runs `next lint`. | Before pushing any PR. | ESLint found a warning or error that CI will reject. |
+| `typecheck` | Runs `tsc --noEmit`. | Before pushing TypeScript changes. | Type contracts drifted or generated types are stale. |
+| `test` | Runs the Vitest unit suite once. | Before pushing logic, data, or docs-lint changes. | A unit, content-lint, route, or pure renderer invariant broke. |
+| `test:watch` | Runs Vitest in watch mode. | While iterating locally. | Same as `test`, but reruns after edits. |
+| `test:e2e` | Runs Playwright against a production build. | Before PRs that touch routes, UI, race flow, or persistence. | Browser flow, routing, build, or selector regression. |
+| `test:e2e:ui` | Opens the Playwright UI runner. | Debugging a failing e2e test locally. | Playwright cannot launch or the app is not built correctly. |
+| `bench:render` | Runs the render benchmark suite. | Renderer, sprite, parallax, road, HUD, or VFX PRs. | Perf harness failure or a large frame-time regression. |
+| `art:generate` | Regenerates placeholder art assets. | Only when intentionally refreshing generated art. | Art generator or manifest contract changed. |
+| `art:check` | Validates art manifest coverage. | Before PRs that touch art. | Missing manifest entry, bad path, or invalid art metadata. |
+| `audio:generate` | Regenerates placeholder audio assets. | Only when intentionally refreshing generated audio. | Audio generator or manifest contract changed. |
+| `audio:check` | Validates audio manifest coverage. | Before PRs that touch audio. | Missing manifest entry, bad path, or invalid audio metadata. |
+| `content-lint` | Runs repository content and docs guardrails. | Before docs, GDD, data, mod, or progress-log PRs. | Legal safety, GDD ledger, progress-log, or content schema issue. |
+| `docs:check` | Checks this script catalogue and shared workflow anchors. | Before docs or contributor workflow PRs. | `docs/SCRIPTS.md`, `AGENTS.md`, or `docs/CONTRIBUTING.md` drifted. |
+| `verify` | Runs docs check, lint, typecheck, unit, content, art, and audio checks. | Before every commit and PR. | Any local CI gate failed. |
+| `verify:full` | Runs `verify` and then Playwright e2e. | Before UI, route, persistence, or release PRs. | Baseline checks or browser smoke failed. |
+
+## Common Runs
+
+| Situation | Command |
+| --- | --- |
+| First local confidence pass | `npm run verify` |
+| Browser or route change | `npm run verify:full` |
+| Renderer change | `npm run verify && npm run bench:render` |
+| Docs-only change | `npm run docs:check && npm run content-lint` |
+| Art change | `npm run art:check` |
+| Audio change | `npm run audio:check` |

--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
     "audio:generate": "vite-node --script scripts/generate-placeholder-audio.ts",
     "audio:check": "vite-node --script scripts/check-audio-manifest.ts",
     "content-lint": "vite-node --script scripts/content-lint.ts",
-    "verify": "npm run lint && npm run typecheck && npm run test && npm run content-lint && npm run art:check && npm run audio:check",
+    "docs:check": "vite-node --script scripts/check-doc-parity.ts",
+    "verify": "npm run docs:check && npm run lint && npm run typecheck && npm run test && npm run content-lint && npm run art:check && npm run audio:check",
     "verify:full": "npm run verify && npm run test:e2e"
   },
   "dependencies": {

--- a/scripts/check-doc-parity.ts
+++ b/scripts/check-doc-parity.ts
@@ -1,0 +1,48 @@
+import fs from "node:fs";
+import path from "node:path";
+
+const repoRoot = process.cwd();
+
+function read(relativePath: string): string {
+  return fs.readFileSync(path.join(repoRoot, relativePath), "utf8");
+}
+
+function fail(message: string): never {
+  console.error(message);
+  process.exit(1);
+}
+
+function assertIncludes(filePath: string, content: string, needle: string): void {
+  const normalizedContent = content.replace(/\s+/g, " ");
+  const normalizedNeedle = needle.replace(/\s+/g, " ");
+  if (!normalizedContent.includes(normalizedNeedle)) {
+    fail(`${filePath} is missing required docs anchor: ${needle}`);
+  }
+}
+
+const packageJson = JSON.parse(read("package.json")) as {
+  scripts?: Record<string, string>;
+};
+const scripts = Object.keys(packageJson.scripts ?? {}).sort();
+const scriptsDoc = read("docs/SCRIPTS.md");
+
+for (const script of scripts) {
+  assertIncludes("docs/SCRIPTS.md", scriptsDoc, `| \`${script}\` |`);
+}
+
+const agents = read("AGENTS.md");
+const contributing = read("docs/CONTRIBUTING.md");
+
+const sharedAnchors = [
+  "Create short-lived branches from `main` named `feat/<slice>`, `fix/<slice>`, `chore/<slice>`, or `docs/<slice>`.",
+  "<type>(<area>): <imperative summary>",
+  "Do not bypass checks with `--no-verify`.",
+  "Do not use em-dashes or en-dashes anywhere.",
+];
+
+for (const anchor of sharedAnchors) {
+  assertIncludes("AGENTS.md", agents, anchor);
+  assertIncludes("docs/CONTRIBUTING.md", contributing, anchor);
+}
+
+console.log(`docs:check: ${scripts.length} scripts and ${sharedAnchors.length} shared anchors verified`);


### PR DESCRIPTION
## GDD sections

- §26 Open source project guidance: contribution guidelines and project structure

## Requirement inventory

- Adds docs/SCRIPTS.md with every package script, when to run it, and likely failure meaning.
- Adds docs/LOCAL_DEV.md with first-clone and troubleshooting guidance.
- Adds scripts/check-doc-parity.ts and npm run docs:check.
- Wires docs:check into npm run verify and CI.
- Links the new docs from AGENTS.md and docs/CONTRIBUTING.md.

Adjacent work left for later: formal code of conduct remains TBD in docs/CONTRIBUTING.md.

## Progress log

- docs/PROGRESS_LOG.md: Contributor dev experience docs

## Test plan

- [x] npm run docs:check
- [x] npm run content-lint
- [x] npm run verify
- [x] No-dash scan and git diff --check

## Followups

None.