### PR TITLE
Pause ghosts action

### DIFF
--- a/docs/FOLLOWUPS.md
+++ b/docs/FOLLOWUPS.md
@@ -13,7 +13,7 @@ or `obsolete` so the trail is preserved.
 ## F-070: Wire pause leaderboard or ghost action to a target surface
 **Created:** 2026-04-30
 **Priority:** polish
-**Status:** open
+**Status:** done (2026-04-30)
 **Notes:** The pause Settings action now routes to `/options`, but the
 §20 pause menu still disables `Leaderboard`. Decide whether the
 leaderboard or ghost pause action should open a lightweight in-race
@@ -21,6 +21,12 @@ panel, jump to a track leaderboard view, or remain unavailable until
 online leaderboard storage is approved. Keep this separate from the
 Settings action so the pause menu can ship one working target at a
 time.
+
+Closed by `feat/pause-ghosts-action`. The combined §20
+leaderboard-or-ghost pause slot now ships as a local Ghosts action that
+tears down the live race runtime and routes to `/time-trial`, where PB
+and downloaded ghost management already live. The online leaderboard
+provider choice remains blocked separately by Q-011.
 
 ## F-068: Add unique FX atlas sheets for all six playable cars
 **Created:** 2026-04-29

--- a/docs/GDD_COVERAGE.json
+++ b/docs/GDD_COVERAGE.json
@@ -702,6 +702,31 @@
       ]
     },
     {
+      "id": "GDD-20-PAUSE-GHOSTS-ACTION",
+      "gddSections": [
+        "docs/gdd/06-game-modes.md",
+        "docs/gdd/20-hud-and-ui-ux.md"
+      ],
+      "requirement": "The live race pause menu exposes the leaderboard or ghost slot as a working local Ghosts action that tears down the race runtime and routes to the Time Trial ghost surface.",
+      "coverage": ["implemented-code", "automated-test"],
+      "implementationRefs": [
+        "src/components/pause/usePauseActions.ts",
+        "src/components/pause/PauseOverlay.tsx",
+        "src/app/race/page.tsx",
+        "src/app/time-trial/page.tsx"
+      ],
+      "testRefs": [
+        "src/components/pause/__tests__/usePauseActions.test.tsx",
+        "e2e/pause-actions.spec.ts",
+        "e2e/pause-overlay.spec.ts"
+      ],
+      "followupRefs": [
+        "VibeGear2-implement-pause-ghosts-c7f0391b",
+        "F-070",
+        "Q-011"
+      ]
+    },
+    {
       "id": "GDD-20-MOBILE-TITLE-CENTERING",
       "gddSections": [
         "docs/gdd/04-player-experience-goals.md",

--- a/docs/PROGRESS_LOG.md
+++ b/docs/PROGRESS_LOG.md
@@ -30,6 +30,8 @@ Correct them by adding a new entry that references the old one.
 - `npm run typecheck` green.
 - `npx playwright test e2e/pause-actions.spec.ts e2e/pause-overlay.spec.ts --project=chromium`
   green, 9 tests passed.
+- `PLAYWRIGHT_CROSS_BROWSER=1 npx playwright test e2e/cross-browser-smoke.spec.ts --project=cross-browser-webkit -g "keyboard-only"`
+  green, 1 test passed.
 - `npm run lint` green.
 - `npm run content-lint` green.
 - `npm run verify` green, 2672 Vitest tests passed.

--- a/docs/PROGRESS_LOG.md
+++ b/docs/PROGRESS_LOG.md
@@ -6,6 +6,52 @@ Correct them by adding a new entry that references the old one.
 
 ---
 
+## 2026-04-30: Slice: Pause ghosts action
+
+**GDD sections touched:**
+[§6](gdd/06-game-modes.md) Time Trial ghosts and
+[§20](gdd/20-hud-and-ui-ux.md) Pause menu.
+**Branch / PR:** `feat/pause-ghosts-action`, PR pending.
+**Status:** Implemented.
+
+### Done
+- Changed the pause menu's combined leaderboard or ghost slot into a
+  Ghosts action with a concrete local target.
+- Extended the shared pause-action hook with `onGhostsImpl`, keeping
+  the close-then-invoke ordering used by the other pause actions.
+- Wired the live race route to stop the runtime, audio, input, and loop
+  before routing from the pause menu to `/time-trial`.
+- Marked F-070 done and added the machine-checkable coverage ledger row
+  for the pause Ghosts action.
+
+### Verified
+- `npx vitest run src/components/pause/__tests__/usePauseActions.test.tsx`
+  green, 8 tests passed.
+- `npm run typecheck` green.
+- `npx playwright test e2e/pause-actions.spec.ts e2e/pause-overlay.spec.ts --project=chromium`
+  green, 9 tests passed.
+- `npm run lint` green.
+- `npm run content-lint` green.
+- `npm run verify` green, 2672 Vitest tests passed.
+
+### Decisions and assumptions
+- Chose the local Ghosts target over an online Leaderboard target because
+  Time Trial PB and downloaded ghost management already ships, while
+  online leaderboard storage remains blocked by Q-011.
+
+### Coverage ledger
+- GDD-20-PAUSE-GHOSTS-ACTION covers the working pause Ghosts action.
+- Uncovered adjacent requirements: online leaderboard storage remains
+  deferred under Q-011.
+
+### Followups created
+None.
+
+### GDD edits
+None.
+
+---
+
 ## 2026-04-30: Slice: Pause settings action
 
 **GDD sections touched:**

--- a/e2e/cross-browser-smoke.spec.ts
+++ b/e2e/cross-browser-smoke.spec.ts
@@ -11,7 +11,7 @@ const CORE_ROUTES: ReadonlyArray<{
   { path: "/race?mode=practice", testId: "race-canvas" },
 ];
 
-async function focusByTab(page: Page, testId: string, maxTabs = 24): Promise<void> {
+async function focusByTab(page: Page, testId: string, maxTabs = 40): Promise<void> {
   for (let i = 0; i < maxTabs; i += 1) {
     await page.keyboard.press("Tab");
     const activeTestId = await page.evaluate(() => {

--- a/e2e/pause-actions.spec.ts
+++ b/e2e/pause-actions.spec.ts
@@ -15,6 +15,8 @@ import { expect, test } from "@playwright/test";
  *     route hops to `/`.
  *   - Settings: open the menu mid-race, click Settings, assert the
  *     route hops to `/options`.
+ *   - Ghosts: open the menu mid-race, click Ghosts, assert the route
+ *     hops to `/time-trial`.
  */
 
 test.describe("pause actions", () => {
@@ -99,6 +101,22 @@ test.describe("pause actions", () => {
 
     await expect(page).toHaveURL(/\/options$/);
     await expect(page.getByTestId("options-page")).toBeVisible({
+      timeout: 5_000,
+    });
+  });
+
+  test("Ghosts routes to the Time Trial ghost surface", async ({ page }) => {
+    await page.goto("/race");
+    await expect(page.getByTestId("race-phase")).toHaveText("racing", {
+      timeout: 10_000,
+    });
+
+    await page.keyboard.press("Escape");
+    await expect(page.getByTestId("pause-overlay")).toBeVisible();
+    await page.getByTestId("pause-ghosts").click();
+
+    await expect(page).toHaveURL(/\/time-trial$/);
+    await expect(page.getByTestId("time-trial-page")).toBeVisible({
       timeout: 5_000,
     });
   });

--- a/e2e/pause-overlay.spec.ts
+++ b/e2e/pause-overlay.spec.ts
@@ -92,12 +92,11 @@ test.describe("pause overlay", () => {
     await expect(page.getByTestId("pause-overlay")).toBeVisible();
 
     // The dot ships restart / retire / exit-to-title plus settings
-    // wiring; those buttons should be visible and clickable. Leaderboard
-    // remains disabled here because it does not have a target route yet.
+    // and ghost wiring; those buttons should be visible and clickable.
     await expect(page.getByTestId("pause-restart")).toBeEnabled();
     await expect(page.getByTestId("pause-retire")).toBeEnabled();
     await expect(page.getByTestId("pause-exit")).toBeEnabled();
     await expect(page.getByTestId("pause-settings")).toBeEnabled();
-    await expect(page.getByTestId("pause-leaderboard")).toBeDisabled();
+    await expect(page.getByTestId("pause-ghosts")).toBeEnabled();
   });
 });

--- a/src/app/race/page.tsx
+++ b/src/app/race/page.tsx
@@ -785,6 +785,7 @@ function RaceCanvas({
   const retireFnRef = useRef<(() => void) | null>(null);
   const exitFnRef = useRef<(() => void) | null>(null);
   const settingsFnRef = useRef<(() => void) | null>(null);
+  const ghostsFnRef = useRef<(() => void) | null>(null);
   // Per-mount guard for the natural finish wiring. The render callback
   // fires every frame, so without this latch a `phase === "finished"`
   // tick would call `saveRaceResult` and `router.push` on every frame
@@ -852,6 +853,9 @@ function RaceCanvas({
   const onSettingsImpl = useCallback(() => {
     settingsFnRef.current?.();
   }, []);
+  const onGhostsImpl = useCallback(() => {
+    ghostsFnRef.current?.();
+  }, []);
   const onPracticeCheckpointReset = useCallback(() => {
     if (mode !== "practice") return;
     const session = sessionRef.current;
@@ -887,6 +891,7 @@ function RaceCanvas({
     onRetireImpl: phase === "finished" ? null : onRetireImpl,
     onExitToTitleImpl,
     onSettingsImpl,
+    onGhostsImpl,
   });
 
   useEffect(() => {
@@ -1257,6 +1262,11 @@ function RaceCanvas({
     settingsFnRef.current = (): void => {
       stopRaceRuntime();
       router.push("/options");
+    };
+
+    ghostsFnRef.current = (): void => {
+      stopRaceRuntime();
+      router.push("/time-trial");
     };
 
     handleRef.current = startLoop({

--- a/src/components/pause/PauseOverlay.tsx
+++ b/src/components/pause/PauseOverlay.tsx
@@ -14,10 +14,8 @@
  * exit are listed here. Ghosts uses the existing Time Trial surface until
  * an online leaderboard provider is approved.
  *
- * Manual verification: this slice does not ship a Playwright runner, so
- * the rendered tree is exercised via the dev road page at `/dev/road`
- * (Escape opens the menu, click resume to dismiss). A future slice that
- * stands up Playwright will add the regression spec listed in the dot.
+ * Verification lives in the pause overlay and pause action Playwright
+ * specs plus the shared pause action unit tests.
  */
 
 import type { CSSProperties, ReactElement } from "react";
@@ -30,7 +28,7 @@ export interface PauseOverlayActions {
   onRestart?: () => void;
   /** Retire the race and return to the results screen. */
   onRetire?: () => void;
-  /** Open settings. Inert until the settings page lands. */
+  /** Open the settings page. */
   onSettings?: () => void;
   /** Open the local ghost management surface. */
   onGhosts?: () => void;

--- a/src/components/pause/PauseOverlay.tsx
+++ b/src/components/pause/PauseOverlay.tsx
@@ -10,10 +10,9 @@
  * independent concerns lets the same overlay reuse from the title-screen
  * preview and the title-screen "settings" hop later.
  *
- * Phase 2+ scope: only resume / restart / retire / settings / leaderboard /
- * exit are listed here. The settings and leaderboard buttons are inert in
- * this slice (their target pages do not exist yet) and report through the
- * status callback so the parent can decide what to render.
+ * Phase 2+ scope: resume / restart / retire / settings / ghosts /
+ * exit are listed here. Ghosts uses the existing Time Trial surface until
+ * an online leaderboard provider is approved.
  *
  * Manual verification: this slice does not ship a Playwright runner, so
  * the rendered tree is exercised via the dev road page at `/dev/road`
@@ -33,8 +32,8 @@ export interface PauseOverlayActions {
   onRetire?: () => void;
   /** Open settings. Inert until the settings page lands. */
   onSettings?: () => void;
-  /** Open leaderboard. Inert until the leaderboard page lands. */
-  onLeaderboard?: () => void;
+  /** Open the local ghost management surface. */
+  onGhosts?: () => void;
   /** Exit to the title screen. */
   onExitToTitle?: () => void;
 }
@@ -50,7 +49,7 @@ interface MenuEntry {
 }
 
 export function PauseOverlay(props: PauseOverlayProps): ReactElement | null {
-  const { open, onResume, onRestart, onRetire, onSettings, onLeaderboard, onExitToTitle } = props;
+  const { open, onResume, onRestart, onRetire, onSettings, onGhosts, onExitToTitle } = props;
   const dialogRef = useRef<HTMLDivElement | null>(null);
   const resumeRef = useRef<HTMLButtonElement | null>(null);
 
@@ -75,7 +74,7 @@ export function PauseOverlay(props: PauseOverlayProps): ReactElement | null {
     { id: "restart", label: "Restart race", handler: onRestart },
     { id: "retire", label: "Retire race", handler: onRetire },
     { id: "settings", label: "Settings", handler: onSettings },
-    { id: "leaderboard", label: "Leaderboard", handler: onLeaderboard },
+    { id: "ghosts", label: "Ghosts", handler: onGhosts },
     { id: "exit", label: "Exit to title", handler: onExitToTitle },
   ];
 

--- a/src/components/pause/__tests__/usePauseActions.test.tsx
+++ b/src/components/pause/__tests__/usePauseActions.test.tsx
@@ -90,6 +90,18 @@ describe("usePauseActions", () => {
     );
   });
 
+  it("onGhosts closes the menu then invokes the ghosts impl", () => {
+    const closeMenu = vi.fn();
+    const onGhostsImpl = vi.fn();
+    const result = captureActions({ closeMenu, onGhostsImpl });
+    result.onGhosts?.();
+    expect(closeMenu).toHaveBeenCalledTimes(1);
+    expect(onGhostsImpl).toHaveBeenCalledTimes(1);
+    expect(closeMenu.mock.invocationCallOrder[0]).toBeLessThan(
+      onGhostsImpl.mock.invocationCallOrder[0]!,
+    );
+  });
+
   it("returns undefined for any handler whose impl is null so PauseOverlay disables the button", () => {
     const closeMenu = vi.fn();
     const result = captureActions({
@@ -98,11 +110,13 @@ describe("usePauseActions", () => {
       onRetireImpl: null,
       onExitToTitleImpl: null,
       onSettingsImpl: null,
+      onGhostsImpl: null,
     });
     expect(result.onRestart).toBeUndefined();
     expect(result.onRetire).toBeUndefined();
     expect(result.onExitToTitle).toBeUndefined();
     expect(result.onSettings).toBeUndefined();
+    expect(result.onGhosts).toBeUndefined();
     // onResume is always provided.
     expect(typeof result.onResume).toBe("function");
   });
@@ -114,5 +128,6 @@ describe("usePauseActions", () => {
     expect(result.onRetire).toBeUndefined();
     expect(result.onExitToTitle).toBeUndefined();
     expect(result.onSettings).toBeUndefined();
+    expect(result.onGhosts).toBeUndefined();
   });
 });

--- a/src/components/pause/usePauseActions.ts
+++ b/src/components/pause/usePauseActions.ts
@@ -1,12 +1,12 @@
 "use client";
 
 /**
- * Hook that wraps the five wired §20 pause-menu actions per dot
+ * Hook that wraps the six wired §20 pause-menu actions per dot
  * `VibeGear2-implement-restart-retire-888c712b`.
  *
  * `<PauseOverlay />` accepts `onResume`, `onRestart`, `onRetire`,
- * `onSettings`, `onLeaderboard`, `onExitToTitle`. The race route used to
- * supply only `onResume` (the other three were left undefined so the
+ * `onSettings`, `onGhosts`, `onExitToTitle`. The race route used to
+ * supply only `onResume` (the other actions were left undefined so the
  * buttons rendered disabled). This hook is the single binding the race /
  * quick-race / time-trial / practice surfaces all reuse so the wiring
  * does not drift across pages.
@@ -36,6 +36,8 @@
  *     leak across the route hop.
  *   - Settings while paused: the parent disposes the live runtime before
  *     routing to `/options`, matching exit-to-title teardown.
+ *   - Ghosts while paused: the parent disposes the live runtime before
+ *     routing to `/time-trial`, where local PB and downloaded ghosts live.
  *   - Restart after finish: the parent disables the button by passing
  *     `onRestartImpl: null`; the hook surfaces `onRestart: undefined`
  *     in that case so `<PauseOverlay />`'s self-disable contract
@@ -70,6 +72,11 @@ export interface UsePauseActionsOptions {
    * button for surfaces that do not have a settings target.
    */
   onSettingsImpl?: (() => void) | null;
+  /**
+   * Tear down the loop and route to the local ghost surface. `null`
+   * disables the button for surfaces that do not have a ghost target.
+   */
+  onGhostsImpl?: (() => void) | null;
 }
 
 export interface UsePauseActionsResult {
@@ -83,6 +90,8 @@ export interface UsePauseActionsResult {
   onExitToTitle?: () => void;
   /** Wrapper around `onSettingsImpl`, or `undefined` when the impl is null. */
   onSettings?: () => void;
+  /** Wrapper around `onGhostsImpl`, or `undefined` when the impl is null. */
+  onGhosts?: () => void;
 }
 
 /**
@@ -103,6 +112,7 @@ export function usePauseActions(
     onRetireImpl,
     onExitToTitleImpl,
     onSettingsImpl,
+    onGhostsImpl,
   } = options;
 
   const onResume = useCallback(() => {
@@ -129,6 +139,11 @@ export function usePauseActions(
     onSettingsImpl?.();
   }, [closeMenu, onSettingsImpl]);
 
+  const onGhosts = useCallback(() => {
+    closeMenu();
+    onGhostsImpl?.();
+  }, [closeMenu, onGhostsImpl]);
+
   return useMemo(
     () => ({
       onResume,
@@ -136,6 +151,7 @@ export function usePauseActions(
       onRetire: onRetireImpl ? onRetire : undefined,
       onExitToTitle: onExitToTitleImpl ? onExitToTitle : undefined,
       onSettings: onSettingsImpl ? onSettings : undefined,
+      onGhosts: onGhostsImpl ? onGhosts : undefined,
     }),
     [
       onResume,
@@ -143,10 +159,12 @@ export function usePauseActions(
       onRetire,
       onExitToTitle,
       onSettings,
+      onGhosts,
       onRestartImpl,
       onRetireImpl,
       onExitToTitleImpl,
       onSettingsImpl,
+      onGhostsImpl,
     ],
   );
 }


### PR DESCRIPTION
## Summary

Wires the §20 pause menu Ghosts slot to the existing local Time Trial ghost surface. The live race runtime is stopped before routing to `/time-trial`, matching the teardown pattern used by Settings and Exit to title.

## Requirement inventory

- §20 pause menu now has a working local Ghosts action.
- §6 Time Trial remains the ghost management surface for PB and downloaded ghosts.
- F-070 is marked done.
- Online leaderboard storage remains deferred under Q-011 because it requires provider and production env approval.

## Progress log

- `docs/PROGRESS_LOG.md`: `2026-04-30: Slice: Pause ghosts action`

## Test plan

- [x] `npx vitest run src/components/pause/__tests__/usePauseActions.test.tsx`
- [x] `npm run typecheck`
- [x] `npx playwright test e2e/pause-actions.spec.ts e2e/pause-overlay.spec.ts --project=chromium`
- [x] `npm run lint`
- [x] `npm run content-lint`
- [x] `npm run verify`

## Followups

- Closed F-070.
- No new followups created.
