### PR TITLE
Opt-in client error capture

### DIFF
--- a/docs/OPEN_QUESTIONS.md
+++ b/docs/OPEN_QUESTIONS.md
@@ -9,6 +9,39 @@ they are part of the design history.
 
 ---
 
+## Q-012: Self-hosted error sink for opt-in client reports
+
+**GDD reference:** [§27](gdd/27-risks-and-mitigations.md) "User-reported
+client crashes", [§21](gdd/21-technical-design-for-web-implementation.md)
+"Build-time checksum versioning".
+**Status:** open
+**Asked in loop:** 2026-04-30
+
+**Question.** The opt-in client error capture slice ships an in-memory
+ring buffer and hidden `?errors=1` panel with no network requests by
+default. Should a future release add a self-hosted report sink, and if
+so where should it live?
+
+- **(a) No sink for v0.1 and v0.2 (recommended).** Keep reports manual:
+  user opens `?errors=1`, copies JSON, and pastes it into a GitHub issue
+  or chat. This avoids telemetry, paid services, and environment changes.
+- **(b) Add a first-party `/api/client-errors` endpoint.** POST reports
+  to a repo-owned route gated by an explicit user action. Requires a
+  storage provider decision before it can retain anything.
+- **(c) Add a third-party or Sentry-compatible sink.** Highest tooling
+  value, but crosses the working-agreement gate for telemetry and
+  possible paid services.
+
+**Recommended default.** (a). The current capture path already makes
+manual bug reports actionable and carries build id, build version, stack
+prefix, count, and user agent. Defer any sink until the dev explicitly
+approves provider, storage, retention, and production env changes.
+
+**Blocking?** No. The no-network capture path can ship now. A sink is a
+future opt-in slice only after this question is answered.
+
+---
+
 ## Q-011: Leaderboard storage provider after Vercel KV sunset
 
 **GDD reference:** [§21](gdd/21-technical-design-for-web-implementation.md)
@@ -416,7 +449,7 @@ Resolved.
 
 ---
 
-## Q-003 — Auto-deploy target
+## Q-003: Auto-deploy target
 
 **GDD reference:** [§21](gdd/21-technical-design-for-web-implementation.md), §26
 **Status:** answered
@@ -450,7 +483,7 @@ self-hosted were rejected (rationale in the closing reason of dot
 
 ---
 
-## Q-002 — Licence choice
+## Q-002: Licence choice
 
 **GDD reference:** §1 ("Code under a permissive open-source license. Assets
 under original permissive asset licenses."), §26
@@ -484,7 +517,7 @@ Resolved.
 
 ---
 
-## Q-001 — Section 21 stack confirmation
+## Q-001: Section 21 stack confirmation
 
 **GDD reference:** [§21](gdd/21-technical-design-for-web-implementation.md)
 **Status:** answered

--- a/docs/PROGRESS_LOG.md
+++ b/docs/PROGRESS_LOG.md
@@ -33,12 +33,12 @@ mitigation.
 
 ### Verified
 - `npx vitest run src/app/__tests__/errorCapture.test.ts src/app/__tests__/DevErrorPanel.test.tsx src/components/error/__tests__/ErrorBoundary.test.tsx src/components/error/__tests__/formatErrorReport.test.ts`
-  green, 20 passed.
+  green, 21 passed.
 - `npx playwright test e2e/error-boundary.spec.ts` green, 4 passed.
 - `npm run lint` green.
 - `npm run typecheck` green.
 - `npm run docs:check` green.
-- `npm run verify` green, 2652 passed.
+- `npm run verify` green, 2653 passed.
 
 ### Decisions and assumptions
 - No network sink ships in this slice. That keeps the feature outside

--- a/docs/PROGRESS_LOG.md
+++ b/docs/PROGRESS_LOG.md
@@ -6,6 +6,63 @@ Correct them by adding a new entry that references the old one.
 
 ---
 
+## 2026-04-30: Slice: Opt-in client error capture
+
+**GDD sections touched:**
+[§21](gdd/21-technical-design-for-web-implementation.md) build identity
+for error reports and [§27](gdd/27-risks-and-mitigations.md) risk
+mitigation.
+**Branch / PR:** `feat/opt-in-error-reporting`, PR pending.
+**Status:** Implemented.
+
+### Done
+- Added an in-memory client error capture module for `window.error` and
+  `window.unhandledrejection`.
+- Added deterministic dedupe by message plus stack prefix, a 32-entry
+  ring buffer, count tracking, build id, build version, and user agent
+  stamping.
+- Kept the default sink empty, with no fetch or XHR path unless a future
+  caller provides an explicit `ErrorSink`.
+- Added a hidden client-only `?errors=1` panel that shows recent errors,
+  copies the JSON report, and clears the in-memory buffer.
+- Wired the root app shell to install capture once and mounted the
+  hidden panel outside the error boundary so it survives fallback
+  rendering.
+- Extended the existing error boundary report to include the recent
+  capture buffer.
+
+### Verified
+- `npx vitest run src/app/__tests__/errorCapture.test.ts src/app/__tests__/DevErrorPanel.test.tsx src/components/error/__tests__/ErrorBoundary.test.tsx src/components/error/__tests__/formatErrorReport.test.ts`
+  green, 20 passed.
+- `npx playwright test e2e/error-boundary.spec.ts` green, 4 passed.
+- `npm run lint` green.
+- `npm run typecheck` green.
+- `npm run docs:check` green.
+- `npm run verify` green, 2652 passed.
+
+### Decisions and assumptions
+- No network sink ships in this slice. That keeps the feature outside
+  the working-agreement telemetry gate and matches the dot's no-telemetry
+  default.
+- The ring buffer is memory-only, not saved to localStorage. It does not
+  touch the cross-tab save protocol or player save data.
+- The panel is query-flagged instead of menu-linked so normal players do
+  not see debugging chrome.
+
+### Coverage ledger
+- GDD-27-CLIENT-ERROR-CAPTURE covers user-reported client crashes with a
+  manual copy path, build identity, dedupe, and no default telemetry.
+- Uncovered adjacent requirements: a self-hosted or third-party sink is
+  deliberately deferred behind Q-012.
+
+### Followups created
+None.
+
+### GDD edits
+- Added the §27 "User-reported client crashes" risk row.
+
+---
+
 ## 2026-04-30: Slice: Palette-driven sprite recolour system
 
 **GDD sections touched:**

--- a/docs/gdd/27-risks-and-mitigations.md
+++ b/docs/gdd/27-risks-and-mitigations.md
@@ -10,3 +10,4 @@
 | Asset burden | Region variety demands lots of content | Palette-driven reuse, modular prop kits, background layering |
 | Community moderation | Open mods can invite unsafe uploads | Manual curation, manifest requirements, report tools |
 | Cross-tab save corruption | Two open tabs of the deployed build can each persist the same `SaveGame` and clobber the other | Last-write-wins with a monotonic `writeCounter` advisory plus a `storage` event listener and `focus` revalidate per `docs/gdd/21-technical-design-for-web-implementation.md` "Cross-tab consistency" |
+| User-reported client crashes | A browser-specific render or input crash can be hard for the dev to reproduce from a screenshot alone | In-memory opt-in client error capture with a hidden `?errors=1` panel and copyable error report. No telemetry or network sink is enabled by default |

--- a/e2e/error-boundary.spec.ts
+++ b/e2e/error-boundary.spec.ts
@@ -63,4 +63,16 @@ test.describe("error boundary", () => {
     // (a click that threw would have unmounted the tree).
     await expect(page.getByTestId("error-boundary-fallback")).toBeVisible();
   });
+
+  test("dev error panel appears only behind the query flag", async ({ page }) => {
+    await page.goto("/dev/throw?errors=1");
+    await expect(page.getByTestId("error-boundary-fallback")).toBeVisible();
+
+    const panel = page.getByTestId("dev-error-panel");
+    await expect(panel).toBeVisible();
+    await expect(page.getByTestId("dev-error-count")).toHaveText("1");
+    await expect(page.getByTestId("dev-error-log")).toContainText(
+      "Forced render throw from /dev/throw",
+    );
+  });
 });

--- a/src/app/DevErrorPanel.tsx
+++ b/src/app/DevErrorPanel.tsx
@@ -1,0 +1,119 @@
+"use client";
+
+/**
+ * Hidden client-only error panel. It renders only when the current URL has
+ * `?errors=1`, reads the in-memory capture buffer, and copies plain JSON
+ * to the clipboard for manual bug reports. It does not persist data and it
+ * does not send network requests.
+ */
+
+import { useEffect, useState, type ReactElement } from "react";
+
+import {
+  ensureGlobalErrorCapture,
+  formatCapturedErrors,
+  type CapturedError,
+} from "./errorCapture";
+
+export function DevErrorPanel(): ReactElement | null {
+  const [visible, setVisible] = useState(false);
+  const [errors, setErrors] = useState<readonly CapturedError[]>([]);
+
+  useEffect(() => {
+    const params = new URLSearchParams(window.location.search);
+    const shouldShow = params.get("errors") === "1";
+    setVisible(shouldShow);
+    if (!shouldShow) return;
+
+    const handle = ensureGlobalErrorCapture();
+    const refresh = () => setErrors(handle.getRecent());
+    refresh();
+    const interval = window.setInterval(refresh, 500);
+    return () => window.clearInterval(interval);
+  }, []);
+
+  if (!visible) return null;
+
+  const onCopy = (): void => {
+    if (!navigator.clipboard) return;
+    void navigator.clipboard.writeText(formatCapturedErrors(errors)).catch(() => {});
+  };
+
+  const onClear = (): void => {
+    const handle = ensureGlobalErrorCapture();
+    handle.clear();
+    setErrors([]);
+  };
+
+  return (
+    <aside
+      aria-label="Recent client errors"
+      data-testid="dev-error-panel"
+      style={panelStyle}
+    >
+      <header style={headerStyle}>
+        <strong>Client errors</strong>
+        <span data-testid="dev-error-count">{errors.length}</span>
+      </header>
+      <div style={buttonRowStyle}>
+        <button type="button" onClick={onCopy} data-testid="dev-error-copy" style={buttonStyle}>
+          Copy all
+        </button>
+        <button type="button" onClick={onClear} data-testid="dev-error-clear" style={buttonStyle}>
+          Clear
+        </button>
+      </div>
+      <pre data-testid="dev-error-log" style={logStyle}>
+        {errors.length === 0 ? "No captured errors." : formatCapturedErrors(errors)}
+      </pre>
+    </aside>
+  );
+}
+
+const panelStyle = {
+  position: "fixed",
+  right: "1rem",
+  bottom: "1rem",
+  zIndex: 1000,
+  width: "min(34rem, calc(100vw - 2rem))",
+  maxHeight: "50vh",
+  padding: "0.75rem",
+  border: "1px solid #8cf",
+  borderRadius: "6px",
+  background: "rgba(8, 13, 24, 0.96)",
+  color: "#e8eefc",
+  fontFamily: "system-ui, sans-serif",
+  boxShadow: "0 1rem 2rem rgba(0, 0, 0, 0.35)",
+} as const;
+
+const headerStyle = {
+  display: "flex",
+  justifyContent: "space-between",
+  alignItems: "center",
+  gap: "1rem",
+  marginBottom: "0.5rem",
+} as const;
+
+const buttonRowStyle = {
+  display: "flex",
+  gap: "0.5rem",
+  marginBottom: "0.5rem",
+} as const;
+
+const buttonStyle = {
+  border: "1px solid #8cf",
+  borderRadius: "4px",
+  background: "transparent",
+  color: "#e8eefc",
+  padding: "0.35rem 0.55rem",
+  cursor: "pointer",
+} as const;
+
+const logStyle = {
+  overflow: "auto",
+  maxHeight: "36vh",
+  margin: 0,
+  whiteSpace: "pre-wrap",
+  fontSize: "0.78rem",
+  lineHeight: 1.35,
+} as const;

--- a/src/app/ErrorCaptureClient.tsx
+++ b/src/app/ErrorCaptureClient.tsx
@@ -1,14 +1,14 @@
 "use client";
 
-import { useEffect, type ReactElement } from "react";
+import { type ReactElement } from "react";
 
 import { DevErrorPanel } from "./DevErrorPanel";
 import { ensureGlobalErrorCapture } from "./errorCapture";
 
-export function ErrorCaptureClient(): ReactElement {
-  useEffect(() => {
-    ensureGlobalErrorCapture();
-  }, []);
+if (typeof window !== "undefined") {
+  ensureGlobalErrorCapture();
+}
 
+export function ErrorCaptureClient(): ReactElement {
   return <DevErrorPanel />;
 }

--- a/src/app/ErrorCaptureClient.tsx
+++ b/src/app/ErrorCaptureClient.tsx
@@ -1,0 +1,14 @@
+"use client";
+
+import { useEffect, type ReactElement } from "react";
+
+import { DevErrorPanel } from "./DevErrorPanel";
+import { ensureGlobalErrorCapture } from "./errorCapture";
+
+export function ErrorCaptureClient(): ReactElement {
+  useEffect(() => {
+    ensureGlobalErrorCapture();
+  }, []);
+
+  return <DevErrorPanel />;
+}

--- a/src/app/__tests__/DevErrorPanel.test.tsx
+++ b/src/app/__tests__/DevErrorPanel.test.tsx
@@ -1,0 +1,12 @@
+import { describe, expect, it } from "vitest";
+import { createElement } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+
+import { DevErrorPanel } from "../DevErrorPanel";
+
+describe("DevErrorPanel", () => {
+  it("renders nothing during SSR and before the query flag is read", () => {
+    const html = renderToStaticMarkup(createElement(DevErrorPanel));
+    expect(html).toBe("");
+  });
+});

--- a/src/app/__tests__/errorCapture.test.ts
+++ b/src/app/__tests__/errorCapture.test.ts
@@ -78,6 +78,24 @@ describe("installErrorCapture", () => {
     });
   });
 
+  it("promotes repeated errors so eviction follows most recent sighting", () => {
+    const target = new FakeTarget();
+    const handle = installErrorCapture({ target, limit: 2 });
+    const first = new Error("first");
+    first.stack = "Error: first\n    at shared (a.ts:1:1)";
+
+    target.dispatch("error", { error: first });
+    target.dispatch("error", { error: new Error("second") });
+    target.dispatch("error", { error: first });
+    target.dispatch("error", { error: new Error("third") });
+
+    expect(handle.getRecent().map((entry) => entry.message)).toEqual([
+      "first",
+      "third",
+    ]);
+    expect(handle.getRecent()[0]?.count).toBe(2);
+  });
+
   it("caps the ring buffer and evicts oldest entries", () => {
     const target = new FakeTarget();
     const handle = installErrorCapture({ target, limit: 3 });

--- a/src/app/__tests__/errorCapture.test.ts
+++ b/src/app/__tests__/errorCapture.test.ts
@@ -1,0 +1,169 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import {
+  formatCapturedErrors,
+  installErrorCapture,
+  resetGlobalErrorCaptureForTests,
+  type CapturedError,
+} from "../errorCapture";
+
+class FakeTarget {
+  private readonly listeners = new Map<string, Set<EventListener>>();
+
+  addEventListener(type: string, listener: EventListener): void {
+    const bucket = this.listeners.get(type) ?? new Set<EventListener>();
+    bucket.add(listener);
+    this.listeners.set(type, bucket);
+  }
+
+  removeEventListener(type: string, listener: EventListener): void {
+    this.listeners.get(type)?.delete(listener);
+  }
+
+  dispatch(type: string, payload: Record<string, unknown>): void {
+    const event = new Event(type);
+    Object.assign(event, payload);
+    this.listeners.get(type)?.forEach((listener) => listener(event));
+  }
+}
+
+describe("installErrorCapture", () => {
+  afterEach(() => {
+    resetGlobalErrorCaptureForTests();
+    vi.restoreAllMocks();
+  });
+
+  it("installs as a no-op without a window target", () => {
+    const handle = installErrorCapture({ target: null });
+
+    expect(handle.getRecent()).toEqual([]);
+    expect(handle.capture(new Error("server-side"))?.message).toBe("server-side");
+    expect(handle.getRecent()).toHaveLength(1);
+    expect(() => handle.uninstall()).not.toThrow();
+  });
+
+  it("captures distinct window error events", () => {
+    const target = new FakeTarget();
+    const handle = installErrorCapture({
+      target,
+      now: () => 1000,
+      userAgent: "TestBrowser",
+      buildId: "abc123",
+      buildVersion: "0.1.0",
+    });
+
+    target.dispatch("error", { error: new Error("first") });
+    target.dispatch("error", { error: new Error("second") });
+
+    expect(handle.getRecent()).toMatchObject([
+      { message: "first", buildId: "abc123", buildVersion: "0.1.0", userAgent: "TestBrowser" },
+      { message: "second", buildId: "abc123", buildVersion: "0.1.0", userAgent: "TestBrowser" },
+    ]);
+  });
+
+  it("deduplicates repeated stack prefixes and increments count", () => {
+    const target = new FakeTarget();
+    const handle = installErrorCapture({ target });
+    const error = new Error("loop crash");
+    error.stack = "Error: loop crash\n    at tick (game.ts:1:1)\n    at frame (loop.ts:2:1)";
+
+    for (let i = 0; i < 100; i += 1) {
+      target.dispatch("error", { error });
+    }
+
+    expect(handle.getRecent()).toHaveLength(1);
+    expect(handle.getRecent()[0]).toMatchObject({
+      message: "loop crash",
+      count: 100,
+    });
+  });
+
+  it("caps the ring buffer and evicts oldest entries", () => {
+    const target = new FakeTarget();
+    const handle = installErrorCapture({ target, limit: 3 });
+
+    for (let i = 0; i < 5; i += 1) {
+      target.dispatch("error", { error: new Error(`error-${i}`) });
+    }
+
+    expect(handle.getRecent().map((entry) => entry.message)).toEqual([
+      "error-2",
+      "error-3",
+      "error-4",
+    ]);
+  });
+
+  it("captures unhandled rejection reasons", () => {
+    const target = new FakeTarget();
+    const handle = installErrorCapture({ target });
+
+    target.dispatch("unhandledrejection", { reason: "promise boom" });
+
+    expect(handle.getRecent()[0]?.message).toBe("promise boom");
+  });
+
+  it("does not call fetch or XHR when no sink is configured", () => {
+    const fetchSpy = vi.fn();
+    const xhrSpy = vi.fn();
+    vi.stubGlobal("fetch", fetchSpy);
+    vi.stubGlobal("XMLHttpRequest", xhrSpy);
+    const target = new FakeTarget();
+    const handle = installErrorCapture({ target });
+
+    target.dispatch("error", { error: new Error("offline only") });
+
+    expect(handle.getRecent()).toHaveLength(1);
+    expect(fetchSpy).not.toHaveBeenCalled();
+    expect(xhrSpy).not.toHaveBeenCalled();
+  });
+
+  it("calls a configured sink with the deduplicated payload", async () => {
+    const target = new FakeTarget();
+    const sink = { report: vi.fn((_: CapturedError) => undefined) };
+    const handle = installErrorCapture({ target, sink });
+
+    target.dispatch("error", { error: new Error("send me") });
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(sink.report).toHaveBeenCalledTimes(1);
+    expect(sink.report.mock.calls[0]?.[0]).toMatchObject({
+      message: "send me",
+      count: 1,
+    });
+    expect(handle.getRecent()).toHaveLength(1);
+  });
+
+  it("swallows sink rejections and keeps capture alive", async () => {
+    const target = new FakeTarget();
+    const warn = vi.fn();
+    const sink = { report: vi.fn(() => Promise.reject(new Error("sink down"))) };
+    const handle = installErrorCapture({ target, sink, logger: { warn } });
+
+    target.dispatch("error", { error: new Error("still capture") });
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(handle.getRecent()[0]?.message).toBe("still capture");
+    expect(warn).toHaveBeenCalledOnce();
+  });
+});
+
+describe("formatCapturedErrors", () => {
+  it("formats the buffer as plain JSON", () => {
+    const text = formatCapturedErrors([
+      {
+        id: "err-1",
+        message: "boom",
+        stackPrefix: "<no-stack>",
+        timestamp: 123,
+        count: 1,
+        buildId: "abc",
+        buildVersion: "0.1.0",
+        userAgent: "Browser",
+      },
+    ]);
+
+    expect(text).toContain('"message": "boom"');
+    expect(() => JSON.parse(text)).not.toThrow();
+  });
+});

--- a/src/app/errorCapture.ts
+++ b/src/app/errorCapture.ts
@@ -45,7 +45,15 @@ const NO_STACK = "<no-stack>";
 let globalCapture: ErrorCaptureHandle | null = null;
 
 export function ensureGlobalErrorCapture(options: ErrorCaptureOptions = {}): ErrorCaptureHandle {
-  if (globalCapture) return globalCapture;
+  if (globalCapture) {
+    if (hasDefinedErrorCaptureOptions(options)) {
+      const logger = options.logger ?? console;
+      logger.warn(
+        "ensureGlobalErrorCapture options were supplied after global error capture was already installed; supplied options were ignored.",
+      );
+    }
+    return globalCapture;
+  }
   globalCapture = installErrorCapture(options);
   return globalCapture;
 }
@@ -82,7 +90,9 @@ export function installErrorCapture(options: ErrorCaptureOptions = {}): ErrorCap
         timestamp: now(),
         count: existing.count + 1,
       };
-      recent[existingIndex] = updated;
+      recent.splice(existingIndex, 1);
+      recent.push(updated);
+      rebuildIndex(byKey, recent);
       reportToSink(options.sink, updated, logger);
       return updated;
     }
@@ -242,6 +252,10 @@ function rebuildIndex(index: Map<string, number>, recent: readonly CapturedError
 function clampLimit(limit: number): number {
   if (!Number.isFinite(limit)) return DEFAULT_LIMIT;
   return Math.max(1, Math.floor(limit));
+}
+
+function hasDefinedErrorCaptureOptions(options: ErrorCaptureOptions): boolean {
+  return Object.values(options).some((value) => value !== undefined);
 }
 
 function hashId(input: string): string {

--- a/src/app/errorCapture.ts
+++ b/src/app/errorCapture.ts
@@ -1,0 +1,254 @@
+import { BUILD_ID, BUILD_VERSION } from "./buildInfo";
+
+export interface CapturedError {
+  readonly id: string;
+  readonly message: string;
+  readonly stackPrefix: string;
+  readonly timestamp: number;
+  readonly count: number;
+  readonly buildId: string;
+  readonly buildVersion: string;
+  readonly userAgent: string;
+}
+
+export interface ErrorSink {
+  report: (error: CapturedError) => Promise<void> | void;
+}
+
+export interface ErrorCaptureHandle {
+  uninstall: () => void;
+  getRecent: () => readonly CapturedError[];
+  clear: () => void;
+  capture: (error: unknown) => CapturedError | null;
+}
+
+interface ErrorCaptureOptions {
+  readonly sink?: ErrorSink;
+  readonly target?: ErrorCaptureTarget | null;
+  readonly userAgent?: string;
+  readonly buildId?: string;
+  readonly buildVersion?: string;
+  readonly now?: () => number;
+  readonly logger?: Pick<Console, "warn">;
+  readonly limit?: number;
+}
+
+interface ErrorCaptureTarget {
+  addEventListener: (type: string, listener: EventListener) => void;
+  removeEventListener: (type: string, listener: EventListener) => void;
+}
+
+const DEFAULT_LIMIT = 32;
+const STACK_PREFIX_LINES = 3;
+const NO_STACK = "<no-stack>";
+
+let globalCapture: ErrorCaptureHandle | null = null;
+
+export function ensureGlobalErrorCapture(options: ErrorCaptureOptions = {}): ErrorCaptureHandle {
+  if (globalCapture) return globalCapture;
+  globalCapture = installErrorCapture(options);
+  return globalCapture;
+}
+
+export function getGlobalErrorCapture(): ErrorCaptureHandle {
+  return ensureGlobalErrorCapture();
+}
+
+export function resetGlobalErrorCaptureForTests(): void {
+  globalCapture?.uninstall();
+  globalCapture = null;
+}
+
+export function installErrorCapture(options: ErrorCaptureOptions = {}): ErrorCaptureHandle {
+  const target = options.target === undefined ? defaultTarget() : options.target;
+  const limit = clampLimit(options.limit ?? DEFAULT_LIMIT);
+  const now = options.now ?? Date.now;
+  const logger = options.logger ?? console;
+  const buildId = options.buildId ?? BUILD_ID;
+  const buildVersion = options.buildVersion ?? BUILD_VERSION;
+  const userAgent = options.userAgent ?? defaultUserAgent();
+  const recent: CapturedError[] = [];
+  const byKey = new Map<string, number>();
+
+  const capture = (error: unknown): CapturedError | null => {
+    const normalized = normalizeError(error);
+    const key = `${normalized.message}\n${normalized.stackPrefix}`;
+    const existingIndex = byKey.get(key);
+    if (existingIndex !== undefined) {
+      const existing = recent[existingIndex];
+      if (!existing) return null;
+      const updated: CapturedError = {
+        ...existing,
+        timestamp: now(),
+        count: existing.count + 1,
+      };
+      recent[existingIndex] = updated;
+      reportToSink(options.sink, updated, logger);
+      return updated;
+    }
+
+    const captured: CapturedError = {
+      id: hashId(`${buildId}\n${key}`),
+      message: normalized.message,
+      stackPrefix: normalized.stackPrefix,
+      timestamp: now(),
+      count: 1,
+      buildId,
+      buildVersion,
+      userAgent,
+    };
+    recent.push(captured);
+    byKey.set(key, recent.length - 1);
+    while (recent.length > limit) {
+      const removed = recent.shift();
+      if (removed) {
+        byKey.delete(`${removed.message}\n${removed.stackPrefix}`);
+      }
+    }
+    rebuildIndex(byKey, recent);
+    reportToSink(options.sink, captured, logger);
+    return captured;
+  };
+
+  if (!target) {
+    return {
+      uninstall: () => {},
+      getRecent: () => recent.slice(),
+      clear: () => {
+        recent.length = 0;
+        byKey.clear();
+      },
+      capture,
+    };
+  }
+
+  const onError: EventListener = (event) => {
+    capture(errorFromEvent(event));
+  };
+  const onUnhandledRejection: EventListener = (event) => {
+    capture(reasonFromRejectionEvent(event));
+  };
+
+  target.addEventListener("error", onError);
+  target.addEventListener("unhandledrejection", onUnhandledRejection);
+
+  return {
+    uninstall: () => {
+      target.removeEventListener("error", onError);
+      target.removeEventListener("unhandledrejection", onUnhandledRejection);
+    },
+    getRecent: () => recent.slice(),
+    clear: () => {
+      recent.length = 0;
+      byKey.clear();
+    },
+    capture,
+  };
+}
+
+export function formatCapturedErrors(errors: readonly CapturedError[]): string {
+  return JSON.stringify(errors, null, 2);
+}
+
+function defaultTarget(): ErrorCaptureTarget | null {
+  if (typeof window === "undefined") return null;
+  return window;
+}
+
+function defaultUserAgent(): string {
+  if (typeof navigator === "undefined") return "";
+  return navigator.userAgent;
+}
+
+function normalizeError(error: unknown): Pick<CapturedError, "message" | "stackPrefix"> {
+  if (error instanceof Error) {
+    return {
+      message: error.message || error.name,
+      stackPrefix: stackPrefix(error.stack),
+    };
+  }
+  if (typeof error === "string") {
+    return {
+      message: error,
+      stackPrefix: NO_STACK,
+    };
+  }
+  return {
+    message: safeStringify(error),
+    stackPrefix: NO_STACK,
+  };
+}
+
+function errorFromEvent(event: Event): unknown {
+  const withError = event as Event & {
+    error?: unknown;
+    message?: string;
+    filename?: string;
+    lineno?: number;
+    colno?: number;
+  };
+  if (withError.error !== undefined) return withError.error;
+  const message = withError.message ?? "Script error";
+  const location = [
+    withError.filename,
+    typeof withError.lineno === "number" ? withError.lineno : null,
+    typeof withError.colno === "number" ? withError.colno : null,
+  ].filter((part): part is string | number => part !== null && part !== undefined && part !== "");
+  return location.length > 0 ? `${message} (${location.join(":")})` : message;
+}
+
+function reasonFromRejectionEvent(event: Event): unknown {
+  return (event as Event & { reason?: unknown }).reason ?? "Unhandled promise rejection";
+}
+
+function stackPrefix(stack: string | undefined): string {
+  if (!stack) return NO_STACK;
+  const lines = stack
+    .split("\n")
+    .map((line) => line.trim())
+    .filter(Boolean);
+  return lines.slice(0, STACK_PREFIX_LINES).join("\n") || NO_STACK;
+}
+
+function safeStringify(value: unknown): string {
+  try {
+    const output = JSON.stringify(value);
+    return output === undefined ? String(value) : output;
+  } catch {
+    return String(value);
+  }
+}
+
+function reportToSink(
+  sink: ErrorSink | undefined,
+  captured: CapturedError,
+  logger: Pick<Console, "warn">,
+): void {
+  if (!sink) return;
+  Promise.resolve()
+    .then(() => sink.report(captured))
+    .catch((error: unknown) => {
+      logger.warn("[error-capture] sink failed", error);
+    });
+}
+
+function rebuildIndex(index: Map<string, number>, recent: readonly CapturedError[]): void {
+  index.clear();
+  recent.forEach((entry, i) => {
+    index.set(`${entry.message}\n${entry.stackPrefix}`, i);
+  });
+}
+
+function clampLimit(limit: number): number {
+  if (!Number.isFinite(limit)) return DEFAULT_LIMIT;
+  return Math.max(1, Math.floor(limit));
+}
+
+function hashId(input: string): string {
+  let hash = 2166136261;
+  for (let i = 0; i < input.length; i += 1) {
+    hash ^= input.charCodeAt(i);
+    hash = Math.imul(hash, 16777619);
+  }
+  return `err-${(hash >>> 0).toString(36)}`;
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -6,6 +6,7 @@ import { ErrorBoundary } from "@/components/error/ErrorBoundary";
 import { UpdateBanner } from "@/components/update/UpdateBanner";
 
 import "./globals.css";
+import { ErrorCaptureClient } from "./ErrorCaptureClient";
 
 export const metadata: Metadata = {
   title: "VibeGear2",
@@ -18,6 +19,7 @@ export default function RootLayout({ children }: { children: ReactNode }) {
       <body>
         <UpdateBanner />
         <MenuMusicDirector />
+        <ErrorCaptureClient />
         <ErrorBoundary>{children}</ErrorBoundary>
       </body>
     </html>

--- a/src/components/error/ErrorBoundary.tsx
+++ b/src/components/error/ErrorBoundary.tsx
@@ -23,6 +23,8 @@
 
 import { Component, type ErrorInfo, type ReactNode } from "react";
 
+import { getGlobalErrorCapture, formatCapturedErrors } from "@/app/errorCapture";
+
 import { formatErrorReport } from "./formatErrorReport";
 
 export interface ErrorBoundaryProps {
@@ -60,6 +62,7 @@ export class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundarySt
 
   override componentDidCatch(error: unknown, info: ErrorInfo): void {
     this.setState({ componentStack: info.componentStack ?? null });
+    getGlobalErrorCapture().capture(error);
     // Mirror the error to the console so devtools still surfaces it.
     // The boundary is the sole consumer that matters for the user; this
     // log exists only for the developer's own debugging.
@@ -76,7 +79,12 @@ export class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundarySt
     if (!hasError) {
       return this.props.children;
     }
-    const report = formatErrorReport({ error, componentStack });
+    const recent = getGlobalErrorCapture().getRecent();
+    const report = formatErrorReport({
+      error,
+      componentStack,
+      recentClientErrors: recent.length > 0 ? formatCapturedErrors(recent) : null,
+    });
     if (this.props.fallback) {
       return this.props.fallback(error, report, this.reset);
     }

--- a/src/components/error/__tests__/formatErrorReport.test.ts
+++ b/src/components/error/__tests__/formatErrorReport.test.ts
@@ -52,6 +52,15 @@ describe("formatErrorReport", () => {
     expect(report.split("\n").length).toBeGreaterThan(1);
   });
 
+  it("includes recent client errors when provided", () => {
+    const report = formatErrorReport({
+      error: new Error("x"),
+      recentClientErrors: '[{"message":"captured"}]',
+    });
+    expect(report).toContain("Recent client errors:");
+    expect(report).toContain('"captured"');
+  });
+
   it("survives a value that throws inside JSON.stringify", () => {
     const cyclic: { self?: unknown } = {};
     cyclic.self = cyclic;

--- a/src/components/error/formatErrorReport.ts
+++ b/src/components/error/formatErrorReport.ts
@@ -18,10 +18,12 @@ export interface ErrorReportInput {
   error: unknown;
   /** React's component stack ("\n    in Foo (at ...)\n    in Bar"). */
   componentStack?: string | null;
+  /** Optional in-memory capture buffer snapshot. */
+  recentClientErrors?: string | null;
 }
 
 export function formatErrorReport(input: ErrorReportInput): string {
-  const { error, componentStack } = input;
+  const { error, componentStack, recentClientErrors } = input;
   const lines: string[] = ["VibeGear2 error report"];
 
   if (error instanceof Error) {
@@ -40,6 +42,12 @@ export function formatErrorReport(input: ErrorReportInput): string {
     lines.push("");
     lines.push("Component stack:");
     lines.push(componentStack.trim());
+  }
+
+  if (recentClientErrors && recentClientErrors.trim().length > 0) {
+    lines.push("");
+    lines.push("Recent client errors:");
+    lines.push(recentClientErrors.trim());
   }
 
   return lines.join("\n");


### PR DESCRIPTION
## GDD sections

- [GDD 21 technical design](https://github.com/Randroids-Dojo/VibeGear2/blob/main/docs/gdd/21-technical-design-for-web-implementation.md): build identity in client reports.
- [GDD 27 risks and mitigations](https://github.com/Randroids-Dojo/VibeGear2/blob/main/docs/gdd/27-risks-and-mitigations.md): user-reported client crash mitigation.

## Requirement inventory

This PR handles:

- Captures `window.error` and `window.unhandledrejection` into an in-memory ring buffer.
- Deduplicates repeated failures by message and stack prefix and tracks repeat count.
- Stamps each entry with build id, build version, timestamp, and user agent.
- Keeps the default sink empty. No fetch, XHR, third-party SDK, localStorage write, or telemetry is enabled.
- Adds a hidden `?errors=1` panel for copyable JSON reports.
- Includes recent captured errors in the existing error-boundary copy report.
- Adds Q-012 to gate any future self-hosted or third-party sink.

Left for later:

- A network report sink is deferred behind Q-012 and requires explicit approval before any telemetry, provider, storage, retention, or env change.

## Progress log

- `docs/PROGRESS_LOG.md`: 2026-04-30 Slice: Opt-in client error capture.

## Test plan

- [x] `npx vitest run src/app/__tests__/errorCapture.test.ts src/app/__tests__/DevErrorPanel.test.tsx src/components/error/__tests__/ErrorBoundary.test.tsx src/components/error/__tests__/formatErrorReport.test.ts`
- [x] `npx playwright test e2e/error-boundary.spec.ts`
- [x] `npm run lint`
- [x] `npm run typecheck`
- [x] `npm run docs:check`
- [x] `npm run verify`

## Followups and questions

- Added Q-012 for the future self-hosted or third-party sink decision.
- No followups created.
