### PR TITLE
Time Trial downloaded ghost selection

### DIFF
--- a/docs/GDD_COVERAGE.json
+++ b/docs/GDD_COVERAGE.json
@@ -271,6 +271,30 @@
       "followupRefs": ["VibeGear2-implement-time-trial-9135b1e7"]
     },
     {
+      "id": "GDD-06-TIME-TRIAL-DOWNLOADED-GHOST",
+      "gddSections": [
+        "docs/gdd/06-game-modes.md",
+        "docs/gdd/21-technical-design-for-web-implementation.md",
+        "docs/gdd/22-data-schemas.md"
+      ],
+      "requirement": "Time Trial supports a separate downloaded ghost replay slot per track, lets the player import a valid replay for an unlocked track, and can start a Time Trial using that downloaded ghost instead of the personal-best ghost.",
+      "coverage": ["implemented-code", "automated-test"],
+      "implementationRefs": [
+        "src/data/schemas.ts",
+        "src/persistence/save.ts",
+        "src/game/modes/timeTrialTargets.ts",
+        "src/app/time-trial/page.tsx",
+        "src/app/race/page.tsx"
+      ],
+      "testRefs": [
+        "src/data/schemas.test.ts",
+        "src/persistence/save.test.ts",
+        "src/game/modes/__tests__/timeTrialTargets.test.ts",
+        "e2e/time-trial.spec.ts"
+      ],
+      "followupRefs": ["VibeGear2-implement-time-trial-40c02d43"]
+    },
+    {
       "id": "GDD-06-QUICK-RACE-MODE",
       "gddSections": [
         "docs/gdd/06-game-modes.md",

--- a/docs/PROGRESS_LOG.md
+++ b/docs/PROGRESS_LOG.md
@@ -6,6 +6,57 @@ Correct them by adding a new entry that references the old one.
 
 ---
 
+## 2026-04-30: Slice: Time Trial downloaded ghost selection
+
+**GDD sections touched:**
+[§6](gdd/06-game-modes.md) Time Trial,
+[§21](gdd/21-technical-design-for-web-implementation.md) local runtime, and
+[§22](gdd/22-data-schemas.md) save schema.
+**Branch / PR:** `feat/time-trial-downloaded-ghosts`, PR pending.
+**Status:** Implemented.
+
+### Done
+- Added a separate `downloadedGhosts` save slot so imported rival replays
+  do not overwrite personal-best ghosts.
+- Extended the Time Trial launch page with downloaded ghost status,
+  JSON import, schema and track-version validation, and a dedicated
+  start link for downloaded ghost races.
+- Taught the race route to use `?ghost=downloaded` as the Time Trial
+  ghost source while keeping personal-best recording unchanged.
+- Added the machine-checkable coverage ledger row for downloaded ghost
+  selection.
+
+### Verified
+- `npx vitest run src/game/modes/__tests__/timeTrialTargets.test.ts src/data/schemas.test.ts src/persistence/save.test.ts`
+  green, 89 tests passed.
+- `npm run typecheck` green.
+- `npm run content-lint` green.
+- `npx playwright test e2e/time-trial.spec.ts e2e/title-screen.spec.ts --project=chromium -g "time trial|Time Trial"`
+  green, 2 tests passed.
+- `npm run lint` green.
+- `npm run verify` green, 2670 Vitest tests passed.
+
+### Decisions and assumptions
+- Kept downloaded ghosts local-only. The GDD names downloaded ghosts but
+  does not require a remote ghost backend for v1.0.
+- Reused the existing replay schema and per-track map shape while keeping
+  imported rivals separate from PB ghosts.
+
+### Coverage ledger
+- GDD-06-TIME-TRIAL-DOWNLOADED-GHOST covers the downloaded ghost save
+  slot, Time Trial import/status UI, and race start link selection.
+- Uncovered adjacent requirements: UTC-midnight fake-clock e2e remains
+  under the §6 modes parent dot.
+
+### Followups created
+None.
+
+### GDD edits
+- `docs/gdd/22-data-schemas.md`: documented `downloadedGhosts` as the
+  imported-rival replay map separate from PB ghosts.
+
+---
+
 ## 2026-04-30: Slice: Time Trial review followups
 
 **GDD sections touched:**

--- a/docs/gdd/22-data-schemas.md
+++ b/docs/gdd/22-data-schemas.md
@@ -402,3 +402,7 @@ v1 -> v2 migrator seeds it to `0` if absent.
 in the runtime schema so v1 / v2 saves still validate before migration, but a
 fully migrated v3 save carries at least an empty map. Each stored entry uses
 the Ghost replay schema below.
+
+`downloadedGhosts` is the §6 Time Trial imported rival replay map keyed by
+track id. It uses the same Ghost replay schema as `ghosts` but stays separate
+so a downloaded rival never overwrites the player's personal-best replay.

--- a/e2e/time-trial.spec.ts
+++ b/e2e/time-trial.spec.ts
@@ -30,6 +30,43 @@ test.describe("time trial launch page", () => {
       "href",
       "/race?mode=timeTrial&track=velvet-coast%2Fharbor-run&weather=clear",
     );
+
+    await expect(
+      page.getByTestId("time-trial-downloaded-ghost-velvet-coast/harbor-run"),
+    ).toHaveText("No time");
+    await page
+      .getByTestId("time-trial-import-ghost-velvet-coast/harbor-run")
+      .setInputFiles({
+        name: "harbor-run-rival.json",
+        mimeType: "application/json",
+        buffer: Buffer.from(
+          JSON.stringify({
+            formatVersion: 1,
+            physicsVersion: 1,
+            fixedStepMs: 16.666666666666668,
+            trackId: "velvet-coast/harbor-run",
+            trackVersion: 1,
+            carId: "sparrow-gt",
+            seed: 123,
+            totalTicks: 1860,
+            finalTimeMs: 31_000,
+            truncated: false,
+            deltas: [],
+          }),
+        ),
+      });
+    await expect(page.getByTestId("time-trial-ghost-import-status")).toHaveText(
+      "Imported downloaded ghost for Harbor Run.",
+    );
+    await expect(
+      page.getByTestId("time-trial-downloaded-ghost-velvet-coast/harbor-run"),
+    ).toHaveText("00:31.000");
+    await expect(
+      page.getByTestId("time-trial-start-downloaded-ghost-velvet-coast/harbor-run"),
+    ).toHaveAttribute(
+      "href",
+      "/race?mode=timeTrial&track=velvet-coast%2Fharbor-run&weather=clear&ghost=downloaded",
+    );
   });
 });
 
@@ -82,6 +119,7 @@ function buildSeedSave() {
       },
     },
     ghosts: {},
+    downloadedGhosts: {},
     writeCounter: 0,
   };
 }

--- a/src/app/race/page.tsx
+++ b/src/app/race/page.tsx
@@ -427,11 +427,16 @@ function resolveTrack(
 }
 
 type RaceMode = "race" | "timeTrial" | "quickRace" | "practice";
+type TimeTrialGhostSource = "personalBest" | "downloaded";
 
 function resolveRaceMode(raw: string | null): RaceMode {
   if (raw === "practice") return "practice";
   if (raw === "quickRace") return "quickRace";
   return raw === "timeTrial" ? "timeTrial" : "race";
+}
+
+function resolveTimeTrialGhostSource(raw: string | null): TimeTrialGhostSource {
+  return raw === "downloaded" ? "downloaded" : "personalBest";
 }
 
 function resolveRaceWeather(
@@ -685,6 +690,7 @@ function RaceShell(): ReactElement {
   const weatherRaw = search?.get("weather") ?? null;
   const tireRaw = search?.get("tire") ?? null;
   const carRaw = search?.get("car") ?? null;
+  const ghostRaw = search?.get("ghost") ?? null;
   const dailyDateKeyRaw = search?.get("daily") ?? null;
   const dailySeedRaw = search?.get("dailySeed") ?? null;
   const dailyCarClassRaw = search?.get("carClass") ?? null;
@@ -717,6 +723,10 @@ function RaceShell(): ReactElement {
     [dailyCarClassRaw, dailyDateKeyRaw, dailySeedRaw, mode, track.id, weather],
   );
   const playerTire = useMemo(() => resolvePlayerTire(tireRaw), [tireRaw]);
+  const ghostSource = useMemo(
+    () => resolveTimeTrialGhostSource(ghostRaw),
+    [ghostRaw],
+  );
   return (
     <RaceCanvas
       track={track}
@@ -727,6 +737,7 @@ function RaceShell(): ReactElement {
       playerTire={playerTire}
       selectedCarId={carRaw}
       dailyChallenge={dailyChallenge}
+      ghostSource={ghostSource}
     />
   );
 }
@@ -740,6 +751,7 @@ interface RaceCanvasProps {
   playerTire: TireKind | undefined;
   selectedCarId: string | null;
   dailyChallenge: DailyChallengeSelection | null;
+  ghostSource: TimeTrialGhostSource;
 }
 
 function RaceCanvas({
@@ -751,6 +763,7 @@ function RaceCanvas({
   playerTire,
   selectedCarId,
   dailyChallenge,
+  ghostSource,
 }: RaceCanvasProps): ReactElement {
   const router = useRouter();
   const canvasRef = useRef<HTMLCanvasElement | null>(null);
@@ -947,7 +960,10 @@ function RaceCanvas({
         timeTrialRecorderRef.current = null;
         return;
       }
-      const currentGhost = timeTrialSaveSnapshot.ghosts?.[track.id] ?? null;
+      const currentGhost =
+        ghostSource === "downloaded"
+          ? timeTrialSaveSnapshot.downloadedGhosts?.[track.id] ?? null
+          : timeTrialSaveSnapshot.ghosts?.[track.id] ?? null;
       const ghostCarStats =
         currentGhost === null
           ? playerStats
@@ -1602,6 +1618,7 @@ function RaceCanvas({
     playerTire,
     selectedCarId,
     dailyChallenge,
+    ghostSource,
   ]);
 
   return (

--- a/src/app/time-trial/page.tsx
+++ b/src/app/time-trial/page.tsx
@@ -2,6 +2,7 @@
 
 import Link from "next/link";
 import {
+  useCallback,
   useEffect,
   useMemo,
   useState,
@@ -11,21 +12,26 @@ import {
 
 import {
   TRACK_RAW,
+  GhostReplaySchema,
   TrackSchema,
   getChampionship,
   type SaveGame,
   type Track,
   type WeatherOption,
 } from "@/data";
-import { buildTimeTrialView } from "@/game/modes/timeTrialTargets";
+import {
+  acceptDownloadedGhost,
+  buildTimeTrialView,
+} from "@/game/modes/timeTrialTargets";
 import { formatLapTime } from "@/render/hudSplits";
-import { defaultSave, loadSave } from "@/persistence";
+import { defaultSave, loadSave, saveSave } from "@/persistence";
 
 const CHAMPIONSHIP_ID = "world-tour-standard";
 const TRACKS_BY_ID = buildTrackMap();
 
 export default function TimeTrialPage(): ReactElement {
   const [save, setSave] = useState<SaveGame | null>(null);
+  const [importStatus, setImportStatus] = useState<string>("");
 
   useEffect(() => {
     const loaded = loadSave();
@@ -40,6 +46,53 @@ export default function TimeTrialPage(): ReactElement {
       tracksById: TRACKS_BY_ID,
     });
   }, [save]);
+
+  const importDownloadedGhost = useCallback(
+    async (
+      track: { readonly id: string; readonly name: string; readonly version: number },
+      file: File | null,
+    ): Promise<void> => {
+      if (!file || !save) return;
+      setImportStatus(`Importing ${file.name}.`);
+      let payload: unknown;
+      try {
+        payload = JSON.parse(await file.text());
+      } catch {
+        setImportStatus("Ghost import failed: file is not valid JSON.");
+        return;
+      }
+      const parsed = GhostReplaySchema.safeParse(payload);
+      if (!parsed.success) {
+        setImportStatus("Ghost import failed: replay schema is invalid.");
+        return;
+      }
+      if (
+        !acceptDownloadedGhost({
+          trackId: track.id,
+          trackVersion: track.version,
+          ghost: parsed.data,
+        })
+      ) {
+        setImportStatus(`Ghost import failed: replay is not for ${track.name}.`);
+        return;
+      }
+      const nextSave: SaveGame = {
+        ...save,
+        downloadedGhosts: {
+          ...(save.downloadedGhosts ?? {}),
+          [track.id]: parsed.data,
+        },
+      };
+      const write = saveSave(nextSave);
+      if (write.kind !== "ok") {
+        setImportStatus("Ghost import failed: save could not be written.");
+        return;
+      }
+      setSave(nextSave);
+      setImportStatus(`Imported downloaded ghost for ${track.name}.`);
+    },
+    [save],
+  );
 
   return (
     <main data-testid="time-trial-page" style={pageStyle}>
@@ -59,6 +112,11 @@ export default function TimeTrialPage(): ReactElement {
           <p data-testid="time-trial-loading">Loading Time Trial tracks.</p>
         ) : (
           <div style={trackListStyle}>
+            {importStatus ? (
+              <p data-testid="time-trial-ghost-import-status" style={statusStyle}>
+                {importStatus}
+              </p>
+            ) : null}
             {view.tracks.map((track) => (
               <article
                 key={track.id}
@@ -107,7 +165,43 @@ export default function TimeTrialPage(): ReactElement {
                       {formatWeather(track.weatherOptions[0] ?? "clear")}
                     </dd>
                   </div>
+                  <div style={statStyle}>
+                    <dt style={statLabelStyle}>Downloaded ghost</dt>
+                    <dd
+                      data-testid={`time-trial-downloaded-ghost-${track.id}`}
+                      style={statValueStyle}
+                    >
+                      {formatOptionalTime(track.downloadedGhostTimeMs)}
+                    </dd>
+                  </div>
                 </dl>
+
+                <div style={ghostActionStyle}>
+                  <label style={ghostImportStyle}>
+                    <span>Import ghost</span>
+                    <input
+                      data-testid={`time-trial-import-ghost-${track.id}`}
+                      type="file"
+                      accept="application/json,.json"
+                      onChange={(event) => {
+                        void importDownloadedGhost(
+                          track,
+                          event.currentTarget.files?.[0] ?? null,
+                        );
+                        event.currentTarget.value = "";
+                      }}
+                    />
+                  </label>
+                  {track.startDownloadedGhostHref ? (
+                    <Link
+                      href={track.startDownloadedGhostHref}
+                      data-testid={`time-trial-start-downloaded-ghost-${track.id}`}
+                      style={ghostStartStyle}
+                    >
+                      Start downloaded ghost
+                    </Link>
+                  ) : null}
+                </div>
               </article>
             ))}
           </div>
@@ -188,6 +282,11 @@ const trackListStyle: CSSProperties = {
   gap: "12px",
 };
 
+const statusStyle: CSSProperties = {
+  margin: 0,
+  color: "#d7e5f7",
+};
+
 const trackRowStyle: CSSProperties = {
   display: "grid",
   gap: "16px",
@@ -238,6 +337,25 @@ const statValueStyle: CSSProperties = {
   margin: 0,
   fontSize: "1rem",
   fontWeight: 800,
+};
+
+const ghostActionStyle: CSSProperties = {
+  display: "flex",
+  flexWrap: "wrap",
+  alignItems: "center",
+  justifyContent: "space-between",
+  gap: "12px",
+};
+
+const ghostImportStyle: CSSProperties = {
+  display: "grid",
+  gap: "6px",
+  color: "#cbd5e1",
+};
+
+const ghostStartStyle: CSSProperties = {
+  color: "#93c5fd",
+  fontWeight: 700,
 };
 
 const startStyle: CSSProperties = {

--- a/src/data/examples/saveGame.example.json
+++ b/src/data/examples/saveGame.example.json
@@ -78,5 +78,6 @@
       "bestRaceMs": 214555
     }
   },
-  "ghosts": {}
+  "ghosts": {},
+  "downloadedGhosts": {}
 }

--- a/src/data/schemas.test.ts
+++ b/src/data/schemas.test.ts
@@ -346,22 +346,17 @@ describe("SaveGameSchema", () => {
     const withGhost = {
       ...saveGameExample,
       ghosts: {
-        "velvet-coast/harbor-run": {
-          formatVersion: 1,
-          physicsVersion: 1,
-          fixedStepMs: 16.6667,
-          trackId: "velvet-coast/harbor-run",
-          trackVersion: 1,
-          carId: "sparrow-gt",
-          seed: 0,
-          totalTicks: 600,
-          finalTimeMs: 10000,
-          truncated: false,
-          deltas: [
-            { tick: 0, mask: 1, values: [0.5] },
-            { tick: 60, mask: 2, values: [1] },
-          ],
-        },
+        "velvet-coast/harbor-run": ghostReplay(),
+      },
+    };
+    expect(SaveGameSchema.safeParse(withGhost).success).toBe(true);
+  });
+
+  it("accepts a save with a populated downloadedGhosts entry", () => {
+    const withGhost = {
+      ...saveGameExample,
+      downloadedGhosts: {
+        "velvet-coast/harbor-run": ghostReplay(),
       },
     };
     expect(SaveGameSchema.safeParse(withGhost).success).toBe(true);
@@ -389,6 +384,25 @@ describe("SaveGameSchema", () => {
     expect(SaveGameSchema.safeParse(broken).success).toBe(false);
   });
 });
+
+function ghostReplay() {
+  return {
+    formatVersion: 1,
+    physicsVersion: 1,
+    fixedStepMs: 16.6667,
+    trackId: "velvet-coast/harbor-run",
+    trackVersion: 1,
+    carId: "sparrow-gt",
+    seed: 0,
+    totalTicks: 600,
+    finalTimeMs: 10000,
+    truncated: false,
+    deltas: [
+      { tick: 0, mask: 1, values: [0.5] },
+      { tick: 60, mask: 2, values: [1] },
+    ],
+  };
+}
 
 describe("GhostReplayDeltaSchema", () => {
   it("accepts a typical numeric-and-boolean delta", () => {

--- a/src/data/schemas.ts
+++ b/src/data/schemas.ts
@@ -964,5 +964,12 @@ export const SaveGameSchema = z.object({
    * record. Per `docs/gdd/22-data-schemas.md`.
    */
   ghosts: z.record(slug, GhostReplaySchema).optional(),
+  /**
+   * §6 Time Trial downloaded ghost replays, keyed by track slug. This slot
+   * is separate from `ghosts` so imported rival runs never overwrite the
+   * player's PB replay. Optional so current v4 saves validate without a
+   * migration; fresh saves seed an empty map.
+   */
+  downloadedGhosts: z.record(slug, GhostReplaySchema).optional(),
 });
 export type SaveGame = z.infer<typeof SaveGameSchema>;

--- a/src/game/modes/__tests__/timeTrialTargets.test.ts
+++ b/src/game/modes/__tests__/timeTrialTargets.test.ts
@@ -4,6 +4,7 @@ import { TRACK_RAW, TrackSchema, getChampionship } from "@/data";
 import { defaultSave } from "@/persistence/save";
 
 import {
+  acceptDownloadedGhost,
   buildTimeTrialView,
   developerBenchmarkMs,
   timeTrialRaceHref,
@@ -19,6 +20,18 @@ describe("timeTrialRaceHref", () => {
         weather: "rain",
       }),
     ).toBe("/race?mode=timeTrial&track=velvet-coast%2Fharbor-run&weather=rain");
+  });
+
+  it("adds a downloaded ghost source when requested", () => {
+    expect(
+      timeTrialRaceHref({
+        trackId: "velvet-coast/harbor-run",
+        weather: "rain",
+        ghost: "downloaded",
+      }),
+    ).toBe(
+      "/race?mode=timeTrial&track=velvet-coast%2Fharbor-run&weather=rain&ghost=downloaded",
+    );
   });
 });
 
@@ -40,6 +53,12 @@ describe("buildTimeTrialView", () => {
       bestLapMs: 30_000,
       bestRaceMs: 90_000,
     };
+    save.downloadedGhosts = {
+      "velvet-coast/harbor-run": replay({
+        trackId: "velvet-coast/harbor-run",
+        finalTimeMs: 32_000,
+      }),
+    };
     const view = buildTimeTrialView({
       save,
       championship: getChampionship(CHAMPIONSHIP_ID),
@@ -54,8 +73,11 @@ describe("buildTimeTrialView", () => {
       personalBestLapMs: 30_000,
       personalBestRaceMs: 90_000,
       developerBenchmarkMs: 31_500,
+      downloadedGhostTimeMs: 32_000,
       startHref:
         "/race?mode=timeTrial&track=velvet-coast%2Fharbor-run&weather=clear",
+      startDownloadedGhostHref:
+        "/race?mode=timeTrial&track=velvet-coast%2Fharbor-run&weather=clear&ghost=downloaded",
     });
   });
 
@@ -75,10 +97,52 @@ describe("buildTimeTrialView", () => {
   });
 });
 
+describe("acceptDownloadedGhost", () => {
+  it("accepts a replay for the selected track and track version", () => {
+    expect(
+      acceptDownloadedGhost({
+        trackId: "velvet-coast/harbor-run",
+        trackVersion: 1,
+        ghost: replay({ trackId: "velvet-coast/harbor-run" }),
+      }),
+    ).toBe(true);
+  });
+
+  it("rejects a replay for another track", () => {
+    expect(
+      acceptDownloadedGhost({
+        trackId: "velvet-coast/harbor-run",
+        trackVersion: 1,
+        ghost: replay({ trackId: "iron-borough/freightline-ring" }),
+      }),
+    ).toBe(false);
+  });
+});
+
 function buildTrackMap() {
   const entries = Object.values(TRACK_RAW).map((raw) => {
     const track = TrackSchema.parse(raw);
     return [track.id, track] as const;
   });
   return new Map(entries);
+}
+
+function replay(overrides: Partial<ReturnType<typeof replayBase>> = {}) {
+  return { ...replayBase(), ...overrides };
+}
+
+function replayBase() {
+  return {
+    formatVersion: 1,
+    physicsVersion: 1,
+    fixedStepMs: 16.666666666666668,
+    trackId: "velvet-coast/harbor-run",
+    trackVersion: 1,
+    carId: "sparrow-gt",
+    seed: 0,
+    totalTicks: 120,
+    finalTimeMs: 2_000,
+    truncated: false,
+    deltas: [],
+  };
 }

--- a/src/game/modes/timeTrialTargets.ts
+++ b/src/game/modes/timeTrialTargets.ts
@@ -1,15 +1,24 @@
-import type { Championship, SaveGame, Track, WeatherOption } from "@/data/schemas";
+import type {
+  Championship,
+  GhostReplay,
+  SaveGame,
+  Track,
+  WeatherOption,
+} from "@/data/schemas";
 
 import { unlockedChampionshipTrackIds } from "./unlockedTracks";
 
 export interface TimeTrialTrackOption {
   readonly id: string;
   readonly name: string;
+  readonly version: number;
   readonly weatherOptions: readonly WeatherOption[];
   readonly personalBestLapMs: number | null;
   readonly personalBestRaceMs: number | null;
   readonly developerBenchmarkMs: number | null;
+  readonly downloadedGhostTimeMs: number | null;
   readonly startHref: string;
+  readonly startDownloadedGhostHref: string | null;
 }
 
 export interface TimeTrialView {
@@ -41,18 +50,29 @@ export function buildTimeTrialView(input: {
       const track = input.tracksById.get(trackId);
       if (!track) return [];
       const record = input.save.records[track.id] ?? null;
+      const downloadedGhost = input.save.downloadedGhosts?.[track.id] ?? null;
       return [
         {
           id: track.id,
           name: track.name,
+          version: track.version,
           weatherOptions: track.weatherOptions,
           personalBestLapMs: record?.bestLapMs ?? null,
           personalBestRaceMs: record?.bestRaceMs ?? null,
           developerBenchmarkMs: developerBenchmarkMs(track.id),
+          downloadedGhostTimeMs: downloadedGhost?.finalTimeMs ?? null,
           startHref: timeTrialRaceHref({
             trackId: track.id,
             weather: track.weatherOptions[0],
           }),
+          startDownloadedGhostHref:
+            downloadedGhost === null
+              ? null
+              : timeTrialRaceHref({
+                  trackId: track.id,
+                  weather: track.weatherOptions[0],
+                  ghost: "downloaded",
+                }),
         },
       ];
     }),
@@ -62,6 +82,7 @@ export function buildTimeTrialView(input: {
 export function timeTrialRaceHref(input: {
   readonly trackId: string;
   readonly weather?: WeatherOption;
+  readonly ghost?: "downloaded";
 }): string {
   const params = new URLSearchParams({
     mode: "timeTrial",
@@ -70,9 +91,23 @@ export function timeTrialRaceHref(input: {
   if (input.weather !== undefined) {
     params.set("weather", input.weather);
   }
+  if (input.ghost !== undefined) {
+    params.set("ghost", input.ghost);
+  }
   return `/race?${params.toString()}`;
 }
 
 export function developerBenchmarkMs(trackId: string): number | null {
   return DEVELOPER_BENCHMARKS_MS[trackId] ?? null;
+}
+
+export function acceptDownloadedGhost(input: {
+  readonly trackId: string;
+  readonly trackVersion: number;
+  readonly ghost: GhostReplay;
+}): boolean {
+  return (
+    input.ghost.trackId === input.trackId &&
+    input.ghost.trackVersion === input.trackVersion
+  );
 }

--- a/src/persistence/save.test.ts
+++ b/src/persistence/save.test.ts
@@ -76,6 +76,12 @@ describe("defaultSave", () => {
     const { SaveGameSchema } = await import("@/data/schemas");
     expect(SaveGameSchema.safeParse(defaultSave()).success).toBe(true);
   });
+
+  it("seeds separate PB and downloaded ghost maps", () => {
+    const save = defaultSave();
+    expect(save.ghosts).toEqual({});
+    expect(save.downloadedGhosts).toEqual({});
+  });
 });
 
 describe("loadSave", () => {

--- a/src/persistence/save.ts
+++ b/src/persistence/save.ts
@@ -157,6 +157,7 @@ export function defaultSave(): SaveGame {
     // migrator seeds the same shape so a fresh save and a migrated save
     // are byte-identical at this slot.
     ghosts: {},
+    downloadedGhosts: {},
     // Cross-tab last-write-wins counter. Seeds at 0; `saveSave` increments
     // before every persist so two tabs can compare which write came last.
     writeCounter: 0,


### PR DESCRIPTION
## Summary
- Add a separate downloaded ghost replay slot in the save schema
- Let the Time Trial launch page import valid ghost JSON per unlocked track
- Add a downloaded-ghost race start link and route selection via ghost=downloaded
- Record coverage for GDD-06-TIME-TRIAL-DOWNLOADED-GHOST

## Test plan
- npx vitest run src/game/modes/__tests__/timeTrialTargets.test.ts src/data/schemas.test.ts src/persistence/save.test.ts
- npm run typecheck
- npm run content-lint
- npx playwright test e2e/time-trial.spec.ts e2e/title-screen.spec.ts --project=chromium -g "time trial|Time Trial"
- npm run lint
- npm run verify

## GDD
- docs/gdd/06-game-modes.md
- docs/gdd/21-technical-design-for-web-implementation.md
- docs/gdd/22-data-schemas.md

## Progress log
- docs/PROGRESS_LOG.md, 2026-04-30 Time Trial downloaded ghost selection