### PR TITLE
Physics-feel benchmark replays

### DIFF
--- a/docs/PROGRESS_LOG.md
+++ b/docs/PROGRESS_LOG.md
@@ -6,6 +6,59 @@ Correct them by adding a new entry that references the old one.
 
 ---
 
+## 2026-04-30: Slice: Physics-feel benchmarks
+
+**GDD sections touched:**
+[§10](gdd/10-driving-model-and-physics.md) driving model,
+[§21](gdd/21-technical-design-for-web-implementation.md) deterministic
+replay tests, and [§27](gdd/27-risks-and-mitigations.md) physics-feel
+mitigation.
+**Branch / PR:** `test/physics-feel-benchmarks`, PR pending.
+**Status:** Implemented.
+
+### Done
+- Added three benchmark-only tracks for straight acceleration, sweeping
+  curve grip, and brake-and-recovery feel.
+- Added compact scripted input streams for each benchmark.
+- Added committed expected lap-time and sample-point baselines.
+- Added a deterministic ghost-replay regression test with a 5 percent
+  lap-time tolerance and exact sample-point checks.
+- Added `UPDATE_BENCHMARK=1` regeneration support for intentional physics
+  tuning changes.
+- Kept `_benchmark` tracks out of the user-facing track catalogue and v1.0
+  content budget.
+
+### Verified
+- `UPDATE_BENCHMARK=1 npx vitest run src/game/__tests__/physics-feel.bench.test.ts`
+  green, 8 passed.
+- `npx vitest run src/game/__tests__/physics-feel.bench.test.ts` green, 8
+  passed.
+- `npx vitest run src/game/__tests__/physics-feel.bench.test.ts src/data/__tests__/tracks-content.test.ts src/data/__tests__/content-budget.test.ts`
+  green, 50 passed.
+
+### Decisions and assumptions
+- Benchmark tracks live under `src/data/tracks/_benchmark/` but use
+  schema-valid ids with the `benchmark/` prefix.
+- The suite uses the current `sparrow-gt` baseline as the starter-car
+  feel reference.
+- Track curve metadata is still compiled for the benchmark tracks, while
+  the physics assertions pin the current lane-relative step output. Future
+  road-aware grip tuning should update the expected JSON in the same PR.
+
+### Coverage ledger
+- GDD-27-PHYSICS-FEEL-BENCHMARKS covers the §27 replayable benchmark
+  tracks mitigation and the §21 deterministic replay-test expectation for
+  physics-feel regression.
+- Uncovered adjacent requirements: live player-facing physics tuning remains
+  unchanged in this slice; future tuning changes should update benchmark
+  expectations with `UPDATE_BENCHMARK=1`.
+
+### Followups created
+None.
+
+### GDD edits
+None.
+
 ## 2026-04-30: Slice: Tagged release v0.1.0
 
 **GDD sections touched:**

--- a/src/data/__tests__/content-budget.test.ts
+++ b/src/data/__tests__/content-budget.test.ts
@@ -92,7 +92,9 @@ function readJson(absPath: string): unknown {
 }
 
 describe("content budget: tracks", () => {
-  const trackJsonFiles = walkJsonFiles(TRACKS_DIR);
+  const trackJsonFiles = walkJsonFiles(TRACKS_DIR).filter(
+    (file) => !file.relPath.startsWith(`_benchmark${path.sep}`),
+  );
 
   it("counts every JSON under src/data/tracks as a valid track", () => {
     const failures: string[] = [];

--- a/src/data/__tests__/content-budget.test.ts
+++ b/src/data/__tests__/content-budget.test.ts
@@ -96,7 +96,7 @@ describe("content budget: tracks", () => {
     (file) => !file.relPath.startsWith(`_benchmark${path.sep}`),
   );
 
-  it("counts every JSON under src/data/tracks as a valid track", () => {
+  it("counts every shipped track JSON as a valid track", () => {
     const failures: string[] = [];
     for (const file of trackJsonFiles) {
       const parsed = TrackSchema.safeParse(readJson(file.absPath));

--- a/src/data/__tests__/tracks-content.test.ts
+++ b/src/data/__tests__/tracks-content.test.ts
@@ -51,6 +51,10 @@ describe("track catalogue", () => {
       expect(TRACK_IDS).toContain(id);
     }
   });
+
+  it("does not register benchmark-only tracks in the user-facing catalogue", () => {
+    expect(TRACK_IDS.some((id) => id.startsWith("benchmark/"))).toBe(false);
+  });
 });
 
 describe.each(EXPECTED_IDS.map((id) => [id] as const))(

--- a/src/data/content-budget.ts
+++ b/src/data/content-budget.ts
@@ -10,9 +10,10 @@
  * one of these limits. Raising a cap requires editing this constant AND the
  * matching GDD row in the same PR (per the §27 mitigation contract).
  *
- * Stretch content (daily challenges, reverse tracks, modder packs) lives
- * outside the v1.0 cap; the cap counts only files registered through the
- * shipped barrels (`src/data/tracks/index.ts`, `src/data/cars/index.ts`).
+ * Stretch content (daily challenges, reverse tracks, modder packs) and
+ * benchmark-only tracks under `src/data/tracks/_benchmark/` live outside
+ * the v1.0 cap; the cap counts only files registered through the shipped
+ * barrels (`src/data/tracks/index.ts`, `src/data/cars/index.ts`).
  */
 
 export const CONTENT_BUDGET = Object.freeze({

--- a/src/data/tracks/_benchmark/brake-and-recover.json
+++ b/src/data/tracks/_benchmark/brake-and-recover.json
@@ -1,0 +1,43 @@
+{
+  "id": "benchmark/brake-and-recover",
+  "name": "Benchmark: Brake and Recover",
+  "tourId": "benchmark",
+  "author": "core",
+  "version": 1,
+  "lengthMeters": 1150,
+  "laps": 1,
+  "laneCount": 3,
+  "weatherOptions": ["clear"],
+  "difficulty": 2,
+  "segments": [
+    {
+      "len": 360,
+      "curve": 0,
+      "grade": 0,
+      "roadsideLeft": "default",
+      "roadsideRight": "default",
+      "hazards": []
+    },
+    {
+      "len": 180,
+      "curve": -0.58,
+      "grade": 0,
+      "roadsideLeft": "default",
+      "roadsideRight": "default",
+      "hazards": []
+    },
+    {
+      "len": 610,
+      "curve": 0,
+      "grade": 0,
+      "roadsideLeft": "default",
+      "roadsideRight": "default",
+      "hazards": []
+    }
+  ],
+  "checkpoints": [
+    { "segmentIndex": 0, "label": "start" },
+    { "segmentIndex": 1, "label": "brake-zone" }
+  ],
+  "spawn": { "gridSlots": 12 }
+}

--- a/src/data/tracks/_benchmark/expected/brake-and-recover.json
+++ b/src/data/tracks/_benchmark/expected/brake-and-recover.json
@@ -1,0 +1,21 @@
+{
+  "trackId": "benchmark/brake-and-recover",
+  "referenceLapTimeMs": 21883.333,
+  "samples": {
+    "60": {
+      "speed": 16,
+      "x": 0,
+      "z": 8.133333
+    },
+    "120": {
+      "speed": 32,
+      "x": 0,
+      "z": 32.266667
+    },
+    "240": {
+      "speed": 27.333333,
+      "x": 0,
+      "z": 112.95
+    }
+  }
+}

--- a/src/data/tracks/_benchmark/expected/straight-accel.json
+++ b/src/data/tracks/_benchmark/expected/straight-accel.json
@@ -1,0 +1,21 @@
+{
+  "trackId": "benchmark/straight-accel",
+  "referenceLapTimeMs": 22466.667,
+  "samples": {
+    "60": {
+      "speed": 16,
+      "x": 0,
+      "z": 8.133333
+    },
+    "120": {
+      "speed": 32,
+      "x": 0,
+      "z": 32.266667
+    },
+    "240": {
+      "speed": 61,
+      "x": 0,
+      "z": 128.226667
+    }
+  }
+}

--- a/src/data/tracks/_benchmark/expected/sweeping-curve.json
+++ b/src/data/tracks/_benchmark/expected/sweeping-curve.json
@@ -1,0 +1,21 @@
+{
+  "trackId": "benchmark/sweeping-curve",
+  "referenceLapTimeMs": 21683.333,
+  "samples": {
+    "60": {
+      "speed": 16,
+      "x": 0,
+      "z": 8.133333
+    },
+    "120": {
+      "speed": 32,
+      "x": 0,
+      "z": 32.266667
+    },
+    "240": {
+      "speed": 61,
+      "x": 0.056794,
+      "z": 128.226667
+    }
+  }
+}

--- a/src/data/tracks/_benchmark/inputs/brake-and-recover.json
+++ b/src/data/tracks/_benchmark/inputs/brake-and-recover.json
@@ -1,0 +1,67 @@
+[
+  {
+    "frame": 0,
+    "input": {
+      "steer": 0,
+      "throttle": 1,
+      "brake": 0,
+      "nitro": false,
+      "handbrake": false,
+      "pause": false,
+      "shiftUp": false,
+      "shiftDown": false
+    }
+  },
+  {
+    "frame": 190,
+    "input": {
+      "steer": 0,
+      "throttle": 0,
+      "brake": 1,
+      "nitro": false,
+      "handbrake": false,
+      "pause": false,
+      "shiftUp": false,
+      "shiftDown": false
+    }
+  },
+  {
+    "frame": 250,
+    "input": {
+      "steer": -0.05,
+      "throttle": 1,
+      "brake": 0,
+      "nitro": false,
+      "handbrake": false,
+      "pause": false,
+      "shiftUp": false,
+      "shiftDown": false
+    }
+  },
+  {
+    "frame": 280,
+    "input": {
+      "steer": 0.05,
+      "throttle": 1,
+      "brake": 0,
+      "nitro": false,
+      "handbrake": false,
+      "pause": false,
+      "shiftUp": false,
+      "shiftDown": false
+    }
+  },
+  {
+    "frame": 310,
+    "input": {
+      "steer": 0,
+      "throttle": 1,
+      "brake": 0,
+      "nitro": false,
+      "handbrake": false,
+      "pause": false,
+      "shiftUp": false,
+      "shiftDown": false
+    }
+  }
+]

--- a/src/data/tracks/_benchmark/inputs/straight-accel.json
+++ b/src/data/tracks/_benchmark/inputs/straight-accel.json
@@ -1,0 +1,15 @@
+[
+  {
+    "frame": 0,
+    "input": {
+      "steer": 0,
+      "throttle": 1,
+      "brake": 0,
+      "nitro": false,
+      "handbrake": false,
+      "pause": false,
+      "shiftUp": false,
+      "shiftDown": false
+    }
+  }
+]

--- a/src/data/tracks/_benchmark/inputs/sweeping-curve.json
+++ b/src/data/tracks/_benchmark/inputs/sweeping-curve.json
@@ -1,0 +1,54 @@
+[
+  {
+    "frame": 0,
+    "input": {
+      "steer": 0,
+      "throttle": 1,
+      "brake": 0,
+      "nitro": false,
+      "handbrake": false,
+      "pause": false,
+      "shiftUp": false,
+      "shiftDown": false
+    }
+  },
+  {
+    "frame": 180,
+    "input": {
+      "steer": -0.04,
+      "throttle": 1,
+      "brake": 0,
+      "nitro": false,
+      "handbrake": false,
+      "pause": false,
+      "shiftUp": false,
+      "shiftDown": false
+    }
+  },
+  {
+    "frame": 210,
+    "input": {
+      "steer": 0.04,
+      "throttle": 1,
+      "brake": 0,
+      "nitro": false,
+      "handbrake": false,
+      "pause": false,
+      "shiftUp": false,
+      "shiftDown": false
+    }
+  },
+  {
+    "frame": 240,
+    "input": {
+      "steer": 0,
+      "throttle": 1,
+      "brake": 0,
+      "nitro": false,
+      "handbrake": false,
+      "pause": false,
+      "shiftUp": false,
+      "shiftDown": false
+    }
+  }
+]

--- a/src/data/tracks/_benchmark/straight-accel.json
+++ b/src/data/tracks/_benchmark/straight-accel.json
@@ -1,0 +1,24 @@
+{
+  "id": "benchmark/straight-accel",
+  "name": "Benchmark: Straight Accel",
+  "tourId": "benchmark",
+  "author": "core",
+  "version": 1,
+  "lengthMeters": 1250,
+  "laps": 1,
+  "laneCount": 3,
+  "weatherOptions": ["clear"],
+  "difficulty": 1,
+  "segments": [
+    {
+      "len": 1250,
+      "curve": 0,
+      "grade": 0,
+      "roadsideLeft": "default",
+      "roadsideRight": "default",
+      "hazards": []
+    }
+  ],
+  "checkpoints": [{ "segmentIndex": 0, "label": "start" }],
+  "spawn": { "gridSlots": 12 }
+}

--- a/src/data/tracks/_benchmark/sweeping-curve.json
+++ b/src/data/tracks/_benchmark/sweeping-curve.json
@@ -1,0 +1,43 @@
+{
+  "id": "benchmark/sweeping-curve",
+  "name": "Benchmark: Sweeping Curve",
+  "tourId": "benchmark",
+  "author": "core",
+  "version": 1,
+  "lengthMeters": 1200,
+  "laps": 1,
+  "laneCount": 3,
+  "weatherOptions": ["clear"],
+  "difficulty": 2,
+  "segments": [
+    {
+      "len": 150,
+      "curve": 0,
+      "grade": 0,
+      "roadsideLeft": "default",
+      "roadsideRight": "default",
+      "hazards": []
+    },
+    {
+      "len": 700,
+      "curve": 0.42,
+      "grade": 0,
+      "roadsideLeft": "default",
+      "roadsideRight": "default",
+      "hazards": []
+    },
+    {
+      "len": 350,
+      "curve": 0,
+      "grade": 0,
+      "roadsideLeft": "default",
+      "roadsideRight": "default",
+      "hazards": []
+    }
+  ],
+  "checkpoints": [
+    { "segmentIndex": 0, "label": "start" },
+    { "segmentIndex": 1, "label": "curve-entry" }
+  ],
+  "spawn": { "gridSlots": 12 }
+}

--- a/src/game/__tests__/physics-feel.bench.test.ts
+++ b/src/game/__tests__/physics-feel.bench.test.ts
@@ -1,0 +1,324 @@
+/**
+ * Deterministic physics-feel benchmarks.
+ *
+ * Source of truth: docs/gdd/27-risks-and-mitigations.md names
+ * "replayable benchmark tracks" as the mitigation for physics-feel risk.
+ * These tracks are dev tooling, not user-facing content.
+ *
+ * The suite replays compact scripted inputs through the ghost replay
+ * pipeline, advances the same pure physics step used by the live car, and
+ * checks lap time against committed expectations. The default tolerance is
+ * deliberately loose at 5 percent so ordinary refactors do not block CI.
+ * Intentional physics tuning changes should run:
+ *
+ *   UPDATE_BENCHMARK=1 npx vitest run src/game/__tests__/physics-feel.bench.test.ts
+ *
+ * Review and commit the expected JSON diffs in the same PR as the tuning
+ * change, with a progress-log note explaining why the new baseline is
+ * correct.
+ */
+
+import fs from "node:fs";
+import path from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+import brakeAndRecoverRaw from "@/data/tracks/_benchmark/brake-and-recover.json";
+import brakeAndRecoverExpectedRaw from "@/data/tracks/_benchmark/expected/brake-and-recover.json";
+import straightAccelExpectedRaw from "@/data/tracks/_benchmark/expected/straight-accel.json";
+import sweepingCurveExpectedRaw from "@/data/tracks/_benchmark/expected/sweeping-curve.json";
+import brakeAndRecoverInputsRaw from "@/data/tracks/_benchmark/inputs/brake-and-recover.json";
+import straightAccelInputsRaw from "@/data/tracks/_benchmark/inputs/straight-accel.json";
+import sweepingCurveInputsRaw from "@/data/tracks/_benchmark/inputs/sweeping-curve.json";
+import straightAccelRaw from "@/data/tracks/_benchmark/straight-accel.json";
+import sweepingCurveRaw from "@/data/tracks/_benchmark/sweeping-curve.json";
+import { getCar, TRACK_IDS } from "@/data";
+import { TrackSchema, type CarBaseStats, type Track } from "@/data/schemas";
+import { createPlayer, createRecorder } from "@/game/ghost";
+import { NEUTRAL_INPUT, type Input } from "@/game/input";
+import { FIXED_STEP_MS, FIXED_STEP_SECONDS } from "@/game/loop";
+import {
+  DEFAULT_TRACK_CONTEXT,
+  INITIAL_CAR_STATE,
+  step,
+  type CarState,
+} from "@/game/physics";
+import { compileTrack } from "@/road/trackCompiler";
+
+const BENCHMARK_TOLERANCE = 0.05;
+const MAX_FRAMES = 60 * 60;
+const SAMPLE_FRAMES = [60, 120, 240] as const;
+const EXPECTED_DIR = "src/data/tracks/_benchmark/expected";
+
+interface ScriptedInputFrame {
+  frame: number;
+  input: Input;
+}
+
+interface BenchmarkSample {
+  speed: number;
+  x: number;
+  z: number;
+}
+
+type SampleFrame = (typeof SAMPLE_FRAMES)[number];
+
+interface BenchmarkResult {
+  trackId: string;
+  referenceLapTimeMs: number;
+  samples: Record<`${SampleFrame}`, BenchmarkSample>;
+}
+
+interface BenchmarkCase {
+  name: string;
+  track: Track;
+  inputs: ScriptedInputFrame[];
+  expected: BenchmarkResult;
+  expectedFile: string;
+}
+
+const CASES: BenchmarkCase[] = [
+  {
+    name: "straight acceleration",
+    track: TrackSchema.parse(straightAccelRaw),
+    inputs: parseScript(straightAccelInputsRaw),
+    expected: straightAccelExpectedRaw as BenchmarkResult,
+    expectedFile: "straight-accel.json",
+  },
+  {
+    name: "sweeping curve grip",
+    track: TrackSchema.parse(sweepingCurveRaw),
+    inputs: parseScript(sweepingCurveInputsRaw),
+    expected: sweepingCurveExpectedRaw as BenchmarkResult,
+    expectedFile: "sweeping-curve.json",
+  },
+  {
+    name: "brake and recovery",
+    track: TrackSchema.parse(brakeAndRecoverRaw),
+    inputs: parseScript(brakeAndRecoverInputsRaw),
+    expected: brakeAndRecoverExpectedRaw as BenchmarkResult,
+    expectedFile: "brake-and-recover.json",
+  },
+];
+
+describe("physics-feel benchmark tracks", () => {
+  it.each(CASES.map((entry) => [entry.name, entry] as const))(
+    "%s compiles and is not user-facing content",
+    (_name, entry) => {
+      const compiled = compileTrack(entry.track);
+      expect(compiled.trackId).toBe(entry.track.id);
+      expect(compiled.totalLengthMeters).toBeGreaterThan(0);
+      expect(TRACK_IDS).not.toContain(entry.track.id);
+    },
+  );
+});
+
+describe("physics-feel ghost replay regression", () => {
+  it.each(CASES.map((entry) => [entry.name, entry] as const))(
+    "%s stays within the reference lap-time tolerance",
+    (_name, entry) => {
+      const actual = runBenchmark(entry);
+
+      if (process.env.UPDATE_BENCHMARK === "1") {
+        writeExpected(entry.expectedFile, actual);
+        expect(actual.referenceLapTimeMs).toBeGreaterThan(0);
+        return;
+      }
+
+      assertWithinTolerance(entry.expected, actual);
+    },
+  );
+
+  it("is exactly deterministic across 100 invocations", () => {
+    for (const entry of CASES) {
+      const first = JSON.stringify(runBenchmark(entry));
+      for (let i = 0; i < 100; i += 1) {
+        expect(JSON.stringify(runBenchmark(entry))).toBe(first);
+      }
+    }
+  });
+
+  it("would fail on a lap-time drift larger than the tolerance", () => {
+    const actual = runBenchmark(CASES[0]!);
+    const staleExpected = {
+      ...actual,
+      referenceLapTimeMs: actual.referenceLapTimeMs * 0.9,
+    };
+    expect(() => assertWithinTolerance(staleExpected, actual)).toThrow(
+      /outside tolerance/u,
+    );
+  });
+});
+
+function parseScript(raw: unknown): ScriptedInputFrame[] {
+  if (!Array.isArray(raw)) {
+    throw new TypeError("benchmark input script must be an array");
+  }
+
+  return raw.map((entry) => {
+    if (entry === null || typeof entry !== "object") {
+      throw new TypeError("benchmark input entry must be an object");
+    }
+    const record = entry as { frame?: unknown; input?: unknown };
+    if (
+      typeof record.frame !== "number" ||
+      !Number.isInteger(record.frame) ||
+      record.frame < 0
+    ) {
+      throw new TypeError("benchmark input frame must be a non-negative integer");
+    }
+    return {
+      frame: record.frame,
+      input: parseInput(record.input),
+    };
+  }).sort((a, b) => a.frame - b.frame);
+}
+
+function parseInput(raw: unknown): Input {
+  const candidate = raw as Partial<Input> | null;
+  if (candidate === null || typeof candidate !== "object") {
+    throw new TypeError("benchmark input payload must be an object");
+  }
+  return {
+    steer: finiteNumber(candidate.steer),
+    throttle: finiteNumber(candidate.throttle),
+    brake: finiteNumber(candidate.brake),
+    nitro: candidate.nitro === true,
+    handbrake: candidate.handbrake === true,
+    pause: candidate.pause === true,
+    shiftUp: candidate.shiftUp === true,
+    shiftDown: candidate.shiftDown === true,
+  };
+}
+
+function finiteNumber(value: unknown): number {
+  return typeof value === "number" && Number.isFinite(value) ? value : 0;
+}
+
+function inputAt(script: readonly ScriptedInputFrame[], frame: number): Input {
+  let current: Input = { ...NEUTRAL_INPUT };
+  for (const entry of script) {
+    if (entry.frame > frame) break;
+    current = entry.input;
+  }
+  return current;
+}
+
+function runBenchmark(entry: BenchmarkCase): BenchmarkResult {
+  const car = getCar("sparrow-gt");
+  if (car === undefined) {
+    throw new Error("sparrow-gt benchmark car is missing");
+  }
+
+  const compiled = compileTrack(entry.track);
+  const replay = recordReplay(entry, car.baseStats);
+  const player = createPlayer(replay);
+
+  let carState: CarState = { ...INITIAL_CAR_STATE };
+  const samples: BenchmarkResult["samples"] = {
+    "60": sampleOf(carState),
+    "120": sampleOf(carState),
+    "240": sampleOf(carState),
+  };
+
+  for (let frame = 0; frame < MAX_FRAMES; frame += 1) {
+    const replayInput = player.readNext(frame) ?? NEUTRAL_INPUT;
+    carState = step(
+      carState,
+      replayInput,
+      car.baseStats,
+      DEFAULT_TRACK_CONTEXT,
+      FIXED_STEP_SECONDS,
+    );
+
+    if (isSampleFrame(frame + 1)) {
+      const sampleKey = `${frame + 1}` as `${SampleFrame}`;
+      samples[sampleKey] = sampleOf(carState);
+    }
+
+    if (carState.z >= compiled.totalLengthMeters) {
+      return {
+        trackId: entry.track.id,
+        referenceLapTimeMs: roundMs((frame + 1) * FIXED_STEP_MS),
+        samples,
+      };
+    }
+  }
+
+  throw new Error(
+    `${entry.track.id} did not finish within ${MAX_FRAMES} benchmark frames`,
+  );
+}
+
+function recordReplay(
+  entry: BenchmarkCase,
+  stats: Readonly<CarBaseStats>,
+) {
+  const compiled = compileTrack(entry.track);
+  const recorder = createRecorder({
+    trackId: entry.track.id,
+    trackVersion: entry.track.version,
+    carId: "sparrow-gt",
+    seed: 0,
+  });
+
+  let carState: CarState = { ...INITIAL_CAR_STATE };
+  for (let frame = 0; frame < MAX_FRAMES; frame += 1) {
+    const scriptedInput = inputAt(entry.inputs, frame);
+    recorder.record(scriptedInput, frame);
+    carState = step(
+      carState,
+      scriptedInput,
+      stats,
+      DEFAULT_TRACK_CONTEXT,
+      FIXED_STEP_SECONDS,
+    );
+    if (carState.z >= compiled.totalLengthMeters) break;
+  }
+
+  return recorder.finalize();
+}
+
+function isSampleFrame(frame: number): frame is SampleFrame {
+  return SAMPLE_FRAMES.includes(frame as SampleFrame);
+}
+
+function sampleOf(state: Readonly<CarState>): BenchmarkSample {
+  return {
+    speed: roundMetric(state.speed),
+    x: roundMetric(state.x),
+    z: roundMetric(state.z),
+  };
+}
+
+function assertWithinTolerance(
+  expected: BenchmarkResult,
+  actual: BenchmarkResult,
+): void {
+  expect(actual.trackId).toBe(expected.trackId);
+  const toleranceMs = expected.referenceLapTimeMs * BENCHMARK_TOLERANCE;
+  const drift = Math.abs(actual.referenceLapTimeMs - expected.referenceLapTimeMs);
+  if (drift > toleranceMs) {
+    throw new Error(
+      `${actual.trackId} lap time ${actual.referenceLapTimeMs}ms drifted ${drift}ms from ${expected.referenceLapTimeMs}ms, outside tolerance ${toleranceMs}ms`,
+    );
+  }
+
+  for (const frame of SAMPLE_FRAMES) {
+    const key = `${frame}` as const;
+    expect(actual.samples[key]).toEqual(expected.samples[key]);
+  }
+}
+
+function writeExpected(fileName: string, result: BenchmarkResult): void {
+  const target = path.join(process.cwd(), EXPECTED_DIR, fileName);
+  fs.writeFileSync(target, `${JSON.stringify(result, null, 2)}\n`);
+}
+
+function roundMetric(value: number): number {
+  return Number(value.toFixed(6));
+}
+
+function roundMs(value: number): number {
+  return Number(value.toFixed(3));
+}

--- a/src/game/__tests__/physics-feel.bench.test.ts
+++ b/src/game/__tests__/physics-feel.bench.test.ts
@@ -213,6 +213,11 @@ function runBenchmark(entry: BenchmarkCase): BenchmarkResult {
   const compiled = compileTrack(entry.track);
   const replay = recordReplay(entry, car.baseStats);
   const player = createPlayer(replay);
+  if (player.mismatchReason !== null) {
+    throw new Error(
+      `${entry.track.id} benchmark replay rejected: ${player.mismatchReason}`,
+    );
+  }
 
   let carState: CarState = { ...INITIAL_CAR_STATE };
   const samples: BenchmarkResult["samples"] = {
@@ -222,7 +227,10 @@ function runBenchmark(entry: BenchmarkCase): BenchmarkResult {
   };
 
   for (let frame = 0; frame < MAX_FRAMES; frame += 1) {
-    const replayInput = player.readNext(frame) ?? NEUTRAL_INPUT;
+    const replayInput = player.readNext(frame);
+    if (replayInput === null) {
+      throw new Error(`${entry.track.id} benchmark replay unexpectedly returned null`);
+    }
     carState = step(
       carState,
       replayInput,


### PR DESCRIPTION
## Summary

- Add three benchmark-only tracks for straight acceleration, sweeping curve grip, and brake-and-recovery feel.
- Add scripted input streams, committed expected lap-time baselines, and a deterministic ghost-replay regression suite.
- Keep benchmark tracks out of the user-facing track catalogue and v1.0 content budget.

## GDD Sections

- docs/gdd/10-driving-model-and-physics.md
- docs/gdd/21-technical-design-for-web-implementation.md
- docs/gdd/27-risks-and-mitigations.md

## Requirement Inventory

- Covers the §27 physics-feel mitigation for replayable benchmark tracks.
- Covers the §21 deterministic replay-test expectation for physics regression.
- Leaves live player-facing physics tuning unchanged. Future tuning changes should regenerate benchmark expectations with `UPDATE_BENCHMARK=1`.

## Dots

- `VibeGear2-implement-physics-feel-465d0cb6`

## Progress Log

- `docs/PROGRESS_LOG.md` entry: `2026-04-30: Slice: Physics-feel benchmarks`

## Verification

- `UPDATE_BENCHMARK=1 npx vitest run src/game/__tests__/physics-feel.bench.test.ts` green, 8 passed.
- `npx vitest run src/game/__tests__/physics-feel.bench.test.ts` green, 8 passed.
- `npx vitest run src/game/__tests__/physics-feel.bench.test.ts src/data/__tests__/tracks-content.test.ts src/data/__tests__/content-budget.test.ts` green, 50 passed.
- `npm run verify` green, 2618 passed.
- `git diff --check` green.
- No U+2014 or U+2013 characters found in touched files.

## Followups

- None.
