### PR TITLE
Per-car FX atlas routing

### DIFF
--- a/docs/FOLLOWUPS.md
+++ b/docs/FOLLOWUPS.md
@@ -31,7 +31,7 @@ provider choice remains blocked separately by Q-011.
 ## F-068: Add unique FX atlas sheets for all six playable cars
 **Created:** 2026-04-29
 **Priority:** polish
-**Status:** open
+**Status:** done (2026-04-30)
 **Notes:** The car FX compositor slice wires the live race renderer to an
 explicit §16 frame contract and extends the original Sparrow atlas with
 damage, brake, nitro, wet spray, and snow trail variants. The current
@@ -39,6 +39,12 @@ runtime still uses that shared Sparrow atlas for the live car overlay.
 Add per-car atlas metadata or generated sheets for the full six-car
 catalogue, route the active car's `visualProfile.spriteSet` into the
 race renderer, and verify each car has equivalent FX coverage.
+
+Closed by `feat/per-car-fx-atlases`. The generated car sheets for all
+six playable visual profiles now include totaled, wet trail, and snow
+trail rows. The live race renderer loads the selected car's atlas and
+passes the matching sprite ids into the car compositor, with tests
+covering catalogue equivalence and non-Sparrow frame resolution.
 
 ## F-067: Add weather particle intensity, glare, and fog readability settings
 **Created:** 2026-04-28

--- a/docs/GDD_COVERAGE.json
+++ b/docs/GDD_COVERAGE.json
@@ -1349,7 +1349,15 @@
       "coverage": ["implemented-code", "automated-test"],
       "implementationRefs": [
         "public/art/cars/sparrow.svg",
+        "public/art/cars/sparrow_gt.svg",
+        "public/art/cars/breaker_s.svg",
+        "public/art/cars/vanta_xr.svg",
+        "public/art/cars/bastion_lm.svg",
+        "public/art/cars/tempest_r.svg",
+        "public/art/cars/nova_shade.svg",
         "public/art.manifest.json",
+        "scripts/generate-placeholder-art.ts",
+        "src/data/atlas/carSprites.ts",
         "src/data/atlas/cars.json",
         "src/app/race/page.tsx",
         "src/render/carSpriteCompositor.ts",
@@ -1357,12 +1365,13 @@
         "src/render/spriteAtlas.ts"
       ],
       "testRefs": [
+        "src/data/atlas/carSprites.test.ts",
         "src/render/__tests__/carSpriteCompositor.test.ts",
         "src/render/__tests__/pseudoRoadCanvas.test.ts",
         "src/render/__tests__/spriteAtlas.test.ts",
         "src/render/__tests__/carFrame.test.ts"
       ],
-      "followupRefs": ["F-051", "F-059", "F-060", "F-068"]
+      "followupRefs": ["F-051", "F-059", "F-060"]
     },
     {
       "id": "GDD-16-CAR-WEATHER-VARIANTS",

--- a/docs/PROGRESS_LOG.md
+++ b/docs/PROGRESS_LOG.md
@@ -6,6 +6,52 @@ Correct them by adding a new entry that references the old one.
 
 ---
 
+## 2026-04-30: Slice: Per-car FX atlas routing
+
+**GDD sections touched:**
+[§11](gdd/11-cars-and-stats.md) car visual profiles,
+[§16](gdd/16-rendering-and-visual-design.md) car sprites, and
+[§17](gdd/17-art-direction.md) car design language.
+**Branch / PR:** `feat/per-car-fx-atlases`, PR pending.
+**Status:** Implemented.
+
+### Done
+- Completed the generated car sprite sheets for all six playable visual
+  profiles with totaled, wet trail, and snow trail rows.
+- Added typed atlas metadata and sprite-set lookup helpers keyed by each
+  car's `visualProfile.spriteSet`.
+- Routed the live race renderer to load the selected car's atlas and pass
+  the matching sprite ids into the car compositor.
+- Marked F-068 done and updated the machine-checkable coverage ledger for
+  the §16 car sprite atlas requirement.
+
+### Verified
+- `npx vitest run src/data/atlas/carSprites.test.ts src/render/__tests__/pseudoRoadCanvas.test.ts src/render/__tests__/carSpriteCompositor.test.ts src/render/__tests__/spriteAtlas.test.ts`
+  green, 83 tests passed.
+- `npm run typecheck` green.
+
+### Decisions and assumptions
+- Kept the existing generated placeholder art style and generator ownership,
+  then extended the generator so future art regeneration preserves the FX
+  rows.
+- Ghost cars continue to use the active player's selected car atlas until
+  ghost replay data stores the recorded car visual profile.
+
+### Coverage ledger
+- GDD-16-CAR-SPRITE-ATLAS now references the six playable car sheets,
+  `src/data/atlas/carSprites.ts`, and the catalogue coverage tests.
+- Uncovered adjacent requirements: ghost replay payloads still do not store
+  a recorded car visual profile, so Time Trial ghost cars keep using the
+  active player's selected car atlas.
+
+### Followups created
+None.
+
+### GDD edits
+None.
+
+---
+
 ## 2026-04-30: Slice: Pause ghosts action
 
 **GDD sections touched:**

--- a/public/art/cars/bastion_lm.svg
+++ b/public/art/cars/bastion_lm.svg
@@ -5,8 +5,11 @@
 <g id="clean"><path d="M-27 12 L27 12 L21 -8 L12 -14 L-12 -14 L-21 -8 Z" fill="#d7dde6"/><path d="M-14 -7 L14 -7 L9 4 L-9 4 Z" fill="#1f2b3a"/><path d="M-22 7 L-12 7 L-12 11 L-22 11 Z" fill="#ff3d38"/><path d="M12 7 L22 7 L22 11 L12 11 Z" fill="#ff3d38"/><path d="M-24 12 L-18 15 L18 15 L24 12 Z" fill="#32363d"/><path d="M-18 -5 L18 -5" stroke="#f5d45f" stroke-width="2"/></g>
 <g id="dented"><use href="#clean"/><path d="M-23 -1 L-17 4 L-21 7" fill="none" stroke="#f5d45f" stroke-width="2" opacity="0.8"/><rect x="13" y="7" width="9" height="4" fill="#d72f31"/></g>
 <g id="battered"><use href="#clean"/><path d="M-24 -2 L-15 5 L-23 8" fill="none" stroke="#32363d" stroke-width="2"/><path d="M14 -4 L22 1 L18 7" fill="none" stroke="#32363d" stroke-width="2"/><rect x="-22" y="7" width="10" height="4" fill="#b83232"/><rect x="13" y="7" width="9" height="4" fill="#b83232"/></g>
+<g id="totaled"><use href="#battered"/><path d="M-26 12 L-18 -4 L-6 8 L8 -6 L24 12" fill="none" stroke="#32363d" stroke-width="3"/><path d="M-18 2 L-8 -5 M11 -7 L21 2" stroke="#f5d45f" stroke-width="2"/><rect x="-23" y="7" width="11" height="4" fill="#8f2626"/><rect x="12" y="7" width="10" height="4" fill="#8f2626"/></g>
 <g id="brake"><use href="#clean"/><rect x="-24" y="6" width="13" height="6" fill="#ff4a44"/><rect x="11" y="6" width="13" height="6" fill="#ff4a44"/></g>
 <g id="nitro"><use href="#clean"/><path d="M-14 15 L0 26 L14 15 Z" fill="#44d7ff" opacity="0.75"/><path d="M-8 15 L0 23 L8 15 Z" fill="#e75cff" opacity="0.8"/></g>
+<g id="wet-trail"><path d="M-28 4 L-8 14 L-32 23 Z" fill="#d8f4ff" opacity="0.55"/><path d="M28 4 L8 14 L32 23 Z" fill="#d8f4ff" opacity="0.55"/><path d="M-22 13 L-3 19 M22 13 L3 19" stroke="#9fd7ef" stroke-width="2" opacity="0.7"/></g>
+<g id="snow-trail"><path d="M-24 9 L24 9 L34 24 L-34 24 Z" fill="#edf7ff" opacity="0.64"/><circle cx="-18" cy="17" r="2" fill="#ffffff" opacity="0.7"/><circle cx="0" cy="20" r="2" fill="#ffffff" opacity="0.7"/><circle cx="17" cy="16" r="2" fill="#ffffff" opacity="0.7"/></g>
 </defs>
 <g transform="translate(32 16) skewX(0)"><use href="#shadow"/><use href="#clean"/></g>
 <g transform="translate(96 16) skewX(4)"><use href="#shadow"/><use href="#clean"/></g>
@@ -44,7 +47,21 @@
 <g transform="translate(608 80) skewX(-12)"><use href="#shadow"/><use href="#battered"/></g>
 <g transform="translate(672 80) skewX(-8)"><use href="#shadow"/><use href="#battered"/></g>
 <g transform="translate(736 80) skewX(-4)"><use href="#shadow"/><use href="#battered"/></g>
+<g transform="translate(32 144) skewX(0)"><use href="#shadow"/><use href="#totaled"/></g>
+<g transform="translate(96 144) skewX(4)"><use href="#shadow"/><use href="#totaled"/></g>
+<g transform="translate(160 144) skewX(8)"><use href="#shadow"/><use href="#totaled"/></g>
+<g transform="translate(224 144) skewX(12)"><use href="#shadow"/><use href="#totaled"/></g>
+<g transform="translate(288 144) skewX(8)"><use href="#shadow"/><use href="#totaled"/></g>
+<g transform="translate(352 144) skewX(4)"><use href="#shadow"/><use href="#totaled"/></g>
+<g transform="translate(416 144) skewX(0)"><use href="#shadow"/><use href="#totaled"/></g>
+<g transform="translate(480 144) skewX(-4)"><use href="#shadow"/><use href="#totaled"/></g>
+<g transform="translate(544 144) skewX(-8)"><use href="#shadow"/><use href="#totaled"/></g>
+<g transform="translate(608 144) skewX(-12)"><use href="#shadow"/><use href="#totaled"/></g>
+<g transform="translate(672 144) skewX(-8)"><use href="#shadow"/><use href="#totaled"/></g>
+<g transform="translate(736 144) skewX(-4)"><use href="#shadow"/><use href="#totaled"/></g>
 <g transform="translate(32 112)"><use href="#shadow"/><use href="#brake"/></g>
 <g transform="translate(96 112)"><use href="#shadow"/><use href="#nitro"/></g>
+<g transform="translate(32 176)"><use href="#wet-trail"/></g>
+<g transform="translate(96 176)"><use href="#snow-trail"/></g>
 <text x="704" y="360" text-anchor="middle" font-family="monospace" font-size="16" font-weight="700" fill="#f5d45f">PLACEHOLDER</text>
 </svg>

--- a/public/art/cars/breaker_s.svg
+++ b/public/art/cars/breaker_s.svg
@@ -5,8 +5,11 @@
 <g id="clean"><path d="M-27 12 L27 12 L21 -8 L12 -14 L-12 -14 L-21 -8 Z" fill="#d94f3f"/><path d="M-14 -7 L14 -7 L9 4 L-9 4 Z" fill="#172033"/><path d="M-22 7 L-12 7 L-12 11 L-22 11 Z" fill="#ff3d38"/><path d="M12 7 L22 7 L22 11 L12 11 Z" fill="#ff3d38"/><path d="M-24 12 L-18 15 L18 15 L24 12 Z" fill="#22191a"/><path d="M-18 -5 L18 -5" stroke="#ffb17a" stroke-width="2"/></g>
 <g id="dented"><use href="#clean"/><path d="M-23 -1 L-17 4 L-21 7" fill="none" stroke="#ffb17a" stroke-width="2" opacity="0.8"/><rect x="13" y="7" width="9" height="4" fill="#d72f31"/></g>
 <g id="battered"><use href="#clean"/><path d="M-24 -2 L-15 5 L-23 8" fill="none" stroke="#22191a" stroke-width="2"/><path d="M14 -4 L22 1 L18 7" fill="none" stroke="#22191a" stroke-width="2"/><rect x="-22" y="7" width="10" height="4" fill="#b83232"/><rect x="13" y="7" width="9" height="4" fill="#b83232"/></g>
+<g id="totaled"><use href="#battered"/><path d="M-26 12 L-18 -4 L-6 8 L8 -6 L24 12" fill="none" stroke="#22191a" stroke-width="3"/><path d="M-18 2 L-8 -5 M11 -7 L21 2" stroke="#ffb17a" stroke-width="2"/><rect x="-23" y="7" width="11" height="4" fill="#8f2626"/><rect x="12" y="7" width="10" height="4" fill="#8f2626"/></g>
 <g id="brake"><use href="#clean"/><rect x="-24" y="6" width="13" height="6" fill="#ff4a44"/><rect x="11" y="6" width="13" height="6" fill="#ff4a44"/></g>
 <g id="nitro"><use href="#clean"/><path d="M-14 15 L0 26 L14 15 Z" fill="#44d7ff" opacity="0.75"/><path d="M-8 15 L0 23 L8 15 Z" fill="#e75cff" opacity="0.8"/></g>
+<g id="wet-trail"><path d="M-28 4 L-8 14 L-32 23 Z" fill="#d8f4ff" opacity="0.55"/><path d="M28 4 L8 14 L32 23 Z" fill="#d8f4ff" opacity="0.55"/><path d="M-22 13 L-3 19 M22 13 L3 19" stroke="#9fd7ef" stroke-width="2" opacity="0.7"/></g>
+<g id="snow-trail"><path d="M-24 9 L24 9 L34 24 L-34 24 Z" fill="#edf7ff" opacity="0.64"/><circle cx="-18" cy="17" r="2" fill="#ffffff" opacity="0.7"/><circle cx="0" cy="20" r="2" fill="#ffffff" opacity="0.7"/><circle cx="17" cy="16" r="2" fill="#ffffff" opacity="0.7"/></g>
 </defs>
 <g transform="translate(32 16) skewX(0)"><use href="#shadow"/><use href="#clean"/></g>
 <g transform="translate(96 16) skewX(4)"><use href="#shadow"/><use href="#clean"/></g>
@@ -44,7 +47,21 @@
 <g transform="translate(608 80) skewX(-12)"><use href="#shadow"/><use href="#battered"/></g>
 <g transform="translate(672 80) skewX(-8)"><use href="#shadow"/><use href="#battered"/></g>
 <g transform="translate(736 80) skewX(-4)"><use href="#shadow"/><use href="#battered"/></g>
+<g transform="translate(32 144) skewX(0)"><use href="#shadow"/><use href="#totaled"/></g>
+<g transform="translate(96 144) skewX(4)"><use href="#shadow"/><use href="#totaled"/></g>
+<g transform="translate(160 144) skewX(8)"><use href="#shadow"/><use href="#totaled"/></g>
+<g transform="translate(224 144) skewX(12)"><use href="#shadow"/><use href="#totaled"/></g>
+<g transform="translate(288 144) skewX(8)"><use href="#shadow"/><use href="#totaled"/></g>
+<g transform="translate(352 144) skewX(4)"><use href="#shadow"/><use href="#totaled"/></g>
+<g transform="translate(416 144) skewX(0)"><use href="#shadow"/><use href="#totaled"/></g>
+<g transform="translate(480 144) skewX(-4)"><use href="#shadow"/><use href="#totaled"/></g>
+<g transform="translate(544 144) skewX(-8)"><use href="#shadow"/><use href="#totaled"/></g>
+<g transform="translate(608 144) skewX(-12)"><use href="#shadow"/><use href="#totaled"/></g>
+<g transform="translate(672 144) skewX(-8)"><use href="#shadow"/><use href="#totaled"/></g>
+<g transform="translate(736 144) skewX(-4)"><use href="#shadow"/><use href="#totaled"/></g>
 <g transform="translate(32 112)"><use href="#shadow"/><use href="#brake"/></g>
 <g transform="translate(96 112)"><use href="#shadow"/><use href="#nitro"/></g>
+<g transform="translate(32 176)"><use href="#wet-trail"/></g>
+<g transform="translate(96 176)"><use href="#snow-trail"/></g>
 <text x="704" y="360" text-anchor="middle" font-family="monospace" font-size="16" font-weight="700" fill="#ffb17a">PLACEHOLDER</text>
 </svg>

--- a/public/art/cars/nova_shade.svg
+++ b/public/art/cars/nova_shade.svg
@@ -5,8 +5,11 @@
 <g id="clean"><path d="M-27 12 L27 12 L21 -8 L12 -14 L-12 -14 L-21 -8 Z" fill="#5b4bd7"/><path d="M-14 -7 L14 -7 L9 4 L-9 4 Z" fill="#14182b"/><path d="M-22 7 L-12 7 L-12 11 L-22 11 Z" fill="#ff3d38"/><path d="M12 7 L22 7 L22 11 L12 11 Z" fill="#ff3d38"/><path d="M-24 12 L-18 15 L18 15 L24 12 Z" fill="#171326"/><path d="M-18 -5 L18 -5" stroke="#ff5bd6" stroke-width="2"/></g>
 <g id="dented"><use href="#clean"/><path d="M-23 -1 L-17 4 L-21 7" fill="none" stroke="#ff5bd6" stroke-width="2" opacity="0.8"/><rect x="13" y="7" width="9" height="4" fill="#d72f31"/></g>
 <g id="battered"><use href="#clean"/><path d="M-24 -2 L-15 5 L-23 8" fill="none" stroke="#171326" stroke-width="2"/><path d="M14 -4 L22 1 L18 7" fill="none" stroke="#171326" stroke-width="2"/><rect x="-22" y="7" width="10" height="4" fill="#b83232"/><rect x="13" y="7" width="9" height="4" fill="#b83232"/></g>
+<g id="totaled"><use href="#battered"/><path d="M-26 12 L-18 -4 L-6 8 L8 -6 L24 12" fill="none" stroke="#171326" stroke-width="3"/><path d="M-18 2 L-8 -5 M11 -7 L21 2" stroke="#ff5bd6" stroke-width="2"/><rect x="-23" y="7" width="11" height="4" fill="#8f2626"/><rect x="12" y="7" width="10" height="4" fill="#8f2626"/></g>
 <g id="brake"><use href="#clean"/><rect x="-24" y="6" width="13" height="6" fill="#ff4a44"/><rect x="11" y="6" width="13" height="6" fill="#ff4a44"/></g>
 <g id="nitro"><use href="#clean"/><path d="M-14 15 L0 26 L14 15 Z" fill="#44d7ff" opacity="0.75"/><path d="M-8 15 L0 23 L8 15 Z" fill="#e75cff" opacity="0.8"/></g>
+<g id="wet-trail"><path d="M-28 4 L-8 14 L-32 23 Z" fill="#d8f4ff" opacity="0.55"/><path d="M28 4 L8 14 L32 23 Z" fill="#d8f4ff" opacity="0.55"/><path d="M-22 13 L-3 19 M22 13 L3 19" stroke="#9fd7ef" stroke-width="2" opacity="0.7"/></g>
+<g id="snow-trail"><path d="M-24 9 L24 9 L34 24 L-34 24 Z" fill="#edf7ff" opacity="0.64"/><circle cx="-18" cy="17" r="2" fill="#ffffff" opacity="0.7"/><circle cx="0" cy="20" r="2" fill="#ffffff" opacity="0.7"/><circle cx="17" cy="16" r="2" fill="#ffffff" opacity="0.7"/></g>
 </defs>
 <g transform="translate(32 16) skewX(0)"><use href="#shadow"/><use href="#clean"/></g>
 <g transform="translate(96 16) skewX(4)"><use href="#shadow"/><use href="#clean"/></g>
@@ -44,7 +47,21 @@
 <g transform="translate(608 80) skewX(-12)"><use href="#shadow"/><use href="#battered"/></g>
 <g transform="translate(672 80) skewX(-8)"><use href="#shadow"/><use href="#battered"/></g>
 <g transform="translate(736 80) skewX(-4)"><use href="#shadow"/><use href="#battered"/></g>
+<g transform="translate(32 144) skewX(0)"><use href="#shadow"/><use href="#totaled"/></g>
+<g transform="translate(96 144) skewX(4)"><use href="#shadow"/><use href="#totaled"/></g>
+<g transform="translate(160 144) skewX(8)"><use href="#shadow"/><use href="#totaled"/></g>
+<g transform="translate(224 144) skewX(12)"><use href="#shadow"/><use href="#totaled"/></g>
+<g transform="translate(288 144) skewX(8)"><use href="#shadow"/><use href="#totaled"/></g>
+<g transform="translate(352 144) skewX(4)"><use href="#shadow"/><use href="#totaled"/></g>
+<g transform="translate(416 144) skewX(0)"><use href="#shadow"/><use href="#totaled"/></g>
+<g transform="translate(480 144) skewX(-4)"><use href="#shadow"/><use href="#totaled"/></g>
+<g transform="translate(544 144) skewX(-8)"><use href="#shadow"/><use href="#totaled"/></g>
+<g transform="translate(608 144) skewX(-12)"><use href="#shadow"/><use href="#totaled"/></g>
+<g transform="translate(672 144) skewX(-8)"><use href="#shadow"/><use href="#totaled"/></g>
+<g transform="translate(736 144) skewX(-4)"><use href="#shadow"/><use href="#totaled"/></g>
 <g transform="translate(32 112)"><use href="#shadow"/><use href="#brake"/></g>
 <g transform="translate(96 112)"><use href="#shadow"/><use href="#nitro"/></g>
+<g transform="translate(32 176)"><use href="#wet-trail"/></g>
+<g transform="translate(96 176)"><use href="#snow-trail"/></g>
 <text x="704" y="360" text-anchor="middle" font-family="monospace" font-size="16" font-weight="700" fill="#ff5bd6">PLACEHOLDER</text>
 </svg>

--- a/public/art/cars/sparrow_gt.svg
+++ b/public/art/cars/sparrow_gt.svg
@@ -5,8 +5,11 @@
 <g id="clean"><path d="M-27 12 L27 12 L21 -8 L12 -14 L-12 -14 L-21 -8 Z" fill="#f2c94c"/><path d="M-14 -7 L14 -7 L9 4 L-9 4 Z" fill="#18243d"/><path d="M-22 7 L-12 7 L-12 11 L-22 11 Z" fill="#ff3d38"/><path d="M12 7 L22 7 L22 11 L12 11 Z" fill="#ff3d38"/><path d="M-24 12 L-18 15 L18 15 L24 12 Z" fill="#111827"/><path d="M-18 -5 L18 -5" stroke="#ffe56e" stroke-width="2"/></g>
 <g id="dented"><use href="#clean"/><path d="M-23 -1 L-17 4 L-21 7" fill="none" stroke="#ffe56e" stroke-width="2" opacity="0.8"/><rect x="13" y="7" width="9" height="4" fill="#d72f31"/></g>
 <g id="battered"><use href="#clean"/><path d="M-24 -2 L-15 5 L-23 8" fill="none" stroke="#111827" stroke-width="2"/><path d="M14 -4 L22 1 L18 7" fill="none" stroke="#111827" stroke-width="2"/><rect x="-22" y="7" width="10" height="4" fill="#b83232"/><rect x="13" y="7" width="9" height="4" fill="#b83232"/></g>
+<g id="totaled"><use href="#battered"/><path d="M-26 12 L-18 -4 L-6 8 L8 -6 L24 12" fill="none" stroke="#111827" stroke-width="3"/><path d="M-18 2 L-8 -5 M11 -7 L21 2" stroke="#ffe56e" stroke-width="2"/><rect x="-23" y="7" width="11" height="4" fill="#8f2626"/><rect x="12" y="7" width="10" height="4" fill="#8f2626"/></g>
 <g id="brake"><use href="#clean"/><rect x="-24" y="6" width="13" height="6" fill="#ff4a44"/><rect x="11" y="6" width="13" height="6" fill="#ff4a44"/></g>
 <g id="nitro"><use href="#clean"/><path d="M-14 15 L0 26 L14 15 Z" fill="#44d7ff" opacity="0.75"/><path d="M-8 15 L0 23 L8 15 Z" fill="#e75cff" opacity="0.8"/></g>
+<g id="wet-trail"><path d="M-28 4 L-8 14 L-32 23 Z" fill="#d8f4ff" opacity="0.55"/><path d="M28 4 L8 14 L32 23 Z" fill="#d8f4ff" opacity="0.55"/><path d="M-22 13 L-3 19 M22 13 L3 19" stroke="#9fd7ef" stroke-width="2" opacity="0.7"/></g>
+<g id="snow-trail"><path d="M-24 9 L24 9 L34 24 L-34 24 Z" fill="#edf7ff" opacity="0.64"/><circle cx="-18" cy="17" r="2" fill="#ffffff" opacity="0.7"/><circle cx="0" cy="20" r="2" fill="#ffffff" opacity="0.7"/><circle cx="17" cy="16" r="2" fill="#ffffff" opacity="0.7"/></g>
 </defs>
 <g transform="translate(32 16) skewX(0)"><use href="#shadow"/><use href="#clean"/></g>
 <g transform="translate(96 16) skewX(4)"><use href="#shadow"/><use href="#clean"/></g>
@@ -44,7 +47,21 @@
 <g transform="translate(608 80) skewX(-12)"><use href="#shadow"/><use href="#battered"/></g>
 <g transform="translate(672 80) skewX(-8)"><use href="#shadow"/><use href="#battered"/></g>
 <g transform="translate(736 80) skewX(-4)"><use href="#shadow"/><use href="#battered"/></g>
+<g transform="translate(32 144) skewX(0)"><use href="#shadow"/><use href="#totaled"/></g>
+<g transform="translate(96 144) skewX(4)"><use href="#shadow"/><use href="#totaled"/></g>
+<g transform="translate(160 144) skewX(8)"><use href="#shadow"/><use href="#totaled"/></g>
+<g transform="translate(224 144) skewX(12)"><use href="#shadow"/><use href="#totaled"/></g>
+<g transform="translate(288 144) skewX(8)"><use href="#shadow"/><use href="#totaled"/></g>
+<g transform="translate(352 144) skewX(4)"><use href="#shadow"/><use href="#totaled"/></g>
+<g transform="translate(416 144) skewX(0)"><use href="#shadow"/><use href="#totaled"/></g>
+<g transform="translate(480 144) skewX(-4)"><use href="#shadow"/><use href="#totaled"/></g>
+<g transform="translate(544 144) skewX(-8)"><use href="#shadow"/><use href="#totaled"/></g>
+<g transform="translate(608 144) skewX(-12)"><use href="#shadow"/><use href="#totaled"/></g>
+<g transform="translate(672 144) skewX(-8)"><use href="#shadow"/><use href="#totaled"/></g>
+<g transform="translate(736 144) skewX(-4)"><use href="#shadow"/><use href="#totaled"/></g>
 <g transform="translate(32 112)"><use href="#shadow"/><use href="#brake"/></g>
 <g transform="translate(96 112)"><use href="#shadow"/><use href="#nitro"/></g>
+<g transform="translate(32 176)"><use href="#wet-trail"/></g>
+<g transform="translate(96 176)"><use href="#snow-trail"/></g>
 <text x="704" y="360" text-anchor="middle" font-family="monospace" font-size="16" font-weight="700" fill="#ffe56e">PLACEHOLDER</text>
 </svg>

--- a/public/art/cars/tempest_r.svg
+++ b/public/art/cars/tempest_r.svg
@@ -5,8 +5,11 @@
 <g id="clean"><path d="M-27 12 L27 12 L21 -8 L12 -14 L-12 -14 L-21 -8 Z" fill="#4bd77f"/><path d="M-14 -7 L14 -7 L9 4 L-9 4 Z" fill="#142636"/><path d="M-22 7 L-12 7 L-12 11 L-22 11 Z" fill="#ff3d38"/><path d="M12 7 L22 7 L22 11 L12 11 Z" fill="#ff3d38"/><path d="M-24 12 L-18 15 L18 15 L24 12 Z" fill="#102018"/><path d="M-18 -5 L18 -5" stroke="#d8ff6b" stroke-width="2"/></g>
 <g id="dented"><use href="#clean"/><path d="M-23 -1 L-17 4 L-21 7" fill="none" stroke="#d8ff6b" stroke-width="2" opacity="0.8"/><rect x="13" y="7" width="9" height="4" fill="#d72f31"/></g>
 <g id="battered"><use href="#clean"/><path d="M-24 -2 L-15 5 L-23 8" fill="none" stroke="#102018" stroke-width="2"/><path d="M14 -4 L22 1 L18 7" fill="none" stroke="#102018" stroke-width="2"/><rect x="-22" y="7" width="10" height="4" fill="#b83232"/><rect x="13" y="7" width="9" height="4" fill="#b83232"/></g>
+<g id="totaled"><use href="#battered"/><path d="M-26 12 L-18 -4 L-6 8 L8 -6 L24 12" fill="none" stroke="#102018" stroke-width="3"/><path d="M-18 2 L-8 -5 M11 -7 L21 2" stroke="#d8ff6b" stroke-width="2"/><rect x="-23" y="7" width="11" height="4" fill="#8f2626"/><rect x="12" y="7" width="10" height="4" fill="#8f2626"/></g>
 <g id="brake"><use href="#clean"/><rect x="-24" y="6" width="13" height="6" fill="#ff4a44"/><rect x="11" y="6" width="13" height="6" fill="#ff4a44"/></g>
 <g id="nitro"><use href="#clean"/><path d="M-14 15 L0 26 L14 15 Z" fill="#44d7ff" opacity="0.75"/><path d="M-8 15 L0 23 L8 15 Z" fill="#e75cff" opacity="0.8"/></g>
+<g id="wet-trail"><path d="M-28 4 L-8 14 L-32 23 Z" fill="#d8f4ff" opacity="0.55"/><path d="M28 4 L8 14 L32 23 Z" fill="#d8f4ff" opacity="0.55"/><path d="M-22 13 L-3 19 M22 13 L3 19" stroke="#9fd7ef" stroke-width="2" opacity="0.7"/></g>
+<g id="snow-trail"><path d="M-24 9 L24 9 L34 24 L-34 24 Z" fill="#edf7ff" opacity="0.64"/><circle cx="-18" cy="17" r="2" fill="#ffffff" opacity="0.7"/><circle cx="0" cy="20" r="2" fill="#ffffff" opacity="0.7"/><circle cx="17" cy="16" r="2" fill="#ffffff" opacity="0.7"/></g>
 </defs>
 <g transform="translate(32 16) skewX(0)"><use href="#shadow"/><use href="#clean"/></g>
 <g transform="translate(96 16) skewX(4)"><use href="#shadow"/><use href="#clean"/></g>
@@ -44,7 +47,21 @@
 <g transform="translate(608 80) skewX(-12)"><use href="#shadow"/><use href="#battered"/></g>
 <g transform="translate(672 80) skewX(-8)"><use href="#shadow"/><use href="#battered"/></g>
 <g transform="translate(736 80) skewX(-4)"><use href="#shadow"/><use href="#battered"/></g>
+<g transform="translate(32 144) skewX(0)"><use href="#shadow"/><use href="#totaled"/></g>
+<g transform="translate(96 144) skewX(4)"><use href="#shadow"/><use href="#totaled"/></g>
+<g transform="translate(160 144) skewX(8)"><use href="#shadow"/><use href="#totaled"/></g>
+<g transform="translate(224 144) skewX(12)"><use href="#shadow"/><use href="#totaled"/></g>
+<g transform="translate(288 144) skewX(8)"><use href="#shadow"/><use href="#totaled"/></g>
+<g transform="translate(352 144) skewX(4)"><use href="#shadow"/><use href="#totaled"/></g>
+<g transform="translate(416 144) skewX(0)"><use href="#shadow"/><use href="#totaled"/></g>
+<g transform="translate(480 144) skewX(-4)"><use href="#shadow"/><use href="#totaled"/></g>
+<g transform="translate(544 144) skewX(-8)"><use href="#shadow"/><use href="#totaled"/></g>
+<g transform="translate(608 144) skewX(-12)"><use href="#shadow"/><use href="#totaled"/></g>
+<g transform="translate(672 144) skewX(-8)"><use href="#shadow"/><use href="#totaled"/></g>
+<g transform="translate(736 144) skewX(-4)"><use href="#shadow"/><use href="#totaled"/></g>
 <g transform="translate(32 112)"><use href="#shadow"/><use href="#brake"/></g>
 <g transform="translate(96 112)"><use href="#shadow"/><use href="#nitro"/></g>
+<g transform="translate(32 176)"><use href="#wet-trail"/></g>
+<g transform="translate(96 176)"><use href="#snow-trail"/></g>
 <text x="704" y="360" text-anchor="middle" font-family="monospace" font-size="16" font-weight="700" fill="#d8ff6b">PLACEHOLDER</text>
 </svg>

--- a/public/art/cars/vanta_xr.svg
+++ b/public/art/cars/vanta_xr.svg
@@ -5,8 +5,11 @@
 <g id="clean"><path d="M-27 12 L27 12 L21 -8 L12 -14 L-12 -14 L-21 -8 Z" fill="#5d6ce1"/><path d="M-14 -7 L14 -7 L9 4 L-9 4 Z" fill="#101a34"/><path d="M-22 7 L-12 7 L-12 11 L-22 11 Z" fill="#ff3d38"/><path d="M12 7 L22 7 L22 11 L12 11 Z" fill="#ff3d38"/><path d="M-24 12 L-18 15 L18 15 L24 12 Z" fill="#141827"/><path d="M-18 -5 L18 -5" stroke="#a7e3ff" stroke-width="2"/></g>
 <g id="dented"><use href="#clean"/><path d="M-23 -1 L-17 4 L-21 7" fill="none" stroke="#a7e3ff" stroke-width="2" opacity="0.8"/><rect x="13" y="7" width="9" height="4" fill="#d72f31"/></g>
 <g id="battered"><use href="#clean"/><path d="M-24 -2 L-15 5 L-23 8" fill="none" stroke="#141827" stroke-width="2"/><path d="M14 -4 L22 1 L18 7" fill="none" stroke="#141827" stroke-width="2"/><rect x="-22" y="7" width="10" height="4" fill="#b83232"/><rect x="13" y="7" width="9" height="4" fill="#b83232"/></g>
+<g id="totaled"><use href="#battered"/><path d="M-26 12 L-18 -4 L-6 8 L8 -6 L24 12" fill="none" stroke="#141827" stroke-width="3"/><path d="M-18 2 L-8 -5 M11 -7 L21 2" stroke="#a7e3ff" stroke-width="2"/><rect x="-23" y="7" width="11" height="4" fill="#8f2626"/><rect x="12" y="7" width="10" height="4" fill="#8f2626"/></g>
 <g id="brake"><use href="#clean"/><rect x="-24" y="6" width="13" height="6" fill="#ff4a44"/><rect x="11" y="6" width="13" height="6" fill="#ff4a44"/></g>
 <g id="nitro"><use href="#clean"/><path d="M-14 15 L0 26 L14 15 Z" fill="#44d7ff" opacity="0.75"/><path d="M-8 15 L0 23 L8 15 Z" fill="#e75cff" opacity="0.8"/></g>
+<g id="wet-trail"><path d="M-28 4 L-8 14 L-32 23 Z" fill="#d8f4ff" opacity="0.55"/><path d="M28 4 L8 14 L32 23 Z" fill="#d8f4ff" opacity="0.55"/><path d="M-22 13 L-3 19 M22 13 L3 19" stroke="#9fd7ef" stroke-width="2" opacity="0.7"/></g>
+<g id="snow-trail"><path d="M-24 9 L24 9 L34 24 L-34 24 Z" fill="#edf7ff" opacity="0.64"/><circle cx="-18" cy="17" r="2" fill="#ffffff" opacity="0.7"/><circle cx="0" cy="20" r="2" fill="#ffffff" opacity="0.7"/><circle cx="17" cy="16" r="2" fill="#ffffff" opacity="0.7"/></g>
 </defs>
 <g transform="translate(32 16) skewX(0)"><use href="#shadow"/><use href="#clean"/></g>
 <g transform="translate(96 16) skewX(4)"><use href="#shadow"/><use href="#clean"/></g>
@@ -44,7 +47,21 @@
 <g transform="translate(608 80) skewX(-12)"><use href="#shadow"/><use href="#battered"/></g>
 <g transform="translate(672 80) skewX(-8)"><use href="#shadow"/><use href="#battered"/></g>
 <g transform="translate(736 80) skewX(-4)"><use href="#shadow"/><use href="#battered"/></g>
+<g transform="translate(32 144) skewX(0)"><use href="#shadow"/><use href="#totaled"/></g>
+<g transform="translate(96 144) skewX(4)"><use href="#shadow"/><use href="#totaled"/></g>
+<g transform="translate(160 144) skewX(8)"><use href="#shadow"/><use href="#totaled"/></g>
+<g transform="translate(224 144) skewX(12)"><use href="#shadow"/><use href="#totaled"/></g>
+<g transform="translate(288 144) skewX(8)"><use href="#shadow"/><use href="#totaled"/></g>
+<g transform="translate(352 144) skewX(4)"><use href="#shadow"/><use href="#totaled"/></g>
+<g transform="translate(416 144) skewX(0)"><use href="#shadow"/><use href="#totaled"/></g>
+<g transform="translate(480 144) skewX(-4)"><use href="#shadow"/><use href="#totaled"/></g>
+<g transform="translate(544 144) skewX(-8)"><use href="#shadow"/><use href="#totaled"/></g>
+<g transform="translate(608 144) skewX(-12)"><use href="#shadow"/><use href="#totaled"/></g>
+<g transform="translate(672 144) skewX(-8)"><use href="#shadow"/><use href="#totaled"/></g>
+<g transform="translate(736 144) skewX(-4)"><use href="#shadow"/><use href="#totaled"/></g>
 <g transform="translate(32 112)"><use href="#shadow"/><use href="#brake"/></g>
 <g transform="translate(96 112)"><use href="#shadow"/><use href="#nitro"/></g>
+<g transform="translate(32 176)"><use href="#wet-trail"/></g>
+<g transform="translate(96 176)"><use href="#snow-trail"/></g>
 <text x="704" y="360" text-anchor="middle" font-family="monospace" font-size="16" font-weight="700" fill="#a7e3ff">PLACEHOLDER</text>
 </svg>

--- a/scripts/generate-placeholder-art.ts
+++ b/scripts/generate-placeholder-art.ts
@@ -299,6 +299,11 @@ function carSheetSvg(car: (typeof CAR_SHEETS)[number]): string {
       id: "battered",
       extra: `<path d="M-24 -2 L-15 5 L-23 8" fill="none" stroke="${car.trim}" stroke-width="2"/><path d="M14 -4 L22 1 L18 7" fill="none" stroke="${car.trim}" stroke-width="2"/>`,
     },
+    {
+      y: 144,
+      id: "totaled",
+      extra: `<path d="M-26 12 L-18 -4 L-6 8 L8 -6 L24 12" fill="none" stroke="${car.trim}" stroke-width="3"/><path d="M-18 2 L-8 -5 M11 -7 L21 2" stroke="${car.accent}" stroke-width="2"/>`,
+    },
   ];
   const dentedExtra = damageRows.find((row) => row.id === "dented")?.extra ?? "";
   const batteredExtra = damageRows.find((row) => row.id === "battered")?.extra ?? "";
@@ -320,12 +325,17 @@ function carSheetSvg(car: (typeof CAR_SHEETS)[number]): string {
       `<g id="clean"><path d="M-27 12 L27 12 L21 -8 L12 -14 L-12 -14 L-21 -8 Z" fill="${car.body}"/><path d="M-14 -7 L14 -7 L9 4 L-9 4 Z" fill="${car.glass}"/><path d="M-22 7 L-12 7 L-12 11 L-22 11 Z" fill="#ff3d38"/><path d="M12 7 L22 7 L22 11 L12 11 Z" fill="#ff3d38"/><path d="M-24 12 L-18 15 L18 15 L24 12 Z" fill="${car.trim}"/><path d="M-18 -5 L18 -5" stroke="${car.accent}" stroke-width="2"/></g>`,
       `<g id="dented"><use href="#clean"/>${dentedExtra}<rect x="13" y="7" width="9" height="4" fill="#d72f31"/></g>`,
       `<g id="battered"><use href="#clean"/>${batteredExtra}<rect x="-22" y="7" width="10" height="4" fill="#b83232"/><rect x="13" y="7" width="9" height="4" fill="#b83232"/></g>`,
+      `<g id="totaled"><use href="#battered"/>${damageRows.find((row) => row.id === "totaled")?.extra ?? ""}<rect x="-23" y="7" width="11" height="4" fill="#8f2626"/><rect x="12" y="7" width="10" height="4" fill="#8f2626"/></g>`,
       '<g id="brake"><use href="#clean"/><rect x="-24" y="6" width="13" height="6" fill="#ff4a44"/><rect x="11" y="6" width="13" height="6" fill="#ff4a44"/></g>',
       '<g id="nitro"><use href="#clean"/><path d="M-14 15 L0 26 L14 15 Z" fill="#44d7ff" opacity="0.75"/><path d="M-8 15 L0 23 L8 15 Z" fill="#e75cff" opacity="0.8"/></g>',
+      '<g id="wet-trail"><path d="M-28 4 L-8 14 L-32 23 Z" fill="#d8f4ff" opacity="0.55"/><path d="M28 4 L8 14 L32 23 Z" fill="#d8f4ff" opacity="0.55"/><path d="M-22 13 L-3 19 M22 13 L3 19" stroke="#9fd7ef" stroke-width="2" opacity="0.7"/></g>',
+      '<g id="snow-trail"><path d="M-24 9 L24 9 L34 24 L-34 24 Z" fill="#edf7ff" opacity="0.64"/><circle cx="-18" cy="17" r="2" fill="#ffffff" opacity="0.7"/><circle cx="0" cy="20" r="2" fill="#ffffff" opacity="0.7"/><circle cx="17" cy="16" r="2" fill="#ffffff" opacity="0.7"/></g>',
       "</defs>",
       ...frames,
       '<g transform="translate(32 112)"><use href="#shadow"/><use href="#brake"/></g>',
       '<g transform="translate(96 112)"><use href="#shadow"/><use href="#nitro"/></g>',
+      '<g transform="translate(32 176)"><use href="#wet-trail"/></g>',
+      '<g transform="translate(96 176)"><use href="#snow-trail"/></g>',
       `<text x="704" y="360" text-anchor="middle" font-family="monospace" font-size="16" font-weight="700" fill="${car.accent}">PLACEHOLDER</text>`,
     ].join("\n"),
   );

--- a/src/app/race/page.tsx
+++ b/src/app/race/page.tsx
@@ -53,9 +53,11 @@ import {
   getChampionship,
   loadTrack,
 } from "@/data";
-import carsAtlasFixture from "@/data/atlas/cars.json";
 import {
-  AtlasMetaSchema,
+  carAtlasMetaForVisualProfile,
+  carSpriteSetForVisualProfile,
+} from "@/data/atlas/carSprites";
+import {
   TrackSchema,
   type AudioSettings,
   type Track,
@@ -128,6 +130,7 @@ import {
 } from "@/road";
 import { drawRoad } from "@/render/pseudoRoadCanvas";
 import { playerCarFrameIndex } from "@/render/carFrame";
+import type { CarSpriteSet } from "@/render/carSpriteCompositor";
 import {
   clampDevicePixelRatio,
   resolveGraphicsSettings,
@@ -178,7 +181,6 @@ const DEFAULT_TRACK_ID = "test/elevation";
 const TOUR_PLACEHOLDER_TRACK_ID = "test/straight";
 const WORLD_TOUR_CHAMPIONSHIP_ID = "world-tour-standard";
 const PLAYER_ID = "player";
-const CARS_ATLAS_META = AtlasMetaSchema.parse(carsAtlasFixture);
 
 /**
  * §20 minimap layout. The wireframe places the minimap in the bottom-left
@@ -489,16 +491,20 @@ function weatherOptionLabel(weather: WeatherOption): string {
 function resolveSessionCar(
   save: SaveGame,
   requestedCarId: string | null,
-): { id: string; stats: CarBaseStats } {
+): { id: string; stats: CarBaseStats; spriteSet: string } {
   const fallbackId = save.garage.activeCarId;
   const requestedIsOwned =
     requestedCarId !== null && save.garage.ownedCars.includes(requestedCarId);
   const carId = requestedIsOwned ? requestedCarId : fallbackId;
   const car = getCar(carId) ?? getCar(fallbackId) ?? CARS[0];
   if (car === undefined) {
-    return { id: fallbackId, stats: STARTER_STATS };
+    return { id: fallbackId, stats: STARTER_STATS, spriteSet: "sparrow_gt" };
   }
-  return { id: car.id, stats: car.baseStats };
+  return {
+    id: car.id,
+    stats: car.baseStats,
+    spriteSet: car.visualProfile.spriteSet,
+  };
 }
 
 /**
@@ -777,6 +783,9 @@ function RaceCanvas({
   const lastBrakeRef = useRef<number>(0);
   const pauseInputHeldRef = useRef<boolean>(false);
   const carAtlasRef = useRef<LoadedAtlas | null>(null);
+  const carSpriteSetRef = useRef<CarSpriteSet>(
+    carSpriteSetForVisualProfile("sparrow_gt"),
+  );
   // Imperative pause-menu effects, populated inside the loop effect
   // below so the hook layer can stay decoupled from the loop / session
   // / config refs. The hook reads these getters once per click; mid-
@@ -825,13 +834,22 @@ function RaceCanvas({
 
   useEffect(() => {
     let active = true;
-    void loadAtlas(CARS_ATLAS_META).then((atlas) => {
-      if (active) carAtlasRef.current = atlas;
-    });
+    const persisted = loadSave();
+    const sessionSave =
+      persisted.kind === "loaded" ? persisted.save : defaultSave();
+    const sessionCar = resolveSessionCar(sessionSave, selectedCarId);
+    const spriteSet = carSpriteSetForVisualProfile(sessionCar.spriteSet);
+    carSpriteSetRef.current = spriteSet;
+    carAtlasRef.current = null;
+    void loadAtlas(carAtlasMetaForVisualProfile(sessionCar.spriteSet)).then(
+      (atlas) => {
+        if (active) carAtlasRef.current = atlas;
+      },
+    );
     return () => {
       active = false;
     };
-  }, []);
+  }, [selectedCarId]);
 
   const pause = usePauseToggle({ loop: () => handleRef.current });
   const { openMenu: openPauseMenu } = pause;
@@ -926,6 +944,7 @@ function RaceCanvas({
     const noCampaignMode = recordsOnlyMode || practiceMode;
     const economyEnabled = mode === "race";
     const sessionCar = resolveSessionCar(sessionSave, selectedCarId);
+    carSpriteSetRef.current = carSpriteSetForVisualProfile(sessionCar.spriteSet);
     const playerStats = sessionCar.stats;
     const initialPlayerDamage = noCampaignMode
       ? PRISTINE_DAMAGE_STATE
@@ -1377,11 +1396,13 @@ function RaceCanvas({
             ? {
                 ...ghostOverlayRef.current,
                 atlas: carAtlasRef.current,
+                spriteId: carSpriteSetRef.current.clean,
                 frameIndex: playerFrameIndex,
               }
             : null,
           playerCar: {
             atlas: carAtlasRef.current,
+            spriteSet: carSpriteSetRef.current,
             frameIndex: playerFrameIndex,
             weather: renderWeather,
             braking: lastBrakeRef.current > 0,

--- a/src/data/atlas/carSprites.test.ts
+++ b/src/data/atlas/carSprites.test.ts
@@ -1,0 +1,72 @@
+import { existsSync, readFileSync } from "node:fs";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+
+import { CARS } from "@/data/cars";
+import { AtlasMetaSchema } from "@/data/schemas";
+import {
+  CAR_ATLAS_METAS,
+  CAR_SPRITE_SET_IDS,
+  CAR_SPRITE_SETS,
+  carAtlasMetaForVisualProfile,
+  carSpriteSetForVisualProfile,
+  isCarSpriteSetId,
+} from "./carSprites";
+
+const PUBLIC_DIR = path.join(process.cwd(), "public");
+
+describe("per-car sprite atlas metadata", () => {
+  it("covers every bundled car visual profile", () => {
+    for (const car of CARS) {
+      const id = car.visualProfile.spriteSet;
+      expect(isCarSpriteSetId(id)).toBe(true);
+      if (!isCarSpriteSetId(id)) {
+        throw new Error(`unknown car sprite set: ${id}`);
+      }
+
+      const meta = carAtlasMetaForVisualProfile(id);
+      const spriteSet = carSpriteSetForVisualProfile(id);
+      expect(AtlasMetaSchema.safeParse(meta).success).toBe(true);
+      expect(meta).toBe(CAR_ATLAS_METAS[id]);
+      expect(spriteSet).toBe(CAR_SPRITE_SETS[id]);
+      expect(meta.image).toBe(`art/cars/${id}.svg`);
+      expect(existsSync(path.join(PUBLIC_DIR, meta.image))).toBe(true);
+    }
+  });
+
+  it("declares equivalent FX coverage for every car sheet", () => {
+    for (const id of CAR_SPRITE_SET_IDS) {
+      const spriteSet = CAR_SPRITE_SETS[id];
+      const meta = carAtlasMetaForVisualProfile(id);
+      expect(meta.sprites[spriteSet.clean]).toHaveLength(12);
+      expect(meta.sprites[spriteSet.damage1]).toHaveLength(12);
+      expect(meta.sprites[spriteSet.damage2]).toHaveLength(12);
+      expect(meta.sprites[spriteSet.damage3]).toHaveLength(12);
+      expect(meta.sprites[spriteSet.brake]).toHaveLength(1);
+      expect(meta.sprites[spriteSet.nitro]).toHaveLength(1);
+      expect(meta.sprites[spriteSet.wetTrail]).toHaveLength(1);
+      expect(meta.sprites[spriteSet.snowTrail]).toHaveLength(1);
+    }
+  });
+
+  it("ships rendered rows for totaled and weather trail frames", () => {
+    for (const meta of Object.values(CAR_ATLAS_METAS)) {
+      const svg = readFileSync(path.join(PUBLIC_DIR, meta.image), "utf8");
+      expect(svg).toContain('id="totaled"');
+      expect(svg).toContain('id="wet-trail"');
+      expect(svg).toContain('id="snow-trail"');
+      expect(svg).toContain('translate(32 144)');
+      expect(svg).toContain('translate(32 176)');
+      expect(svg).toContain('translate(96 176)');
+    }
+  });
+
+  it("falls back to the starter atlas for unknown visual profiles", () => {
+    expect(carAtlasMetaForVisualProfile("unknown").image).toBe(
+      "art/cars/sparrow_gt.svg",
+    );
+    expect(carSpriteSetForVisualProfile("unknown").clean).toBe(
+      "sparrow_gt_clean",
+    );
+  });
+});

--- a/src/data/atlas/carSprites.ts
+++ b/src/data/atlas/carSprites.ts
@@ -1,0 +1,94 @@
+import type { AtlasFrame, AtlasMeta } from "@/data/schemas";
+import type { CarSpriteSet } from "@/render/carSpriteCompositor";
+
+export const CAR_SPRITE_SET_IDS = [
+  "sparrow_gt",
+  "breaker_s",
+  "vanta_xr",
+  "bastion_lm",
+  "tempest_r",
+  "nova_shade",
+] as const;
+
+export type CarSpriteSetId = (typeof CAR_SPRITE_SET_IDS)[number];
+
+const FRAME_WIDTH = 64;
+const FRAME_HEIGHT = 32;
+const ATLAS_WIDTH = 768;
+const ATLAS_HEIGHT = 384;
+const DEFAULT_SPRITE_SET_ID: CarSpriteSetId = "sparrow_gt";
+
+function directionalRow(y: number): AtlasFrame[] {
+  return Array.from({ length: 12 }, (_, index) => ({
+    x: index * FRAME_WIDTH,
+    y,
+    w: FRAME_WIDTH,
+    h: FRAME_HEIGHT,
+  }));
+}
+
+function oneFrame(x: number, y: number): AtlasFrame[] {
+  return [{ x, y, w: FRAME_WIDTH, h: FRAME_HEIGHT }];
+}
+
+function spriteSetFor(id: string): CarSpriteSet {
+  return Object.freeze({
+    clean: `${id}_clean`,
+    damage1: `${id}_dented`,
+    damage2: `${id}_battered`,
+    damage3: `${id}_totaled`,
+    brake: `${id}_brake`,
+    nitro: `${id}_nitro`,
+    wetTrail: `${id}_wet_trail`,
+    snowTrail: `${id}_snow_trail`,
+  });
+}
+
+function atlasMetaFor(id: CarSpriteSetId): AtlasMeta {
+  const spriteSet = spriteSetFor(id);
+  return {
+    image: `art/cars/${id}.svg`,
+    width: ATLAS_WIDTH,
+    height: ATLAS_HEIGHT,
+    sprites: {
+      [spriteSet.clean]: directionalRow(0),
+      [spriteSet.damage1]: directionalRow(32),
+      [spriteSet.damage2]: directionalRow(64),
+      [spriteSet.brake]: oneFrame(0, 96),
+      [spriteSet.nitro]: oneFrame(64, 96),
+      [spriteSet.damage3]: directionalRow(128),
+      [spriteSet.wetTrail]: oneFrame(0, 160),
+      [spriteSet.snowTrail]: oneFrame(64, 160),
+    },
+  };
+}
+
+export const CAR_SPRITE_SETS: Readonly<Record<CarSpriteSetId, CarSpriteSet>> =
+  Object.freeze(
+    Object.fromEntries(
+      CAR_SPRITE_SET_IDS.map((id) => [id, spriteSetFor(id)]),
+    ) as Record<CarSpriteSetId, CarSpriteSet>,
+  );
+
+export const CAR_ATLAS_METAS: Readonly<Record<CarSpriteSetId, AtlasMeta>> =
+  Object.freeze(
+    Object.fromEntries(
+      CAR_SPRITE_SET_IDS.map((id) => [id, atlasMetaFor(id)]),
+    ) as Record<CarSpriteSetId, AtlasMeta>,
+  );
+
+export function isCarSpriteSetId(value: string): value is CarSpriteSetId {
+  return CAR_SPRITE_SET_IDS.includes(value as CarSpriteSetId);
+}
+
+export function carSpriteSetForVisualProfile(value: string): CarSpriteSet {
+  return CAR_SPRITE_SETS[
+    isCarSpriteSetId(value) ? value : DEFAULT_SPRITE_SET_ID
+  ];
+}
+
+export function carAtlasMetaForVisualProfile(value: string): AtlasMeta {
+  return CAR_ATLAS_METAS[
+    isCarSpriteSetId(value) ? value : DEFAULT_SPRITE_SET_ID
+  ];
+}

--- a/src/render/__tests__/pseudoRoadCanvas.test.ts
+++ b/src/render/__tests__/pseudoRoadCanvas.test.ts
@@ -280,6 +280,40 @@ function loadedCarAtlas(): LoadedAtlas {
   };
 }
 
+function loadedCustomCarAtlas(): LoadedAtlas {
+  return {
+    image: {} as HTMLImageElement,
+    fallback: false,
+    meta: {
+      image: "art/cars/custom.svg",
+      width: 128,
+      height: 192,
+      sprites: {
+        custom_clean: [
+          { x: 10, y: 0, w: 64, h: 32 },
+          { x: 11, y: 0, w: 64, h: 32 },
+        ],
+        custom_dented: [
+          { x: 20, y: 0, w: 64, h: 32 },
+          { x: 21, y: 0, w: 64, h: 32 },
+        ],
+        custom_battered: [
+          { x: 60, y: 0, w: 64, h: 32 },
+          { x: 61, y: 0, w: 64, h: 32 },
+        ],
+        custom_totaled: [
+          { x: 70, y: 0, w: 64, h: 32 },
+          { x: 71, y: 0, w: 64, h: 32 },
+        ],
+        custom_wet_trail: [{ x: 30, y: 0, w: 64, h: 32 }],
+        custom_brake: [{ x: 40, y: 0, w: 64, h: 32 }],
+        custom_nitro: [{ x: 50, y: 0, w: 64, h: 32 }],
+        custom_snow_trail: [{ x: 80, y: 0, w: 64, h: 32 }],
+      },
+    },
+  };
+}
+
 function loadedRoadsideAtlas(): LoadedAtlas {
   return {
     image: {} as HTMLImageElement,
@@ -1242,6 +1276,34 @@ describe("drawRoad player car overlay", () => {
 
     const draws = spy.calls.filter((c): c is DrawImageCall => c.type === "drawImage");
     expect(draws.map((draw) => draw.sx)).toEqual([64, 256, 128, 192, 320]);
+  });
+
+  it("uses the supplied car sprite set when resolving atlas FX frames", () => {
+    const spy = makeCanvasSpy();
+    drawRoad(spy.ctx, EMPTY_STRIPS, VIEWPORT, {
+      playerCar: {
+        atlas: loadedCustomCarAtlas(),
+        spriteSet: {
+          clean: "custom_clean",
+          damage1: "custom_dented",
+          damage2: "custom_battered",
+          damage3: "custom_totaled",
+          brake: "custom_brake",
+          nitro: "custom_nitro",
+          wetTrail: "custom_wet_trail",
+          snowTrail: "custom_snow_trail",
+        },
+        frameIndex: 1,
+        braking: true,
+        nitroActive: true,
+        weather: "heavy_rain",
+        speedMetersPerSecond: 20,
+        damageTotal: 0.55,
+      },
+    });
+
+    const draws = spy.calls.filter((c): c is DrawImageCall => c.type === "drawImage");
+    expect(draws.map((draw) => draw.sx)).toEqual([11, 30, 40, 50, 61]);
   });
 
   it("does not paint the live player car when omitted or null", () => {

--- a/src/render/pseudoRoadCanvas.ts
+++ b/src/render/pseudoRoadCanvas.ts
@@ -37,6 +37,7 @@ import { drawParallax, type ParallaxLayer } from "./parallax";
 import {
   resolveCarRenderFrames,
   selectCarFramePlan,
+  type CarSpriteSet,
 } from "./carSpriteCompositor";
 import { frame, spriteCanRecolour, spriteFrameCount, type LoadedAtlas } from "./spriteAtlas";
 export {
@@ -253,6 +254,7 @@ export interface DrawRoadOptions {
     nitroActive?: boolean;
     speedMetersPerSecond?: number;
     damageTotal?: number;
+    spriteSet?: CarSpriteSet;
   } | null;
 }
 
@@ -1210,6 +1212,7 @@ function drawPlayerCar(
         weather: car.weather,
         speedMetersPerSecond: car.speedMetersPerSecond ?? 0,
         damageTotal: car.damageTotal ?? 0,
+        spriteSet: car.spriteSet,
       }),
     );
     if (frames) {


### PR DESCRIPTION
## Summary
- Complete generated FX rows for all six playable car sheets: totaled, wet trail, and snow trail.
- Add typed atlas metadata and sprite-set lookup helpers keyed by each car visual profile.
- Route live race rendering to load the selected car atlas and pass its sprite ids into the car compositor.
- Close F-068 and update the GDD coverage ledger.

## GDD inventory
- Implements §11 car visual profile usage in live race rendering.
- Implements §16 car sprite atlas coverage for directional, damage, brake, nitro, wet trail, and snow trail frames across the playable catalogue.
- Implements §17 car design language through existing generated geometric placeholder sheets.
- Adjacent uncovered requirement: ghost replay payloads still do not store a recorded car visual profile, so Time Trial ghost cars use the active player's selected car atlas for now.

## Tracking
- Progress log: `docs/PROGRESS_LOG.md` slice `2026-04-30: Slice: Per-car FX atlas routing`
- Followup closed: F-068
- Coverage ledger: GDD-16-CAR-SPRITE-ATLAS

## Test plan
- [x] `npx vitest run src/data/atlas/carSprites.test.ts src/render/__tests__/pseudoRoadCanvas.test.ts src/render/__tests__/carSpriteCompositor.test.ts src/render/__tests__/spriteAtlas.test.ts`
- [x] `npm run typecheck`
- [x] `npm run lint`
- [x] `npm run content-lint`
- [x] `npm run art:check`
- [x] `npm run docs:check`
- [x] `npm run verify`
- [x] Browser smoke: seeded active car `breaker-s`, opened `/race?mode=quickRace&track=test/elevation&car=breaker-s`, verified `/art/cars/breaker_s.svg` was requested and the canvas was nonblank.
- [x] `git diff --check`
- [x] Touched-file Unicode dash scan
