### PR TITLE
Daily Challenge UTC fake-clock e2e

### DIFF
--- a/docs/GDD_COVERAGE.json
+++ b/docs/GDD_COVERAGE.json
@@ -203,9 +203,10 @@
       "testRefs": [
         "src/game/modes/__tests__/dailyChallenge.test.ts",
         "src/app/__tests__/page.test.tsx",
-        "e2e/title-screen.spec.ts"
+        "e2e/title-screen.spec.ts",
+        "e2e/daily-challenge.spec.ts"
       ],
-      "followupRefs": []
+      "followupRefs": ["VibeGear2-implement-daily-challenge-a44efeff"]
     },
     {
       "id": "GDD-06-DAILY-CHALLENGE-RESULT-SHARE",

--- a/docs/PROGRESS_LOG.md
+++ b/docs/PROGRESS_LOG.md
@@ -6,6 +6,59 @@ Correct them by adding a new entry that references the old one.
 
 ---
 
+## 2026-04-30: Slice: Daily Challenge UTC fake-clock e2e
+
+**GDD sections touched:**
+[§6](gdd/06-game-modes.md) Daily Challenge and
+[§21](gdd/21-technical-design-for-web-implementation.md) browser e2e
+verification.
+**Branch / PR:** `test/daily-utc-fake-clock`, PR pending.
+**Status:** Implemented.
+
+### Done
+- Moved the Daily Challenge entry panel into a client-rendered component
+  so the user-facing route can be verified under Playwright's browser
+  clock.
+- Added Playwright coverage that fixes the browser clock before and
+  after UTC midnight, proving `/daily` rolls the entry date, seed, and
+  race link by UTC day.
+- Added Playwright coverage that starts a Daily Challenge run before
+  UTC midnight and verifies the chosen daily marker stays fixed after
+  the browser clock crosses into the next UTC day.
+- Updated the machine-checkable coverage ledger for Daily Challenge
+  selection.
+
+### Verified
+- `npx vitest run src/game/modes/__tests__/dailyChallenge.test.ts`
+  green, 12 tests passed.
+- `npm run typecheck` green.
+- `npx playwright test e2e/daily-challenge.spec.ts e2e/title-screen.spec.ts --project=chromium -g "daily|Daily"`
+  green, 3 tests passed.
+- `npm run lint` green.
+- `npm run content-lint` green.
+- `npm run verify` green, 2670 Vitest tests passed.
+
+### Decisions and assumptions
+- Kept bundled daily track and car-class data in the server page, while
+  moving only date-sensitive selection and rendering to the client. That
+  makes the visible route testable with a browser clock without changing
+  the daily selection algorithm.
+
+### Coverage ledger
+- GDD-06-DAILY-CHALLENGE-SELECTION now includes
+  `e2e/daily-challenge.spec.ts` and the slice dot for fake-clock route
+  verification.
+- Uncovered adjacent requirements: none for the current §6 Daily
+  Challenge fake-clock gap.
+
+### Followups created
+None.
+
+### GDD edits
+None.
+
+---
+
 ## 2026-04-30: Slice: Time Trial downloaded ghost selection
 
 **GDD sections touched:**

--- a/e2e/daily-challenge.spec.ts
+++ b/e2e/daily-challenge.spec.ts
@@ -1,0 +1,44 @@
+import { expect, test } from "@playwright/test";
+
+test.describe("daily challenge UTC clock", () => {
+  test("rolls the entry route by UTC day under a browser fake clock", async ({
+    page,
+  }) => {
+    await page.clock.setFixedTime("2026-04-30T23:59:50Z");
+    await page.goto("/daily");
+
+    await expect(page.getByTestId("daily-page")).toBeVisible();
+    await expect(page.locator("#daily-title")).toHaveText("2026-04-30");
+    const aprilSeed = await page.getByTestId("daily-seed").textContent();
+    const aprilStartHref = await page
+      .getByTestId("daily-start")
+      .getAttribute("href");
+    expect(aprilStartHref).toContain("daily=2026-04-30");
+
+    await page.clock.setFixedTime("2026-05-01T00:00:05Z");
+    await page.goto("/daily");
+
+    await expect(page.locator("#daily-title")).toHaveText("2026-05-01");
+    await expect(page.getByTestId("daily-seed")).not.toHaveText(
+      aprilSeed ?? "",
+    );
+    await expect(page.getByTestId("daily-start")).toHaveAttribute(
+      "href",
+      /daily=2026-05-01/,
+    );
+  });
+
+  test("keeps the chosen daily marker after starting across UTC midnight", async ({
+    page,
+  }) => {
+    await page.clock.setFixedTime("2026-04-30T23:59:50Z");
+    await page.goto("/daily");
+
+    await expect(page.locator("#daily-title")).toHaveText("2026-04-30");
+    await page.getByTestId("daily-start").click();
+    await expect(page).toHaveURL(/daily=2026-04-30/);
+
+    await page.clock.setFixedTime("2026-05-01T00:00:05Z");
+    await expect(page).toHaveURL(/daily=2026-04-30/);
+  });
+});

--- a/src/app/daily/DailyChallengePanel.tsx
+++ b/src/app/daily/DailyChallengePanel.tsx
@@ -1,0 +1,107 @@
+"use client";
+
+import Link from "next/link";
+import { useEffect, useMemo, useState } from "react";
+
+import type { CarClass } from "@/data/schemas";
+import {
+  dailyChallengeRaceHref,
+  formatDailyChallengeShareText,
+  selectDailyChallenge,
+  type DailyChallengeTrack,
+} from "@/game/modes/dailyChallenge";
+import { weatherLabel } from "@/game/preRaceCard";
+
+import { DailyShareButton } from "./DailyShareButton";
+import styles from "./page.module.css";
+
+interface DailyChallengePanelProps {
+  readonly tracks: readonly DailyChallengeTrack[];
+  readonly carClasses: readonly CarClass[];
+  readonly initialDateIso: string;
+}
+
+export function DailyChallengePanel({
+  tracks,
+  carClasses,
+  initialDateIso,
+}: DailyChallengePanelProps) {
+  const [selectionDate, setSelectionDate] = useState(
+    () => new Date(initialDateIso),
+  );
+
+  useEffect(() => {
+    setSelectionDate(new Date());
+  }, []);
+
+  const challenge = useMemo(
+    () => selectDailyChallenge(selectionDate, tracks, carClasses),
+    [carClasses, selectionDate, tracks],
+  );
+  const shareText = formatDailyChallengeShareText(challenge);
+  const raceHref = dailyChallengeRaceHref(challenge);
+
+  return (
+    <section className={styles.shell} aria-labelledby="daily-title">
+      <header className={styles.header}>
+        <p className={styles.eyebrow}>Daily Challenge</p>
+        <h1 className={styles.title} id="daily-title">
+          {challenge.dateKey}
+        </h1>
+        <p className={styles.summary}>
+          Fixed track and weather for one UTC day, with a daily car class
+          recommendation.
+        </p>
+      </header>
+
+      <article className={styles.panel}>
+        <dl className={styles.stats}>
+          <div className={styles.stat}>
+            <dt>Track</dt>
+            <dd data-testid="daily-track">{challenge.trackId}</dd>
+          </div>
+          <div className={styles.stat}>
+            <dt>Weather</dt>
+            <dd data-testid="daily-weather">
+              {weatherLabel(challenge.weather)}
+            </dd>
+          </div>
+          <div className={styles.stat}>
+            <dt>Recommended class</dt>
+            <dd data-testid="daily-car-class">
+              {formatCarClass(challenge.carClass)}
+            </dd>
+          </div>
+          <div className={styles.stat}>
+            <dt>Seed</dt>
+            <dd data-testid="daily-seed">{challenge.seed}</dd>
+          </div>
+        </dl>
+
+        <div className={styles.actions}>
+          <Link
+            className={styles.button}
+            href={raceHref}
+            data-testid="daily-start"
+          >
+            Start run
+          </Link>
+          <Link className={styles.secondary} href="/" data-testid="daily-back">
+            Back to title
+          </Link>
+        </div>
+
+        <div className={styles.share}>
+          <DailyShareButton text={shareText} />
+        </div>
+      </article>
+    </section>
+  );
+}
+
+function formatCarClass(carClass: CarClass): string {
+  return carClass
+    .split("-")
+    .map((part) => `${part[0]?.toUpperCase() ?? ""}${part.slice(1)}`)
+    .join(" ");
+}

--- a/src/app/daily/page.tsx
+++ b/src/app/daily/page.tsx
@@ -1,89 +1,20 @@
-import Link from "next/link";
-
 import { CARS, TRACK_IDS, TRACK_RAW } from "@/data";
 import { TrackSchema, type CarClass } from "@/data/schemas";
-import {
-  dailyChallengeRaceHref,
-  formatDailyChallengeShareText,
-  selectDailyChallenge,
-  type DailyChallengeTrack,
-} from "@/game/modes/dailyChallenge";
-import { weatherLabel } from "@/game/preRaceCard";
+import type { DailyChallengeTrack } from "@/game/modes/dailyChallenge";
 
-import { DailyShareButton } from "./DailyShareButton";
+import { DailyChallengePanel } from "./DailyChallengePanel";
 import styles from "./page.module.css";
 
 export const dynamic = "force-dynamic";
 
 export default function DailyChallengePage() {
-  const challenge = selectDailyChallenge(
-    new Date(),
-    bundledDailyTracks(),
-    bundledCarClasses(),
-  );
-  const shareText = formatDailyChallengeShareText(challenge);
-  const raceHref = dailyChallengeRaceHref(challenge);
-
   return (
     <main className={styles.main} data-testid="daily-page">
-      <section className={styles.shell} aria-labelledby="daily-title">
-        <header className={styles.header}>
-          <p className={styles.eyebrow}>Daily Challenge</p>
-          <h1 className={styles.title} id="daily-title">
-            {challenge.dateKey}
-          </h1>
-          <p className={styles.summary}>
-            Fixed track and weather for one UTC day, with a daily car class
-            recommendation.
-          </p>
-        </header>
-
-        <article className={styles.panel}>
-          <dl className={styles.stats}>
-            <div className={styles.stat}>
-              <dt>Track</dt>
-              <dd data-testid="daily-track">{challenge.trackId}</dd>
-            </div>
-            <div className={styles.stat}>
-              <dt>Weather</dt>
-              <dd data-testid="daily-weather">
-                {weatherLabel(challenge.weather)}
-              </dd>
-            </div>
-            <div className={styles.stat}>
-              <dt>Recommended class</dt>
-              <dd data-testid="daily-car-class">
-                {formatCarClass(challenge.carClass)}
-              </dd>
-            </div>
-            <div className={styles.stat}>
-              <dt>Seed</dt>
-              <dd data-testid="daily-seed">{challenge.seed}</dd>
-            </div>
-          </dl>
-
-          <div className={styles.actions}>
-            <Link
-              className={styles.button}
-              href={raceHref}
-              data-testid="daily-start"
-            >
-              Start run
-            </Link>
-            <Link
-              className={styles.secondary}
-              href="/"
-              data-testid="daily-back"
-            >
-              Back to title
-            </Link>
-          </div>
-
-          <div className={styles.share}>
-            <DailyShareButton text={shareText} />
-          </div>
-        </article>
-      </section>
+      <DailyChallengePanel
+        tracks={bundledDailyTracks()}
+        carClasses={bundledCarClasses()}
+        initialDateIso={new Date().toISOString()}
+      />
     </main>
   );
 }
@@ -102,11 +33,4 @@ function bundledCarClasses(): CarClass[] {
   const seen = new Set<CarClass>();
   for (const car of CARS) seen.add(car.class);
   return [...seen];
-}
-
-function formatCarClass(carClass: CarClass): string {
-  return carClass
-    .split("-")
-    .map((part) => `${part[0]?.toUpperCase() ?? ""}${part.slice(1)}`)
-    .join(" ");
 }


### PR DESCRIPTION
## Summary
- Move the date-sensitive Daily Challenge entry panel into a client component so browser fake clocks can verify the visible route.
- Add Playwright coverage for UTC-day rollover on `/daily` and for started Daily Challenge runs keeping their original daily marker after the browser clock crosses midnight.
- Update the GDD coverage ledger and progress log for `GDD-06-DAILY-CHALLENGE-SELECTION`.

## GDD coverage
- `docs/gdd/06-game-modes.md`: Daily Challenge uses a deterministic UTC-day seed and fixed entry route.
- `docs/gdd/21-technical-design-for-web-implementation.md`: user-visible behavior is covered by browser e2e.

## Requirement inventory
- Handles browser-visible UTC-day rollover for the Daily Challenge entry date, seed, and race link.
- Handles the parent-dot edge case that a run started before UTC midnight keeps its original daily marker.
- Leaves no adjacent Daily Challenge fake-clock gap in this slice.

## Progress log
- `docs/PROGRESS_LOG.md`: 2026-04-30 Daily Challenge UTC fake-clock e2e.

## Test plan
- [x] `npx vitest run src/game/modes/__tests__/dailyChallenge.test.ts`
- [x] `npm run typecheck`
- [x] `npx playwright test e2e/daily-challenge.spec.ts e2e/title-screen.spec.ts --project=chromium -g "daily|Daily"`
- [x] `npm run lint`
- [x] `npm run content-lint`
- [x] `npm run verify`
- [x] `grep -rn $'\u2014\|\u2013' src/app/daily e2e/daily-challenge.spec.ts docs/GDD_COVERAGE.json docs/PROGRESS_LOG.md`
- [x] `git diff --check`

## Followups
None.
