### PR TITLE
Node 24 GitHub Actions runtime

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,9 +31,9 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: 20
           cache: npm
@@ -70,7 +70,7 @@ jobs:
 
       - name: Upload Playwright report on failure
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: playwright-report
           path: playwright-report
@@ -87,9 +87,9 @@ jobs:
     timeout-minutes: 5
     continue-on-error: true
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: 20
           cache: npm
@@ -115,9 +115,9 @@ jobs:
       name: production
       url: ${{ env.PRODUCTION_URL }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: 20
 

--- a/.github/workflows/labels.yml
+++ b/.github/workflows/labels.yml
@@ -17,10 +17,10 @@ jobs:
     name: Sync GitHub issue labels
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Sync labels
-        uses: crazy-max/ghaction-github-labeler@v5
+        uses: crazy-max/ghaction-github-labeler@v6
         with:
           yaml-file: .github/labels.yml
           skip-delete: true

--- a/docs/PROGRESS_LOG.md
+++ b/docs/PROGRESS_LOG.md
@@ -6,6 +6,47 @@ Correct them by adding a new entry that references the old one.
 
 ---
 
+## 2026-04-30: Slice: Node 24 GitHub Actions runtime
+
+**Branch / PR:** `chore/node24-github-actions`, PR pending.
+**Status:** Implemented.
+
+### Done
+- Updated CI workflow actions that execute on GitHub's action runtime:
+  `actions/checkout` to `v6`, `actions/setup-node` to `v6`, and
+  `actions/upload-artifact` to `v7`.
+- Updated the label sync workflow to use `actions/checkout@v6` and
+  `crazy-max/ghaction-github-labeler@v6`.
+- Kept the project verification runtime pinned to Node 20. The warning was
+  about the action runtime, not the Vite and test runtime for the game.
+
+### Verified
+- `ruby -e "require 'yaml'; ['.github/workflows/ci.yml','.github/workflows/labels.yml'].each { |f| YAML.load_file(f); puts \"#{f}: ok\" }"`
+  green.
+- `npm run docs:check` green.
+- `npm run content-lint` green.
+- `npm run lint` green.
+- `grep -rn $'\u2014\|\u2013' .github/workflows/ci.yml .github/workflows/labels.yml docs/PROGRESS_LOG.md`
+  returned nothing.
+
+### Decisions and assumptions
+- Treated the GitHub Actions annotation as a maintenance blocker because
+  Node.js 20 action runtime compatibility changes begin on June 2, 2026 and
+  removal is scheduled for September 16, 2026.
+- Did not change `node-version: 20` in CI. That belongs in a separate
+  runtime upgrade slice if the project decides to move the app toolchain.
+
+### Coverage ledger
+- No GDD coverage change. This is CI maintenance.
+
+### Followups created
+None.
+
+### GDD edits
+None.
+
+---
+
 ## 2026-04-30: Slice: Region art theme registry
 
 **GDD sections touched:**


### PR DESCRIPTION
## Summary
- Update GitHub-hosted action runtime dependencies to Node 24 compatible major versions.
- Keep the project test runtime on Node 20 because this slice only addresses action runtime deprecation warnings.
- Log the maintenance slice in docs/PROGRESS_LOG.md.

## GDD
- No GDD change. This is CI maintenance.

## Progress log
- docs/PROGRESS_LOG.md entry: 2026-04-30: Slice: Node 24 GitHub Actions runtime

## Test plan
- ruby -e "require 'yaml'; ['.github/workflows/ci.yml','.github/workflows/labels.yml'].each { |f| YAML.load_file(f); puts \"#{f}: ok\" }"\n- npm run docs:check\n- npm run content-lint\n- npm run lint\n- grep -rn $'\\u2014\\|\\u2013' .github/workflows/ci.yml .github/workflows/labels.yml docs/PROGRESS_LOG.md\n\n## Followups\n- None\n