### PR TITLE
Time Trial review followups

### DIFF
--- a/docs/PROGRESS_LOG.md
+++ b/docs/PROGRESS_LOG.md
@@ -6,6 +6,43 @@ Correct them by adding a new entry that references the old one.
 
 ---
 
+## 2026-04-30: Slice: Time Trial review followups
+
+**GDD sections touched:**
+[§6](gdd/06-game-modes.md) Time Trial and Quick Race unlocks, and
+[§21](gdd/21-technical-design-for-web-implementation.md) local runtime.
+**Branch / PR:** `fix/time-trial-review-followups`, PR pending.
+**Status:** Implemented.
+
+### Done
+- Extracted shared unlocked championship track selection for Quick Race
+  and Time Trial after PR review flagged drift risk.
+- Tightened the Time Trial weather formatter to the schema enum type
+  after PR review flagged loose string typing.
+
+### Verified
+- `npx vitest run src/game/modes/__tests__/timeTrialTargets.test.ts src/game/modes/__tests__/quickRace.test.ts`
+  green, 8 tests passed.
+- `npm run typecheck` green.
+- `npm run lint` green.
+- `npm run verify` green, 2665 Vitest tests passed.
+
+### Decisions and assumptions
+- Treated the comments from PR #125 as required follow-up work because
+  the PR was merged before the local review fixes were pushed.
+
+### Coverage ledger
+- No new ledger row. This keeps the existing Time Trial launch coverage
+  row accurate while reducing implementation drift risk.
+
+### Followups created
+None.
+
+### GDD edits
+None.
+
+---
+
 ## 2026-04-30: Slice: Time Trial benchmark launch page
 
 **GDD sections touched:**

--- a/docs/PROGRESS_LOG.md
+++ b/docs/PROGRESS_LOG.md
@@ -32,8 +32,10 @@ Correct them by adding a new entry that references the old one.
   the PR was merged before the local review fixes were pushed.
 
 ### Coverage ledger
-- No new ledger row. This keeps the existing Time Trial launch coverage
-  row accurate while reducing implementation drift risk.
+- GDD-06-TIME-TRIAL-BENCHMARK-LAUNCH remains the relevant ledger row
+  for the Time Trial launch surface.
+- Uncovered adjacent requirements: downloaded ghost selection and
+  UTC-midnight fake-clock e2e remain under the §6 modes parent dot.
 
 ### Followups created
 None.

--- a/src/app/time-trial/page.tsx
+++ b/src/app/time-trial/page.tsx
@@ -15,6 +15,7 @@ import {
   getChampionship,
   type SaveGame,
   type Track,
+  type WeatherOption,
 } from "@/data";
 import { buildTimeTrialView } from "@/game/modes/timeTrialTargets";
 import { formatLapTime } from "@/render/hudSplits";
@@ -132,7 +133,7 @@ function formatOptionalTime(ms: number | null): string {
   return ms === null ? "No time" : formatLapTime(ms);
 }
 
-function formatWeather(weather: string): string {
+function formatWeather(weather: WeatherOption): string {
   return weather
     .split("_")
     .map((part) => part.charAt(0).toUpperCase() + part.slice(1))

--- a/src/game/modes/quickRace.ts
+++ b/src/game/modes/quickRace.ts
@@ -6,6 +6,8 @@ import type {
   WeatherOption,
 } from "@/data/schemas";
 
+import { unlockedChampionshipTrackIds } from "./unlockedTracks";
+
 export interface QuickRaceTrackOption {
   readonly id: string;
   readonly name: string;
@@ -34,7 +36,7 @@ export function buildQuickRaceView(input: {
   readonly tracksById: ReadonlyMap<string, Track>;
   readonly carsById: ReadonlyMap<string, Car>;
 }): QuickRaceView {
-  const unlockedTrackIds = unlockedQuickRaceTrackIds(
+  const unlockedTrackIds = unlockedChampionshipTrackIds(
     input.save,
     input.championship,
   );
@@ -66,24 +68,4 @@ export function quickRaceHref(input: QuickRaceHrefInput): string {
     car: input.carId,
   });
   return `/race?${params.toString()}`;
-}
-
-function unlockedQuickRaceTrackIds(
-  save: SaveGame,
-  championship: Championship,
-): readonly string[] {
-  const firstTourId = championship.tours[0]?.id;
-  const unlocked = new Set(save.progress.unlockedTours);
-  if (firstTourId) unlocked.add(firstTourId);
-  const seen = new Set<string>();
-  const ids: string[] = [];
-  for (const tour of championship.tours) {
-    if (!unlocked.has(tour.id)) continue;
-    for (const trackId of tour.tracks) {
-      if (seen.has(trackId)) continue;
-      seen.add(trackId);
-      ids.push(trackId);
-    }
-  }
-  return ids;
 }

--- a/src/game/modes/timeTrialTargets.ts
+++ b/src/game/modes/timeTrialTargets.ts
@@ -1,5 +1,7 @@
 import type { Championship, SaveGame, Track, WeatherOption } from "@/data/schemas";
 
+import { unlockedChampionshipTrackIds } from "./unlockedTracks";
+
 export interface TimeTrialTrackOption {
   readonly id: string;
   readonly name: string;
@@ -30,7 +32,7 @@ export function buildTimeTrialView(input: {
   readonly championship: Championship;
   readonly tracksById: ReadonlyMap<string, Track>;
 }): TimeTrialView {
-  const unlockedTrackIds = unlockedTimeTrialTrackIds(
+  const unlockedTrackIds = unlockedChampionshipTrackIds(
     input.save,
     input.championship,
   );
@@ -73,24 +75,4 @@ export function timeTrialRaceHref(input: {
 
 export function developerBenchmarkMs(trackId: string): number | null {
   return DEVELOPER_BENCHMARKS_MS[trackId] ?? null;
-}
-
-function unlockedTimeTrialTrackIds(
-  save: SaveGame,
-  championship: Championship,
-): readonly string[] {
-  const firstTourId = championship.tours[0]?.id;
-  const unlocked = new Set(save.progress.unlockedTours);
-  if (firstTourId) unlocked.add(firstTourId);
-  const seen = new Set<string>();
-  const ids: string[] = [];
-  for (const tour of championship.tours) {
-    if (!unlocked.has(tour.id)) continue;
-    for (const trackId of tour.tracks) {
-      if (seen.has(trackId)) continue;
-      seen.add(trackId);
-      ids.push(trackId);
-    }
-  }
-  return ids;
 }

--- a/src/game/modes/unlockedTracks.ts
+++ b/src/game/modes/unlockedTracks.ts
@@ -1,0 +1,21 @@
+import type { Championship, SaveGame } from "@/data/schemas";
+
+export function unlockedChampionshipTrackIds(
+  save: SaveGame,
+  championship: Championship,
+): readonly string[] {
+  const firstTourId = championship.tours[0]?.id;
+  const unlocked = new Set(save.progress.unlockedTours);
+  if (firstTourId) unlocked.add(firstTourId);
+  const seen = new Set<string>();
+  const ids: string[] = [];
+  for (const tour of championship.tours) {
+    if (!unlocked.has(tour.id)) continue;
+    for (const trackId of tour.tracks) {
+      if (seen.has(trackId)) continue;
+      seen.add(trackId);
+      ids.push(trackId);
+    }
+  }
+  return ids;
+}


### PR DESCRIPTION
## Summary
- Share unlocked championship track selection between Quick Race and Time Trial
- Tighten Time Trial weather label formatting to the WeatherOption schema enum
- Log the follow-up slice separately because PR #125 was merged before the local review fixes were pushed

## Test plan
- npx vitest run src/game/modes/__tests__/timeTrialTargets.test.ts src/game/modes/__tests__/quickRace.test.ts
- npm run typecheck
- npm run lint
- npm run verify

## GDD
- docs/gdd/06-game-modes.md
- docs/gdd/21-technical-design-for-web-implementation.md

## Progress log
- docs/PROGRESS_LOG.md, 2026-04-30 Time Trial review followups