### PR TITLE
Performance settings

### DIFF
--- a/docs/GDD_COVERAGE.json
+++ b/docs/GDD_COVERAGE.json
@@ -1467,6 +1467,37 @@
         "e2e/options-screen.spec.ts"
       ],
       "followupRefs": ["F-014"]
+    },
+    {
+      "id": "GDD-27-PERFORMANCE-SETTINGS",
+      "gddSections": [
+        "docs/gdd/16-rendering-and-visual-design.md",
+        "docs/gdd/20-hud-and-ui-ux.md",
+        "docs/gdd/21-technical-design-for-web-implementation.md",
+        "docs/gdd/22-data-schemas.md",
+        "docs/gdd/27-risks-and-mitigations.md"
+      ],
+      "requirement": "The options screen exposes persisted draw distance, sprite density, and pixel-ratio caps, and the race renderer consumes those settings at session start.",
+      "coverage": ["implemented-code", "automated-test"],
+      "implementationRefs": [
+        "src/components/options/PerformancePane.tsx",
+        "src/components/options/performancePaneState.ts",
+        "src/render/graphicsSettings.ts",
+        "src/render/pseudoRoadCanvas.ts",
+        "src/app/options/page.tsx",
+        "src/app/race/page.tsx",
+        "src/persistence/migrations/v3ToV4.ts",
+        "src/persistence/save.ts"
+      ],
+      "testRefs": [
+        "src/components/options/__tests__/performancePaneState.test.ts",
+        "src/components/options/__tests__/PerformancePane.test.tsx",
+        "src/render/__tests__/graphicsSettings.test.ts",
+        "src/render/__tests__/pseudoRoadCanvas.test.ts",
+        "src/persistence/migrations/v3ToV4.test.ts",
+        "e2e/options-screen.spec.ts"
+      ],
+      "followupRefs": ["VibeGear2-implement-performance-settings-2de5d437"]
     }
   ]
 }

--- a/docs/PROGRESS_LOG.md
+++ b/docs/PROGRESS_LOG.md
@@ -6,6 +6,47 @@ Correct them by adding a new entry that references the old one.
 
 ---
 
+## 2026-04-29: Slice: Performance settings
+
+**GDD sections touched:**
+[§16](gdd/16-rendering-and-visual-design.md) performance targets,
+[§20](gdd/20-hud-and-ui-ux.md) Settings,
+[§21](gdd/21-technical-design-for-web-implementation.md) performance
+constraints, [§22](gdd/22-data-schemas.md) SaveGame settings, and
+[§27](gdd/27-risks-and-mitigations.md) browser performance.
+**Branch / PR:** `feat/performance-settings`, PR TBD.
+**Status:** Implemented.
+
+### Done
+- Added persisted graphics settings for auto or manual draw distance, sprite
+  density, and pixel-ratio caps.
+- Added the Performance options pane and reset-to-defaults coverage.
+- Wired race startup to resolve graphics settings, cap canvas DPR, adjust
+  projection draw distance, and thin roadside sprites deterministically.
+- Added v3 to v4 save migration coverage.
+
+### Verified
+- `npx vitest run src/render/__tests__/graphicsSettings.test.ts src/render/__tests__/pseudoRoadCanvas.test.ts src/components/options/__tests__/performancePaneState.test.ts src/components/options/__tests__/PerformancePane.test.tsx src/components/options/__tests__/optionsResetState.test.ts src/data/__tests__/settings-schema.test.ts src/persistence/migrations/v3ToV4.test.ts src/persistence/migrations/migrations.test.ts src/persistence/save.test.ts` green, 129 passed.
+- `npm run typecheck` green.
+- `npx playwright test e2e/options-screen.spec.ts` green, 11 passed.
+- `npm run verify` green, 2609 passed.
+
+### Decisions and assumptions
+- Graphics settings are sampled when a race starts, matching the existing
+  controls and accessibility settings flow. Mid-race setting changes apply on
+  the next race mount.
+
+### Coverage ledger
+- GDD-27-PERFORMANCE-SETTINGS covers the §27 browser-performance controls.
+- Uncovered adjacent requirements: cross-browser verification of the final
+  settings matrix remains tracked by `VibeGear2-implement-cross-browser-7cf643ce`.
+
+### Followups created
+None.
+
+### GDD edits
+None.
+
 ## 2026-04-29: Slice: Contributor dev experience review follow-up
 
 **GDD sections touched:**

--- a/docs/PROGRESS_LOG.md
+++ b/docs/PROGRESS_LOG.md
@@ -14,7 +14,7 @@ Correct them by adding a new entry that references the old one.
 [§21](gdd/21-technical-design-for-web-implementation.md) performance
 constraints, [§22](gdd/22-data-schemas.md) SaveGame settings, and
 [§27](gdd/27-risks-and-mitigations.md) browser performance.
-**Branch / PR:** `feat/performance-settings`, PR TBD.
+**Branch / PR:** `feat/performance-settings`, PR #112.
 **Status:** Implemented.
 
 ### Done

--- a/e2e/garage-flow.spec.ts
+++ b/e2e/garage-flow.spec.ts
@@ -1,6 +1,6 @@
 import { expect, test } from "@playwright/test";
 
-const SAVE_KEY = "vibegear2:save:v3";
+const SAVE_KEY = "vibegear2:save:v4";
 
 interface SeededSave {
   version: number;
@@ -138,7 +138,7 @@ test.describe("garage flow", () => {
 
 function buildGarageFlowSave(): SeededSave {
   return {
-    version: 3,
+    version: 4,
     profileName: "GarageFlowTester",
     settings: {
       displaySpeedUnit: "kph",

--- a/e2e/garage-repairs.spec.ts
+++ b/e2e/garage-repairs.spec.ts
@@ -1,6 +1,6 @@
 import { expect, test } from "@playwright/test";
 
-const SAVE_KEY = "vibegear2:save:v3";
+const SAVE_KEY = "vibegear2:save:v4";
 
 interface SeededSave {
   version: number;
@@ -43,7 +43,7 @@ interface SeededSave {
 
 function buildGarageSave(): SeededSave {
   return {
-    version: 3,
+    version: 4,
     profileName: "GarageRepairTester",
     settings: {
       displaySpeedUnit: "kph",

--- a/e2e/garage-summary.spec.ts
+++ b/e2e/garage-summary.spec.ts
@@ -1,6 +1,6 @@
 import { expect, test } from "@playwright/test";
 
-const SAVE_KEY = "vibegear2:save:v3";
+const SAVE_KEY = "vibegear2:save:v4";
 
 interface SeededSave {
   version: number;
@@ -42,7 +42,7 @@ interface SeededSave {
 
 function buildGarageSave(overrides: Partial<SeededSave["garage"]> = {}): SeededSave {
   return {
-    version: 3,
+    version: 4,
     profileName: "GarageSummaryTester",
     settings: {
       displaySpeedUnit: "kph",

--- a/e2e/garage-upgrades.spec.ts
+++ b/e2e/garage-upgrades.spec.ts
@@ -1,6 +1,6 @@
 import { expect, test } from "@playwright/test";
 
-const SAVE_KEY = "vibegear2:save:v3";
+const SAVE_KEY = "vibegear2:save:v4";
 
 interface SeededSave {
   version: number;
@@ -36,7 +36,7 @@ function buildGarageSave(
   overrides: Partial<SeededSave["garage"]> = {},
 ): SeededSave {
   return {
-    version: 3,
+    version: 4,
     profileName: "GarageUpgradeTester",
     settings: {
       displaySpeedUnit: "kph",

--- a/e2e/options-accessibility.spec.ts
+++ b/e2e/options-accessibility.spec.ts
@@ -7,7 +7,7 @@ import { expect, test } from "@playwright/test";
  * `src/components/options/__tests__/accessibilityPaneState.test.ts`.
  */
 
-const SAVE_KEY = "vibegear2:save:v3";
+const SAVE_KEY = "vibegear2:save:v4";
 const ASSIST_KEYS = [
   "autoAccelerate",
   "brakeAssist",

--- a/e2e/options-difficulty.spec.ts
+++ b/e2e/options-difficulty.spec.ts
@@ -7,7 +7,7 @@ import { expect, test } from "@playwright/test";
  * `src/components/options/__tests__/difficultyPaneState.test.ts`.
  */
 
-const SAVE_KEY = "vibegear2:save:v3";
+const SAVE_KEY = "vibegear2:save:v4";
 
 test.describe("options difficulty pane", () => {
   test.beforeEach(async ({ page }) => {

--- a/e2e/options-screen.spec.ts
+++ b/e2e/options-screen.spec.ts
@@ -95,7 +95,7 @@ test.describe("options screen", () => {
         screenShakeScale: 0.25,
       };
       window.localStorage.setItem(key, JSON.stringify(save));
-    }, "vibegear2:save:v3");
+    }, "vibegear2:save:v4");
 
     await reset.click();
     await expect(page.getByTestId("options-reset-status")).toContainText(
@@ -105,7 +105,7 @@ test.describe("options screen", () => {
     const persisted = await page.evaluate((key) => {
       const raw = window.localStorage.getItem(key);
       return raw ? JSON.parse(raw) : null;
-    }, "vibegear2:save:v3");
+    }, "vibegear2:save:v4");
 
     expect(persisted?.settings?.assists?.autoAccelerate).toBe(false);
     expect(persisted?.settings?.difficultyPreset).toBe("normal");
@@ -133,7 +133,7 @@ test.describe("options screen", () => {
     const persisted = await page.evaluate((key) => {
       const raw = window.localStorage.getItem(key);
       return raw ? JSON.parse(raw) : null;
-    }, "vibegear2:save:v3");
+    }, "vibegear2:save:v4");
     expect(persisted?.settings?.displaySpeedUnit).toBe("mph");
 
     await page.reload();
@@ -181,7 +181,7 @@ test.describe("options screen", () => {
     const persisted = await page.evaluate((key) => {
       const raw = window.localStorage.getItem(key);
       return raw ? JSON.parse(raw) : null;
-    }, "vibegear2:save:v3");
+    }, "vibegear2:save:v4");
 
     expect(persisted?.settings?.audio).toEqual({
       master: 0.45,
@@ -212,7 +212,7 @@ test.describe("options screen", () => {
     const persisted = await page.evaluate((key) => {
       const raw = window.localStorage.getItem(key);
       return raw ? JSON.parse(raw) : null;
-    }, "vibegear2:save:v3");
+    }, "vibegear2:save:v4");
     expect(persisted?.settings?.keyBindings?.nitro).toEqual(["KeyN"]);
 
     await page.getByTestId("controls-remap-brake").click();
@@ -247,6 +247,35 @@ test.describe("options screen", () => {
     const speed = Number(speedText);
     expect(Number.isFinite(speed)).toBe(true);
     expect(speed).toBeGreaterThan(0);
+  });
+
+  test("Performance settings persist and reload", async ({ page }) => {
+    await page.goto("/options");
+    await page.getByTestId("options-tab-performance").click();
+
+    await expect(page.getByTestId("performance-pane")).toBeVisible();
+    await page.getByTestId("performance-mode-auto").uncheck();
+    await page.getByTestId("performance-draw-distance").selectOption("medium");
+    await page.getByTestId("performance-sprite-density").selectOption("0.5");
+    await page.getByTestId("performance-pixel-ratio").selectOption("1");
+
+    const persisted = await page.evaluate((key) => {
+      const raw = window.localStorage.getItem(key);
+      return raw ? JSON.parse(raw) : null;
+    }, "vibegear2:save:v4");
+    expect(persisted?.settings?.graphics).toEqual({
+      mode: "manual",
+      drawDistance: "medium",
+      spriteDensity: 0.5,
+      pixelRatioCap: 1,
+    });
+
+    await page.reload();
+    await page.getByTestId("options-tab-performance").click();
+    await expect(page.getByTestId("performance-mode-auto")).not.toBeChecked();
+    await expect(page.getByTestId("performance-draw-distance")).toHaveValue("medium");
+    await expect(page.getByTestId("performance-sprite-density")).toHaveValue("0.5");
+    await expect(page.getByTestId("performance-pixel-ratio")).toHaveValue("1");
   });
 
   test("Back to title link returns to /", async ({ page }) => {

--- a/e2e/pre-race.spec.ts
+++ b/e2e/pre-race.spec.ts
@@ -1,6 +1,6 @@
 import { expect, test } from "@playwright/test";
 
-const SAVE_KEY = "vibegear2:save:v3";
+const SAVE_KEY = "vibegear2:save:v4";
 
 test.describe("pre-race tire selection", () => {
   test.beforeEach(async ({ page }) => {
@@ -52,7 +52,7 @@ test.describe("pre-race tire selection", () => {
 
 function buildSave() {
   return {
-    version: 3,
+    version: 4,
     profileName: "PreRaceTester",
     settings: {
       displaySpeedUnit: "kph",

--- a/e2e/profile-export.spec.ts
+++ b/e2e/profile-export.spec.ts
@@ -13,7 +13,7 @@ import { expect, test } from "@playwright/test";
  * localStorage round-trip.
  */
 
-const SAVE_KEY = "vibegear2:save:v3";
+const SAVE_KEY = "vibegear2:save:v4";
 
 test.describe("options profile pane", () => {
   test.beforeEach(async ({ page }) => {

--- a/e2e/profile-export.spec.ts
+++ b/e2e/profile-export.spec.ts
@@ -63,7 +63,7 @@ test.describe("options profile pane", () => {
       version: number;
       profileName: string;
     };
-    expect(contents.version).toBe(3);
+    expect(contents.version).toBe(4);
     expect(contents.profileName).toBe("Player");
   });
 

--- a/e2e/race-finish.spec.ts
+++ b/e2e/race-finish.spec.ts
@@ -1,6 +1,6 @@
 import { expect, test } from "@playwright/test";
 
-const SAVE_KEY = "vibegear2:save:v3";
+const SAVE_KEY = "vibegear2:save:v4";
 
 /**
  * Natural race-finish e2e per F-038. Drives a single-lap race on
@@ -334,7 +334,7 @@ test.describe("quick race result persistence", () => {
 
 function buildRaceDamageSave() {
   return {
-    version: 3,
+    version: 4,
     profileName: "RaceDamageTester",
     settings: {
       displaySpeedUnit: "kph",

--- a/e2e/save-persistence.spec.ts
+++ b/e2e/save-persistence.spec.ts
@@ -23,7 +23,7 @@ import { expect, test } from "@playwright/test";
  * the first one.
  */
 
-const SAVE_KEY = "vibegear2:save:v3";
+const SAVE_KEY = "vibegear2:save:v4";
 
 interface SeededSave {
   version: number;
@@ -63,7 +63,7 @@ interface SeededSave {
  */
 function buildSeededSave(): SeededSave {
   return {
-    version: 3,
+    version: 4,
     profileName: "PersistenceTester",
     settings: {
       displaySpeedUnit: "kph",

--- a/e2e/tour-flow.spec.ts
+++ b/e2e/tour-flow.spec.ts
@@ -1,6 +1,6 @@
 import { expect, test, type Page } from "@playwright/test";
 
-const SAVE_KEY = "vibegear2:save:v3";
+const SAVE_KEY = "vibegear2:save:v4";
 
 test.describe("World Tour race progression", () => {
   test("entering Velvet Coast from the world hub completes all four races", async ({
@@ -154,7 +154,7 @@ function buildFreshTourSave() {
 
 function buildFinalRaceSave() {
   return {
-    version: 3,
+    version: 4,
     profileName: "TourFlowTester",
     settings: {
       displaySpeedUnit: "kph",

--- a/e2e/world-tour.spec.ts
+++ b/e2e/world-tour.spec.ts
@@ -1,6 +1,6 @@
 import { expect, test } from "@playwright/test";
 
-const SAVE_KEY = "vibegear2:save:v3";
+const SAVE_KEY = "vibegear2:save:v4";
 
 interface SeededSave {
   version: number;
@@ -95,7 +95,7 @@ test.describe("world tour hub", () => {
 
 function buildWorldTourSave(): SeededSave {
   return {
-    version: 3,
+    version: 4,
     profileName: "WorldTourTester",
     settings: {
       displaySpeedUnit: "kph",

--- a/src/app/options/page.tsx
+++ b/src/app/options/page.tsx
@@ -30,6 +30,7 @@ import { AudioPane } from "@/components/options/AudioPane";
 import { ControlsPane } from "@/components/options/ControlsPane";
 import { DifficultyPane } from "@/components/options/DifficultyPane";
 import { DisplayPane } from "@/components/options/DisplayPane";
+import { PerformancePane } from "@/components/options/PerformancePane";
 import { ProfileSection } from "@/components/options/ProfileSection";
 import { resetShippedOptionsToDefaults } from "@/components/options/optionsResetState";
 import { defaultSave, loadSave, saveSave } from "@/persistence";
@@ -89,9 +90,7 @@ const TABS: ReadonlyArray<TabSpec> = [
   {
     key: "performance",
     label: "Performance",
-    headline: "Performance settings coming soon",
-    body: "Draw distance, sprite density, and pixel ratio sliders ship with the performance settings slice.",
-    dotId: "VibeGear2-implement-performance-settings-2de5d437",
+    pane: () => <PerformancePane />,
   },
   {
     key: "profile",

--- a/src/app/race/page.tsx
+++ b/src/app/race/page.tsx
@@ -126,6 +126,10 @@ import {
 } from "@/road";
 import { drawRoad } from "@/render/pseudoRoadCanvas";
 import { playerCarFrameIndex } from "@/render/carFrame";
+import {
+  clampDevicePixelRatio,
+  resolveGraphicsSettings,
+} from "@/render/graphicsSettings";
 import { loadAtlas, type LoadedAtlas } from "@/render/spriteAtlas";
 import { drawMinimap, type MinimapCar } from "@/render/hudMinimap";
 import type { ParallaxLayer } from "@/render/parallax";
@@ -194,11 +198,12 @@ function minimapBoxFor(viewport: Viewport): { x: number; y: number; w: number; h
 function resizeCanvasBackingStore(
   canvas: HTMLCanvasElement,
   ctx: CanvasRenderingContext2D,
+  pixelRatioCap = 2,
 ): Viewport {
   const rect = canvas.getBoundingClientRect();
   const width = Math.max(1, Math.round(rect.width || VIEWPORT_WIDTH));
   const height = Math.max(1, Math.round(rect.height || VIEWPORT_HEIGHT));
-  const dpr = Math.min(window.devicePixelRatio || 1, 2);
+  const dpr = clampDevicePixelRatio(window.devicePixelRatio || 1, pixelRatioCap);
   const backingWidth = Math.max(1, Math.round(width * dpr));
   const backingHeight = Math.max(1, Math.round(height * dpr));
   if (canvas.width !== backingWidth) canvas.width = backingWidth;
@@ -843,6 +848,7 @@ function RaceCanvas({
         : defaultSave().settings;
     const persistedAssists = persistedSettings.assists;
     const persistedDifficulty = persistedSettings.difficultyPreset;
+    const graphics = resolveGraphicsSettings(persistedSettings.graphics);
     const persistedKeyBindings = readKeyBindings(sessionSave);
     const practiceMode = mode === "practice";
     const ghostEnabled = mode === "timeTrial";
@@ -946,7 +952,7 @@ function RaceCanvas({
       z: 0,
       depth: CAMERA_DEPTH,
     };
-    let viewport = resizeCanvasBackingStore(canvas, ctx);
+    let viewport = resizeCanvasBackingStore(canvas, ctx, graphics.pixelRatioCap);
     setTouchLayout(touchLayoutFor(viewport));
     let parallaxLayers = createTemperateParallaxLayers(viewport);
 
@@ -962,7 +968,7 @@ function RaceCanvas({
     const totalLength = track.compiled.totalLengthMeters;
 
     const resize = (): void => {
-      viewport = resizeCanvasBackingStore(canvas, ctx);
+      viewport = resizeCanvasBackingStore(canvas, ctx, graphics.pixelRatioCap);
       setTouchLayout(touchLayoutFor(viewport));
       parallaxLayers = createTemperateParallaxLayers(viewport);
       minimapBox = minimapBoxFor(viewport);
@@ -1236,7 +1242,9 @@ function RaceCanvas({
           lastRaceSfxTick = session.tick;
           playRaceSfxEvents(raceSfx, session.audioEvents, persistedSettings.audio);
         }
-        const strips = project(track.compiled.segments, camera, viewport);
+        const strips = project(track.compiled.segments, camera, viewport, {
+          drawDistance: graphics.drawDistanceSegments,
+        });
         const playerFrameIndex = playerCarFrameIndex(
           lastSteerRef.current,
           upcomingCurvature(track.compiled.segments, camera.z, SEGMENT_LENGTH * 5),
@@ -1280,6 +1288,7 @@ function RaceCanvas({
           tunnelAdaptation: {
             intensityScale: tunnelOcclusion(tunnelState),
           },
+          spriteDensityFactor: graphics.spriteDensityFactor,
           ghostCar: ghostOverlayRef.current
             ? {
                 ...ghostOverlayRef.current,

--- a/src/components/options/AccessibilityPane.tsx
+++ b/src/components/options/AccessibilityPane.tsx
@@ -66,10 +66,7 @@ export function AccessibilityPane(): ReactElement {
   const persist = useCallback((next: SaveGame, successMessage: string) => {
     const writeResult = saveSave(next);
     if (writeResult.kind === "ok") {
-      setSave({
-        ...next,
-        writeCounter: (next.writeCounter ?? 0) + 1,
-      });
+      setSave(writeResult.save);
       setStatus({ kind: "info", message: successMessage });
       return;
     }

--- a/src/components/options/AudioPane.tsx
+++ b/src/components/options/AudioPane.tsx
@@ -47,10 +47,7 @@ export function AudioPane(): ReactElement {
   const persist = useCallback((next: SaveGame, successMessage: string) => {
     const writeResult = saveSave(next);
     if (writeResult.kind === "ok") {
-      setSave({
-        ...next,
-        writeCounter: (next.writeCounter ?? 0) + 1,
-      });
+      setSave(writeResult.save);
       setStatus({ kind: "info", message: successMessage });
       return;
     }

--- a/src/components/options/ControlsPane.tsx
+++ b/src/components/options/ControlsPane.tsx
@@ -69,11 +69,12 @@ export function ControlsPane(): ReactElement {
         return;
       }
 
-      setSave(result.save);
       const write = saveSave(result.save);
       if (write.kind === "ok") {
+        setSave(write.save);
         setStatus({ kind: "info", message: `${label} binding saved.` });
       } else {
+        setSave(result.save);
         setStatus({
           kind: "error",
           message: `Save failed (${write.reason}); change kept in memory only.`,
@@ -88,12 +89,13 @@ export function ControlsPane(): ReactElement {
   const onReset = useCallback(() => {
     if (!save) return;
     const next = resetKeyBindings(save);
-    setSave(next);
     setListeningAction(null);
     const write = saveSave(next);
     if (write.kind === "ok") {
+      setSave(write.save);
       setStatus({ kind: "info", message: "Key bindings reset to defaults." });
     } else {
+      setSave(next);
       setStatus({
         kind: "error",
         message: `Save failed (${write.reason}); defaults kept in memory only.`,

--- a/src/components/options/DifficultyPane.tsx
+++ b/src/components/options/DifficultyPane.tsx
@@ -84,15 +84,16 @@ export function DifficultyPane(): ReactElement {
       if (!save) return;
       const result = applyPresetSelection(save, preset);
       if (result.kind === "noop") return;
-      setSave(result.save);
       const writeResult = saveSave(result.save);
       const label = getPresetSpec(preset).label;
       if (writeResult.kind === "ok") {
+        setSave(writeResult.save);
         setStatus({
           kind: "info",
           message: `Difficulty preset set to ${label}.`,
         });
       } else {
+        setSave(result.save);
         setStatus({
           kind: "error",
           message: `Save failed (${writeResult.reason}); change kept in memory only.`,

--- a/src/components/options/DisplayPane.tsx
+++ b/src/components/options/DisplayPane.tsx
@@ -45,10 +45,7 @@ export function DisplayPane(): ReactElement {
   const persist = useCallback((next: SaveGame, successMessage: string) => {
     const writeResult = saveSave(next);
     if (writeResult.kind === "ok") {
-      setSave({
-        ...next,
-        writeCounter: (next.writeCounter ?? 0) + 1,
-      });
+      setSave(writeResult.save);
       setStatus({ kind: "info", message: successMessage });
       return;
     }

--- a/src/components/options/PerformancePane.tsx
+++ b/src/components/options/PerformancePane.tsx
@@ -45,10 +45,7 @@ export function PerformancePane(): ReactElement {
   const persist = useCallback((next: SaveGame, message: string) => {
     const result = saveSave(next);
     if (result.kind === "ok") {
-      setSave({
-        ...next,
-        writeCounter: (next.writeCounter ?? 0) + 1,
-      });
+      setSave(result.save);
       setStatus({ kind: "info", message });
       return;
     }

--- a/src/components/options/PerformancePane.tsx
+++ b/src/components/options/PerformancePane.tsx
@@ -1,0 +1,262 @@
+"use client";
+
+import type { CSSProperties, ReactElement } from "react";
+import { useCallback, useEffect, useState } from "react";
+
+import type { GraphicsSettings, SaveGame } from "@/data/schemas";
+import { defaultSave, loadSave, saveSave } from "@/persistence";
+
+import {
+  GRAPHICS_DRAW_DISTANCE_OPTIONS,
+  GRAPHICS_PIXEL_RATIO_OPTIONS,
+  GRAPHICS_SPRITE_DENSITY_OPTIONS,
+  PERFORMANCE_PANE_HEADLINE,
+  PERFORMANCE_PANE_SUBTITLE,
+  applyGraphicsSettings,
+  readGraphicsSettings,
+  resetGraphicsSettings,
+} from "./performancePaneState";
+
+interface PaneStatus {
+  readonly kind: "idle" | "info" | "error";
+  readonly message: string;
+}
+
+export function PerformancePane(): ReactElement {
+  const [save, setSave] = useState<SaveGame | null>(null);
+  const [status, setStatus] = useState<PaneStatus>({ kind: "idle", message: "" });
+
+  useEffect(() => {
+    const outcome = loadSave();
+    if (outcome.kind === "loaded") {
+      setSave(outcome.save);
+      return;
+    }
+
+    setSave(defaultSave());
+    if (outcome.reason !== "missing" && outcome.reason !== "no-storage") {
+      setStatus({
+        kind: "info",
+        message: `Loaded default save (reason: ${outcome.reason}).`,
+      });
+    }
+  }, []);
+
+  const persist = useCallback((next: SaveGame, message: string) => {
+    const result = saveSave(next);
+    if (result.kind === "ok") {
+      setSave({
+        ...next,
+        writeCounter: (next.writeCounter ?? 0) + 1,
+      });
+      setStatus({ kind: "info", message });
+      return;
+    }
+
+    setSave(next);
+    setStatus({
+      kind: "error",
+      message: `Save failed (${result.reason}); change kept in memory only.`,
+    });
+  }, []);
+
+  const applyPatch = useCallback(
+    (patch: Partial<GraphicsSettings>, message: string) => {
+      if (!save) return;
+      const result = applyGraphicsSettings(save, patch);
+      if (result.kind === "noop") return;
+      persist(result.save, message);
+    },
+    [persist, save],
+  );
+
+  const onReset = useCallback(() => {
+    if (!save) return;
+    persist(resetGraphicsSettings(save), "Performance settings reset to defaults.");
+  }, [persist, save]);
+
+  if (!save) {
+    return (
+      <div data-testid="performance-pane-loading" style={loadingStyle}>
+        Loading performance settings.
+      </div>
+    );
+  }
+
+  const graphics = readGraphicsSettings(save);
+
+  return (
+    <div data-testid="performance-pane" style={paneStyle}>
+      <header style={headerStyle}>
+        <h2 style={headlineStyle}>{PERFORMANCE_PANE_HEADLINE}</h2>
+        <p style={subtitleStyle}>{PERFORMANCE_PANE_SUBTITLE}</p>
+      </header>
+
+      <fieldset style={fieldsetStyle}>
+        <legend style={legendStyle}>Mode</legend>
+        <label style={inlineLabelStyle}>
+          <input
+            type="checkbox"
+            checked={graphics.mode === "auto"}
+            onChange={(event) =>
+              applyPatch(
+                { mode: event.currentTarget.checked ? "auto" : "manual" },
+                event.currentTarget.checked
+                  ? "Automatic performance tuning enabled."
+                  : "Manual performance tuning enabled.",
+              )
+            }
+            data-testid="performance-mode-auto"
+          />
+          Auto tune for this device
+        </label>
+      </fieldset>
+
+      <label style={selectLabelStyle}>
+        <span style={selectTitleStyle}>Draw distance</span>
+        <select
+          value={graphics.drawDistance}
+          disabled={graphics.mode === "auto"}
+          onChange={(event) =>
+            applyPatch(
+              { drawDistance: event.currentTarget.value as GraphicsSettings["drawDistance"] },
+              "Draw distance updated.",
+            )
+          }
+          data-testid="performance-draw-distance"
+        >
+          {GRAPHICS_DRAW_DISTANCE_OPTIONS.map((option) => (
+            <option key={option.value} value={option.value}>
+              {option.label}
+            </option>
+          ))}
+        </select>
+      </label>
+
+      <label style={selectLabelStyle}>
+        <span style={selectTitleStyle}>Sprite density</span>
+        <select
+          value={graphics.spriteDensity}
+          disabled={graphics.mode === "auto"}
+          onChange={(event) =>
+            applyPatch(
+              { spriteDensity: Number(event.currentTarget.value) as GraphicsSettings["spriteDensity"] },
+              "Sprite density updated.",
+            )
+          }
+          data-testid="performance-sprite-density"
+        >
+          {GRAPHICS_SPRITE_DENSITY_OPTIONS.map((option) => (
+            <option key={option.value} value={option.value}>
+              {option.label}
+            </option>
+          ))}
+        </select>
+      </label>
+
+      <label style={selectLabelStyle}>
+        <span style={selectTitleStyle}>Pixel ratio cap</span>
+        <select
+          value={graphics.pixelRatioCap}
+          disabled={graphics.mode === "auto"}
+          onChange={(event) =>
+            applyPatch(
+              { pixelRatioCap: Number(event.currentTarget.value) as GraphicsSettings["pixelRatioCap"] },
+              "Pixel ratio cap updated.",
+            )
+          }
+          data-testid="performance-pixel-ratio"
+        >
+          {GRAPHICS_PIXEL_RATIO_OPTIONS.map((option) => (
+            <option key={option.value} value={option.value}>
+              {option.label}
+            </option>
+          ))}
+        </select>
+      </label>
+
+      <button type="button" style={buttonStyle} onClick={onReset} data-testid="performance-reset">
+        Reset performance settings
+      </button>
+
+      {status.kind !== "idle" ? (
+        <p style={statusStyle(status.kind)} data-testid="performance-status">
+          {status.message}
+        </p>
+      ) : null}
+    </div>
+  );
+}
+
+const paneStyle: CSSProperties = {
+  display: "grid",
+  gap: "1rem",
+};
+
+const loadingStyle: CSSProperties = {
+  color: "var(--muted, #aaa)",
+};
+
+const headerStyle: CSSProperties = {
+  display: "grid",
+  gap: "0.35rem",
+};
+
+const headlineStyle: CSSProperties = {
+  margin: 0,
+  color: "var(--fg, #ddd)",
+  fontSize: "1.2rem",
+};
+
+const subtitleStyle: CSSProperties = {
+  margin: 0,
+  maxWidth: "44rem",
+  color: "var(--muted, #aaa)",
+  lineHeight: 1.45,
+};
+
+const fieldsetStyle: CSSProperties = {
+  border: "1px solid var(--muted, #444)",
+  borderRadius: "8px",
+  padding: "1rem",
+};
+
+const legendStyle: CSSProperties = {
+  padding: "0 0.4rem",
+  color: "var(--accent, #8cf)",
+  fontWeight: 700,
+};
+
+const inlineLabelStyle: CSSProperties = {
+  display: "flex",
+  gap: "0.6rem",
+  alignItems: "center",
+  color: "var(--fg, #ddd)",
+};
+
+const selectLabelStyle: CSSProperties = {
+  display: "grid",
+  gap: "0.4rem",
+  color: "var(--fg, #ddd)",
+};
+
+const selectTitleStyle: CSSProperties = {
+  fontWeight: 700,
+};
+
+const buttonStyle: CSSProperties = {
+  justifySelf: "start",
+  border: "1px solid var(--muted, #555)",
+  borderRadius: "6px",
+  padding: "0.4rem 0.7rem",
+  background: "transparent",
+  color: "var(--fg, #ddd)",
+  cursor: "pointer",
+};
+
+function statusStyle(kind: PaneStatus["kind"]): CSSProperties {
+  return {
+    margin: 0,
+    color: kind === "error" ? "var(--danger, #f88)" : "var(--accent, #8cf)",
+  };
+}

--- a/src/components/options/ProfileSection.tsx
+++ b/src/components/options/ProfileSection.tsx
@@ -140,7 +140,7 @@ export function ProfileSection(): ReactElement {
         setSave(result.save);
         return;
       }
-      setSave(result.save);
+      setSave(writeResult.save);
       setStatus({
         kind: "info",
         message: `Imported profile from ${file.name}.`,

--- a/src/components/options/__tests__/PerformancePane.test.tsx
+++ b/src/components/options/__tests__/PerformancePane.test.tsx
@@ -1,0 +1,14 @@
+import { describe, expect, it } from "vitest";
+import { createElement } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+
+import { PerformancePane } from "../PerformancePane";
+
+describe("PerformancePane SSR shell", () => {
+  it("renders the loading state before client hydration", () => {
+    const html = renderToStaticMarkup(createElement(PerformancePane));
+
+    expect(html).toContain('data-testid="performance-pane-loading"');
+    expect(html).toContain("Loading performance settings.");
+  });
+});

--- a/src/components/options/__tests__/optionsResetState.test.ts
+++ b/src/components/options/__tests__/optionsResetState.test.ts
@@ -5,7 +5,7 @@ import { defaultSave } from "@/persistence";
 import { resetShippedOptionsToDefaults } from "../optionsResetState";
 
 describe("resetShippedOptionsToDefaults", () => {
-  it("resets assists, audio, display, and difficulty to defaults", () => {
+  it("resets assists, audio, display, difficulty, key bindings, and graphics to defaults", () => {
     const save = defaultSave();
     const customised = {
       ...save,
@@ -19,6 +19,12 @@ describe("resetShippedOptionsToDefaults", () => {
         audio: { master: 0.25, music: 0.35, sfx: 0.45 },
         difficultyPreset: "hard" as const,
         displaySpeedUnit: "mph" as const,
+        graphics: {
+          mode: "manual" as const,
+          drawDistance: "low" as const,
+          spriteDensity: 0.25 as const,
+          pixelRatioCap: 1 as const,
+        },
       },
     };
 
@@ -30,6 +36,7 @@ describe("resetShippedOptionsToDefaults", () => {
       expect(result.save.settings.audio).toEqual(defaultSave().settings.audio);
       expect(result.save.settings.difficultyPreset).toBe("normal");
       expect(result.save.settings.displaySpeedUnit).toBe("kph");
+      expect(result.save.settings.graphics).toEqual(defaultSave().settings.graphics);
     }
   });
 
@@ -52,6 +59,12 @@ describe("resetShippedOptionsToDefaults", () => {
         keyBindings: {
           throttle: ["KeyI"],
           brake: ["KeyK"],
+        },
+        graphics: {
+          mode: "manual" as const,
+          drawDistance: "low" as const,
+          spriteDensity: 0.25 as const,
+          pixelRatioCap: 1 as const,
         },
         assists: {
           ...save.settings.assists,
@@ -80,6 +93,7 @@ describe("resetShippedOptionsToDefaults", () => {
       expect(result.save.settings.keyBindings).toEqual(
         defaultSave().settings.keyBindings,
       );
+      expect(result.save.settings.graphics).toEqual(defaultSave().settings.graphics);
     }
   });
 

--- a/src/components/options/__tests__/performancePaneState.test.ts
+++ b/src/components/options/__tests__/performancePaneState.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from "vitest";
+
+import { defaultSave } from "@/persistence";
+import { DEFAULT_GRAPHICS_SETTINGS } from "@/render/graphicsSettings";
+
+import {
+  applyGraphicsSettings,
+  readGraphicsSettings,
+  resetGraphicsSettings,
+} from "../performancePaneState";
+
+describe("performancePaneState", () => {
+  it("reads default graphics settings from a fresh save", () => {
+    expect(readGraphicsSettings(defaultSave())).toEqual(DEFAULT_GRAPHICS_SETTINGS);
+  });
+
+  it("applies manual graphics settings without mutating the input", () => {
+    const save = defaultSave();
+    const before = JSON.stringify(save);
+
+    const result = applyGraphicsSettings(save, {
+      mode: "manual",
+      drawDistance: "medium",
+      spriteDensity: 0.5,
+      pixelRatioCap: 1,
+    });
+
+    expect(result.kind).toBe("applied");
+    if (result.kind === "applied") {
+      expect(result.save.settings.graphics).toEqual({
+        mode: "manual",
+        drawDistance: "medium",
+        spriteDensity: 0.5,
+        pixelRatioCap: 1,
+      });
+    }
+    expect(JSON.stringify(save)).toBe(before);
+  });
+
+  it("returns noop for same settings", () => {
+    expect(applyGraphicsSettings(defaultSave(), DEFAULT_GRAPHICS_SETTINGS)).toEqual({
+      kind: "noop",
+      reason: "same-value",
+    });
+  });
+
+  it("resets graphics settings to defaults", () => {
+    const changed = applyGraphicsSettings(defaultSave(), {
+      mode: "manual",
+      drawDistance: "low",
+    });
+    expect(changed.kind).toBe("applied");
+    if (changed.kind !== "applied") return;
+
+    expect(resetGraphicsSettings(changed.save).settings.graphics).toEqual(
+      DEFAULT_GRAPHICS_SETTINGS,
+    );
+  });
+});

--- a/src/components/options/optionsResetState.ts
+++ b/src/components/options/optionsResetState.ts
@@ -23,6 +23,7 @@ export function resetShippedOptionsToDefaults(
       difficultyPreset: defaults.settings.difficultyPreset,
       displaySpeedUnit: defaults.settings.displaySpeedUnit,
       keyBindings: defaults.settings.keyBindings,
+      graphics: defaults.settings.graphics,
     },
   };
 
@@ -33,7 +34,8 @@ export function resetShippedOptionsToDefaults(
     next.settings.difficultyPreset === save.settings.difficultyPreset &&
     next.settings.displaySpeedUnit === save.settings.displaySpeedUnit &&
     JSON.stringify(next.settings.keyBindings) ===
-      JSON.stringify(save.settings.keyBindings)
+      JSON.stringify(save.settings.keyBindings) &&
+    JSON.stringify(next.settings.graphics) === JSON.stringify(save.settings.graphics)
   ) {
     return { kind: "noop", reason: "already-default" };
   }

--- a/src/components/options/performancePaneState.ts
+++ b/src/components/options/performancePaneState.ts
@@ -1,0 +1,76 @@
+import type { GraphicsSettings, SaveGame } from "@/data/schemas";
+import {
+  DEFAULT_GRAPHICS_SETTINGS,
+  type GraphicsTier,
+  normalizeGraphicsSettings,
+} from "@/render/graphicsSettings";
+
+export const PERFORMANCE_PANE_HEADLINE = "Performance";
+export const PERFORMANCE_PANE_SUBTITLE =
+  "Tune road visibility, roadside prop density, and high-DPI canvas cost for weaker devices.";
+
+export const GRAPHICS_DRAW_DISTANCE_OPTIONS: ReadonlyArray<{
+  readonly value: GraphicsTier;
+  readonly label: string;
+  readonly description: string;
+}> = [
+  { value: "low", label: "Low", description: "Shortest safe visibility for low-end devices." },
+  { value: "medium", label: "Medium", description: "Reduced horizon for integrated GPUs." },
+  { value: "high", label: "High", description: "Default full-distance road view." },
+  { value: "ultra", label: "Ultra", description: "Extra horizon on fast desktops." },
+];
+
+export const GRAPHICS_SPRITE_DENSITY_OPTIONS = [
+  { value: 0.25, label: "25%" },
+  { value: 0.5, label: "50%" },
+  { value: 0.75, label: "75%" },
+  { value: 1, label: "100%" },
+] as const;
+
+export const GRAPHICS_PIXEL_RATIO_OPTIONS = [
+  { value: 1, label: "1x" },
+  { value: 1.5, label: "1.5x" },
+  { value: 2, label: "2x" },
+] as const;
+
+export type ApplyGraphicsSettingsResult =
+  | { kind: "applied"; save: SaveGame }
+  | { kind: "noop"; reason: "same-value" };
+
+export function readGraphicsSettings(save: SaveGame): GraphicsSettings {
+  return normalizeGraphicsSettings(save.settings.graphics);
+}
+
+export function applyGraphicsSettings(
+  save: SaveGame,
+  patch: Partial<GraphicsSettings>,
+): ApplyGraphicsSettingsResult {
+  const current = readGraphicsSettings(save);
+  const next: GraphicsSettings = {
+    ...current,
+    ...patch,
+  };
+  if (JSON.stringify(current) === JSON.stringify(next)) {
+    return { kind: "noop", reason: "same-value" };
+  }
+  return {
+    kind: "applied",
+    save: {
+      ...save,
+      settings: {
+        ...save.settings,
+        graphics: next,
+      },
+    },
+  };
+}
+
+export function resetGraphicsSettings(save: SaveGame): SaveGame {
+  return {
+    ...save,
+    settings: {
+      ...save.settings,
+      graphics: { ...DEFAULT_GRAPHICS_SETTINGS },
+    },
+  };
+}

--- a/src/data/__tests__/settings-schema.test.ts
+++ b/src/data/__tests__/settings-schema.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vitest";
 import {
   AccessibilitySettingsSchema,
   AudioSettingsSchema,
+  GraphicsSettingsSchema,
   KeyBindingsSchema,
   SaveGameSettingsSchema,
 } from "@/data/schemas";
@@ -182,6 +183,30 @@ describe("KeyBindingsSchema", () => {
   });
 });
 
+describe("GraphicsSettingsSchema", () => {
+  it("accepts the §27 performance controls", () => {
+    expect(
+      GraphicsSettingsSchema.safeParse({
+        mode: "manual",
+        drawDistance: "medium",
+        spriteDensity: 0.5,
+        pixelRatioCap: 1.5,
+      }).success,
+    ).toBe(true);
+  });
+
+  it("rejects unsupported performance control values", () => {
+    expect(
+      GraphicsSettingsSchema.safeParse({
+        mode: "manual",
+        drawDistance: "extreme",
+        spriteDensity: 0.6,
+        pixelRatioCap: 3,
+      }).success,
+    ).toBe(false);
+  });
+});
+
 describe("SaveGameSettingsSchema (v2 expansion)", () => {
   const minimumV1Compat = {
     displaySpeedUnit: "kph",
@@ -217,6 +242,12 @@ describe("SaveGameSettingsSchema (v2 expansion)", () => {
           weatherFlashReduction: false,
         },
         keyBindings: { accelerate: ["ArrowUp"] },
+        graphics: {
+          mode: "auto",
+          drawDistance: "high",
+          spriteDensity: 1,
+          pixelRatioCap: 2,
+        },
       }).success,
     ).toBe(true);
   });

--- a/src/data/examples/saveGame.example.json
+++ b/src/data/examples/saveGame.example.json
@@ -1,5 +1,5 @@
 {
-  "version": 3,
+  "version": 4,
   "profileName": "Player",
   "settings": {
     "displaySpeedUnit": "kph",
@@ -31,6 +31,12 @@
       "pause": ["Escape"],
       "shiftUp": ["KeyE"],
       "shiftDown": ["KeyQ"]
+    },
+    "graphics": {
+      "mode": "auto",
+      "drawDistance": "high",
+      "spriteDensity": 1,
+      "pixelRatioCap": 2
     }
   },
   "garage": {

--- a/src/data/schemas.ts
+++ b/src/data/schemas.ts
@@ -672,6 +672,19 @@ export const KeyBindingsSchema = z.record(
 );
 export type KeyBindings = z.infer<typeof KeyBindingsSchema>;
 
+export const GraphicsSettingsSchema = z.object({
+  mode: z.enum(["auto", "manual"]),
+  drawDistance: z.enum(["low", "medium", "high", "ultra"]),
+  spriteDensity: z.union([
+    z.literal(0.25),
+    z.literal(0.5),
+    z.literal(0.75),
+    z.literal(1),
+  ]),
+  pixelRatioCap: z.union([z.literal(1), z.literal(1.5), z.literal(2)]),
+});
+export type GraphicsSettings = z.infer<typeof GraphicsSettingsSchema>;
+
 export const SaveGameSettingsSchema = z.object({
   displaySpeedUnit: SpeedUnitSchema,
   assists: AssistSettingsSchema,
@@ -706,6 +719,11 @@ export const SaveGameSettingsSchema = z.object({
    * fall back to the defaults when a key is missing.
    */
   keyBindings: KeyBindingsSchema.optional(),
+  /**
+   * §27 browser-performance controls. Optional so v3 saves migrate cleanly;
+   * the v3ToV4 migrator and `defaultSave()` fill the documented defaults.
+   */
+  graphics: GraphicsSettingsSchema.optional(),
 });
 export type SaveGameSettings = z.infer<typeof SaveGameSettingsSchema>;
 

--- a/src/persistence/migrations/index.ts
+++ b/src/persistence/migrations/index.ts
@@ -10,6 +10,7 @@
  * `docs/gdd/22-data-schemas.md` and the
  * `implement-savegamesettings-b948015a` dot. v3 adds the §6 Time Trial
  * PB ghost-replay slot (`ghosts: {}`) per the F-021 follow-up dot.
+ * v4 adds §27 graphics settings for browser-performance controls.
  *
  * docs/WORKING_AGREEMENT.md §11 requires dev confirmation before dropping
  * or renaming persisted save fields. New migrations must be additive or
@@ -18,8 +19,9 @@
 
 import { migrateV1ToV2 } from "./v1ToV2";
 import { migrateV2ToV3 } from "./v2ToV3";
+import { migrateV3ToV4 } from "./v3ToV4";
 
-export const CURRENT_SAVE_VERSION = 3 as const;
+export const CURRENT_SAVE_VERSION = 4 as const;
 
 export type Migration = (input: unknown) => unknown;
 
@@ -27,6 +29,7 @@ export const migrations: Record<number, Migration> = {
   // Each entry maps from-version to a function that returns the from+1 shape.
   1: migrateV1ToV2,
   2: migrateV2ToV3,
+  3: migrateV3ToV4,
 };
 
 /**

--- a/src/persistence/migrations/v3ToV4.test.ts
+++ b/src/persistence/migrations/v3ToV4.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from "vitest";
+
+import { SaveGameSchema } from "@/data/schemas";
+import { DEFAULT_GRAPHICS_SETTINGS } from "@/render/graphicsSettings";
+
+import { migrateV2ToV3 } from "./v2ToV3";
+import { migrateV3ToV4 } from "./v3ToV4";
+import v2Default from "./__fixtures__/v2-default-save.json";
+
+describe("migrateV3ToV4", () => {
+  it("adds default graphics settings to a v3 save", () => {
+    const v3 = migrateV2ToV3(v2Default);
+    const migrated = migrateV3ToV4(v3);
+
+    expect((migrated as { version: number }).version).toBe(4);
+    expect(
+      (migrated as { settings: { graphics: unknown } }).settings.graphics,
+    ).toEqual(DEFAULT_GRAPHICS_SETTINGS);
+    const result = SaveGameSchema.safeParse(migrated);
+    expect(result.success).toBe(true);
+  });
+
+  it("preserves an existing graphics bundle", () => {
+    const v3 = migrateV2ToV3(v2Default) as Record<string, unknown>;
+    const settings = v3.settings as Record<string, unknown>;
+    const migrated = migrateV3ToV4({
+      ...v3,
+      settings: {
+        ...settings,
+        graphics: {
+          mode: "manual",
+          drawDistance: "low",
+          spriteDensity: 0.25,
+          pixelRatioCap: 1,
+        },
+      },
+    });
+
+    expect(
+      (migrated as { settings: { graphics: unknown } }).settings.graphics,
+    ).toEqual({
+      mode: "manual",
+      drawDistance: "low",
+      spriteDensity: 0.25,
+      pixelRatioCap: 1,
+    });
+  });
+
+  it("rejects non-v3 input", () => {
+    expect(() => migrateV3ToV4({ version: 2 })).toThrow(
+      /expected version 3/u,
+    );
+  });
+});

--- a/src/persistence/migrations/v3ToV4.ts
+++ b/src/persistence/migrations/v3ToV4.ts
@@ -1,0 +1,42 @@
+import { DEFAULT_GRAPHICS_SETTINGS } from "@/render/graphicsSettings";
+
+/**
+ * v3 -> v4 save migration.
+ *
+ * v4 adds §27 graphics settings for draw distance, sprite density, and
+ * pixel-ratio caps. The migration is additive and preserves any existing
+ * hand-authored graphics object when present.
+ */
+export function migrateV3ToV4(input: unknown): unknown {
+  if (input === null || typeof input !== "object" || Array.isArray(input)) {
+    throw new TypeError("v3 -> v4 migration: input must be an object");
+  }
+
+  const source = input as Record<string, unknown>;
+  if (source.version !== 3) {
+    throw new TypeError(
+      `v3 -> v4 migration: expected version 3, got ${String(source.version)}`,
+    );
+  }
+
+  const settings =
+    source.settings !== null
+    && typeof source.settings === "object"
+    && !Array.isArray(source.settings)
+      ? source.settings as Record<string, unknown>
+      : {};
+
+  return {
+    ...source,
+    version: 4,
+    settings: {
+      ...settings,
+      graphics:
+        settings.graphics !== null
+        && typeof settings.graphics === "object"
+        && !Array.isArray(settings.graphics)
+          ? settings.graphics
+          : { ...DEFAULT_GRAPHICS_SETTINGS },
+    },
+  };
+}

--- a/src/persistence/save.test.ts
+++ b/src/persistence/save.test.ts
@@ -175,6 +175,7 @@ describe("saveSave", () => {
     const state = defaultSave();
     const result = saveSave(state, { storage, logger });
     expect(result.kind).toBe("ok");
+    expect(result.kind === "ok" ? result.save.writeCounter : null).toBe(1);
 
     const raw = storage.getItem(storageKey(CURRENT_SAVE_VERSION));
     expect(raw).not.toBeNull();

--- a/src/persistence/save.ts
+++ b/src/persistence/save.ts
@@ -22,6 +22,7 @@
 
 import { SaveGameSchema, type SaveGame } from "@/data/schemas";
 import { DEFAULT_KEY_BINDINGS } from "@/game/input";
+import { DEFAULT_GRAPHICS_SETTINGS } from "@/render/graphicsSettings";
 
 import { CURRENT_SAVE_VERSION, migrate } from "./migrations";
 import {
@@ -125,6 +126,7 @@ export function defaultSave(): SaveGame {
       // §19 key bindings: clone the runtime defaults into a plain object
       // so the persisted shape stays mutable and JSON-serialisable.
       keyBindings: cloneDefaultKeyBindings(),
+      graphics: { ...DEFAULT_GRAPHICS_SETTINGS },
     },
     garage: {
       credits: 0,

--- a/src/persistence/save.ts
+++ b/src/persistence/save.ts
@@ -53,7 +53,7 @@ export type SaveLoadFailure =
   | "migration-failed";
 
 export type SaveWriteOutcome =
-  | { kind: "ok" }
+  | { kind: "ok"; save: SaveGame }
   | { kind: "error"; reason: "no-storage" | "quota-exceeded" | "serialization-failed" };
 
 /**
@@ -282,7 +282,7 @@ export function saveSave(state: SaveGame, io: SaveIO = {}): SaveWriteOutcome {
 
   try {
     storage.setItem(storageKey(CURRENT_SAVE_VERSION), serialized);
-    return { kind: "ok" };
+    return { kind: "ok", save: validated.data };
   } catch (error) {
     if (isQuotaExceeded(error)) {
       logger.warn("localStorage quota exceeded", error);

--- a/src/render/__tests__/graphicsSettings.test.ts
+++ b/src/render/__tests__/graphicsSettings.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  DEFAULT_GRAPHICS_SETTINGS,
+  clampDevicePixelRatio,
+  detectAutoTier,
+  resolveGraphicsSettings,
+} from "../graphicsSettings";
+
+describe("graphicsSettings", () => {
+  it("detects low tier for very small CPU budgets or high-DPI screens", () => {
+    expect(detectAutoTier({ hardwareConcurrency: 2, devicePixelRatio: 1 })).toBe("low");
+    expect(detectAutoTier({ hardwareConcurrency: 8, devicePixelRatio: 3 })).toBe("low");
+  });
+
+  it("detects medium, high, and ultra tiers from deterministic hints", () => {
+    expect(detectAutoTier({ hardwareConcurrency: 4, devicePixelRatio: 1 })).toBe("medium");
+    expect(detectAutoTier({ hardwareConcurrency: 8, devicePixelRatio: 1 })).toBe("high");
+    expect(detectAutoTier({ hardwareConcurrency: 12, devicePixelRatio: 1 })).toBe("ultra");
+  });
+
+  it("honours manual overrides", () => {
+    const resolved = resolveGraphicsSettings({
+      mode: "manual",
+      drawDistance: "low",
+      spriteDensity: 0.25,
+      pixelRatioCap: 1,
+    });
+
+    expect(resolved).toEqual({
+      mode: "manual",
+      drawDistanceSegments: 90,
+      spriteDensityFactor: 0.25,
+      pixelRatioCap: 1,
+    });
+  });
+
+  it("uses defaults when settings are missing", () => {
+    expect(resolveGraphicsSettings(undefined).mode).toBe(DEFAULT_GRAPHICS_SETTINGS.mode);
+  });
+
+  it("clamps backing-store DPR to the selected cap", () => {
+    expect(clampDevicePixelRatio(3, 1.5)).toBe(1.5);
+    expect(clampDevicePixelRatio(0.5, 2)).toBe(1);
+  });
+});

--- a/src/render/__tests__/pseudoRoadCanvas.test.ts
+++ b/src/render/__tests__/pseudoRoadCanvas.test.ts
@@ -748,43 +748,31 @@ describe("drawRoad roadside sprites", () => {
     ).toHaveLength(2);
   });
 
-  it("deterministically reduces roadside sprite density", () => {
-    const full = makeCanvasSpy();
-    const reduced = makeCanvasSpy();
-    const strips: readonly Strip[] = [
+  it("maps roadside sprite density to fixed opportunity slots", () => {
+    const strips: readonly Strip[] = [0, 10, 20, 30].map((index) =>
       strip({
-        screenY: 440,
-        screenW: 260,
+        screenY: 440 - index,
+        screenW: 260 - index,
         segment: {
           ...strip({}).segment,
-          index: 0,
+          index,
           roadsideLeftId: "tree_pine",
           roadsideRightId: "default",
         },
       }),
-      strip({
-        screenY: 400,
-        screenW: 220,
-        segment: {
-          ...strip({}).segment,
-          index: 10,
-          roadsideLeftId: "tree_pine",
-          roadsideRightId: "default",
-        },
-      }),
-    ];
-
-    drawRoad(full.ctx, strips, VIEWPORT, {});
-    drawRoad(reduced.ctx, strips, VIEWPORT, { spriteDensityFactor: 0.25 });
-
-    const fullTrees = full.calls.filter(
-      (c): c is FillCall => c.type === "fill" && c.fillStyle === "#245c2f",
     );
-    const reducedTrees = reduced.calls.filter(
-      (c): c is FillCall => c.type === "fill" && c.fillStyle === "#245c2f",
-    );
-    expect(fullTrees.length).toBeGreaterThan(reducedTrees.length);
-    expect(reducedTrees).toHaveLength(1);
+    const treeCountFor = (spriteDensityFactor: number): number => {
+      const spy = makeCanvasSpy();
+      drawRoad(spy.ctx, strips, VIEWPORT, { spriteDensityFactor });
+      return spy.calls.filter(
+        (c): c is FillCall => c.type === "fill" && c.fillStyle === "#245c2f",
+      ).length;
+    };
+
+    expect(treeCountFor(1)).toBe(4);
+    expect(treeCountFor(0.75)).toBe(3);
+    expect(treeCountFor(0.5)).toBe(2);
+    expect(treeCountFor(0.25)).toBe(1);
   });
 
   it("skips the default roadside id", () => {

--- a/src/render/__tests__/pseudoRoadCanvas.test.ts
+++ b/src/render/__tests__/pseudoRoadCanvas.test.ts
@@ -748,6 +748,45 @@ describe("drawRoad roadside sprites", () => {
     ).toHaveLength(2);
   });
 
+  it("deterministically reduces roadside sprite density", () => {
+    const full = makeCanvasSpy();
+    const reduced = makeCanvasSpy();
+    const strips: readonly Strip[] = [
+      strip({
+        screenY: 440,
+        screenW: 260,
+        segment: {
+          ...strip({}).segment,
+          index: 0,
+          roadsideLeftId: "tree_pine",
+          roadsideRightId: "default",
+        },
+      }),
+      strip({
+        screenY: 400,
+        screenW: 220,
+        segment: {
+          ...strip({}).segment,
+          index: 10,
+          roadsideLeftId: "tree_pine",
+          roadsideRightId: "default",
+        },
+      }),
+    ];
+
+    drawRoad(full.ctx, strips, VIEWPORT, {});
+    drawRoad(reduced.ctx, strips, VIEWPORT, { spriteDensityFactor: 0.25 });
+
+    const fullTrees = full.calls.filter(
+      (c): c is FillCall => c.type === "fill" && c.fillStyle === "#245c2f",
+    );
+    const reducedTrees = reduced.calls.filter(
+      (c): c is FillCall => c.type === "fill" && c.fillStyle === "#245c2f",
+    );
+    expect(fullTrees.length).toBeGreaterThan(reducedTrees.length);
+    expect(reducedTrees).toHaveLength(1);
+  });
+
   it("skips the default roadside id", () => {
     const spy = makeCanvasSpy();
     const strips: readonly Strip[] = [

--- a/src/render/graphicsSettings.ts
+++ b/src/render/graphicsSettings.ts
@@ -1,0 +1,104 @@
+import type { GraphicsSettings } from "@/data/schemas";
+import { DRAW_DISTANCE } from "@/road/constants";
+
+export type GraphicsTier = GraphicsSettings["drawDistance"];
+
+export interface DeviceHints {
+  readonly hardwareConcurrency?: number;
+  readonly devicePixelRatio?: number;
+}
+
+export interface ResolvedGraphicsSettings {
+  readonly mode: GraphicsSettings["mode"];
+  readonly drawDistanceSegments: number;
+  readonly spriteDensityFactor: number;
+  readonly pixelRatioCap: number;
+}
+
+export const DEFAULT_GRAPHICS_SETTINGS: GraphicsSettings = {
+  mode: "auto",
+  drawDistance: "high",
+  spriteDensity: 1,
+  pixelRatioCap: 2,
+};
+
+export const DRAW_DISTANCE_BY_TIER: Record<GraphicsTier, number> = {
+  low: 90,
+  medium: 160,
+  high: DRAW_DISTANCE,
+  ultra: 420,
+};
+
+const AUTO_TIER_SETTINGS: Record<GraphicsTier, Omit<GraphicsSettings, "mode">> = {
+  low: {
+    drawDistance: "low",
+    spriteDensity: 0.25,
+    pixelRatioCap: 1,
+  },
+  medium: {
+    drawDistance: "medium",
+    spriteDensity: 0.5,
+    pixelRatioCap: 1.5,
+  },
+  high: {
+    drawDistance: "high",
+    spriteDensity: 0.75,
+    pixelRatioCap: 2,
+  },
+  ultra: {
+    drawDistance: "ultra",
+    spriteDensity: 1,
+    pixelRatioCap: 2,
+  },
+};
+
+export function detectAutoTier(hints: DeviceHints = browserDeviceHints()): GraphicsTier {
+  const cores = hints.hardwareConcurrency ?? 4;
+  const dpr = hints.devicePixelRatio ?? 1;
+  if (cores <= 2 || dpr >= 3) return "low";
+  if (cores <= 4 || dpr >= 2.25) return "medium";
+  if (cores >= 12 && dpr <= 1.5) return "ultra";
+  return "high";
+}
+
+export function browserDeviceHints(): DeviceHints {
+  return {
+    hardwareConcurrency:
+      typeof navigator === "undefined" ? undefined : navigator.hardwareConcurrency,
+    devicePixelRatio:
+      typeof window === "undefined" ? undefined : window.devicePixelRatio,
+  };
+}
+
+export function normalizeGraphicsSettings(
+  settings: GraphicsSettings | undefined,
+): GraphicsSettings {
+  return settings ?? DEFAULT_GRAPHICS_SETTINGS;
+}
+
+export function resolveGraphicsSettings(
+  settings: GraphicsSettings | undefined,
+  hints: DeviceHints = browserDeviceHints(),
+): ResolvedGraphicsSettings {
+  const normalized = normalizeGraphicsSettings(settings);
+  const effective =
+    normalized.mode === "auto"
+      ? AUTO_TIER_SETTINGS[detectAutoTier(hints)]
+      : normalized;
+  return {
+    mode: normalized.mode,
+    drawDistanceSegments: DRAW_DISTANCE_BY_TIER[effective.drawDistance],
+    spriteDensityFactor: effective.spriteDensity,
+    pixelRatioCap: effective.pixelRatioCap,
+  };
+}
+
+export function clampDevicePixelRatio(
+  actualDevicePixelRatio: number,
+  pixelRatioCap: number,
+): number {
+  const actual = Number.isFinite(actualDevicePixelRatio)
+    ? actualDevicePixelRatio
+    : 1;
+  return Math.max(1, Math.min(actual, pixelRatioCap));
+}

--- a/src/render/pseudoRoadCanvas.ts
+++ b/src/render/pseudoRoadCanvas.ts
@@ -413,9 +413,10 @@ function shouldKeepSpriteForDensity(strip: Strip, side: "left" | "right", densit
   const clamped = Math.max(0, Math.min(1, density));
   if (clamped >= 1) return true;
   if (clamped <= 0) return false;
-  const denominator = Math.max(1, Math.round(1 / clamped));
-  const sideOffset = side === "left" ? 0 : 1;
-  return (strip.segment.index + sideOffset) % denominator === 0;
+  const drawOffset = side === "left" ? 0 : Math.floor(ROADSIDE_DRAW_PERIOD / 2);
+  const opportunityIndex = Math.floor((strip.segment.index + drawOffset) / ROADSIDE_DRAW_PERIOD);
+  const keptSlots = Math.max(1, Math.min(4, Math.round(clamped * 4)));
+  return opportunityIndex % 4 < keptSlots;
 }
 
 function drawRoadsideSprites(

--- a/src/render/pseudoRoadCanvas.ts
+++ b/src/render/pseudoRoadCanvas.ts
@@ -182,6 +182,11 @@ export interface DrawRoadOptions {
     phaseMeters?: number;
   };
   /**
+   * Performance knob from §27. `1` draws the authored roadside cadence;
+   * lower values skip a deterministic subset of billboard opportunities.
+   */
+  spriteDensityFactor?: number;
+  /**
    * Optional ghost car overlay per F-022. The §6 Time Trial flow drives
    * a second physics step from the recorded `Player.readNext` inputs to
    * derive the ghost's world position, projects it to the screen with
@@ -345,6 +350,7 @@ export function drawRoad(
         strips,
         viewport,
         highContrastSigns,
+        options.spriteDensityFactor,
       );
       ctx.restore();
     } else {
@@ -354,6 +360,7 @@ export function drawRoad(
         strips,
         viewport,
         highContrastSigns,
+        options.spriteDensityFactor,
       );
     }
   }
@@ -402,17 +409,27 @@ function shouldDrawRoadsideSprite(strip: Strip, side: "left" | "right"): boolean
   return (strip.segment.index + offset) % ROADSIDE_DRAW_PERIOD === 0;
 }
 
+function shouldKeepSpriteForDensity(strip: Strip, side: "left" | "right", density = 1): boolean {
+  const clamped = Math.max(0, Math.min(1, density));
+  if (clamped >= 1) return true;
+  if (clamped <= 0) return false;
+  const denominator = Math.max(1, Math.round(1 / clamped));
+  const sideOffset = side === "left" ? 0 : 1;
+  return (strip.segment.index + sideOffset) % denominator === 0;
+}
+
 function drawRoadsideSprites(
   ctx: CanvasRenderingContext2D,
   strips: readonly Strip[],
   viewport: Viewport,
   highContrastSigns = false,
+  spriteDensityFactor = 1,
 ): void {
   for (let i = strips.length - 1; i >= 0; i--) {
     const strip = strips[i];
     if (!strip?.visible) continue;
-    drawRoadsideSprite(ctx, strip, viewport, "left", highContrastSigns);
-    drawRoadsideSprite(ctx, strip, viewport, "right", highContrastSigns);
+    drawRoadsideSprite(ctx, strip, viewport, "left", highContrastSigns, spriteDensityFactor);
+    drawRoadsideSprite(ctx, strip, viewport, "right", highContrastSigns, spriteDensityFactor);
   }
 }
 
@@ -422,8 +439,10 @@ function drawRoadsideSprite(
   viewport: Viewport,
   side: "left" | "right",
   highContrastSigns: boolean,
+  spriteDensityFactor: number,
 ): void {
   if (!shouldDrawRoadsideSprite(strip, side)) return;
+  if (!shouldKeepSpriteForDensity(strip, side, spriteDensityFactor)) return;
   const id =
     side === "left" ? strip.segment.roadsideLeftId : strip.segment.roadsideRightId;
   const style = roadsideStyleFor(id);


### PR DESCRIPTION
## Summary
- Add persisted graphics settings for draw distance, sprite density, and pixel-ratio caps.
- Replace the Performance options placeholder with a real pane.
- Wire race startup to consume the settings for projection, canvas DPR, and roadside sprite density.
- Add the v3 to v4 save migration and coverage ledger entry.

## GDD
- docs/gdd/16-rendering-and-visual-design.md
- docs/gdd/20-hud-and-ui-ux.md
- docs/gdd/21-technical-design-for-web-implementation.md
- docs/gdd/22-data-schemas.md
- docs/gdd/27-risks-and-mitigations.md

## Requirements
- Handles adjustable draw distance, sprite density, and pixel-ratio caps from GDD section 27.
- Adds persisted save settings and migration coverage.
- Leaves cross-browser matrix verification to VibeGear2-implement-cross-browser-7cf643ce.

## Progress log
- docs/PROGRESS_LOG.md: 2026-04-29 Performance settings

## Test plan
- npx vitest run src/render/__tests__/graphicsSettings.test.ts src/render/__tests__/pseudoRoadCanvas.test.ts src/components/options/__tests__/performancePaneState.test.ts src/components/options/__tests__/PerformancePane.test.tsx src/components/options/__tests__/optionsResetState.test.ts src/data/__tests__/settings-schema.test.ts src/persistence/migrations/v3ToV4.test.ts src/persistence/migrations/migrations.test.ts src/persistence/save.test.ts
- npm run typecheck
- npm run lint
- npm run content-lint
- npx playwright test e2e/options-screen.spec.ts
- npm run verify

## Followups
- None.