### PR TITLE
Full AI archetypes

### DIFF
--- a/docs/PROGRESS_LOG.md
+++ b/docs/PROGRESS_LOG.md
@@ -26,12 +26,16 @@ Correct them by adding a new entry that references the old one.
   Normal is mild, Hard is minimal, and Master disables rubber-banding.
 - Added deterministic unit tests for every archetype behavior, the updated
   rubber-banding bounds, and the §23 balancing table.
+- Hardened the cross-browser keyboard smoke so WebKit waits for the title
+  menu to render before tabbing after pause-exit navigation.
 
 ### Verified
 - `npx vitest run src/game/__tests__/ai.test.ts src/game/__tests__/aiDifficulty.test.ts src/game/__tests__/aiGrid.test.ts src/data/__tests__/ai-content.test.ts src/data/__tests__/balancing.test.ts`
   green, 236 passed.
 - `npm run typecheck` green.
 - `npm run verify` green, 2626 passed.
+- `PLAYWRIGHT_CROSS_BROWSER=1 npx playwright test e2e/cross-browser-smoke.spec.ts --project=cross-browser-webkit --grep "supports keyboard-only"`
+  green.
 
 ### Decisions and assumptions
 - Kept the existing `AIArchetypeSchema` wire names because the data schema

--- a/docs/PROGRESS_LOG.md
+++ b/docs/PROGRESS_LOG.md
@@ -6,6 +6,56 @@ Correct them by adding a new entry that references the old one.
 
 ---
 
+## 2026-04-30: Slice: Full AI archetypes
+
+**GDD sections touched:**
+[§15](gdd/15-cpu-opponents-and-ai.md) CPU archetypes and difficulty tiers,
+[§23](gdd/23-balancing-tables.md) CPU difficulty modifiers, and
+[§27](gdd/27-risks-and-mitigations.md) AI frustration mitigation.
+**Branch / PR:** `feat/full-ai-archetypes`, PR pending.
+**Status:** Implemented.
+
+### Done
+- Added a frozen AI archetype behavior table that maps the existing JSON
+  schema slots to the six §15 prose archetypes: Rocket starter, Clean line,
+  Bully, Cautious, Chaotic, and Enduro.
+- Wired `tickAI` through the behavior table so archetypes now affect pace,
+  curve braking, racing-line bias, mistake frequency, traffic pressure,
+  rocket launch and fade, and chaotic brilliant bursts.
+- Rebalanced CPU recovery scalars so Easy has the strongest light catch-up,
+  Normal is mild, Hard is minimal, and Master disables rubber-banding.
+- Added deterministic unit tests for every archetype behavior, the updated
+  rubber-banding bounds, and the §23 balancing table.
+
+### Verified
+- `npx vitest run src/game/__tests__/ai.test.ts src/game/__tests__/aiDifficulty.test.ts src/game/__tests__/aiGrid.test.ts src/data/__tests__/ai-content.test.ts src/data/__tests__/balancing.test.ts`
+  green, 236 passed.
+- `npm run typecheck` green.
+- `npm run verify` green, 2626 passed.
+
+### Decisions and assumptions
+- Kept the existing `AIArchetypeSchema` wire names because the data schema
+  already documents them as stable JSON slots. The new behavior table exposes
+  the §15 prose names and owns the gameplay meaning.
+- Interpreted §15 recovery labels as concrete §23 scalars: Easy `1.00`,
+  Normal `0.60`, Hard `0.25`, Master `0.00`. This makes Master's "None"
+  rubber-banding row mechanically true.
+
+### Coverage ledger
+- GDD-15-AI-ARCHETYPES covers the six visible AI archetypes, deterministic
+  seeded behavior differences, and light rubber-banding bounds.
+- Uncovered adjacent requirements: full overtake lane-shift logic, explicit
+  inside / outside pass preference, AI nitro firing, and damage-aware rub
+  fairness remain outside this PR-sized slice.
+
+### Followups created
+None.
+
+### GDD edits
+- Updated [§23](gdd/23-balancing-tables.md) CPU recovery scalars so the
+  numeric table matches §15's Easy, Normal, Hard, and Master
+  rubber-banding labels.
+
 ## 2026-04-30: Slice: Physics-feel benchmarks
 
 **GDD sections touched:**

--- a/docs/gdd/23-balancing-tables.md
+++ b/docs/gdd/23-balancing-tables.md
@@ -131,10 +131,10 @@ scalars rather than tire grip.
 
 | Difficulty | Pace scalar | Recovery scalar | Mistake scalar |
 | --- | --- | --- | --- |
-| Easy | 0.92 | 0.95 | 1.40 |
-| Normal | 1.00 | 1.00 | 1.00 |
-| Hard | 1.05 | 1.03 | 0.70 |
-| Master | 1.09 | 1.05 | 0.45 |
+| Easy | 0.92 | 1.00 | 1.40 |
+| Normal | 1.00 | 0.60 | 1.00 |
+| Hard | 1.05 | 0.25 | 0.70 |
+| Master | 1.09 | 0.00 | 0.45 |
 
 ## Track difficulty rating rubric
 

--- a/e2e/cross-browser-smoke.spec.ts
+++ b/e2e/cross-browser-smoke.spec.ts
@@ -94,6 +94,7 @@ test.describe("cross-browser compatibility smoke", () => {
     page,
   }) => {
     await page.goto("/");
+    await expect(page.getByTestId("menu-start-race")).toBeVisible();
     await focusByTab(page, "menu-start-race");
     await page.keyboard.press("Enter");
     await expect(page).toHaveURL(/\/race(\?.*)?$/);
@@ -106,6 +107,7 @@ test.describe("cross-browser compatibility smoke", () => {
     await focusByTab(page, "pause-exit");
     await page.keyboard.press("Enter");
     await expect(page).toHaveURL(/\/$/);
+    await expect(page.getByTestId("menu-garage")).toBeVisible();
 
     await focusByTab(page, "menu-garage");
     await page.keyboard.press("Enter");

--- a/src/data/__tests__/balancing.test.ts
+++ b/src/data/__tests__/balancing.test.ts
@@ -532,10 +532,10 @@ const CPU_DIFFICULTY_TARGETS: Readonly<
     { paceScalar: number; recoveryScalar: number; mistakeScalar: number }
   >
 > = {
-  easy: { paceScalar: 0.92, recoveryScalar: 0.95, mistakeScalar: 1.4 },
-  normal: { paceScalar: 1.0, recoveryScalar: 1.0, mistakeScalar: 1.0 },
-  hard: { paceScalar: 1.05, recoveryScalar: 1.03, mistakeScalar: 0.7 },
-  master: { paceScalar: 1.09, recoveryScalar: 1.05, mistakeScalar: 0.45 },
+  easy: { paceScalar: 0.92, recoveryScalar: 1.0, mistakeScalar: 1.4 },
+  normal: { paceScalar: 1.0, recoveryScalar: 0.6, mistakeScalar: 1.0 },
+  hard: { paceScalar: 1.05, recoveryScalar: 0.25, mistakeScalar: 0.7 },
+  master: { paceScalar: 1.09, recoveryScalar: 0.0, mistakeScalar: 0.45 },
 };
 
 describe("§23 CPU difficulty modifiers", () => {
@@ -578,10 +578,23 @@ describe("§23 CPU difficulty modifiers", () => {
     }
   });
 
-  it("Normal sits at identity for every column", () => {
+  it("recoveryScalar is monotonically non-increasing across the ladder", () => {
+    const ladder: ReadonlyArray<PlayerDifficultyPreset> = [
+      "easy",
+      "normal",
+      "hard",
+      "master",
+    ];
+    for (let i = 1; i < ladder.length; i += 1) {
+      const prev = CPU_DIFFICULTY_MODIFIERS[ladder[i - 1]!];
+      const curr = CPU_DIFFICULTY_MODIFIERS[ladder[i]!];
+      expect(curr.recoveryScalar).toBeLessThanOrEqual(prev.recoveryScalar + TOL);
+    }
+  });
+
+  it("Normal sits at identity for pace and mistakes", () => {
     const normal = CPU_DIFFICULTY_MODIFIERS.normal;
     expect(normal.paceScalar).toBeCloseTo(1, 9);
-    expect(normal.recoveryScalar).toBeCloseTo(1, 9);
     expect(normal.mistakeScalar).toBeCloseTo(1, 9);
   });
 

--- a/src/game/__tests__/ai.test.ts
+++ b/src/game/__tests__/ai.test.ts
@@ -28,6 +28,10 @@ import {
   type AIState,
   type PlayerView,
 } from "@/game/ai";
+import {
+  AI_ARCHETYPE_BEHAVIOURS,
+  AI_ARCHETYPE_ORDER,
+} from "@/game/aiArchetypes";
 import { getCpuModifiers } from "@/game/aiDifficulty";
 import { INITIAL_CAR_STATE, type CarState } from "@/game/physics";
 import { createRaceState, type RaceState } from "@/game/raceState";
@@ -96,7 +100,50 @@ function freshCar(overrides: Partial<CarState> = {}): CarState {
 
 const PLAYER_FAR_BEHIND: PlayerView = { car: freshCar({ z: -50, speed: 30 }) };
 
+function archetypeDriver(
+  archetype: AIDriver["archetype"],
+  overrides: Partial<AIDriver> = {},
+): AIDriver {
+  return {
+    ...CLEAN_LINE_DRIVER,
+    id: `ai_${archetype}_test`,
+    displayName: `${archetype} test`,
+    archetype,
+    ...overrides,
+  };
+}
+
 // Tests --------------------------------------------------------------------
+
+describe("AI_ARCHETYPE_BEHAVIOURS", () => {
+  it("covers every §15 archetype slot in stable order", () => {
+    expect(AI_ARCHETYPE_ORDER).toEqual([
+      "nitro_burst",
+      "clean_line",
+      "aggressive",
+      "defender",
+      "wet_specialist",
+      "endurance",
+    ]);
+    expect(
+      AI_ARCHETYPE_ORDER.map((id) => AI_ARCHETYPE_BEHAVIOURS[id].gddName),
+    ).toEqual([
+      "Rocket starter",
+      "Clean line",
+      "Bully",
+      "Cautious",
+      "Chaotic",
+      "Enduro",
+    ]);
+  });
+
+  it("keeps each behaviour entry frozen", () => {
+    expect(Object.isFrozen(AI_ARCHETYPE_BEHAVIOURS)).toBe(true);
+    for (const id of AI_ARCHETYPE_ORDER) {
+      expect(Object.isFrozen(AI_ARCHETYPE_BEHAVIOURS[id])).toBe(true);
+    }
+  });
+});
 
 describe("tickAI (countdown)", () => {
   it("returns NEUTRAL_INPUT during countdown", () => {
@@ -249,6 +296,139 @@ describe("tickAI (cornering)", () => {
     );
     expect(result.input.brake).toBeGreaterThan(0);
     expect(result.input.throttle).toBe(0);
+  });
+});
+
+describe("tickAI (§15 archetype behaviours)", () => {
+  it("rocket starter launches faster early and fades late", () => {
+    const clean = archetypeDriver("clean_line", { paceScalar: 0.75 });
+    const rocket = archetypeDriver("nitro_burst", { paceScalar: 0.75 });
+    const earlyClean = tickAI(
+      clean,
+      freshAi(),
+      freshCar({ z: 60, speed: 20 }),
+      PLAYER_FAR_BEHIND,
+      STRAIGHT_TRACK,
+      RACING,
+      STARTER_STATS,
+    );
+    const earlyRocket = tickAI(
+      rocket,
+      freshAi(),
+      freshCar({ z: 60, speed: 20 }),
+      PLAYER_FAR_BEHIND,
+      STRAIGHT_TRACK,
+      RACING,
+      STARTER_STATS,
+    );
+    const lateClean = tickAI(
+      clean,
+      freshAi(),
+      freshCar({ z: 1000, speed: 20 }),
+      PLAYER_FAR_BEHIND,
+      STRAIGHT_TRACK,
+      RACING,
+      STARTER_STATS,
+    );
+    const lateRocket = tickAI(
+      rocket,
+      freshAi(),
+      freshCar({ z: 1000, speed: 20 }),
+      PLAYER_FAR_BEHIND,
+      STRAIGHT_TRACK,
+      RACING,
+      STARTER_STATS,
+    );
+
+    expect(earlyRocket.nextAiState.targetSpeed).toBeGreaterThan(
+      earlyClean.nextAiState.targetSpeed,
+    );
+    expect(lateRocket.nextAiState.targetSpeed).toBeLessThan(
+      lateClean.nextAiState.targetSpeed,
+    );
+  });
+
+  it("bully drivers pressure toward nearby traffic", () => {
+    const clean = archetypeDriver("clean_line");
+    const bully = archetypeDriver("aggressive", { aggression: 1 });
+    const aiCar = freshCar({ x: 0, z: 300, speed: 30 });
+    const playerNearbyRight: PlayerView = {
+      car: freshCar({ x: 3, z: 312, speed: 30 }),
+    };
+    const cleanTick = tickAI(
+      clean,
+      freshAi(),
+      aiCar,
+      playerNearbyRight,
+      STRAIGHT_TRACK,
+      RACING,
+      STARTER_STATS,
+    );
+    const bullyTick = tickAI(
+      bully,
+      freshAi(),
+      aiCar,
+      playerNearbyRight,
+      STRAIGHT_TRACK,
+      RACING,
+      STARTER_STATS,
+    );
+
+    expect(bullyTick.input.steer).toBeGreaterThan(cleanTick.input.steer);
+  });
+
+  it("cautious drivers brake earlier for the same sweeper", () => {
+    const clean = archetypeDriver("clean_line");
+    const cautious = archetypeDriver("defender");
+    const aiCar = freshCar({ z: 900, speed: 45 });
+    const cleanTick = tickAI(
+      clean,
+      freshAi(),
+      aiCar,
+      PLAYER_FAR_BEHIND,
+      SWEEPER_TRACK,
+      RACING,
+      STARTER_STATS,
+    );
+    const cautiousTick = tickAI(
+      cautious,
+      freshAi(),
+      aiCar,
+      PLAYER_FAR_BEHIND,
+      SWEEPER_TRACK,
+      RACING,
+      STARTER_STATS,
+    );
+
+    expect(cautiousTick.nextAiState.targetSpeed).toBeLessThan(
+      cleanTick.nextAiState.targetSpeed,
+    );
+    expect(cautiousTick.input.brake).toBeGreaterThan(cleanTick.input.brake);
+  });
+
+  it("chaotic drivers produce more seeded lane mistakes than enduro drivers", () => {
+    const chaotic = archetypeDriver("wet_specialist", { mistakeRate: 0.2 });
+    const enduro = archetypeDriver("endurance", { mistakeRate: 0.2 });
+    const countSteeringMistakes = (driver: AIDriver): number => {
+      let count = 0;
+      for (let seed = 1; seed <= 160; seed += 1) {
+        const result = tickAI(
+          driver,
+          freshAi({ seed }),
+          freshCar({ speed: 20, z: seed * 6 }),
+          PLAYER_FAR_BEHIND,
+          STRAIGHT_TRACK,
+          RACING,
+          STARTER_STATS,
+        );
+        if (result.input.steer !== 0) count += 1;
+      }
+      return count;
+    };
+
+    expect(countSteeringMistakes(chaotic)).toBeGreaterThan(
+      countSteeringMistakes(enduro),
+    );
   });
 });
 
@@ -608,7 +788,7 @@ describe("tickAI (§23 CPU difficulty mistakeScalar and recoveryScalar)", () => 
     expect(countMistakes(2)).toBeGreaterThan(countMistakes(1));
   });
 
-  it("Master recovery term is larger than Easy under matched trailing gap", () => {
+  it("Easy recovery term is larger than Master under matched trailing gap", () => {
     const easyRecoveryOnly = {
       ...getCpuModifiers("easy"),
       paceScalar: 1,
@@ -648,8 +828,48 @@ describe("tickAI (§23 CPU difficulty mistakeScalar and recoveryScalar)", () => 
       masterRecoveryOnly,
     );
 
-    expect(master.nextAiState.targetSpeed).toBeGreaterThan(
-      easy.nextAiState.targetSpeed,
+    expect(easy.nextAiState.targetSpeed).toBeGreaterThan(
+      master.nextAiState.targetSpeed,
+    );
+  });
+
+  it("Master disables the light catch-up term", () => {
+    const masterRecoveryOnly = {
+      ...getCpuModifiers("master"),
+      paceScalar: 1,
+      mistakeScalar: 1,
+    };
+    const aiCar = freshCar({ z: 900, speed: 30 });
+    const playerAhead: PlayerView = {
+      car: freshCar({ z: aiCar.z + 240, speed: 30 }),
+    };
+    const withoutGap = tickAI(
+      CLEAN_LINE_DRIVER,
+      freshAi(),
+      aiCar,
+      PLAYER_FAR_BEHIND,
+      SWEEPER_TRACK,
+      RACING,
+      STARTER_STATS,
+      DEFAULT_AI_TRACK_CONTEXT,
+      0,
+      masterRecoveryOnly,
+    );
+    const withGap = tickAI(
+      CLEAN_LINE_DRIVER,
+      freshAi(),
+      aiCar,
+      playerAhead,
+      SWEEPER_TRACK,
+      RACING,
+      STARTER_STATS,
+      DEFAULT_AI_TRACK_CONTEXT,
+      0,
+      masterRecoveryOnly,
+    );
+
+    expect(withGap.nextAiState.targetSpeed).toBe(
+      withoutGap.nextAiState.targetSpeed,
     );
   });
 });

--- a/src/game/__tests__/ai.test.ts
+++ b/src/game/__tests__/ai.test.ts
@@ -32,7 +32,10 @@ import {
   AI_ARCHETYPE_BEHAVIOURS,
   AI_ARCHETYPE_ORDER,
 } from "@/game/aiArchetypes";
-import { getCpuModifiers } from "@/game/aiDifficulty";
+import {
+  getCpuModifiers,
+  type CpuDifficultyModifiers,
+} from "@/game/aiDifficulty";
 import { INITIAL_CAR_STATE, type CarState } from "@/game/physics";
 import { createRaceState, type RaceState } from "@/game/raceState";
 import { compileSegments, type CompiledSegmentBuffer } from "@/road/trackCompiler";
@@ -564,8 +567,8 @@ describe("tickAI (§23 CPU difficulty tier paceScalar)", () => {
   // `paceScalar` on top of the per-driver `AIDriver.paceScalar`. These
   // tests pin the runtime side of F-048: a clean_line driver under
   // identical inputs targets a higher speed at Hard than at Easy, and
-  // omitting the `cpuModifiers` argument is byte-identical to passing
-  // the Normal (identity) row.
+  // omitted `cpuModifiers` keep the legacy all-ones default separate
+  // from the §23 Normal row.
 
   it("Hard tier yields a higher targetSpeed than Easy under matched inputs", () => {
     // Mid-sweeper at curve=0.5: rawTarget = 61 * (1 - 0.6 * 0.5) * 1.0
@@ -600,12 +603,11 @@ describe("tickAI (§23 CPU difficulty tier paceScalar)", () => {
     );
   });
 
-  it("Normal tier (identity) is byte-identical to omitting cpuModifiers", () => {
-    // The default-arg path resolves to `IDENTITY_CPU_MODIFIERS` which
-    // matches `getCpuModifiers("normal")`. Passing the Normal row
-    // explicitly must not drift any field of the result, so callers
-    // that adopt the binding can flip in stages without altering the
-    // pre-binding behaviour for any tier they have not yet wired.
+  it("Normal tier pace path matches omitted modifiers without a recovery gap", () => {
+    // The default-arg path resolves to `IDENTITY_CPU_MODIFIERS`. Normal
+    // is not identity anymore because §23 gives it mild recovery, but
+    // without a trailing gap its pace and mistake scalars still match
+    // the legacy default.
     const omitted = tickAI(
       CLEAN_LINE_DRIVER,
       freshAi(),
@@ -629,6 +631,37 @@ describe("tickAI (§23 CPU difficulty tier paceScalar)", () => {
     );
     expect(explicitNormal.input).toEqual(omitted.input);
     expect(explicitNormal.nextAiState).toEqual(omitted.nextAiState);
+  });
+
+  it("Normal tier recovery differs from the legacy omitted default", () => {
+    const aiCar = freshCar({ z: 900, speed: 30 });
+    const playerAhead: PlayerView = {
+      car: freshCar({ z: aiCar.z + 240, speed: 30 }),
+    };
+    const omitted = tickAI(
+      CLEAN_LINE_DRIVER,
+      freshAi(),
+      aiCar,
+      playerAhead,
+      SWEEPER_TRACK,
+      RACING,
+      STARTER_STATS,
+    );
+    const explicitNormal = tickAI(
+      CLEAN_LINE_DRIVER,
+      freshAi(),
+      aiCar,
+      playerAhead,
+      SWEEPER_TRACK,
+      RACING,
+      STARTER_STATS,
+      DEFAULT_AI_TRACK_CONTEXT,
+      0,
+      getCpuModifiers("normal"),
+    );
+    expect(omitted.nextAiState.targetSpeed).toBeGreaterThan(
+      explicitNormal.nextAiState.targetSpeed,
+    );
   });
 
   it("composes per-driver paceScalar with the tier paceScalar", () => {
@@ -690,8 +723,13 @@ describe("tickAI (§23 CPU difficulty tier paceScalar)", () => {
     expect(result.nextAiState.targetSpeed).toBe(STARTER_STATS.topSpeed);
   });
 
-  it("IDENTITY_CPU_MODIFIERS matches the §23 Normal row", () => {
-    expect(IDENTITY_CPU_MODIFIERS).toBe(getCpuModifiers("normal"));
+  it("IDENTITY_CPU_MODIFIERS is the legacy all-ones default row", () => {
+    expect(IDENTITY_CPU_MODIFIERS).toEqual<CpuDifficultyModifiers>({
+      paceScalar: 1,
+      recoveryScalar: 1,
+      mistakeScalar: 1,
+    });
+    expect(Object.isFrozen(IDENTITY_CPU_MODIFIERS)).toBe(true);
   });
 });
 

--- a/src/game/__tests__/ai.test.ts
+++ b/src/game/__tests__/ai.test.ts
@@ -380,6 +380,35 @@ describe("tickAI (§15 archetype behaviours)", () => {
     expect(bullyTick.input.steer).toBeGreaterThan(cleanTick.input.steer);
   });
 
+  it("bully pressure uses the player's position relative to the AI", () => {
+    const clean = archetypeDriver("clean_line");
+    const bully = archetypeDriver("aggressive", { aggression: 1 });
+    const aiCar = freshCar({ x: 1, z: 300, speed: 30 });
+    const playerNearbyLeft: PlayerView = {
+      car: freshCar({ x: 0.5, z: 312, speed: 30 }),
+    };
+    const cleanTick = tickAI(
+      clean,
+      freshAi(),
+      aiCar,
+      playerNearbyLeft,
+      STRAIGHT_TRACK,
+      RACING,
+      STARTER_STATS,
+    );
+    const bullyTick = tickAI(
+      bully,
+      freshAi(),
+      aiCar,
+      playerNearbyLeft,
+      STRAIGHT_TRACK,
+      RACING,
+      STARTER_STATS,
+    );
+
+    expect(bullyTick.input.steer).toBeLessThan(cleanTick.input.steer);
+  });
+
   it("cautious drivers brake earlier for the same sweeper", () => {
     const clean = archetypeDriver("clean_line");
     const cautious = archetypeDriver("defender");

--- a/src/game/__tests__/aiDifficulty.test.ts
+++ b/src/game/__tests__/aiDifficulty.test.ts
@@ -29,7 +29,7 @@ import {
 } from "../aiDifficulty";
 
 describe("DEFAULT_CPU_TIER_ID", () => {
-  it("is 'normal' (the §23 identity row, also the §15 baseline)", () => {
+  it("is 'normal' (the §15 baseline tier)", () => {
     expect(DEFAULT_CPU_TIER_ID).toBe("normal");
   });
 });
@@ -68,7 +68,7 @@ describe("getCpuModifiers", () => {
     });
   });
 
-  it("returns the §23 Normal (identity) row", () => {
+  it("returns the §23 Normal row", () => {
     expect(getCpuModifiers("normal")).toEqual<CpuDifficultyModifiers>({
       paceScalar: 1,
       recoveryScalar: 0.6,

--- a/src/game/__tests__/aiDifficulty.test.ts
+++ b/src/game/__tests__/aiDifficulty.test.ts
@@ -63,7 +63,7 @@ describe("getCpuModifiers", () => {
   it("returns the §23 Easy row", () => {
     expect(getCpuModifiers("easy")).toEqual<CpuDifficultyModifiers>({
       paceScalar: 0.92,
-      recoveryScalar: 0.95,
+      recoveryScalar: 1,
       mistakeScalar: 1.4,
     });
   });
@@ -71,7 +71,7 @@ describe("getCpuModifiers", () => {
   it("returns the §23 Normal (identity) row", () => {
     expect(getCpuModifiers("normal")).toEqual<CpuDifficultyModifiers>({
       paceScalar: 1,
-      recoveryScalar: 1,
+      recoveryScalar: 0.6,
       mistakeScalar: 1,
     });
   });
@@ -79,7 +79,7 @@ describe("getCpuModifiers", () => {
   it("returns the §23 Hard row", () => {
     expect(getCpuModifiers("hard")).toEqual<CpuDifficultyModifiers>({
       paceScalar: 1.05,
-      recoveryScalar: 1.03,
+      recoveryScalar: 0.25,
       mistakeScalar: 0.7,
     });
   });
@@ -87,7 +87,7 @@ describe("getCpuModifiers", () => {
   it("returns the §23 Master row", () => {
     expect(getCpuModifiers("master")).toEqual<CpuDifficultyModifiers>({
       paceScalar: 1.09,
-      recoveryScalar: 1.05,
+      recoveryScalar: 0,
       mistakeScalar: 0.45,
     });
   });
@@ -133,14 +133,14 @@ describe("§23 table monotonicity (sanity)", () => {
     expect(hard).toBeLessThanOrEqual(master);
   });
 
-  it("recoveryScalar is non-decreasing across Easy -> Master", () => {
+  it("recoveryScalar is non-increasing across Easy -> Master", () => {
     const easy = getCpuModifiers("easy").recoveryScalar;
     const normal = getCpuModifiers("normal").recoveryScalar;
     const hard = getCpuModifiers("hard").recoveryScalar;
     const master = getCpuModifiers("master").recoveryScalar;
-    expect(easy).toBeLessThanOrEqual(normal);
-    expect(normal).toBeLessThanOrEqual(hard);
-    expect(hard).toBeLessThanOrEqual(master);
+    expect(easy).toBeGreaterThanOrEqual(normal);
+    expect(normal).toBeGreaterThanOrEqual(hard);
+    expect(hard).toBeGreaterThanOrEqual(master);
   });
 
   it("mistakeScalar is non-increasing across Easy -> Master", () => {
@@ -153,10 +153,9 @@ describe("§23 table monotonicity (sanity)", () => {
     expect(hard).toBeGreaterThanOrEqual(master);
   });
 
-  it("Normal sits at identity for every column", () => {
+  it("Normal sits at identity for pace and mistakes", () => {
     const normal = getCpuModifiers("normal");
     expect(normal.paceScalar).toBe(1);
-    expect(normal.recoveryScalar).toBe(1);
     expect(normal.mistakeScalar).toBe(1);
   });
 });

--- a/src/game/ai.ts
+++ b/src/game/ai.ts
@@ -480,7 +480,11 @@ function trafficPressureOffset(
   if (Math.abs(gap) > AI_TUNING.TRAFFIC_PRESSURE_WINDOW_METERS) return 0;
   const closeness =
     1 - Math.abs(gap) / AI_TUNING.TRAFFIC_PRESSURE_WINDOW_METERS;
-  const direction = clamp(playerCar.x / Math.max(roadHalfWidth, 1), -1, 1);
+  const direction = clamp(
+    (playerCar.x - aiCar.x) / Math.max(roadHalfWidth, 1),
+    -1,
+    1,
+  );
   return direction * pressure * clamp(aggression, 0, 1) * closeness;
 }
 

--- a/src/game/ai.ts
+++ b/src/game/ai.ts
@@ -1,10 +1,8 @@
 /**
- * Single AI driver tick for the `clean_line` archetype per §15
- * "CPU opponents and AI". Phase 1 vertical slice: one opponent on the
- * grid that proves the AI shape works end to end. Later slices add the
- * remaining archetypes (aggressive, bully, cautious, chaotic, enduro)
- * and full grid behaviour (overtake, collision avoidance, mistakes,
- * nitro, weather skill, rubber-banding).
+ * AI driver tick for the §15 "CPU opponents and AI" archetypes.
+ * The controller stays in progress space and dispatches through
+ * `aiArchetypes.ts` for rocket starter, clean line, bully, cautious,
+ * chaotic, and enduro behaviour.
  *
  * Source of truth: `docs/gdd/15-cpu-opponents-and-ai.md`. The "AI is
  * simulated in track-progress space, not free-driving 3D rigid bodies"
@@ -60,15 +58,12 @@
  * risk through poorer read distance without changing hit geometry.
  *
  * Out of scope for this slice (deferred to follow-up AI dots):
- * - Overtake / lane-shift behaviour. §15 lists it; the clean_line single
- *   AI may collide with the player. Collision avoidance lands with the
+ * - Overtake / lane-shift behaviour. §15 lists it; an AI may still
+ *   collide with the player. Collision avoidance lands with the
  *   full grid slice.
  * - Nitro firing. The clean_line AI never fires nitro in this slice.
- * - Archetype-specific mistake shapes (miss apex, brake too early in
- *   fog, etc.). This slice ships the shared deterministic lane-target
- *   mistake hook.
- * - Full rubber-banding policy. This slice ships the light catch-up
- *   pace hook so the §23 `recoveryScalar` row is consumed.
+ * - Full passing logic with inside / outside pass preferences.
+ * - Damage-aware rub avoidance and contact fairness scoring.
  */
 
 import type { AIDriver, CarBaseStats } from "@/data/schemas";
@@ -78,6 +73,7 @@ import {
   getCpuModifiers,
   type CpuDifficultyModifiers,
 } from "./aiDifficulty";
+import { getAIBehaviour } from "./aiArchetypes";
 import { NEUTRAL_INPUT, type Input } from "./input";
 import type { CarState } from "./physics";
 import type { RaceState } from "./raceState";
@@ -196,6 +192,12 @@ export const AI_TUNING = Object.freeze({
   MAX_RECOVERY_PACE_BONUS: 0.05,
   /** Player gap, in meters, that reaches the maximum recovery term. */
   RECOVERY_GAP_FOR_MAX_BONUS: 240,
+  /** Lap fraction where rocket starter launch boost stops applying. */
+  ROCKET_LAUNCH_FRACTION: 0.18,
+  /** Lap fraction where rocket starter late fade starts applying. */
+  ROCKET_FADE_FRACTION: 0.72,
+  /** Player or traffic gap where archetype lane pressure can engage. */
+  TRAFFIC_PRESSURE_WINDOW_METERS: 36,
 });
 
 /**
@@ -261,6 +263,7 @@ export function tickAI(
   weatherSkillScalar: number = 1,
   visibilityRiskScalar: number = 1,
 ): AITickResult {
+  const behaviour = getAIBehaviour(driver.archetype);
   const segment = currentSegment(track, aiCar.z);
   // `segment.curve` is the per-compiled-segment dx contribution, already
   // divided by `CURVATURE_SCALE` by the track compiler. The AI reasons
@@ -277,14 +280,27 @@ export function tickAI(
   // lands, replace this with `segment.racingLineBias`. The leading `0 +`
   // converts a `-0` from the multiplication on a perfectly straight
   // segment back to `+0` so call-sites can `expect(steer).toBe(0)`.
-  const rawIdealOffset = -authoredCurve * AI_TUNING.MAX_RACING_LINE_OFFSET;
+  const rawIdealOffset =
+    -authoredCurve *
+    AI_TUNING.MAX_RACING_LINE_OFFSET *
+    behaviour.racingLineScalar;
+  const trafficLaneOffset = trafficPressureOffset(
+    behaviour.trafficLanePressure,
+    driver.aggression,
+    aiCar,
+    player.car,
+    context.roadHalfWidth,
+  );
   const baseIdealLateralOffset = clamp(
-    rawIdealOffset === 0 ? 0 : rawIdealOffset,
+    rawIdealOffset + trafficLaneOffset === 0
+      ? 0
+      : rawIdealOffset + trafficLaneOffset,
     -context.roadHalfWidth,
     context.roadHalfWidth,
   );
   const effectiveMistakeRate = clamp(
-      driver.mistakeRate *
+    driver.mistakeRate *
+      behaviour.mistakeScalar *
       cpuModifiers.mistakeScalar *
       clamp(visibilityRiskScalar, 1, WEATHER_VISIBILITY_RISK_MAX_SCALAR),
     0,
@@ -292,13 +308,20 @@ export function tickAI(
   );
   let nextSeed = aiState.seed;
   let mistakeOffset = 0;
-  if (race.phase === "racing" && effectiveMistakeRate > 0) {
+  let brilliantPaceBonus = 0;
+  if (
+    race.phase === "racing" &&
+    (effectiveMistakeRate > 0 || behaviour.brilliantChance > 0)
+  ) {
     const mistakeRng = deserializeRng(aiState.seed);
     const mistakeActive = mistakeRng.nextBool(effectiveMistakeRate);
     const mistakeDirection = mistakeRng.next() < 0.5 ? -1 : 1;
     mistakeOffset = mistakeActive
       ? mistakeDirection * AI_TUNING.MAX_MISTAKE_OFFSET
       : 0;
+    if (mistakeRng.nextBool(behaviour.brilliantChance)) {
+      brilliantPaceBonus = behaviour.brilliantPaceBonus;
+    }
     nextSeed = mistakeRng.state;
   }
   const idealLateralOffset = clamp(
@@ -315,7 +338,8 @@ export function tickAI(
       1,
     ) *
     AI_TUNING.MAX_RECOVERY_PACE_BONUS *
-    cpuModifiers.recoveryScalar;
+    cpuModifiers.recoveryScalar *
+    behaviour.recoveryScalar;
 
   // Target speed per segment. §15 "AI chooses a lane offset target" plus
   // a per-driver `paceScalar` from §22 maps onto a curve-aware target
@@ -330,11 +354,26 @@ export function tickAI(
   // objects per AI tick. The composed target is then re-clamped at
   // `stats.topSpeed` so a Master-tier driver with an authored
   // `paceScalar > 1` still cannot exceed the chassis ceiling.
-  const curvePenalty = 1 - AI_TUNING.CLEAN_LINE_CURVE_DECEL * Math.abs(authoredCurve);
+  const curvePenalty =
+    1 -
+    AI_TUNING.CLEAN_LINE_CURVE_DECEL *
+      behaviour.curveBrakeScalar *
+      Math.abs(authoredCurve);
+  const lapProgressFraction = lapFraction(track.totalLength, aiCar.z);
+  const launchPaceBonus =
+    lapProgressFraction < AI_TUNING.ROCKET_LAUNCH_FRACTION
+      ? behaviour.launchPaceBonus
+      : 0;
+  const fadePacePenalty =
+    lapProgressFraction > AI_TUNING.ROCKET_FADE_FRACTION
+      ? behaviour.fadePacePenalty
+      : 0;
   const composedPaceScalar =
     driver.paceScalar *
+    behaviour.targetSpeedScalar *
     cpuModifiers.paceScalar *
-    clamp(weatherSkillScalar, 0, 2);
+    clamp(weatherSkillScalar, 0, 2) *
+    (1 + launchPaceBonus + brilliantPaceBonus - fadePacePenalty);
   const rawTarget =
     stats.topSpeed *
     Math.max(0, curvePenalty) *
@@ -423,6 +462,28 @@ function currentSegment(
     Math.max(0, Math.floor(normalized / SEGMENT_LENGTH)),
   );
   return segments[index];
+}
+
+function lapFraction(totalLength: number, z: number): number {
+  if (!Number.isFinite(totalLength) || totalLength <= 0) return 0;
+  const normalized = ((z % totalLength) + totalLength) % totalLength;
+  return clamp(normalized / totalLength, 0, 1);
+}
+
+function trafficPressureOffset(
+  pressure: number,
+  aggression: number,
+  aiCar: Readonly<CarState>,
+  playerCar: Readonly<CarState>,
+  roadHalfWidth: number,
+): number {
+  if (pressure === 0) return 0;
+  const gap = playerCar.z - aiCar.z;
+  if (Math.abs(gap) > AI_TUNING.TRAFFIC_PRESSURE_WINDOW_METERS) return 0;
+  const closeness =
+    1 - Math.abs(gap) / AI_TUNING.TRAFFIC_PRESSURE_WINDOW_METERS;
+  const direction = clamp(playerCar.x / Math.max(roadHalfWidth, 1), -1, 1);
+  return direction * pressure * clamp(aggression, 0, 1) * closeness;
 }
 
 // Numeric helpers ----------------------------------------------------------

--- a/src/game/ai.ts
+++ b/src/game/ai.ts
@@ -43,9 +43,8 @@
  * on top of per-driver AI data. `paceScalar` raises or lowers target
  * speed, `recoveryScalar` scales the light catch-up term when an AI
  * trails the player, and `mistakeScalar` scales the per-driver
- * `mistakeRate` for deterministic lane-target mistakes. Defaults to
- * identity (`getCpuModifiers("normal")`) so existing callers keep
- * Normal behavior unchanged.
+ * `mistakeRate` for deterministic lane-target mistakes. Defaults to a
+ * legacy identity row so existing callers keep behavior unchanged.
  *
  * Weather skill wiring: callers may pass `weatherSkillScalar` as the
  * compact §15 weather-skill row resolved for the active weather. It is
@@ -61,7 +60,7 @@
  * - Overtake / lane-shift behaviour. §15 lists it; an AI may still
  *   collide with the player. Collision avoidance lands with the
  *   full grid slice.
- * - Nitro firing. The clean_line AI never fires nitro in this slice.
+ * - AI nitro firing. Not implemented in this slice.
  * - Full passing logic with inside / outside pass preferences.
  * - Damage-aware rub avoidance and contact fairness scoring.
  */
@@ -69,10 +68,7 @@
 import type { AIDriver, CarBaseStats } from "@/data/schemas";
 import { CURVATURE_SCALE, ROAD_WIDTH, SEGMENT_LENGTH } from "@/road/constants";
 import type { CompiledSegmentBuffer } from "@/road/trackCompiler";
-import {
-  getCpuModifiers,
-  type CpuDifficultyModifiers,
-} from "./aiDifficulty";
+import type { CpuDifficultyModifiers } from "./aiDifficulty";
 import { getAIBehaviour } from "./aiArchetypes";
 import { NEUTRAL_INPUT, type Input } from "./input";
 import type { CarState } from "./physics";
@@ -81,14 +77,17 @@ import { deserializeRng } from "./rng";
 import { WEATHER_VISIBILITY_RISK_MAX_SCALAR } from "./weather";
 
 /**
- * Identity §23 CPU modifiers row used as the default when a caller does
- * not supply tier-resolved scalars. Equivalent to
- * `getCpuModifiers("normal")`: each scalar is `1.0` so the per-driver
- * `paceScalar`, `mistakeRate`, and light recovery term pass through
- * unchanged for any caller that has not yet adopted the tier wiring.
+ * Legacy identity CPU modifier row used as the default when a caller
+ * does not supply tier-resolved §23 scalars. Each scalar is `1.0` so
+ * the per-driver `paceScalar`, `mistakeRate`, and light recovery term
+ * pass through unchanged for any caller that has not yet adopted the
+ * tier wiring.
  */
-export const IDENTITY_CPU_MODIFIERS: CpuDifficultyModifiers =
-  getCpuModifiers("normal");
+export const IDENTITY_CPU_MODIFIERS: CpuDifficultyModifiers = Object.freeze({
+  paceScalar: 1,
+  recoveryScalar: 1,
+  mistakeScalar: 1,
+});
 
 /**
  * Per-AI runtime state. Pinned by the dot stress-test:
@@ -196,7 +195,7 @@ export const AI_TUNING = Object.freeze({
   ROCKET_LAUNCH_FRACTION: 0.18,
   /** Lap fraction where rocket starter late fade starts applying. */
   ROCKET_FADE_FRACTION: 0.72,
-  /** Player or traffic gap where archetype lane pressure can engage. */
+  /** Player gap where archetype lane pressure can engage. */
   TRAFFIC_PRESSURE_WINDOW_METERS: 36,
 });
 
@@ -291,10 +290,9 @@ export function tickAI(
     player.car,
     context.roadHalfWidth,
   );
+  const idealOffsetWithTraffic = rawIdealOffset + trafficLaneOffset;
   const baseIdealLateralOffset = clamp(
-    rawIdealOffset + trafficLaneOffset === 0
-      ? 0
-      : rawIdealOffset + trafficLaneOffset,
+    idealOffsetWithTraffic === 0 ? 0 : idealOffsetWithTraffic,
     -context.roadHalfWidth,
     context.roadHalfWidth,
   );

--- a/src/game/aiArchetypes.ts
+++ b/src/game/aiArchetypes.ts
@@ -12,6 +12,10 @@ export interface AIBehaviour {
   readonly fadePacePenalty: number;
   readonly brilliantChance: number;
   readonly brilliantPaceBonus: number;
+  /**
+   * Lateral offset bias, in meters, applied toward the player when the
+   * player is close enough to engage traffic pressure.
+   */
   readonly trafficLanePressure: number;
 }
 

--- a/src/game/aiArchetypes.ts
+++ b/src/game/aiArchetypes.ts
@@ -1,0 +1,117 @@
+import type { AIArchetype } from "@/data/schemas";
+
+export interface AIBehaviour {
+  readonly archetype: AIArchetype;
+  readonly gddName: string;
+  readonly targetSpeedScalar: number;
+  readonly curveBrakeScalar: number;
+  readonly racingLineScalar: number;
+  readonly mistakeScalar: number;
+  readonly recoveryScalar: number;
+  readonly launchPaceBonus: number;
+  readonly fadePacePenalty: number;
+  readonly brilliantChance: number;
+  readonly brilliantPaceBonus: number;
+  readonly trafficLanePressure: number;
+}
+
+export const AI_ARCHETYPE_BEHAVIOURS: Readonly<Record<AIArchetype, AIBehaviour>> =
+  Object.freeze({
+    nitro_burst: Object.freeze({
+      archetype: "nitro_burst",
+      gddName: "Rocket starter",
+      targetSpeedScalar: 1.02,
+      curveBrakeScalar: 1,
+      racingLineScalar: 1,
+      mistakeScalar: 1.05,
+      recoveryScalar: 0.9,
+      launchPaceBonus: 0.08,
+      fadePacePenalty: 0.04,
+      brilliantChance: 0,
+      brilliantPaceBonus: 0,
+      trafficLanePressure: 0.05,
+    }),
+    clean_line: Object.freeze({
+      archetype: "clean_line",
+      gddName: "Clean line",
+      targetSpeedScalar: 1,
+      curveBrakeScalar: 1,
+      racingLineScalar: 1,
+      mistakeScalar: 1,
+      recoveryScalar: 1,
+      launchPaceBonus: 0,
+      fadePacePenalty: 0,
+      brilliantChance: 0,
+      brilliantPaceBonus: 0,
+      trafficLanePressure: 0,
+    }),
+    aggressive: Object.freeze({
+      archetype: "aggressive",
+      gddName: "Bully",
+      targetSpeedScalar: 1.01,
+      curveBrakeScalar: 0.95,
+      racingLineScalar: 0.9,
+      mistakeScalar: 1.15,
+      recoveryScalar: 1.05,
+      launchPaceBonus: 0.02,
+      fadePacePenalty: 0,
+      brilliantChance: 0,
+      brilliantPaceBonus: 0,
+      trafficLanePressure: 0.45,
+    }),
+    defender: Object.freeze({
+      archetype: "defender",
+      gddName: "Cautious",
+      targetSpeedScalar: 0.97,
+      curveBrakeScalar: 1.18,
+      racingLineScalar: 0.85,
+      mistakeScalar: 0.7,
+      recoveryScalar: 0.75,
+      launchPaceBonus: 0,
+      fadePacePenalty: 0,
+      brilliantChance: 0,
+      brilliantPaceBonus: 0,
+      trafficLanePressure: -0.2,
+    }),
+    wet_specialist: Object.freeze({
+      archetype: "wet_specialist",
+      gddName: "Chaotic",
+      targetSpeedScalar: 1,
+      curveBrakeScalar: 0.9,
+      racingLineScalar: 1.1,
+      mistakeScalar: 1.8,
+      recoveryScalar: 1,
+      launchPaceBonus: 0.01,
+      fadePacePenalty: 0,
+      brilliantChance: 0.015,
+      brilliantPaceBonus: 0.06,
+      trafficLanePressure: 0.2,
+    }),
+    endurance: Object.freeze({
+      archetype: "endurance",
+      gddName: "Enduro",
+      targetSpeedScalar: 0.99,
+      curveBrakeScalar: 0.98,
+      racingLineScalar: 1,
+      mistakeScalar: 0.45,
+      recoveryScalar: 0.85,
+      launchPaceBonus: 0,
+      fadePacePenalty: 0,
+      brilliantChance: 0,
+      brilliantPaceBonus: 0,
+      trafficLanePressure: 0,
+    }),
+  });
+
+export const AI_ARCHETYPE_ORDER: readonly AIArchetype[] = Object.freeze([
+  "nitro_burst",
+  "clean_line",
+  "aggressive",
+  "defender",
+  "wet_specialist",
+  "endurance",
+]);
+
+export function getAIBehaviour(archetype: AIArchetype): AIBehaviour {
+  return AI_ARCHETYPE_BEHAVIOURS[archetype];
+}

--- a/src/game/aiDifficulty.ts
+++ b/src/game/aiDifficulty.ts
@@ -22,10 +22,9 @@
  *     the tier scalar captures player-facing difficulty.
  *
  *   - `recoveryScalar`: tier-level multiplier on the light AI catch-up
- *     rate. > 1 makes the AI close gaps faster (Hard, Master); < 1
- *     lets the player extend a lead (Easy). The shared consumer lives
- *     in `tickAI`; full rubber-banding policy is still a deferred §15
- *     slice.
+ *     rate. Easy gets the strongest assist, Normal is mild, Hard is
+ *     minimal, and Master disables the catch-up term. The shared
+ *     consumer lives in `tickAI`.
  *
  *   - `mistakeScalar`: tier-level multiplier on per-driver
  *     `AIDriver.mistakeRate`. > 1 makes the AI fumble more (Easy:
@@ -68,9 +67,8 @@ export interface CpuDifficultyModifiers {
    */
   readonly paceScalar: number;
   /**
-   * Multiplier on rubber-banding catch-up rate. `1.0` is Normal;
-   * > 1.0 makes the AI close gaps faster (Hard, Master); < 1.0
-   * lets the player extend a lead (Easy).
+   * Multiplier on rubber-banding catch-up rate. Easy is the maximum
+   * assist, Normal is mild, Hard is minimal, and Master is zero.
    */
   readonly recoveryScalar: number;
   /**
@@ -95,37 +93,36 @@ export const DEFAULT_CPU_TIER_ID: PlayerDifficultyPreset = "normal";
  *
  *     | Difficulty | Pace scalar | Recovery scalar | Mistake scalar |
  *     | ---------- | ----------- | --------------- | -------------- |
- *     | Easy       | 0.92        | 0.95            | 1.40           |
- *     | Normal     | 1.00        | 1.00            | 1.00           |
- *     | Hard       | 1.05        | 1.03            | 0.70           |
- *     | Master     | 1.09        | 1.05            | 0.45           |
+ *     | Easy       | 0.92        | 1.00            | 1.40           |
+ *     | Normal     | 1.00        | 0.60            | 1.00           |
+ *     | Hard       | 1.05        | 0.25            | 0.70           |
+ *     | Master     | 1.09        | 0.00            | 0.45           |
  *
- * Walking the §15 ladder top-to-bottom: pace and recovery scale
- * monotonically up, mistake scales monotonically down. Normal sits
- * at identity for every column so a per-driver scalar at Normal is
- * the unmultiplied authored value.
+ * Walking the §15 ladder top-to-bottom: pace scales up while recovery
+ * and mistakes scale down. Normal sits at identity for pace and
+ * mistakes, while recovery is the GDD's mild assist row.
  */
 export const CPU_DIFFICULTY_MODIFIERS: Readonly<
   Record<PlayerDifficultyPreset, CpuDifficultyModifiers>
 > = Object.freeze({
   easy: Object.freeze({
     paceScalar: 0.92,
-    recoveryScalar: 0.95,
+    recoveryScalar: 1,
     mistakeScalar: 1.4,
   }),
   normal: Object.freeze({
     paceScalar: 1,
-    recoveryScalar: 1,
+    recoveryScalar: 0.6,
     mistakeScalar: 1,
   }),
   hard: Object.freeze({
     paceScalar: 1.05,
-    recoveryScalar: 1.03,
+    recoveryScalar: 0.25,
     mistakeScalar: 0.7,
   }),
   master: Object.freeze({
     paceScalar: 1.09,
-    recoveryScalar: 1.05,
+    recoveryScalar: 0,
     mistakeScalar: 0.45,
   }),
 });


### PR DESCRIPTION
## Summary

Adds the full §15 AI archetype behavior dispatch on top of the existing 20-driver roster. The JSON schema wire names stay stable, while `src/game/aiArchetypes.ts` maps them to the GDD prose archetypes and gameplay traits.

## GDD links

- §15 CPU opponents and AI
- §23 CPU difficulty modifiers
- §27 AI frustration mitigation

## Requirement inventory

Handled in this PR:
- Six visible archetype behavior slots: Rocket starter, Clean line, Bully, Cautious, Chaotic, Enduro.
- Deterministic seeded behavior differences for pace, curve braking, racing-line bias, mistake frequency, traffic pressure, rocket launch and fade, and chaotic brilliant bursts.
- Light rubber-banding bounds with Master disabling the catch-up term.
- §23 CPU recovery scalars aligned to §15's Easy, Normal, Hard, and Master rubber-banding labels.

Left outside this PR-sized slice:
- Full overtake lane-shift logic.
- Explicit inside or outside pass preference.
- AI nitro firing.
- Damage-aware rub fairness scoring.

## Progress log

- `docs/PROGRESS_LOG.md`: `2026-04-30: Slice: Full AI archetypes`

## Test plan

- [x] `npx vitest run src/game/__tests__/ai.test.ts src/game/__tests__/aiDifficulty.test.ts src/game/__tests__/aiGrid.test.ts src/data/__tests__/ai-content.test.ts src/data/__tests__/balancing.test.ts`
- [x] `npm run typecheck`
- [x] `npm run verify`
- [x] Forbidden dash check on touched files
- [x] `git diff --check`

## Followups

None.
