### PR TITLE
Daily Challenge result share

### DIFF
--- a/docs/GDD_COVERAGE.json
+++ b/docs/GDD_COVERAGE.json
@@ -208,6 +208,28 @@
       "followupRefs": []
     },
     {
+      "id": "GDD-06-DAILY-CHALLENGE-RESULT-SHARE",
+      "gddSections": [
+        "docs/gdd/06-game-modes.md",
+        "docs/gdd/20-hud-and-ui-ux.md",
+        "docs/gdd/21-technical-design-for-web-implementation.md"
+      ],
+      "requirement": "Finished Daily Challenge runs carry the fixed daily marker into the race result and render a copyable share string based on the actual best lap.",
+      "coverage": ["implemented-code", "automated-test"],
+      "implementationRefs": [
+        "src/game/modes/dailyChallenge.ts",
+        "src/game/raceResult.ts",
+        "src/app/race/page.tsx",
+        "src/app/race/results/page.tsx"
+      ],
+      "testRefs": [
+        "src/game/modes/__tests__/dailyChallenge.test.ts",
+        "src/game/__tests__/raceResult.test.ts",
+        "e2e/results-screen.spec.ts"
+      ],
+      "followupRefs": ["VibeGear2-implement-result-backed-4fece8d6"]
+    },
+    {
       "id": "GDD-06-TIME-TRIAL-PB-RECORDS",
       "gddSections": [
         "docs/gdd/06-game-modes.md",

--- a/docs/PROGRESS_LOG.md
+++ b/docs/PROGRESS_LOG.md
@@ -6,6 +6,61 @@ Correct them by adding a new entry that references the old one.
 
 ---
 
+## 2026-04-30: Slice: Daily Challenge result share
+
+**GDD sections touched:**
+[§6](gdd/06-game-modes.md) Community challenge,
+[§20](gdd/20-hud-and-ui-ux.md) results screen, and
+[§21](gdd/21-technical-design-for-web-implementation.md) local runtime.
+**Branch / PR:** `feat/daily-result-share`, PR pending.
+**Status:** Implemented.
+
+### Done
+- Extended Daily Challenge race links with the UTC date key, seed, and
+  recommended car class so the race can identify a daily run after the
+  route hop.
+- Added an optional Daily Challenge marker to `RaceResult` and carried it
+  through both natural-finish and retire result handoffs for marked
+  Time Trial runs.
+- Rendered a Daily Challenge share panel on the results screen when a
+  marked result is present. The copied text uses the player's actual
+  best lap when available.
+- Added the machine-checkable coverage ledger row for the result-share
+  requirement.
+
+### Verified
+- `npx vitest run src/game/modes/__tests__/dailyChallenge.test.ts src/game/__tests__/raceResult.test.ts`
+  green, 71 tests passed.
+- `npm run typecheck` green.
+- `npx playwright test e2e/results-screen.spec.ts --project=chromium -g "Daily Challenge share|all seven"`
+  green, 2 tests passed.
+- `npm run build` green.
+- `npm run verify` green, 2660 Vitest tests passed.
+- `grep -rn $'\u2014\|\u2013' src/game/modes/dailyChallenge.ts src/game/modes/__tests__/dailyChallenge.test.ts src/game/raceResult.ts src/game/__tests__/raceResult.test.ts src/app/race/page.tsx src/app/race/results/page.tsx e2e/results-screen.spec.ts docs/GDD_COVERAGE.json docs/PROGRESS_LOG.md`
+  returned nothing.
+
+### Decisions and assumptions
+- Kept Daily Challenge as a marked Time Trial run rather than adding a
+  separate race mode. That preserves the no-economy, no-damage path and
+  keeps the slice focused on the missing share-result handoff.
+- A marked Daily Challenge without a completed lap still renders the
+  existing `no result` share text.
+
+### Coverage ledger
+- GDD-06-DAILY-CHALLENGE-RESULT-SHARE covers the Daily Challenge result
+  marker, result-screen share panel, and actual-best-lap share string.
+- Uncovered adjacent requirements: developer benchmark display,
+  downloaded ghost selection, and UTC-midnight fake-clock e2e remain
+  under the §6 modes parent dot.
+
+### Followups created
+None.
+
+### GDD edits
+None.
+
+---
+
 ## 2026-04-30: Slice: Node 24 GitHub Actions runtime
 
 **Branch / PR:** `chore/node24-github-actions`, PR pending.

--- a/e2e/results-screen.spec.ts
+++ b/e2e/results-screen.spec.ts
@@ -79,6 +79,19 @@ const SEED_TOUR_RESULT = {
   },
 };
 
+const SEED_DAILY_RESULT = {
+  ...SEED_RESULT,
+  trackId: "velvet-coast/harbor-run",
+  creditsAwarded: 0,
+  dailyChallenge: {
+    dateKey: "2026-04-30",
+    seed: 123456,
+    trackId: "velvet-coast/harbor-run",
+    weather: "rain",
+    carClass: "balance",
+  },
+};
+
 test.describe("race results screen", () => {
   test("renders all seven §20 fields and both CTAs", async ({ page }) => {
     await page.goto("/race/results");
@@ -190,6 +203,30 @@ test.describe("race results screen", () => {
     await expect(page).toHaveURL(
       /\/race\?track=velvet-coast%2Fsunpier-loop&tour=velvet-coast&raceIndex=1$/,
     );
+  });
+
+  test("renders result-backed Daily Challenge share text", async ({
+    context,
+    page,
+  }) => {
+    await page.goto("/race/results");
+    await context.grantPermissions(["clipboard-read", "clipboard-write"], {
+      origin: new URL(page.url()).origin,
+    });
+    await page.evaluate(
+      ([key, payload]) => {
+        sessionStorage.setItem(key, payload);
+      },
+      [STORAGE_KEY, JSON.stringify(SEED_DAILY_RESULT)] as const,
+    );
+    await page.reload();
+
+    await expect(page.getByTestId("results-daily-share")).toBeVisible();
+    await expect(page.getByTestId("daily-share-text")).toHaveValue(
+      /VibeGear2 Daily 2026-04-30 0:30.000 velvet-coast\/harbor-run rain balance/,
+    );
+    await page.getByTestId("daily-share").click();
+    await expect(page.getByTestId("daily-share-status")).toHaveText("Copied");
   });
 
   test("direct nav with no result renders the empty fallback", async ({

--- a/src/app/race/page.tsx
+++ b/src/app/race/page.tsx
@@ -106,11 +106,13 @@ import {
   nitroUpgradeTierForUpgrades,
 } from "@/game/nitro";
 import {
+  CarClassSchema,
   WeatherOptionSchema,
   type AIDriver,
   type CarBaseStats,
   type WeatherOption,
 } from "@/data/schemas";
+import type { DailyChallengeSelection } from "@/game/modes/dailyChallenge";
 import {
   CAMERA_DEPTH,
   CAMERA_HEIGHT,
@@ -441,6 +443,32 @@ function resolveRaceWeather(
   return track.compiled.weatherOptions.includes(parsed.data) ? parsed.data : undefined;
 }
 
+function resolveDailyChallengeMarker(input: {
+  mode: RaceMode;
+  dateKey: string | null;
+  seed: string | null;
+  carClass: string | null;
+  trackId: string;
+  weather: RaceSessionConfig["weather"];
+}): DailyChallengeSelection | null {
+  if (input.mode !== "timeTrial") return null;
+  if (input.weather === undefined) return null;
+  if (input.dateKey === null || !/^\d{4}-\d{2}-\d{2}$/.test(input.dateKey)) {
+    return null;
+  }
+  const seed = Number(input.seed);
+  if (!Number.isSafeInteger(seed) || seed < 0) return null;
+  const carClass = CarClassSchema.safeParse(input.carClass);
+  if (!carClass.success) return null;
+  return {
+    dateKey: input.dateKey,
+    seed,
+    trackId: input.trackId,
+    weather: input.weather,
+    carClass: carClass.data,
+  };
+}
+
 function resolvePlayerTire(raw: string | null): TireKind | undefined {
   return raw === "wet" || raw === "dry" ? raw : undefined;
 }
@@ -656,6 +684,9 @@ function RaceShell(): ReactElement {
   const weatherRaw = search?.get("weather") ?? null;
   const tireRaw = search?.get("tire") ?? null;
   const carRaw = search?.get("car") ?? null;
+  const dailyDateKeyRaw = search?.get("daily") ?? null;
+  const dailySeedRaw = search?.get("dailySeed") ?? null;
+  const dailyCarClassRaw = search?.get("carClass") ?? null;
   const tourId = search?.get("tour") ?? null;
   const raceIndexRaw = search?.get("raceIndex") ?? null;
   const tourContext = useMemo(
@@ -672,6 +703,18 @@ function RaceShell(): ReactElement {
     () => resolveRaceWeather(weatherRaw, track),
     [track, weatherRaw],
   );
+  const dailyChallenge = useMemo(
+    () =>
+      resolveDailyChallengeMarker({
+        mode,
+        dateKey: dailyDateKeyRaw,
+        seed: dailySeedRaw,
+        carClass: dailyCarClassRaw,
+        trackId: track.id,
+        weather,
+      }),
+    [dailyCarClassRaw, dailyDateKeyRaw, dailySeedRaw, mode, track.id, weather],
+  );
   const playerTire = useMemo(() => resolvePlayerTire(tireRaw), [tireRaw]);
   return (
     <RaceCanvas
@@ -682,6 +725,7 @@ function RaceShell(): ReactElement {
       weather={weather}
       playerTire={playerTire}
       selectedCarId={carRaw}
+      dailyChallenge={dailyChallenge}
     />
   );
 }
@@ -694,6 +738,7 @@ interface RaceCanvasProps {
   weather: RaceSessionConfig["weather"];
   playerTire: TireKind | undefined;
   selectedCarId: string | null;
+  dailyChallenge: DailyChallengeSelection | null;
 }
 
 function RaceCanvas({
@@ -704,6 +749,7 @@ function RaceCanvas({
   weather,
   playerTire,
   selectedCarId,
+  dailyChallenge,
 }: RaceCanvasProps): ReactElement {
   const router = useRouter();
   const canvasRef = useRef<HTMLCanvasElement | null>(null);
@@ -1133,6 +1179,7 @@ function RaceCanvas({
         championship: tourContext?.championship,
         tourId: tourContext?.tourId,
         currentTrackIndex: tourContext?.raceIndex,
+        dailyChallenge,
       });
       // F-034: credit the wallet (DNF cars receive the §12 participation
       // cash) and mirror the delta onto `RaceResult.creditsAwarded` so
@@ -1457,6 +1504,7 @@ function RaceCanvas({
               championship: tourContext?.championship,
               tourId: tourContext?.tourId,
               currentTrackIndex: tourContext?.raceIndex,
+              dailyChallenge,
             });
             // F-034: credit the wallet from the same numbers the
             // results screen will render. The `commitRaceCredits`
@@ -1552,6 +1600,7 @@ function RaceCanvas({
     weather,
     playerTire,
     selectedCarId,
+    dailyChallenge,
   ]);
 
   return (

--- a/src/app/race/page.tsx
+++ b/src/app/race/page.tsx
@@ -456,7 +456,8 @@ function resolveDailyChallengeMarker(input: {
   if (input.dateKey === null || !/^\d{4}-\d{2}-\d{2}$/.test(input.dateKey)) {
     return null;
   }
-  const seed = Number(input.seed);
+  if (input.seed === null || !/^\d+$/.test(input.seed.trim())) return null;
+  const seed = Number.parseInt(input.seed, 10);
   if (!Number.isSafeInteger(seed) || seed < 0) return null;
   const carClass = CarClassSchema.safeParse(input.carClass);
   if (!carClass.success) return null;

--- a/src/app/race/results/page.tsx
+++ b/src/app/race/results/page.tsx
@@ -47,6 +47,8 @@ import {
   clearRaceResult,
   loadRaceResult,
 } from "@/components/results/raceResultStorage";
+import { DailyShareButton } from "@/app/daily/DailyShareButton";
+import { formatDailyChallengeShareText } from "@/game/modes/dailyChallenge";
 import type { RaceResult } from "@/game/raceResult";
 import type { FinalCarRecord } from "@/game/raceRules";
 
@@ -134,6 +136,9 @@ function ResultsView(props: ResultsViewProps): ReactElement {
   );
   const playerFinished = playerRow?.status === "finished";
   const playerBestLapMs = playerRow?.bestLapMs ?? null;
+  const dailyShareText = result.dailyChallenge
+    ? formatDailyChallengeShareText(result.dailyChallenge, playerBestLapMs)
+    : null;
   const tourProgress = result.tourProgress ?? null;
   const continueTourHref =
     result.nextRace && tourProgress && tourProgress.nextRaceIndex !== null
@@ -248,6 +253,19 @@ function ResultsView(props: ResultsViewProps): ReactElement {
             bestLapMs={playerBestLapMs}
             playerFinished={playerFinished}
           />
+
+          {dailyShareText ? (
+            <section
+              data-testid="results-daily-share"
+              style={dailySharePanelStyle}
+              aria-labelledby="results-daily-share-title"
+            >
+              <h3 id="results-daily-share-title" style={subHeading}>
+                Daily Challenge
+              </h3>
+              <DailyShareButton text={dailyShareText} />
+            </section>
+          ) : null}
         </div>
       </section>
 
@@ -449,6 +467,12 @@ const fastestStyle: CSSProperties = {
 const nextStyle: CSSProperties = {
   margin: 0,
   fontSize: "0.95rem",
+};
+
+const dailySharePanelStyle: CSSProperties = {
+  display: "grid",
+  gap: "0.5rem",
+  marginTop: "0.2rem",
 };
 
 const ctaRowStyle: CSSProperties = {

--- a/src/game/__tests__/raceResult.test.ts
+++ b/src/game/__tests__/raceResult.test.ts
@@ -602,6 +602,25 @@ describe("buildRaceResult: records patch", () => {
   });
 });
 
+describe("buildRaceResult: Daily Challenge marker", () => {
+  it("carries the Daily Challenge marker without changing records logic", () => {
+    const dailyChallenge = {
+      dateKey: "2026-04-30",
+      seed: 123456,
+      trackId: "test-circuit",
+      weather: "rain" as const,
+      carClass: "balance" as const,
+    };
+    const result = buildRaceResult(makeInput({ dailyChallenge }));
+
+    expect(result.dailyChallenge).toEqual(dailyChallenge);
+    expect(result.recordsUpdated).toEqual({
+      trackId: "test-circuit",
+      bestLapMs: 30_000,
+    });
+  });
+});
+
 describe("buildRaceResult: purity and determinism", () => {
   it("does not mutate frozen inputs", () => {
     const final = Object.freeze(makeFinalState());

--- a/src/game/modes/__tests__/dailyChallenge.test.ts
+++ b/src/game/modes/__tests__/dailyChallenge.test.ts
@@ -125,6 +125,9 @@ describe("dailyChallengeRaceHref", () => {
     expect(href).toContain("mode=timeTrial");
     expect(href).toContain(`track=${encodeURIComponent(challenge.trackId)}`);
     expect(href).toContain(`weather=${challenge.weather}`);
+    expect(href).toContain(`daily=${challenge.dateKey}`);
+    expect(href).toContain(`dailySeed=${challenge.seed}`);
+    expect(href).toContain(`carClass=${challenge.carClass}`);
   });
 });
 

--- a/src/game/modes/dailyChallenge.ts
+++ b/src/game/modes/dailyChallenge.ts
@@ -78,6 +78,9 @@ export function dailyChallengeRaceHref(
     mode: "timeTrial",
     track: challenge.trackId,
     weather: challenge.weather,
+    daily: challenge.dateKey,
+    dailySeed: `${challenge.seed}`,
+    carClass: challenge.carClass,
   });
   return `/race?${params.toString()}`;
 }

--- a/src/game/raceResult.ts
+++ b/src/game/raceResult.ts
@@ -56,6 +56,7 @@ import {
   computeRaceReward,
   DNF_PARTICIPATION_CREDITS,
 } from "./economy";
+import type { DailyChallengeSelection } from "./modes/dailyChallenge";
 import {
   computeBonuses,
   sponsorBonus,
@@ -197,6 +198,10 @@ export interface RecordsUpdatePatch {
  *   - `recordsUpdated`: optional patch the caller applies if the mode
  *     records PBs. `null` when no PB was set or when the player did not
  *     complete a single timed lap.
+ *
+ *   - `dailyChallenge`: optional marker carried from the Daily Challenge
+ *     entry route. Results uses it to render a share string based on the
+ *     actual run instead of the pre-race placeholder.
  */
 export interface RaceResult {
   trackId: string;
@@ -213,6 +218,7 @@ export interface RaceResult {
   fastestLap: FinalRaceState["fastestLap"];
   nextRace: NextRaceCard | null;
   tourProgress?: TourResultProgress | null;
+  dailyChallenge?: DailyChallengeSelection | null;
   recordsUpdated: RecordsUpdatePatch | null;
 }
 
@@ -283,6 +289,8 @@ export interface BuildRaceResultInput {
    * sponsor predicate fails closed (no bonus credited).
    */
   sponsorContext?: SponsorEvaluationContext | null;
+  /** Daily Challenge marker carried from the entry route, if any. */
+  dailyChallenge?: DailyChallengeSelection | null;
 }
 
 const ZERO_DAMAGE: DamageDelta = Object.freeze({ engine: 0, tires: 0, body: 0 });
@@ -338,6 +346,7 @@ export function buildRaceResult(input: BuildRaceResultInput): RaceResult {
     currentTrackIndex,
     sponsor = null,
     sponsorContext = null,
+    dailyChallenge = null,
   } = input;
 
   // Resolve the per-track base reward. Caller override wins; otherwise
@@ -472,6 +481,7 @@ export function buildRaceResult(input: BuildRaceResultInput): RaceResult {
     fastestLap: finalState.fastestLap,
     nextRace,
     tourProgress,
+    dailyChallenge,
     recordsUpdated,
   };
 }


### PR DESCRIPTION
## Summary
- Carry Daily Challenge markers from the daily entry route into Time Trial race results.
- Render a result-screen share panel that uses the actual best lap.
- Add coverage ledger and progress log entries for the daily result-share requirement.

## GDD
- §6 Community challenge
- §20 Results screen
- §21 Local runtime

## Progress log
- docs/PROGRESS_LOG.md entry: 2026-04-30: Slice: Daily Challenge result share

## Test plan
- npx vitest run src/game/modes/__tests__/dailyChallenge.test.ts src/game/__tests__/raceResult.test.ts
- npm run typecheck
- npx playwright test e2e/results-screen.spec.ts --project=chromium -g "Daily Challenge share|all seven"
- npm run build
- npm run verify
- forbidden dash scan over touched files returned nothing

## Followups
- None
