### PR TITLE
Pause settings action

### DIFF
--- a/docs/FOLLOWUPS.md
+++ b/docs/FOLLOWUPS.md
@@ -10,6 +10,18 @@ or `obsolete` so the trail is preserved.
 
 ---
 
+## F-070: Wire pause leaderboard or ghost action to a target surface
+**Created:** 2026-04-30
+**Priority:** polish
+**Status:** open
+**Notes:** The pause Settings action now routes to `/options`, but the
+§20 pause menu still disables `Leaderboard`. Decide whether the
+leaderboard or ghost pause action should open a lightweight in-race
+panel, jump to a track leaderboard view, or remain unavailable until
+online leaderboard storage is approved. Keep this separate from the
+Settings action so the pause menu can ship one working target at a
+time.
+
 ## F-068: Add unique FX atlas sheets for all six playable cars
 **Created:** 2026-04-29
 **Priority:** polish

--- a/docs/GDD_COVERAGE.json
+++ b/docs/GDD_COVERAGE.json
@@ -680,6 +680,28 @@
       "followupRefs": []
     },
     {
+      "id": "GDD-20-PAUSE-SETTINGS-ACTION",
+      "gddSections": [
+        "docs/gdd/20-hud-and-ui-ux.md"
+      ],
+      "requirement": "The live race pause menu exposes Settings as a working action that tears down the race runtime and routes to the options screen.",
+      "coverage": ["implemented-code", "automated-test"],
+      "implementationRefs": [
+        "src/components/pause/usePauseActions.ts",
+        "src/components/pause/PauseOverlay.tsx",
+        "src/app/race/page.tsx"
+      ],
+      "testRefs": [
+        "src/components/pause/__tests__/usePauseActions.test.tsx",
+        "e2e/pause-actions.spec.ts",
+        "e2e/pause-overlay.spec.ts"
+      ],
+      "followupRefs": [
+        "VibeGear2-implement-pause-settings-626c3ecf",
+        "F-070"
+      ]
+    },
+    {
       "id": "GDD-20-MOBILE-TITLE-CENTERING",
       "gddSections": [
         "docs/gdd/04-player-experience-goals.md",

--- a/docs/PROGRESS_LOG.md
+++ b/docs/PROGRESS_LOG.md
@@ -6,6 +6,53 @@ Correct them by adding a new entry that references the old one.
 
 ---
 
+## 2026-04-30: Slice: Pause settings action
+
+**GDD sections touched:**
+[§20](gdd/20-hud-and-ui-ux.md) Pause menu and Settings.
+**Branch / PR:** `feat/pause-settings-action`, PR pending.
+**Status:** Implemented.
+
+### Done
+- Extended the shared pause-action hook with a Settings action that
+  closes the menu before invoking the page-owned navigation effect.
+- Wired the live race route to stop the race runtime, audio, input, and
+  loop before routing from the pause menu to `/options`.
+- Updated pause overlay and pause action e2e coverage so Settings is a
+  working route target instead of a disabled menu item.
+- Added the machine-checkable coverage ledger row for the pause Settings
+  action.
+
+### Verified
+- `npx vitest run src/components/pause/__tests__/usePauseActions.test.tsx`
+  green, 7 tests passed.
+- `npm run typecheck` green.
+- `npx playwright test e2e/pause-actions.spec.ts e2e/pause-overlay.spec.ts --project=chromium`
+  green, 8 tests passed.
+- `npm run lint` green.
+- `npm run content-lint` green.
+- `npm run verify` green, 2671 Vitest tests passed.
+
+### Decisions and assumptions
+- Treated Settings like Exit to title for teardown: the live runtime is
+  stopped before the route hop so audio, input, and animation callbacks
+  do not survive into `/options`.
+- Kept the pause Leaderboard action disabled because there is no
+  route-level target for an in-race leaderboard or ghost view yet.
+
+### Coverage ledger
+- GDD-20-PAUSE-SETTINGS-ACTION covers the working pause Settings action.
+- Uncovered adjacent requirements: F-070 tracks the remaining pause
+  leaderboard or ghost target.
+
+### Followups created
+- F-070: Wire pause leaderboard or ghost action to a target surface.
+
+### GDD edits
+None.
+
+---
+
 ## 2026-04-30: Slice: Daily Challenge UTC fake-clock e2e
 
 **GDD sections touched:**

--- a/e2e/pause-actions.spec.ts
+++ b/e2e/pause-actions.spec.ts
@@ -13,6 +13,8 @@ import { expect, test } from "@playwright/test";
  *     hops to `/race/results` with the DNF placement label.
  *   - Exit-to-Title: open the menu mid-race, click Exit, assert the
  *     route hops to `/`.
+ *   - Settings: open the menu mid-race, click Settings, assert the
+ *     route hops to `/options`.
  */
 
 test.describe("pause actions", () => {
@@ -81,6 +83,22 @@ test.describe("pause actions", () => {
     // Route hops to the title screen.
     await expect(page).toHaveURL(/\/$/);
     await expect(page.getByTestId("game-title")).toBeVisible({
+      timeout: 5_000,
+    });
+  });
+
+  test("Settings routes to the options screen", async ({ page }) => {
+    await page.goto("/race");
+    await expect(page.getByTestId("race-phase")).toHaveText("racing", {
+      timeout: 10_000,
+    });
+
+    await page.keyboard.press("Escape");
+    await expect(page.getByTestId("pause-overlay")).toBeVisible();
+    await page.getByTestId("pause-settings").click();
+
+    await expect(page).toHaveURL(/\/options$/);
+    await expect(page.getByTestId("options-page")).toBeVisible({
       timeout: 5_000,
     });
   });

--- a/e2e/pause-overlay.spec.ts
+++ b/e2e/pause-overlay.spec.ts
@@ -91,14 +91,13 @@ test.describe("pause overlay", () => {
     await page.keyboard.press("Escape");
     await expect(page.getByTestId("pause-overlay")).toBeVisible();
 
-    // The dot ships the restart / retire / exit-to-title wiring; all
-    // three buttons should now be visible and clickable. Settings and
-    // leaderboard remain disabled here because the page does not pass
-    // their handlers yet (their target routes land in later slices).
+    // The dot ships restart / retire / exit-to-title plus settings
+    // wiring; those buttons should be visible and clickable. Leaderboard
+    // remains disabled here because it does not have a target route yet.
     await expect(page.getByTestId("pause-restart")).toBeEnabled();
     await expect(page.getByTestId("pause-retire")).toBeEnabled();
     await expect(page.getByTestId("pause-exit")).toBeEnabled();
-    await expect(page.getByTestId("pause-settings")).toBeDisabled();
+    await expect(page.getByTestId("pause-settings")).toBeEnabled();
     await expect(page.getByTestId("pause-leaderboard")).toBeDisabled();
   });
 });

--- a/src/app/race/page.tsx
+++ b/src/app/race/page.tsx
@@ -784,6 +784,7 @@ function RaceCanvas({
   const restartFnRef = useRef<(() => void) | null>(null);
   const retireFnRef = useRef<(() => void) | null>(null);
   const exitFnRef = useRef<(() => void) | null>(null);
+  const settingsFnRef = useRef<(() => void) | null>(null);
   // Per-mount guard for the natural finish wiring. The render callback
   // fires every frame, so without this latch a `phase === "finished"`
   // tick would call `saveRaceResult` and `router.push` on every frame
@@ -848,6 +849,9 @@ function RaceCanvas({
   const onExitToTitleImpl = useCallback(() => {
     exitFnRef.current?.();
   }, []);
+  const onSettingsImpl = useCallback(() => {
+    settingsFnRef.current?.();
+  }, []);
   const onPracticeCheckpointReset = useCallback(() => {
     if (mode !== "practice") return;
     const session = sessionRef.current;
@@ -882,6 +886,7 @@ function RaceCanvas({
     onRestartImpl: phase === "finished" ? null : onRestartImpl,
     onRetireImpl: phase === "finished" ? null : onRetireImpl,
     onExitToTitleImpl,
+    onSettingsImpl,
   });
 
   useEffect(() => {
@@ -1247,6 +1252,11 @@ function RaceCanvas({
     exitFnRef.current = (): void => {
       stopRaceRuntime();
       router.push("/");
+    };
+
+    settingsFnRef.current = (): void => {
+      stopRaceRuntime();
+      router.push("/options");
     };
 
     handleRef.current = startLoop({

--- a/src/components/pause/__tests__/usePauseActions.test.tsx
+++ b/src/components/pause/__tests__/usePauseActions.test.tsx
@@ -78,6 +78,18 @@ describe("usePauseActions", () => {
     );
   });
 
+  it("onSettings closes the menu then invokes the settings impl", () => {
+    const closeMenu = vi.fn();
+    const onSettingsImpl = vi.fn();
+    const result = captureActions({ closeMenu, onSettingsImpl });
+    result.onSettings?.();
+    expect(closeMenu).toHaveBeenCalledTimes(1);
+    expect(onSettingsImpl).toHaveBeenCalledTimes(1);
+    expect(closeMenu.mock.invocationCallOrder[0]).toBeLessThan(
+      onSettingsImpl.mock.invocationCallOrder[0]!,
+    );
+  });
+
   it("returns undefined for any handler whose impl is null so PauseOverlay disables the button", () => {
     const closeMenu = vi.fn();
     const result = captureActions({
@@ -85,10 +97,12 @@ describe("usePauseActions", () => {
       onRestartImpl: null,
       onRetireImpl: null,
       onExitToTitleImpl: null,
+      onSettingsImpl: null,
     });
     expect(result.onRestart).toBeUndefined();
     expect(result.onRetire).toBeUndefined();
     expect(result.onExitToTitle).toBeUndefined();
+    expect(result.onSettings).toBeUndefined();
     // onResume is always provided.
     expect(typeof result.onResume).toBe("function");
   });
@@ -99,5 +113,6 @@ describe("usePauseActions", () => {
     expect(result.onRestart).toBeUndefined();
     expect(result.onRetire).toBeUndefined();
     expect(result.onExitToTitle).toBeUndefined();
+    expect(result.onSettings).toBeUndefined();
   });
 });

--- a/src/components/pause/usePauseActions.ts
+++ b/src/components/pause/usePauseActions.ts
@@ -1,7 +1,7 @@
 "use client";
 
 /**
- * Hook that wraps the four §20 pause-menu actions per dot
+ * Hook that wraps the five wired §20 pause-menu actions per dot
  * `VibeGear2-implement-restart-retire-888c712b`.
  *
  * `<PauseOverlay />` accepts `onResume`, `onRestart`, `onRetire`,
@@ -34,6 +34,8 @@
  *   - Exit to title while paused: `onExitToTitleImpl` disposes the
  *     loop before navigating so a torn-down rAF / audio handle cannot
  *     leak across the route hop.
+ *   - Settings while paused: the parent disposes the live runtime before
+ *     routing to `/options`, matching exit-to-title teardown.
  *   - Restart after finish: the parent disables the button by passing
  *     `onRestartImpl: null`; the hook surfaces `onRestart: undefined`
  *     in that case so `<PauseOverlay />`'s self-disable contract
@@ -63,6 +65,11 @@ export interface UsePauseActionsOptions {
    * for symmetry with the other two actions).
    */
   onExitToTitleImpl?: (() => void) | null;
+  /**
+   * Tear down the loop and route to settings. `null` disables the
+   * button for surfaces that do not have a settings target.
+   */
+  onSettingsImpl?: (() => void) | null;
 }
 
 export interface UsePauseActionsResult {
@@ -74,6 +81,8 @@ export interface UsePauseActionsResult {
   onRetire?: () => void;
   /** Wrapper around `onExitToTitleImpl`, or `undefined` when the impl is null. */
   onExitToTitle?: () => void;
+  /** Wrapper around `onSettingsImpl`, or `undefined` when the impl is null. */
+  onSettings?: () => void;
 }
 
 /**
@@ -88,7 +97,13 @@ export interface UsePauseActionsResult {
 export function usePauseActions(
   options: UsePauseActionsOptions,
 ): UsePauseActionsResult {
-  const { closeMenu, onRestartImpl, onRetireImpl, onExitToTitleImpl } = options;
+  const {
+    closeMenu,
+    onRestartImpl,
+    onRetireImpl,
+    onExitToTitleImpl,
+    onSettingsImpl,
+  } = options;
 
   const onResume = useCallback(() => {
     closeMenu();
@@ -109,21 +124,29 @@ export function usePauseActions(
     onExitToTitleImpl?.();
   }, [closeMenu, onExitToTitleImpl]);
 
+  const onSettings = useCallback(() => {
+    closeMenu();
+    onSettingsImpl?.();
+  }, [closeMenu, onSettingsImpl]);
+
   return useMemo(
     () => ({
       onResume,
       onRestart: onRestartImpl ? onRestart : undefined,
       onRetire: onRetireImpl ? onRetire : undefined,
       onExitToTitle: onExitToTitleImpl ? onExitToTitle : undefined,
+      onSettings: onSettingsImpl ? onSettings : undefined,
     }),
     [
       onResume,
       onRestart,
       onRetire,
       onExitToTitle,
+      onSettings,
       onRestartImpl,
       onRetireImpl,
       onExitToTitleImpl,
+      onSettingsImpl,
     ],
   );
 }


### PR DESCRIPTION
## Summary
- Wire the live pause menu Settings action through the shared pause-action hook.
- Stop the race runtime, audio, input, and loop before routing to `/options`.
- Update pause e2e coverage and add the pause Settings coverage ledger row.
- Add F-070 for the remaining pause leaderboard or ghost target.

## GDD coverage
- `docs/gdd/20-hud-and-ui-ux.md`: Pause menu Settings action.

## Requirement inventory
- Handles Settings as a working pause action from live races.
- Keeps Restart, Retire, Resume, and Exit behavior unchanged.
- Leaves Leaderboard disabled because it has no route-level target yet. Tracked in F-070.

## Progress log
- `docs/PROGRESS_LOG.md`: 2026-04-30 Pause settings action.

## Test plan
- [x] `npx vitest run src/components/pause/__tests__/usePauseActions.test.tsx`
- [x] `npm run typecheck`
- [x] `npx playwright test e2e/pause-actions.spec.ts e2e/pause-overlay.spec.ts --project=chromium`
- [x] `npm run lint`
- [x] `npm run content-lint`
- [x] `npm run verify`
- [x] `grep -rn $'\u2014\|\u2013' src/components/pause src/app/race/page.tsx e2e/pause-actions.spec.ts e2e/pause-overlay.spec.ts docs/FOLLOWUPS.md docs/GDD_COVERAGE.json docs/PROGRESS_LOG.md`
- [x] `git diff --check`

## Followups
- F-070: Wire pause leaderboard or ghost action to a target surface.
