### PR TITLE
Browser compatibility matrix

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,14 @@ are documented in [`.github/workflows/ci.yml`](.github/workflows/ci.yml) and
 "Run workflow" button on the CI workflow with `run_bench=true`; it is
 informational and never gates a merge or deploy.
 
+## Supported Browsers
+
+The current support and release-smoke evidence matrix lives in
+[`docs/BROWSER_COMPATIBILITY.md`](docs/BROWSER_COMPATIBILITY.md). Automated
+coverage runs Chromium, Firefox, and WebKit through Playwright; real Safari,
+Windows Edge, and Chrome on macOS are manual tagged-release checks until they
+are automated.
+
 ### One-time setup (human only)
 
 1. Create the Vercel project from this GitHub repo. Disable "Production

--- a/docs/BROWSER_COMPATIBILITY.md
+++ b/docs/BROWSER_COMPATIBILITY.md
@@ -1,0 +1,57 @@
+# Browser Compatibility
+
+This matrix records the browser and viewport combinations VibeGear2 supports
+or intends to support for v1.0. Keep rows append-only where practical: when a
+target fails, keep the row with the reproducer; when a target is dropped, mark
+it dropped with the date.
+
+Automated evidence comes from `npm run test:e2e:cross-browser` in CI. Manual
+rows are required before a tagged release.
+
+## Current Matrix
+
+Build under test: `bfb5300`
+
+| Browser | OS or device class | Viewport | Verification | Date | Result | Evidence |
+| --- | --- | --- | --- | --- | --- | --- |
+| Chromium | Linux GitHub runner | Desktop Chrome default | Playwright cross-browser smoke | 2026-04-30 | pass | [CI run 25144458887](https://github.com/Randroids-Dojo/VibeGear2/actions/runs/25144458887) |
+| Firefox | Linux GitHub runner | Desktop Firefox default | Playwright cross-browser smoke | 2026-04-30 | pass | [CI run 25144458887](https://github.com/Randroids-Dojo/VibeGear2/actions/runs/25144458887) |
+| WebKit | Linux GitHub runner | Desktop Safari profile | Playwright cross-browser smoke | 2026-04-30 | pass | [CI run 25144458887](https://github.com/Randroids-Dojo/VibeGear2/actions/runs/25144458887) |
+| Chrome | macOS | Desktop | Manual smoke | pending | not-yet-run | Required for tagged release |
+| Safari | macOS | Desktop | Manual smoke | pending | not-yet-run | Required for tagged release |
+| Edge | Windows | Desktop | Manual smoke | pending | not-yet-run | Required for tagged release |
+| Chromium-class browser | Steam Deck class | 1280 by 800 | Playwright layout smoke | 2026-04-30 | pass | [CI run 25144458887](https://github.com/Randroids-Dojo/VibeGear2/actions/runs/25144458887) |
+
+## Smoke Scope
+
+The automated smoke covers:
+
+- title, options, garage, world, and practice race route boot
+- live race canvas rendering with spatial color variation
+- reduced-motion media-query support
+- Steam Deck class 1280 by 800 race surface bounds
+- keyboard-only title to race to pause to title to garage navigation
+
+## Manual Release Rows
+
+Before a tagged release, update the pending manual rows with:
+
+- the exact browser version
+- the OS version
+- the tested build SHA
+- a pass or fail result
+- evidence, such as a CI run, issue, screenshot, or PR comment
+
+If a manual target fails, keep the row and link the reproducer. If a browser
+or device class is no longer supported, change the result to `dropped` and
+record the date.
+
+## Known Gaps
+
+- Real desktop Safari remains a manual release check. Playwright WebKit is
+  the automated proxy, not a replacement for a final Safari smoke.
+- Edge on Windows remains a manual release check.
+- Mobile browser support is outside this matrix until the mobile touch pass
+  becomes release scope.
+- Lighthouse, axe, and bundle-budget gates are tracked separately by
+  `VibeGear2-implement-ci-bundle-57af4a04`.

--- a/docs/COMPATIBILITY_MATRIX.md
+++ b/docs/COMPATIBILITY_MATRIX.md
@@ -4,6 +4,9 @@ This file records the browser, performance, and accessibility verification
 expected before a tagged release. Keep it current when the cross-browser
 smoke or release verification changes.
 
+For the published support table with per-browser evidence rows, see
+[`BROWSER_COMPATIBILITY.md`](BROWSER_COMPATIBILITY.md).
+
 ## Automated Smoke
 
 Run from the repository root:

--- a/docs/GDD_COVERAGE.json
+++ b/docs/GDD_COVERAGE.json
@@ -1517,6 +1517,21 @@
       ],
       "testRefs": ["e2e/cross-browser-smoke.spec.ts"],
       "followupRefs": ["VibeGear2-implement-cross-browser-7cf643ce"]
+    },
+    {
+      "id": "GDD-25-BROWSER-COMPATIBILITY-MATRIX",
+      "gddSections": [
+        "docs/gdd/25-development-roadmap.md",
+        "docs/gdd/27-risks-and-mitigations.md"
+      ],
+      "requirement": "The v1.0 release docs publish a browser compatibility matrix with supported browser, OS, viewport, build SHA, date, result, and evidence rows for automated and manual smoke targets.",
+      "coverage": ["implemented-code"],
+      "implementationRefs": [
+        "docs/BROWSER_COMPATIBILITY.md",
+        "docs/COMPATIBILITY_MATRIX.md",
+        "README.md"
+      ],
+      "followupRefs": ["VibeGear2-implement-browser-61518e15"]
     }
   ]
 }

--- a/docs/PROGRESS_LOG.md
+++ b/docs/PROGRESS_LOG.md
@@ -11,7 +11,7 @@ Correct them by adding a new entry that references the old one.
 **GDD sections touched:**
 [§25](gdd/25-development-roadmap.md) v1.0 browser compatibility matrix and
 [§27](gdd/27-risks-and-mitigations.md) browser performance.
-**Branch / PR:** `docs/browser-compatibility-matrix`, PR pending.
+**Branch / PR:** `docs/browser-compatibility-matrix`, PR #115.
 **Status:** Implemented.
 
 ### Done

--- a/docs/PROGRESS_LOG.md
+++ b/docs/PROGRESS_LOG.md
@@ -6,6 +6,46 @@ Correct them by adding a new entry that references the old one.
 
 ---
 
+## 2026-04-29: Slice: Browser compatibility matrix
+
+**GDD sections touched:**
+[§25](gdd/25-development-roadmap.md) v1.0 browser compatibility matrix and
+[§27](gdd/27-risks-and-mitigations.md) browser performance.
+**Branch / PR:** `docs/browser-compatibility-matrix`, PR pending.
+**Status:** Implemented.
+
+### Done
+- Added `docs/BROWSER_COMPATIBILITY.md` with per-browser, OS, viewport,
+  build SHA, date, result, and evidence rows.
+- Recorded the current automated Chromium, Firefox, WebKit, and Steam Deck
+  class smoke evidence from main CI run 25144458887 at build `bfb5300`.
+- Flagged Chrome on macOS, Safari on macOS, and Edge on Windows as pending
+  manual tagged-release rows.
+- Linked the published browser matrix from README and the release
+  compatibility checklist.
+- Added a GDD coverage ledger entry for the published matrix.
+
+### Verified
+- `npm run docs:check && npm run content-lint` green.
+
+### Decisions and assumptions
+- Manual rows stay in the matrix as `not-yet-run` instead of being omitted,
+  so release gaps remain visible.
+- Mobile browser support remains outside the matrix until the mobile touch
+  pass becomes release scope.
+
+### Coverage ledger
+- GDD-25-BROWSER-COMPATIBILITY-MATRIX covers the §25 v1.0 browser
+  compatibility matrix deliverable.
+- Uncovered adjacent requirements: Lighthouse, axe, and bundle-budget gates
+  remain tracked by `VibeGear2-implement-ci-bundle-57af4a04`.
+
+### Followups created
+None.
+
+### GDD edits
+None.
+
 ## 2026-04-29: Slice: Cross-browser verification
 
 **GDD sections touched:**


### PR DESCRIPTION
## Summary
- Add docs/BROWSER_COMPATIBILITY.md with browser, OS, viewport, build SHA, date, result, and evidence rows.
- Link the published support matrix from README and the release compatibility checklist.
- Add a GDD coverage ledger entry and progress log entry for the v1.0 browser matrix deliverable.

## GDD
- docs/gdd/25-development-roadmap.md
- docs/gdd/27-risks-and-mitigations.md

## Requirement inventory
- Covers the v1.0 browser compatibility matrix deliverable from §25.
- Records current automated Chromium, Firefox, WebKit, and Steam Deck class evidence from main CI.
- Leaves Lighthouse, axe, and bundle-budget gates to VibeGear2-implement-ci-bundle-57af4a04.

## Progress log
- docs/PROGRESS_LOG.md, 2026-04-29 Browser compatibility matrix

## Test plan
- npm run docs:check && npm run content-lint

## Followups
- None.