### PR TITLE
Time Trial benchmark launch page

### DIFF
--- a/docs/GDD_COVERAGE.json
+++ b/docs/GDD_COVERAGE.json
@@ -250,6 +250,27 @@
       "followupRefs": []
     },
     {
+      "id": "GDD-06-TIME-TRIAL-BENCHMARK-LAUNCH",
+      "gddSections": [
+        "docs/gdd/06-game-modes.md",
+        "docs/gdd/20-hud-and-ui-ux.md",
+        "docs/gdd/21-technical-design-for-web-implementation.md"
+      ],
+      "requirement": "The Time Trial entry surface lists unlocked tracks, shows saved personal bests, displays official developer benchmark targets, and starts the selected track in Time Trial mode.",
+      "coverage": ["implemented-code", "automated-test"],
+      "implementationRefs": [
+        "src/game/modes/timeTrialTargets.ts",
+        "src/app/time-trial/page.tsx",
+        "src/app/page.tsx"
+      ],
+      "testRefs": [
+        "src/game/modes/__tests__/timeTrialTargets.test.ts",
+        "e2e/time-trial.spec.ts",
+        "e2e/title-screen.spec.ts"
+      ],
+      "followupRefs": ["VibeGear2-implement-time-trial-9135b1e7"]
+    },
+    {
       "id": "GDD-06-QUICK-RACE-MODE",
       "gddSections": [
         "docs/gdd/06-game-modes.md",

--- a/docs/PROGRESS_LOG.md
+++ b/docs/PROGRESS_LOG.md
@@ -6,6 +6,57 @@ Correct them by adding a new entry that references the old one.
 
 ---
 
+## 2026-04-30: Slice: Time Trial benchmark launch page
+
+**GDD sections touched:**
+[§6](gdd/06-game-modes.md) Time Trial,
+[§20](gdd/20-hud-and-ui-ux.md) entry UI, and
+[§21](gdd/21-technical-design-for-web-implementation.md) local runtime.
+**Branch / PR:** `feat/time-trial-benchmarks`, PR pending.
+**Status:** Implemented.
+
+### Done
+- Replaced the `/time-trial` redirect with a launch page that lists
+  unlocked Time Trial tracks.
+- Added a pure Time Trial view builder that carries saved PB lap and
+  race records, official benchmark targets, default weather, and
+  race-start links.
+- Added official benchmark targets for the current bundled Velvet Coast
+  and Iron Borough tracks.
+- Updated title-screen navigation coverage to expect the launch page.
+- Added the machine-checkable coverage ledger row for the Time Trial
+  benchmark-launch requirement.
+
+### Verified
+- `npx vitest run src/game/modes/__tests__/timeTrialTargets.test.ts`
+  green, 5 tests passed.
+- `npm run typecheck` green.
+- `npx playwright test e2e/time-trial.spec.ts e2e/title-screen.spec.ts --project=chromium -g "time trial|Time Trial"`
+  green, 2 tests passed.
+- `npm run lint` green.
+- `npm run verify` green, 2665 Vitest tests passed.
+
+### Decisions and assumptions
+- Treated developer benchmarks as display-only official targets. They do
+  not gate progression and do not replace PB persistence.
+- Kept downloaded ghost selection out of this slice so the Time Trial
+  entry surface could land as a PR-sized change.
+
+### Coverage ledger
+- GDD-06-TIME-TRIAL-BENCHMARK-LAUNCH covers unlocked track listing,
+  personal best display, developer benchmark display, and Time Trial
+  start links.
+- Uncovered adjacent requirements: downloaded ghost selection and
+  UTC-midnight fake-clock e2e remain under the §6 modes parent dot.
+
+### Followups created
+None.
+
+### GDD edits
+None.
+
+---
+
 ## 2026-04-30: Slice: Daily Challenge result share
 
 **GDD sections touched:**

--- a/e2e/time-trial.spec.ts
+++ b/e2e/time-trial.spec.ts
@@ -1,0 +1,87 @@
+import { expect, test } from "@playwright/test";
+
+const SAVE_KEY = "vibegear2:save:v4";
+
+test.describe("time trial launch page", () => {
+  test("lists unlocked tracks with benchmark targets and PBs", async ({
+    page,
+  }) => {
+    await page.goto("/");
+    await page.evaluate(
+      ({ key, save }) => window.localStorage.setItem(key, JSON.stringify(save)),
+      { key: SAVE_KEY, save: buildSeedSave() },
+    );
+
+    await page.goto("/time-trial");
+
+    await expect(page.getByTestId("time-trial-page")).toBeVisible();
+    await expect(
+      page.getByTestId("time-trial-track-velvet-coast/harbor-run"),
+    ).toBeVisible();
+    await expect(
+      page.getByTestId("time-trial-pb-velvet-coast/harbor-run"),
+    ).toHaveText("00:30.000");
+    await expect(
+      page.getByTestId("time-trial-benchmark-velvet-coast/harbor-run"),
+    ).toHaveText("00:31.500");
+    await expect(
+      page.getByTestId("time-trial-start-velvet-coast/harbor-run"),
+    ).toHaveAttribute(
+      "href",
+      "/race?mode=timeTrial&track=velvet-coast%2Fharbor-run&weather=clear",
+    );
+  });
+});
+
+function buildSeedSave() {
+  return {
+    version: 4,
+    profileName: "Test Driver",
+    settings: {
+      displaySpeedUnit: "kph",
+      assists: {
+        steeringAssist: false,
+        autoNitro: false,
+        weatherVisualReduction: false,
+        autoAccelerate: false,
+        brakeAssist: false,
+        steeringSmoothing: false,
+        nitroToggleMode: false,
+        reducedSimultaneousInput: false,
+      },
+      difficultyPreset: "normal",
+      transmissionMode: "auto",
+    },
+    garage: {
+      credits: 1000,
+      ownedCars: ["sparrow-gt"],
+      activeCarId: "sparrow-gt",
+      installedUpgrades: {
+        "sparrow-gt": {
+          engine: 0,
+          gearbox: 0,
+          dryTires: 0,
+          wetTires: 0,
+          nitro: 0,
+          armor: 0,
+          cooling: 0,
+          aero: 0,
+        },
+      },
+      pendingDamage: {},
+      lastRaceCashEarned: 0,
+    },
+    progress: {
+      unlockedTours: ["velvet-coast"],
+      completedTours: [],
+    },
+    records: {
+      "velvet-coast/harbor-run": {
+        bestLapMs: 30_000,
+        bestRaceMs: 90_000,
+      },
+    },
+    ghosts: {},
+    writeCounter: 0,
+  };
+}

--- a/e2e/title-screen.spec.ts
+++ b/e2e/title-screen.spec.ts
@@ -113,14 +113,13 @@ test.describe("title screen", () => {
     await expect(page.getByTestId("world-page")).toBeVisible();
   });
 
-  test("Time Trial link navigates to time-trial race mode", async ({ page }) => {
+  test("Time Trial link navigates to the time-trial launch page", async ({
+    page,
+  }) => {
     await page.goto("/");
     await page.getByTestId("menu-time-trial").click();
-    await expect(page).toHaveURL(/\/race\?mode=timeTrial$/);
-    await expect(page.getByTestId("race-canvas")).toHaveAttribute(
-      "data-mode",
-      "timeTrial",
-    );
+    await expect(page).toHaveURL(/\/time-trial$/);
+    await expect(page.getByTestId("time-trial-page")).toBeVisible();
   });
 
   test("Quick Race link navigates to quick-race picker", async ({ page }) => {

--- a/src/app/time-trial/page.tsx
+++ b/src/app/time-trial/page.tsx
@@ -1,5 +1,257 @@
-import { redirect } from "next/navigation";
+"use client";
 
-export default function TimeTrialPage(): never {
-  redirect("/race?mode=timeTrial");
+import Link from "next/link";
+import {
+  useEffect,
+  useMemo,
+  useState,
+  type CSSProperties,
+  type ReactElement,
+} from "react";
+
+import {
+  TRACK_RAW,
+  TrackSchema,
+  getChampionship,
+  type SaveGame,
+  type Track,
+} from "@/data";
+import { buildTimeTrialView } from "@/game/modes/timeTrialTargets";
+import { formatLapTime } from "@/render/hudSplits";
+import { defaultSave, loadSave } from "@/persistence";
+
+const CHAMPIONSHIP_ID = "world-tour-standard";
+const TRACKS_BY_ID = buildTrackMap();
+
+export default function TimeTrialPage(): ReactElement {
+  const [save, setSave] = useState<SaveGame | null>(null);
+
+  useEffect(() => {
+    const loaded = loadSave();
+    setSave(loaded.kind === "loaded" ? loaded.save : defaultSave());
+  }, []);
+
+  const view = useMemo(() => {
+    if (!save) return null;
+    return buildTimeTrialView({
+      save,
+      championship: getChampionship(CHAMPIONSHIP_ID),
+      tracksById: TRACKS_BY_ID,
+    });
+  }, [save]);
+
+  return (
+    <main data-testid="time-trial-page" style={pageStyle}>
+      <section style={shellStyle} aria-labelledby="time-trial-title">
+        <header style={headerStyle}>
+          <p style={eyebrowStyle}>Time Trial</p>
+          <h1 id="time-trial-title" style={titleStyle}>
+            Ghost chase
+          </h1>
+          <p style={subtitleStyle}>
+            Run unlocked tracks against your saved personal best and the
+            official benchmark target.
+          </p>
+        </header>
+
+        {!view ? (
+          <p data-testid="time-trial-loading">Loading Time Trial tracks.</p>
+        ) : (
+          <div style={trackListStyle}>
+            {view.tracks.map((track) => (
+              <article
+                key={track.id}
+                data-testid={`time-trial-track-${track.id}`}
+                style={trackRowStyle}
+              >
+                <div style={trackHeaderStyle}>
+                  <div>
+                    <h2 style={trackTitleStyle}>{track.name}</h2>
+                    <p style={trackMetaStyle}>{track.id}</p>
+                  </div>
+                  <Link
+                    href={track.startHref}
+                    data-testid={`time-trial-start-${track.id}`}
+                    style={startStyle}
+                  >
+                    Start
+                  </Link>
+                </div>
+
+                <dl style={statsStyle}>
+                  <div style={statStyle}>
+                    <dt style={statLabelStyle}>Personal best</dt>
+                    <dd
+                      data-testid={`time-trial-pb-${track.id}`}
+                      style={statValueStyle}
+                    >
+                      {formatOptionalTime(track.personalBestLapMs)}
+                    </dd>
+                  </div>
+                  <div style={statStyle}>
+                    <dt style={statLabelStyle}>Benchmark</dt>
+                    <dd
+                      data-testid={`time-trial-benchmark-${track.id}`}
+                      style={statValueStyle}
+                    >
+                      {formatOptionalTime(track.developerBenchmarkMs)}
+                    </dd>
+                  </div>
+                  <div style={statStyle}>
+                    <dt style={statLabelStyle}>Default weather</dt>
+                    <dd
+                      data-testid={`time-trial-weather-${track.id}`}
+                      style={statValueStyle}
+                    >
+                      {formatWeather(track.weatherOptions[0] ?? "clear")}
+                    </dd>
+                  </div>
+                </dl>
+              </article>
+            ))}
+          </div>
+        )}
+
+        <Link href="/" data-testid="time-trial-back" style={backStyle}>
+          Back to title
+        </Link>
+      </section>
+    </main>
+  );
 }
+
+function buildTrackMap(): ReadonlyMap<string, Track> {
+  const entries = Object.values(TRACK_RAW).map((raw) => {
+    const track = TrackSchema.parse(raw);
+    return [track.id, track] as const;
+  });
+  return new Map(entries);
+}
+
+function formatOptionalTime(ms: number | null): string {
+  return ms === null ? "No time" : formatLapTime(ms);
+}
+
+function formatWeather(weather: string): string {
+  return weather
+    .split("_")
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+    .join(" ");
+}
+
+const pageStyle: CSSProperties = {
+  minHeight: "100vh",
+  background: "#0b0e14",
+  color: "#e6e8eb",
+  fontFamily: "system-ui, sans-serif",
+  padding: "48px 20px",
+};
+
+const shellStyle: CSSProperties = {
+  width: "min(960px, 100%)",
+  margin: "0 auto",
+  display: "grid",
+  gap: "22px",
+};
+
+const headerStyle: CSSProperties = {
+  display: "grid",
+  gap: "10px",
+};
+
+const eyebrowStyle: CSSProperties = {
+  margin: 0,
+  color: "#93c5fd",
+  fontSize: "0.86rem",
+  fontWeight: 700,
+  letterSpacing: "0.08em",
+  textTransform: "uppercase",
+};
+
+const titleStyle: CSSProperties = {
+  margin: 0,
+  fontSize: "clamp(2rem, 7vw, 4.5rem)",
+  lineHeight: 0.95,
+};
+
+const subtitleStyle: CSSProperties = {
+  maxWidth: "64ch",
+  margin: 0,
+  color: "#b8c0cc",
+  fontSize: "1.05rem",
+  lineHeight: 1.6,
+};
+
+const trackListStyle: CSSProperties = {
+  display: "grid",
+  gap: "12px",
+};
+
+const trackRowStyle: CSSProperties = {
+  display: "grid",
+  gap: "16px",
+  padding: "18px",
+  border: "1px solid #28415f",
+  borderRadius: "8px",
+  background: "#111827",
+};
+
+const trackHeaderStyle: CSSProperties = {
+  display: "flex",
+  alignItems: "start",
+  justifyContent: "space-between",
+  gap: "16px",
+};
+
+const trackTitleStyle: CSSProperties = {
+  margin: 0,
+  fontSize: "1.2rem",
+};
+
+const trackMetaStyle: CSSProperties = {
+  margin: "4px 0 0",
+  color: "#9aa3ad",
+};
+
+const statsStyle: CSSProperties = {
+  display: "grid",
+  gridTemplateColumns: "repeat(auto-fit, minmax(150px, 1fr))",
+  gap: "10px",
+  margin: 0,
+};
+
+const statStyle: CSSProperties = {
+  minWidth: 0,
+  padding: "10px",
+  background: "#172033",
+};
+
+const statLabelStyle: CSSProperties = {
+  marginBottom: "4px",
+  color: "#9aa3ad",
+  fontSize: "0.76rem",
+  textTransform: "uppercase",
+};
+
+const statValueStyle: CSSProperties = {
+  margin: 0,
+  fontSize: "1rem",
+  fontWeight: 800,
+};
+
+const startStyle: CSSProperties = {
+  display: "inline-flex",
+  alignItems: "center",
+  justifyContent: "center",
+  minHeight: "40px",
+  padding: "0 14px",
+  borderRadius: "6px",
+  background: "#facc15",
+  color: "#111827",
+  fontWeight: 800,
+  textDecoration: "none",
+};
+
+const backStyle: CSSProperties = {
+  color: "#9aa3ad",
+};

--- a/src/game/modes/__tests__/timeTrialTargets.test.ts
+++ b/src/game/modes/__tests__/timeTrialTargets.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from "vitest";
+
+import { TRACK_RAW, TrackSchema, getChampionship } from "@/data";
+import { defaultSave } from "@/persistence/save";
+
+import {
+  buildTimeTrialView,
+  developerBenchmarkMs,
+  timeTrialRaceHref,
+} from "../timeTrialTargets";
+
+const CHAMPIONSHIP_ID = "world-tour-standard";
+
+describe("timeTrialRaceHref", () => {
+  it("builds a Time Trial race link with the selected track and weather", () => {
+    expect(
+      timeTrialRaceHref({
+        trackId: "velvet-coast/harbor-run",
+        weather: "rain",
+      }),
+    ).toBe("/race?mode=timeTrial&track=velvet-coast%2Fharbor-run&weather=rain");
+  });
+});
+
+describe("developerBenchmarkMs", () => {
+  it("returns official benchmark targets for bundled Time Trial tracks", () => {
+    expect(developerBenchmarkMs("velvet-coast/harbor-run")).toBe(31_500);
+    expect(developerBenchmarkMs("iron-borough/outer-exchange")).toBe(48_600);
+  });
+
+  it("returns null for tracks without an official target", () => {
+    expect(developerBenchmarkMs("test/straight")).toBeNull();
+  });
+});
+
+describe("buildTimeTrialView", () => {
+  it("shows unlocked tracks with PBs, developer benchmarks, and start links", () => {
+    const save = defaultSave();
+    save.records["velvet-coast/harbor-run"] = {
+      bestLapMs: 30_000,
+      bestRaceMs: 90_000,
+    };
+    const view = buildTimeTrialView({
+      save,
+      championship: getChampionship(CHAMPIONSHIP_ID),
+      tracksById: buildTrackMap(),
+    });
+
+    const harbor = view.tracks.find(
+      (track) => track.id === "velvet-coast/harbor-run",
+    );
+    expect(harbor).toMatchObject({
+      name: "Harbor Run",
+      personalBestLapMs: 30_000,
+      personalBestRaceMs: 90_000,
+      developerBenchmarkMs: 31_500,
+      startHref:
+        "/race?mode=timeTrial&track=velvet-coast%2Fharbor-run&weather=clear",
+    });
+  });
+
+  it("limits the initial list to unlocked tour tracks", () => {
+    const view = buildTimeTrialView({
+      save: defaultSave(),
+      championship: getChampionship(CHAMPIONSHIP_ID),
+      tracksById: buildTrackMap(),
+    });
+
+    expect(view.tracks.map((track) => track.id)).toEqual([
+      "velvet-coast/harbor-run",
+      "velvet-coast/sunpier-loop",
+      "velvet-coast/cliffline-arc",
+      "velvet-coast/lighthouse-fall",
+    ]);
+  });
+});
+
+function buildTrackMap() {
+  const entries = Object.values(TRACK_RAW).map((raw) => {
+    const track = TrackSchema.parse(raw);
+    return [track.id, track] as const;
+  });
+  return new Map(entries);
+}

--- a/src/game/modes/timeTrialTargets.ts
+++ b/src/game/modes/timeTrialTargets.ts
@@ -1,0 +1,96 @@
+import type { Championship, SaveGame, Track, WeatherOption } from "@/data/schemas";
+
+export interface TimeTrialTrackOption {
+  readonly id: string;
+  readonly name: string;
+  readonly weatherOptions: readonly WeatherOption[];
+  readonly personalBestLapMs: number | null;
+  readonly personalBestRaceMs: number | null;
+  readonly developerBenchmarkMs: number | null;
+  readonly startHref: string;
+}
+
+export interface TimeTrialView {
+  readonly tracks: readonly TimeTrialTrackOption[];
+}
+
+const DEVELOPER_BENCHMARKS_MS: Readonly<Record<string, number>> = Object.freeze({
+  "velvet-coast/harbor-run": 31_500,
+  "velvet-coast/sunpier-loop": 32_200,
+  "velvet-coast/cliffline-arc": 38_800,
+  "velvet-coast/lighthouse-fall": 40_400,
+  "iron-borough/freightline-ring": 41_700,
+  "iron-borough/rivet-tunnel": 43_200,
+  "iron-borough/foundry-mile": 46_500,
+  "iron-borough/outer-exchange": 48_600,
+});
+
+export function buildTimeTrialView(input: {
+  readonly save: SaveGame;
+  readonly championship: Championship;
+  readonly tracksById: ReadonlyMap<string, Track>;
+}): TimeTrialView {
+  const unlockedTrackIds = unlockedTimeTrialTrackIds(
+    input.save,
+    input.championship,
+  );
+  return {
+    tracks: unlockedTrackIds.flatMap((trackId) => {
+      const track = input.tracksById.get(trackId);
+      if (!track) return [];
+      const record = input.save.records[track.id] ?? null;
+      return [
+        {
+          id: track.id,
+          name: track.name,
+          weatherOptions: track.weatherOptions,
+          personalBestLapMs: record?.bestLapMs ?? null,
+          personalBestRaceMs: record?.bestRaceMs ?? null,
+          developerBenchmarkMs: developerBenchmarkMs(track.id),
+          startHref: timeTrialRaceHref({
+            trackId: track.id,
+            weather: track.weatherOptions[0],
+          }),
+        },
+      ];
+    }),
+  };
+}
+
+export function timeTrialRaceHref(input: {
+  readonly trackId: string;
+  readonly weather?: WeatherOption;
+}): string {
+  const params = new URLSearchParams({
+    mode: "timeTrial",
+    track: input.trackId,
+  });
+  if (input.weather !== undefined) {
+    params.set("weather", input.weather);
+  }
+  return `/race?${params.toString()}`;
+}
+
+export function developerBenchmarkMs(trackId: string): number | null {
+  return DEVELOPER_BENCHMARKS_MS[trackId] ?? null;
+}
+
+function unlockedTimeTrialTrackIds(
+  save: SaveGame,
+  championship: Championship,
+): readonly string[] {
+  const firstTourId = championship.tours[0]?.id;
+  const unlocked = new Set(save.progress.unlockedTours);
+  if (firstTourId) unlocked.add(firstTourId);
+  const seen = new Set<string>();
+  const ids: string[] = [];
+  for (const tour of championship.tours) {
+    if (!unlocked.has(tour.id)) continue;
+    for (const trackId of tour.tracks) {
+      if (seen.has(trackId)) continue;
+      seen.add(trackId);
+      ids.push(trackId);
+    }
+  }
+  return ids;
+}


### PR DESCRIPTION
## Summary
- Replace the /time-trial redirect with a launch page listing unlocked Time Trial tracks.
- Show saved personal bests, official benchmark targets, default weather, and start links.
- Add pure view-builder coverage, browser coverage, progress log, and coverage ledger entries.

## GDD
- §6 Time Trial
- §20 Entry UI
- §21 Local runtime

## Progress log
- docs/PROGRESS_LOG.md entry: 2026-04-30: Slice: Time Trial benchmark launch page

## Test plan
- npx vitest run src/game/modes/__tests__/timeTrialTargets.test.ts
- npm run typecheck
- npx playwright test e2e/time-trial.spec.ts e2e/title-screen.spec.ts --project=chromium -g "time trial|Time Trial"
- npm run lint
- npm run verify
- forbidden dash scan over touched files returned nothing

## Followups
- None
