### PR TITLE
Region art theme registry

### DIFF
--- a/docs/GDD_COVERAGE.json
+++ b/docs/GDD_COVERAGE.json
@@ -2,6 +2,27 @@
   "version": 1,
   "requirements": [
     {
+      "id": "GDD-17-REGION-THEME-REGISTRY",
+      "gddSections": [
+        "docs/gdd/08-world-and-progression-design.md",
+        "docs/gdd/14-weather-and-environmental-systems.md",
+        "docs/gdd/17-art-direction.md",
+        "docs/gdd/22-data-schemas.md"
+      ],
+      "requirement": "Each World Tour region has a typed art theme package covering palette, sky treatment, road shoulder type, prop categories, weather presets, tunnel materials, and UI accent color. Bundled track weather options must be allowed by the owning region theme.",
+      "coverage": ["implemented-code", "automated-test"],
+      "implementationRefs": [
+        "src/data/schemas.ts",
+        "src/data/regions/",
+        "src/data/index.ts",
+        "docs/gdd/22-data-schemas.md"
+      ],
+      "testRefs": [
+        "src/data/regions/__tests__/regions-content.test.ts"
+      ],
+      "followupRefs": ["VibeGear2-implement-region-art-43d6f582"]
+    },
+    {
       "id": "GDD-17-PLACEHOLDER-ART-MANIFEST",
       "gddSections": [
         "docs/gdd/17-art-direction.md",

--- a/docs/PROGRESS_LOG.md
+++ b/docs/PROGRESS_LOG.md
@@ -6,6 +6,75 @@ Correct them by adding a new entry that references the old one.
 
 ---
 
+## 2026-04-30: Slice: Region art theme registry
+
+**GDD sections touched:**
+[§8](gdd/08-world-and-progression-design.md) original tours,
+[§14](gdd/14-weather-and-environmental-systems.md) track-specific weather,
+[§17](gdd/17-art-direction.md) region art themes, and
+[§22](gdd/22-data-schemas.md) data schemas.
+**Branch / PR:** `feat/region-art-theme-registry`, PR pending.
+**Status:** Implemented.
+
+### Done
+- Added `RegionThemeSchema` for the seven §17 region art fields:
+  palette, sky treatment, road shoulder type, prop categories, weather
+  presets, tunnel materials, and UI accent color.
+- Added eight static region theme JSON files for the World Tour regions
+  from §8.
+- Added `src/data/regions/index.ts` with `REGIONS`, `REGIONS_BY_ID`,
+  `REGION_IDS`, and `loadRegion(id)`.
+- Re-exported the region registry through the shared data barrel.
+- Added content tests that validate every region, pin deterministic
+  loading, check UI accent contrast, and assert bundled track weather is
+  allowed by the owning region.
+- Documented the region theme JSON contract in §22 and added the
+  machine-checkable coverage ledger row.
+
+### Verified
+- `npx vitest run src/data/regions/__tests__/regions-content.test.ts src/data/palettes/__tests__/regionPalettes.test.ts src/data/__tests__/tracks-content.test.ts`
+  green, 38 passed.
+- `npx vitest run src/data/regions/__tests__/regions-content.test.ts`
+  green, 6 passed.
+- `npm run typecheck` green.
+- `npm run docs:check` green.
+- `npm run content-lint` green.
+- `npm run verify` green, 2659 passed.
+- `npm run build` green.
+- `node -e "JSON.parse(require('fs').readFileSync('docs/GDD_COVERAGE.json','utf8')); console.log('ok')"`
+  green.
+- `grep -rn $'\u2014\|\u2013' src/data/regions src/data/schemas.ts docs/gdd/22-data-schemas.md`
+  returned nothing.
+
+### Decisions and assumptions
+- Kept `TrackSchema.tourId` as the region key instead of renaming track
+  JSON. That preserves existing content and keeps the registry consumer
+  contract clear.
+- Used the current `WeatherOptionSchema` ids for region weather presets.
+  Region profiles that describe visual variants like heat haze, dust storm,
+  crosswind visuals, or neon rain map to the nearest existing weather ids
+  until a later weather-taxonomy slice adds new ids.
+- Included the current first-two-tour authored track weather in the region
+  presets so the new validation can be enforced immediately without
+  invalidating shipped MVP tracks.
+
+### Coverage ledger
+- GDD-17-REGION-THEME-REGISTRY covers typed World Tour region art packages,
+  static region loading, §8 weather-profile pins, UI accent readability, and
+  track weather validation against region presets.
+- Uncovered adjacent requirements: renderer consumers still need to read
+  region sky, horizon, shoulder, tunnel material, prop categories, and UI
+  accent data instead of local defaults.
+
+### Followups created
+None.
+
+### GDD edits
+- Added the `RegionTheme` JSON schema and bundled track weather validation
+  rule to [§22](gdd/22-data-schemas.md).
+
+---
+
 ## 2026-04-30: Slice: Opt-in client error capture
 
 **GDD sections touched:**

--- a/docs/gdd/22-data-schemas.md
+++ b/docs/gdd/22-data-schemas.md
@@ -179,6 +179,39 @@ colors from §16: amber road-edge warnings, red severe damage, cyan wet-grip
 UI, magenta or electric-blue nitro-full readout, and clean PB green or record
 gold.
 
+## Region theme JSON schema
+
+Region theme files define the art-direction package for each tour. Palette
+files own sprite recolouring. Region themes own the wider world-art contract
+that renderers, HUD accents, weather setup, and track validation read.
+
+```
+{
+  "id": "velvet-coast",
+  "name": "Velvet Coast",
+  "palette": {
+    "sky": "#16304f",
+    "horizon": "#356f83",
+    "road": "#5f5f5a",
+    "shoulder": "#263047",
+    "grass": "#2e6e36",
+    "accent": "#e8d15f"
+  },
+  "skyTreatment": "clear",
+  "roadShoulderType": "guardrail",
+  "propCategories": ["resorts", "marinas", "cliff-roads", "guardrails"],
+  "weatherPresets": ["clear", "dusk", "light_rain", "rain", "fog"],
+  "tunnelMaterials": ["coastal-concrete", "white-tile", "service-lighting"],
+  "uiAccent": "#f2cf5b"
+}
+```
+
+`src/data/schemas.ts` owns `RegionThemeSchema`. `src/data/regions/index.ts`
+statically registers the eight v1.0 World Tour regions and exposes
+`loadRegion(id)`. Bundled track content must reference a known `tourId`, and
+each track `weatherOptions` entry must be included in that region's
+`weatherPresets`.
+
 ## Hazard registry JSON schema
 
 ```

--- a/src/data/index.ts
+++ b/src/data/index.ts
@@ -31,6 +31,12 @@ export {
   HAZARDS_BY_ID,
   getHazard,
 } from "./hazards";
+export {
+  REGION_IDS,
+  REGIONS,
+  REGIONS_BY_ID,
+  loadRegion,
+} from "./regions";
 
 import { compileTrack } from "@/road/trackCompiler";
 import type { CompiledTrack } from "@/road/types";

--- a/src/data/regions/__tests__/regions-content.test.ts
+++ b/src/data/regions/__tests__/regions-content.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, it } from "vitest";
+
+import { REGION_IDS, REGIONS, REGIONS_BY_ID, TRACK_RAW, loadRegion } from "@/data";
+import { RegionThemeSchema, TrackSchema } from "@/data/schemas";
+import { parseHexColor } from "@/data/palettes";
+
+const EXPECTED_REGION_IDS = [
+  "breakwater-isles",
+  "crown-circuit",
+  "ember-steppe",
+  "glass-ridge",
+  "iron-borough",
+  "moss-frontier",
+  "neon-meridian",
+  "velvet-coast",
+];
+
+const REQUIRED_REGION_WEATHER: Readonly<Record<string, readonly string[]>> = {
+  "velvet-coast": ["clear", "dusk", "light_rain"],
+  "iron-borough": ["overcast", "fog"],
+  "ember-steppe": ["clear"],
+  "breakwater-isles": ["rain", "heavy_rain"],
+  "glass-ridge": ["snow", "fog", "dusk"],
+  "neon-meridian": ["night", "rain"],
+  "moss-frontier": ["heavy_rain", "fog"],
+  "crown-circuit": ["clear", "rain", "fog", "snow"],
+};
+
+describe("region art theme registry", () => {
+  it("registers the eight World Tour regions", () => {
+    expect([...REGION_IDS].sort()).toEqual(EXPECTED_REGION_IDS);
+  });
+
+  it("validates every shipped region theme", () => {
+    expect(REGIONS).toHaveLength(8);
+    for (const region of REGIONS) {
+      const parsed = RegionThemeSchema.safeParse(region);
+      if (!parsed.success) {
+        throw new Error(
+          `RegionThemeSchema rejected ${region.id}: ${JSON.stringify(parsed.error.issues, null, 2)}`,
+        );
+      }
+      expect(REGIONS_BY_ID[region.id]).toBe(region);
+    }
+  });
+
+  it("loads deterministic region objects", () => {
+    const first = loadRegion("velvet-coast");
+    const second = loadRegion("velvet-coast");
+    expect(first.palette.sky).toBe("#16304f");
+    expect(first).toEqual(second);
+    expect(first).toBe(second);
+  });
+
+  it("includes the GDD weather profile for each region", () => {
+    for (const [regionId, requiredWeather] of Object.entries(REQUIRED_REGION_WEATHER)) {
+      const region = loadRegion(regionId);
+      for (const weather of requiredWeather) {
+        expect(region.weatherPresets).toContain(weather);
+      }
+    }
+  });
+
+  it("allows every bundled track weather option through its region theme", () => {
+    for (const [id, raw] of Object.entries(TRACK_RAW)) {
+      const parsed = TrackSchema.parse(raw);
+      if (id.startsWith("test/")) continue;
+      const region = loadRegion(parsed.tourId);
+      for (const weather of parsed.weatherOptions) {
+        expect(region.weatherPresets, `${id} ${weather}`).toContain(weather);
+      }
+    }
+  });
+
+  it("gives every UI accent readable contrast against the shoulder color", () => {
+    for (const region of REGIONS) {
+      expect(
+        contrastRatio(region.uiAccent, region.palette.shoulder),
+        region.id,
+      ).toBeGreaterThanOrEqual(4.5);
+    }
+  });
+});
+
+function contrastRatio(a: string, b: string): number {
+  const l1 = relativeLuminance(a);
+  const l2 = relativeLuminance(b);
+  const light = Math.max(l1, l2);
+  const dark = Math.min(l1, l2);
+  return (light + 0.05) / (dark + 0.05);
+}
+
+function relativeLuminance(hex: string): number {
+  const { r, g, b } = parseHexColor(hex);
+  return (
+    0.2126 * linearChannel(r) +
+    0.7152 * linearChannel(g) +
+    0.0722 * linearChannel(b)
+  );
+}
+
+function linearChannel(channel: number): number {
+  const value = channel / 255;
+  return value <= 0.03928 ? value / 12.92 : ((value + 0.055) / 1.055) ** 2.4;
+}

--- a/src/data/regions/breakwater-isles.json
+++ b/src/data/regions/breakwater-isles.json
@@ -1,0 +1,18 @@
+{
+  "id": "breakwater-isles",
+  "name": "Breakwater Isles",
+  "palette": {
+    "sky": "#15324a",
+    "horizon": "#3d6d78",
+    "road": "#596164",
+    "shoulder": "#1f3038",
+    "grass": "#2f6147",
+    "accent": "#72c8d4"
+  },
+  "skyTreatment": "storm",
+  "roadShoulderType": "concrete",
+  "propCategories": ["causeways", "sea-bridges", "harbor-lights", "spray-barriers"],
+  "weatherPresets": ["rain", "heavy_rain", "overcast"],
+  "tunnelMaterials": ["wet-concrete", "sea-wall-tile", "cool-white-lighting"],
+  "uiAccent": "#8ed9e2"
+}

--- a/src/data/regions/crown-circuit.json
+++ b/src/data/regions/crown-circuit.json
@@ -1,0 +1,18 @@
+{
+  "id": "crown-circuit",
+  "name": "Crown Circuit",
+  "palette": {
+    "sky": "#18284e",
+    "horizon": "#4c5c7a",
+    "road": "#555762",
+    "shoulder": "#252535",
+    "grass": "#33573d",
+    "accent": "#d8cf87"
+  },
+  "skyTreatment": "mixed",
+  "roadShoulderType": "cliff-edge",
+  "propCategories": ["finale-hubs", "international-banners", "cliff-edges", "grandstands"],
+  "weatherPresets": ["clear", "rain", "fog", "snow"],
+  "tunnelMaterials": ["polished-concrete", "gold-trim", "broadcast-lighting"],
+  "uiAccent": "#f0dc84"
+}

--- a/src/data/regions/ember-steppe.json
+++ b/src/data/regions/ember-steppe.json
@@ -1,0 +1,18 @@
+{
+  "id": "ember-steppe",
+  "name": "Ember Steppe",
+  "palette": {
+    "sky": "#26334f",
+    "horizon": "#7c6353",
+    "road": "#635d54",
+    "shoulder": "#2b2d35",
+    "grass": "#6f5b35",
+    "accent": "#d98a4b"
+  },
+  "skyTreatment": "desert-haze",
+  "roadShoulderType": "sand",
+  "propCategories": ["desert-highways", "canyon-walls", "heat-signs", "rock-spires"],
+  "weatherPresets": ["clear", "fog"],
+  "tunnelMaterials": ["sandstone", "dark-asphalt", "amber-work-lights"],
+  "uiAccent": "#f0a05a"
+}

--- a/src/data/regions/glass-ridge.json
+++ b/src/data/regions/glass-ridge.json
@@ -1,0 +1,18 @@
+{
+  "id": "glass-ridge",
+  "name": "Glass Ridge",
+  "palette": {
+    "sky": "#172a4b",
+    "horizon": "#6f8295",
+    "road": "#60686c",
+    "shoulder": "#23313a",
+    "grass": "#586f78",
+    "accent": "#9ad7e6"
+  },
+  "skyTreatment": "snow",
+  "roadShoulderType": "snowbank",
+  "propCategories": ["alpine-passes", "snowbanks", "tunnels", "warning-posts"],
+  "weatherPresets": ["snow", "fog", "dusk"],
+  "tunnelMaterials": ["cold-concrete", "ice-tile", "blue-safety-lighting"],
+  "uiAccent": "#b7edf5"
+}

--- a/src/data/regions/index.ts
+++ b/src/data/regions/index.ts
@@ -1,0 +1,40 @@
+import breakwaterIsles from "./breakwater-isles.json";
+import crownCircuit from "./crown-circuit.json";
+import emberSteppe from "./ember-steppe.json";
+import glassRidge from "./glass-ridge.json";
+import ironBorough from "./iron-borough.json";
+import mossFrontier from "./moss-frontier.json";
+import neonMeridian from "./neon-meridian.json";
+import velvetCoast from "./velvet-coast.json";
+import { RegionThemeSchema, type RegionTheme } from "../schemas";
+
+export const REGIONS: readonly RegionTheme[] = Object.freeze(
+  [
+    velvetCoast,
+    ironBorough,
+    emberSteppe,
+    breakwaterIsles,
+    glassRidge,
+    neonMeridian,
+    mossFrontier,
+    crownCircuit,
+  ].map((region) => Object.freeze(RegionThemeSchema.parse(region))),
+);
+
+export const REGIONS_BY_ID = Object.freeze(
+  Object.fromEntries(REGIONS.map((region) => [region.id, region])),
+) as Readonly<Record<string, RegionTheme>>;
+
+export const REGION_IDS: readonly string[] = Object.freeze(
+  REGIONS.map((region) => region.id),
+);
+
+export function loadRegion(id: string): RegionTheme {
+  const region = REGIONS_BY_ID[id];
+  if (region === undefined) {
+    throw new Error(
+      `loadRegion: unknown region id "${id}". Known ids: ${REGION_IDS.join(", ")}`,
+    );
+  }
+  return region;
+}

--- a/src/data/regions/iron-borough.json
+++ b/src/data/regions/iron-borough.json
@@ -1,0 +1,18 @@
+{
+  "id": "iron-borough",
+  "name": "Iron Borough",
+  "palette": {
+    "sky": "#192638",
+    "horizon": "#4b5863",
+    "road": "#565b5e",
+    "shoulder": "#202832",
+    "grass": "#36413d",
+    "accent": "#7ba7c7"
+  },
+  "skyTreatment": "overcast",
+  "roadShoulderType": "concrete",
+  "propCategories": ["industrial-ports", "ring-roads", "gantries", "barriers"],
+  "weatherPresets": ["overcast", "fog", "clear", "rain"],
+  "tunnelMaterials": ["ribbed-concrete", "steel-panel", "sodium-lighting"],
+  "uiAccent": "#8db6d8"
+}

--- a/src/data/regions/moss-frontier.json
+++ b/src/data/regions/moss-frontier.json
@@ -1,0 +1,18 @@
+{
+  "id": "moss-frontier",
+  "name": "Moss Frontier",
+  "palette": {
+    "sky": "#17344a",
+    "horizon": "#49725d",
+    "road": "#535c52",
+    "shoulder": "#203126",
+    "grass": "#2f6238",
+    "accent": "#9bcf79"
+  },
+  "skyTreatment": "fog",
+  "roadShoulderType": "gravel",
+  "propCategories": ["forest-highways", "villages", "mist-signs", "wood-rails"],
+  "weatherPresets": ["heavy_rain", "rain", "fog"],
+  "tunnelMaterials": ["moss-concrete", "timber-brace", "warm-lamp-lighting"],
+  "uiAccent": "#b5df8d"
+}

--- a/src/data/regions/neon-meridian.json
+++ b/src/data/regions/neon-meridian.json
@@ -1,0 +1,18 @@
+{
+  "id": "neon-meridian",
+  "name": "Neon Meridian",
+  "palette": {
+    "sky": "#101d45",
+    "horizon": "#334d74",
+    "road": "#4d5264",
+    "shoulder": "#1d2638",
+    "grass": "#263a52",
+    "accent": "#c38cff"
+  },
+  "skyTreatment": "night-neon",
+  "roadShoulderType": "neon-curb",
+  "propCategories": ["metro-outskirts", "neon-signs", "glass-rails", "rain-pylons"],
+  "weatherPresets": ["night", "rain", "dusk"],
+  "tunnelMaterials": ["black-ceramic", "neon-strip", "violet-service-lighting"],
+  "uiAccent": "#d9a6ff"
+}

--- a/src/data/regions/velvet-coast.json
+++ b/src/data/regions/velvet-coast.json
@@ -1,0 +1,18 @@
+{
+  "id": "velvet-coast",
+  "name": "Velvet Coast",
+  "palette": {
+    "sky": "#16304f",
+    "horizon": "#356f83",
+    "road": "#5f5f5a",
+    "shoulder": "#263047",
+    "grass": "#2e6e36",
+    "accent": "#e8d15f"
+  },
+  "skyTreatment": "clear",
+  "roadShoulderType": "guardrail",
+  "propCategories": ["resorts", "marinas", "cliff-roads", "guardrails"],
+  "weatherPresets": ["clear", "dusk", "light_rain", "rain", "fog"],
+  "tunnelMaterials": ["coastal-concrete", "white-tile", "service-lighting"],
+  "uiAccent": "#f2cf5b"
+}

--- a/src/data/schemas.ts
+++ b/src/data/schemas.ts
@@ -99,9 +99,9 @@ export const RegionThemeSchema = z.object({
   palette: RegionThemePaletteSchema,
   skyTreatment: SkyTreatmentSchema,
   roadShoulderType: RoadShoulderTypeSchema,
-  propCategories: z.array(z.string().min(1)).min(1),
+  propCategories: z.array(slug).min(1),
   weatherPresets: z.array(WeatherOptionSchema).min(1),
-  tunnelMaterials: z.array(z.string().min(1)).min(1),
+  tunnelMaterials: z.array(slug).min(1),
   uiAccent: HexColorSchema,
 });
 export type RegionTheme = z.infer<typeof RegionThemeSchema>;

--- a/src/data/schemas.ts
+++ b/src/data/schemas.ts
@@ -14,7 +14,7 @@
 
 import { z } from "zod";
 
-import { RegionPaletteSchema } from "./palettes/_schema";
+import { HexColorSchema, RegionPaletteSchema } from "./palettes/_schema";
 
 // Shared primitives ---------------------------------------------------------
 
@@ -56,6 +56,55 @@ export const WeatherOptionSchema = z.enum([
   "night",
 ]);
 export type WeatherOption = z.infer<typeof WeatherOptionSchema>;
+
+// Region theme --------------------------------------------------------------
+
+export const SkyTreatmentSchema = z.enum([
+  "clear",
+  "overcast",
+  "dusk",
+  "night-neon",
+  "snow",
+  "fog",
+  "desert-haze",
+  "storm",
+  "mixed",
+]);
+export type SkyTreatment = z.infer<typeof SkyTreatmentSchema>;
+
+export const RoadShoulderTypeSchema = z.enum([
+  "sand",
+  "guardrail",
+  "concrete",
+  "snowbank",
+  "gravel",
+  "neon-curb",
+  "cliff-edge",
+]);
+export type RoadShoulderType = z.infer<typeof RoadShoulderTypeSchema>;
+
+export const RegionThemePaletteSchema = z.object({
+  sky: HexColorSchema,
+  horizon: HexColorSchema,
+  road: HexColorSchema,
+  shoulder: HexColorSchema,
+  grass: HexColorSchema,
+  accent: HexColorSchema,
+});
+export type RegionThemePalette = z.infer<typeof RegionThemePaletteSchema>;
+
+export const RegionThemeSchema = z.object({
+  id: singleSegmentSlug,
+  name: z.string().min(1),
+  palette: RegionThemePaletteSchema,
+  skyTreatment: SkyTreatmentSchema,
+  roadShoulderType: RoadShoulderTypeSchema,
+  propCategories: z.array(z.string().min(1)).min(1),
+  weatherPresets: z.array(WeatherOptionSchema).min(1),
+  tunnelMaterials: z.array(z.string().min(1)).min(1),
+  uiAccent: HexColorSchema,
+});
+export type RegionTheme = z.infer<typeof RegionThemeSchema>;
 
 export const HazardKindSchema = z.enum([
   "puddle",


### PR DESCRIPTION
## Summary
- Add RegionThemeSchema for the seven GDD region art fields.
- Add eight World Tour region JSON theme records and a static loadRegion registry.
- Validate region content, UI accent contrast, deterministic loading, and track weather against region presets.

## GDD links
- docs/gdd/08-world-and-progression-design.md
- docs/gdd/14-weather-and-environmental-systems.md
- docs/gdd/17-art-direction.md
- docs/gdd/22-data-schemas.md

## Requirement inventory
- Handles typed per-region palette, sky treatment, shoulder type, prop categories, weather presets, tunnel materials, and UI accent.
- Handles static loading for the eight v1.0 World Tour regions.
- Handles bundled track weather validation against the owning region.
- Leaves renderer consumers to later slices: sky, horizon, shoulder, tunnel material, prop kit, and HUD accent wiring still read local defaults.

## Progress log
- docs/PROGRESS_LOG.md: Region art theme registry
- Coverage ledger: GDD-17-REGION-THEME-REGISTRY

## Test plan
- [x] npx vitest run src/data/regions/__tests__/regions-content.test.ts src/data/palettes/__tests__/regionPalettes.test.ts src/data/__tests__/tracks-content.test.ts
- [x] npm run typecheck
- [x] npm run docs:check
- [x] npm run content-lint
- [x] npm run lint
- [x] npm run verify
- [x] npm run build
- [x] grep -rn $'\u2014\|\u2013' src/data/regions src/data/schemas.ts src/data/index.ts docs/gdd/22-data-schemas.md docs/GDD_COVERAGE.json docs/PROGRESS_LOG.md

## Followups
- None.