### PR TITLE
Ember Steppe track set

### DIFF
--- a/docs/GDD_COVERAGE.json
+++ b/docs/GDD_COVERAGE.json
@@ -982,6 +982,32 @@
       ]
     },
     {
+      "id": "GDD-24-EMBER-STEPPE-TRACK-SET",
+      "gddSections": [
+        "docs/gdd/09-track-design.md",
+        "docs/gdd/22-data-schemas.md",
+        "docs/gdd/24-content-plan.md"
+      ],
+      "requirement": "The Ember Steppe World Tour region has four registered, schema-valid, compiler-valid bundled track JSON files matching the §24 track list, region weather profile, and desert hazard palette.",
+      "coverage": ["implemented-code", "automated-test"],
+      "implementationRefs": [
+        "src/data/tracks/index.ts",
+        "src/data/tracks/ember-steppe-redglass-straight.json",
+        "src/data/tracks/ember-steppe-mesa-coil.json",
+        "src/data/tracks/ember-steppe-dustbreak-causeway.json",
+        "src/data/tracks/ember-steppe-cinder-gate.json"
+      ],
+      "testRefs": [
+        "src/data/__tests__/tracks-content.test.ts",
+        "src/data/__tests__/championship-content.test.ts",
+        "src/data/regions/__tests__/regions-content.test.ts",
+        "src/data/__tests__/content-budget.test.ts",
+        "src/road/__tests__/trackCompiler.test.ts",
+        "src/road/__tests__/trackCompiler.golden.test.ts"
+      ],
+      "followupRefs": ["VibeGear2-implement-ember-steppe-5d879662"]
+    },
+    {
       "id": "GDD-19-MOBILE-RACE-INPUT",
       "gddSections": [
         "docs/gdd/19-controls-and-input.md",

--- a/docs/PROGRESS_LOG.md
+++ b/docs/PROGRESS_LOG.md
@@ -6,6 +6,56 @@ Correct them by adding a new entry that references the old one.
 
 ---
 
+## 2026-04-30: Slice: Ember Steppe track set
+
+**GDD sections touched:**
+[§9](gdd/09-track-design.md) track design,
+[§22](gdd/22-data-schemas.md) track schema, and
+[§24](gdd/24-content-plan.md) full v1.0 content.
+**Branch / PR:** `feat/ember-steppe-tracks`, PR pending.
+**Status:** Implemented.
+
+### Done
+- Added the four planned Ember Steppe tracks from the §24 World Tour
+  list: Redglass Straight, Mesa Coil, Dustbreak Causeway, and Cinder
+  Gate.
+- Registered the new tracks in the browser-safe track catalogue.
+- Tightened content tests so the authored World Tour set through Ember
+  Steppe must resolve in both the track catalogue and championship
+  cross-reference tests.
+- Added machine-checkable coverage for the Ember Steppe track set.
+
+### Verified
+- `npx vitest run src/data/__tests__/tracks-content.test.ts src/data/__tests__/championship-content.test.ts src/data/regions/__tests__/regions-content.test.ts src/data/__tests__/content-budget.test.ts src/road/__tests__/trackCompiler.test.ts src/road/__tests__/trackCompiler.golden.test.ts`
+  green, 123 tests passed.
+- `npx vitest run src/data/__tests__/hazards-content.test.ts src/data/__tests__/tracks-content.test.ts src/data/__tests__/championship-content.test.ts`
+  green, 60 tests passed after replacing invalid hazard ids.
+- `npx playwright test e2e/world-tour.spec.ts e2e/tour-flow.spec.ts --project=chromium`
+  green, 3 tests passed.
+- `npm run content-lint` green.
+- `npm run verify` green, 2687 Vitest tests passed.
+
+### Decisions and assumptions
+- Kept Ember Steppe weather to `clear` and `fog` because the region
+  theme registry currently allows those presets for this tour.
+- Used existing hazard ids from the schema-backed registry, with
+  `gravel_band` as the desert-specific recurring hazard.
+
+### Coverage ledger
+- GDD-24-EMBER-STEPPE-TRACK-SET covers the four third-tour bundled
+  track JSON files, catalogue registration, and content validation.
+- Uncovered adjacent requirements: the remaining five v1.0 World Tour
+  regions still need authored track JSON before strict championship
+  track resolution can be enabled.
+
+### Followups created
+None.
+
+### GDD edits
+None.
+
+---
+
 ## 2026-04-30: Slice: Per-car FX atlas routing
 
 **GDD sections touched:**

--- a/docs/PROGRESS_LOG.md
+++ b/docs/PROGRESS_LOG.md
@@ -30,10 +30,12 @@ Correct them by adding a new entry that references the old one.
   green, 123 tests passed.
 - `npx vitest run src/data/__tests__/hazards-content.test.ts src/data/__tests__/tracks-content.test.ts src/data/__tests__/championship-content.test.ts`
   green, 60 tests passed after replacing invalid hazard ids.
+- `npx vitest run src/render/__tests__/pseudoRoadCanvas.test.ts src/data/__tests__/tracks-content.test.ts src/data/__tests__/championship-content.test.ts src/data/__tests__/hazards-content.test.ts`
+  green, 113 tests passed after adding Ember Steppe roadside renderer support.
 - `npx playwright test e2e/world-tour.spec.ts e2e/tour-flow.spec.ts --project=chromium`
   green, 3 tests passed.
 - `npm run content-lint` green.
-- `npm run verify` green, 2687 Vitest tests passed.
+- `npm run verify` green, 2688 Vitest tests passed.
 
 ### Decisions and assumptions
 - Kept Ember Steppe weather to `clear` and `fog` because the region

--- a/docs/PROGRESS_LOG.md
+++ b/docs/PROGRESS_LOG.md
@@ -12,7 +12,7 @@ Correct them by adding a new entry that references the old one.
 [§9](gdd/09-track-design.md) track design,
 [§22](gdd/22-data-schemas.md) track schema, and
 [§24](gdd/24-content-plan.md) full v1.0 content.
-**Branch / PR:** `feat/ember-steppe-tracks`, PR pending.
+**Branch / PR:** `feat/ember-steppe-tracks`, PR #132.
 **Status:** Implemented.
 
 ### Done

--- a/src/data/__tests__/championship-content.test.ts
+++ b/src/data/__tests__/championship-content.test.ts
@@ -143,8 +143,9 @@ describe("world-tour-standard track id cross-references", () => {
       expect(unresolved).toEqual([]);
     });
   } else {
-    it("resolves every §24 MVP track id for the first two tours", () => {
-      expect(mvpTrackIds.filter((id) => !hasBundledTrack(id))).toEqual([]);
+    it("resolves every authored §24 track id through Ember Steppe", () => {
+      const authoredTrackIds = wt.tours.slice(0, 3).flatMap((t) => t.tracks);
+      expect(authoredTrackIds.filter((id) => !hasBundledTrack(id))).toEqual([]);
     });
 
     it("permits unresolved track ids during the MVP content window", () => {

--- a/src/data/__tests__/tracks-content.test.ts
+++ b/src/data/__tests__/tracks-content.test.ts
@@ -27,7 +27,19 @@ const EXPECTED_MVP_TRACK_IDS = [
   "iron-borough/outer-exchange",
 ];
 
+const EXPECTED_AUTHORED_TOUR_TRACK_IDS = [
+  ...EXPECTED_MVP_TRACK_IDS,
+  "ember-steppe/redglass-straight",
+  "ember-steppe/mesa-coil",
+  "ember-steppe/dustbreak-causeway",
+  "ember-steppe/cinder-gate",
+];
+
 const EXPECTED_IDS = [
+  "ember-steppe/cinder-gate",
+  "ember-steppe/dustbreak-causeway",
+  "ember-steppe/mesa-coil",
+  "ember-steppe/redglass-straight",
   "iron-borough/foundry-mile",
   "iron-borough/freightline-ring",
   "iron-borough/outer-exchange",
@@ -46,8 +58,8 @@ describe("track catalogue", () => {
     expect([...TRACK_IDS].sort()).toEqual(EXPECTED_IDS);
   });
 
-  it("registers the two-tour §24 MVP track set", () => {
-    for (const id of EXPECTED_MVP_TRACK_IDS) {
+  it("registers the authored World Tour track set through Ember Steppe", () => {
+    for (const id of EXPECTED_AUTHORED_TOUR_TRACK_IDS) {
       expect(TRACK_IDS).toContain(id);
     }
   });
@@ -122,5 +134,41 @@ describe("§24 MVP track set", () => {
         track.segments.some((segment) => segment.grade !== 0),
       ),
     ).toBe(true);
+  });
+});
+
+describe("§24 Ember Steppe track set", () => {
+  const emberTrackIds = EXPECTED_AUTHORED_TOUR_TRACK_IDS.filter((id) =>
+    id.startsWith("ember-steppe/"),
+  );
+
+  it("covers all four planned Ember Steppe tracks", () => {
+    expect(emberTrackIds).toEqual([
+      "ember-steppe/redglass-straight",
+      "ember-steppe/mesa-coil",
+      "ember-steppe/dustbreak-causeway",
+      "ember-steppe/cinder-gate",
+    ]);
+    for (const id of emberTrackIds) {
+      expect(TRACK_IDS).toContain(id);
+    }
+  });
+
+  it("uses the Ember Steppe region weather profile and desert hazards", () => {
+    const tracks = emberTrackIds.map((id) => TrackSchema.parse(TRACK_RAW[id]));
+    const weather = new Set<string>();
+    const hazards = new Set<string>();
+    for (const track of tracks) {
+      expect(track.tourId).toBe("ember-steppe");
+      expect(track.laps).toBe(1);
+      expect(track.laneCount).toBe(3);
+      for (const option of track.weatherOptions) weather.add(option);
+      for (const segment of track.segments) {
+        for (const hazard of segment.hazards) hazards.add(hazard);
+      }
+    }
+    expect([...weather].sort()).toEqual(["clear", "fog"]);
+    expect(hazards.has("gravel_band")).toBe(true);
+    expect(hazards.has("traffic_cone")).toBe(true);
   });
 });

--- a/src/data/tracks/ember-steppe-cinder-gate.json
+++ b/src/data/tracks/ember-steppe-cinder-gate.json
@@ -1,0 +1,27 @@
+{
+  "id": "ember-steppe/cinder-gate",
+  "name": "Cinder Gate",
+  "tourId": "ember-steppe",
+  "author": "core",
+  "version": 1,
+  "lengthMeters": 1920,
+  "laps": 1,
+  "laneCount": 3,
+  "weatherOptions": ["clear", "fog"],
+  "difficulty": 5,
+  "segments": [
+    { "len": 240, "curve": 0.04, "grade": 0.02, "roadsideLeft": "rock_spire", "roadsideRight": "sign_marker", "hazards": [] },
+    { "len": 240, "curve": -0.16, "grade": 0.04, "roadsideLeft": "rock_boulder", "roadsideRight": "heat_sign", "hazards": ["gravel_band"] },
+    { "len": 280, "curve": 0.2, "grade": -0.02, "roadsideLeft": "heat_sign", "roadsideRight": "rock_spire", "hazards": ["sign_marker"] },
+    { "len": 280, "curve": -0.08, "grade": 0.05, "roadsideLeft": "fence_post", "roadsideRight": "rock_boulder", "hazards": [] },
+    { "len": 260, "curve": 0.14, "grade": -0.05, "roadsideLeft": "rock_spire", "roadsideRight": "heat_sign", "hazards": ["traffic_cone"] },
+    { "len": 260, "curve": -0.12, "grade": 0.01, "roadsideLeft": "rock_boulder", "roadsideRight": "sign_marker", "hazards": ["gravel_band"] },
+    { "len": 360, "curve": 0, "grade": 0, "roadsideLeft": "heat_sign", "roadsideRight": "rock_spire", "hazards": [] }
+  ],
+  "checkpoints": [
+    { "segmentIndex": 0, "label": "start" },
+    { "segmentIndex": 2, "label": "cinder-cut" },
+    { "segmentIndex": 5, "label": "gate" }
+  ],
+  "spawn": { "gridSlots": 12 }
+}

--- a/src/data/tracks/ember-steppe-dustbreak-causeway.json
+++ b/src/data/tracks/ember-steppe-dustbreak-causeway.json
@@ -1,0 +1,27 @@
+{
+  "id": "ember-steppe/dustbreak-causeway",
+  "name": "Dustbreak Causeway",
+  "tourId": "ember-steppe",
+  "author": "core",
+  "version": 1,
+  "lengthMeters": 1860,
+  "laps": 1,
+  "laneCount": 3,
+  "weatherOptions": ["clear", "fog"],
+  "difficulty": 4,
+  "segments": [
+    { "len": 260, "curve": 0, "grade": 0, "roadsideLeft": "heat_sign", "roadsideRight": "fence_post", "hazards": [] },
+    { "len": 220, "curve": -0.1, "grade": -0.01, "roadsideLeft": "rock_boulder", "roadsideRight": "rock_spire", "hazards": ["gravel_band"] },
+    { "len": 280, "curve": 0.12, "grade": 0.02, "roadsideLeft": "rock_spire", "roadsideRight": "heat_sign", "hazards": [] },
+    { "len": 240, "curve": 0, "grade": 0.05, "roadsideLeft": "sign_marker", "roadsideRight": "rock_boulder", "hazards": ["traffic_cone"] },
+    { "len": 300, "curve": -0.14, "grade": -0.04, "roadsideLeft": "rock_boulder", "roadsideRight": "sign_marker", "hazards": [] },
+    { "len": 260, "curve": 0.1, "grade": 0.01, "roadsideLeft": "heat_sign", "roadsideRight": "rock_spire", "hazards": ["gravel_band"] },
+    { "len": 300, "curve": 0, "grade": 0, "roadsideLeft": "fence_post", "roadsideRight": "heat_sign", "hazards": [] }
+  ],
+  "checkpoints": [
+    { "segmentIndex": 0, "label": "start" },
+    { "segmentIndex": 3, "label": "causeway" },
+    { "segmentIndex": 5, "label": "dustbreak" }
+  ],
+  "spawn": { "gridSlots": 12 }
+}

--- a/src/data/tracks/ember-steppe-mesa-coil.json
+++ b/src/data/tracks/ember-steppe-mesa-coil.json
@@ -1,0 +1,27 @@
+{
+  "id": "ember-steppe/mesa-coil",
+  "name": "Mesa Coil",
+  "tourId": "ember-steppe",
+  "author": "core",
+  "version": 1,
+  "lengthMeters": 1800,
+  "laps": 1,
+  "laneCount": 3,
+  "weatherOptions": ["clear"],
+  "difficulty": 4,
+  "segments": [
+    { "len": 220, "curve": 0.08, "grade": 0.02, "roadsideLeft": "rock_boulder", "roadsideRight": "heat_sign", "hazards": [] },
+    { "len": 220, "curve": 0.18, "grade": 0.03, "roadsideLeft": "rock_spire", "roadsideRight": "rock_boulder", "hazards": ["gravel_band"] },
+    { "len": 260, "curve": -0.2, "grade": -0.01, "roadsideLeft": "heat_sign", "roadsideRight": "rock_spire", "hazards": [] },
+    { "len": 260, "curve": 0.16, "grade": 0.04, "roadsideLeft": "rock_boulder", "roadsideRight": "sign_marker", "hazards": ["sign_marker"] },
+    { "len": 280, "curve": -0.12, "grade": -0.03, "roadsideLeft": "fence_post", "roadsideRight": "rock_boulder", "hazards": [] },
+    { "len": 260, "curve": 0.06, "grade": 0.01, "roadsideLeft": "rock_spire", "roadsideRight": "heat_sign", "hazards": ["traffic_cone"] },
+    { "len": 300, "curve": 0, "grade": 0, "roadsideLeft": "sign_marker", "roadsideRight": "rock_spire", "hazards": [] }
+  ],
+  "checkpoints": [
+    { "segmentIndex": 0, "label": "start" },
+    { "segmentIndex": 2, "label": "coil" },
+    { "segmentIndex": 5, "label": "mesa-drop" }
+  ],
+  "spawn": { "gridSlots": 12 }
+}

--- a/src/data/tracks/ember-steppe-redglass-straight.json
+++ b/src/data/tracks/ember-steppe-redglass-straight.json
@@ -1,0 +1,26 @@
+{
+  "id": "ember-steppe/redglass-straight",
+  "name": "Redglass Straight",
+  "tourId": "ember-steppe",
+  "author": "core",
+  "version": 1,
+  "lengthMeters": 1740,
+  "laps": 1,
+  "laneCount": 3,
+  "weatherOptions": ["clear", "fog"],
+  "difficulty": 3,
+  "segments": [
+    { "len": 300, "curve": 0, "grade": 0.01, "roadsideLeft": "rock_spire", "roadsideRight": "sign_marker", "hazards": [] },
+    { "len": 260, "curve": 0.04, "grade": 0, "roadsideLeft": "heat_sign", "roadsideRight": "rock_boulder", "hazards": ["gravel_band"] },
+    { "len": 320, "curve": 0, "grade": 0.03, "roadsideLeft": "rock_boulder", "roadsideRight": "heat_sign", "hazards": [] },
+    { "len": 240, "curve": -0.08, "grade": -0.02, "roadsideLeft": "sign_marker", "roadsideRight": "rock_spire", "hazards": ["traffic_cone"] },
+    { "len": 260, "curve": 0.08, "grade": 0, "roadsideLeft": "rock_spire", "roadsideRight": "fence_post", "hazards": [] },
+    { "len": 360, "curve": 0, "grade": 0, "roadsideLeft": "heat_sign", "roadsideRight": "sign_marker", "hazards": [] }
+  ],
+  "checkpoints": [
+    { "segmentIndex": 0, "label": "start" },
+    { "segmentIndex": 2, "label": "redglass" },
+    { "segmentIndex": 4, "label": "heat-haze" }
+  ],
+  "spawn": { "gridSlots": 12 }
+}

--- a/src/data/tracks/index.ts
+++ b/src/data/tracks/index.ts
@@ -18,6 +18,10 @@ import ironBoroughFoundryMile from "./iron-borough-foundry-mile.json";
 import ironBoroughFreightlineRing from "./iron-borough-freightline-ring.json";
 import ironBoroughOuterExchange from "./iron-borough-outer-exchange.json";
 import ironBoroughRivetTunnel from "./iron-borough-rivet-tunnel.json";
+import emberSteppeCinderGate from "./ember-steppe-cinder-gate.json";
+import emberSteppeDustbreakCauseway from "./ember-steppe-dustbreak-causeway.json";
+import emberSteppeMesaCoil from "./ember-steppe-mesa-coil.json";
+import emberSteppeRedglassStraight from "./ember-steppe-redglass-straight.json";
 import velvetCoastClifflineArc from "./velvet-coast-cliffline-arc.json";
 import velvetCoastHarborRun from "./velvet-coast-harbor-run.json";
 import velvetCoastLighthouseFall from "./velvet-coast-lighthouse-fall.json";
@@ -35,6 +39,10 @@ export const TRACK_RAW: Readonly<Record<string, unknown>> = Object.freeze({
   "iron-borough/rivet-tunnel": ironBoroughRivetTunnel,
   "iron-borough/foundry-mile": ironBoroughFoundryMile,
   "iron-borough/outer-exchange": ironBoroughOuterExchange,
+  "ember-steppe/redglass-straight": emberSteppeRedglassStraight,
+  "ember-steppe/mesa-coil": emberSteppeMesaCoil,
+  "ember-steppe/dustbreak-causeway": emberSteppeDustbreakCauseway,
+  "ember-steppe/cinder-gate": emberSteppeCinderGate,
 });
 
 /** Sorted list of available track slugs for menu builders. */

--- a/src/render/__tests__/pseudoRoadCanvas.test.ts
+++ b/src/render/__tests__/pseudoRoadCanvas.test.ts
@@ -763,6 +763,42 @@ describe("drawRoad roadside sprites", () => {
     expect(fillRects.some((call) => call.fillStyle === "#1b3a20")).toBe(true);
   });
 
+  it("paints Ember Steppe roadside ids instead of skipping them", () => {
+    const spy = makeCanvasSpy();
+    const strips: readonly Strip[] = [
+      strip({
+        screenY: 440,
+        screenW: 260,
+        segment: {
+          ...strip({}).segment,
+          index: 0,
+          roadsideLeftId: "rock_spire",
+          roadsideRightId: "default",
+        },
+      }),
+      strip({
+        screenY: 300,
+        screenW: 110,
+        segment: {
+          ...strip({}).segment,
+          index: 5,
+          roadsideLeftId: "default",
+          roadsideRightId: "heat_sign",
+        },
+      }),
+    ];
+
+    drawRoad(spy.ctx, strips, VIEWPORT, {});
+
+    const fills = spy.calls.filter((c): c is FillCall => c.type === "fill");
+    expect(fills.some((call) => call.fillStyle === "#767c82")).toBe(true);
+
+    const fillRects = spy.calls.filter(
+      (c): c is FillRectCall => c.type === "fillRect",
+    );
+    expect(fillRects.some((call) => call.fillStyle === "#e7d24d")).toBe(true);
+  });
+
   it("draws cached palette recoloured atlas roadside sprites", () => {
     const spy = makeCanvasSpy();
     const cache = new PaletteCache<CanvasImageSource>(4);

--- a/src/render/pseudoRoadCanvas.ts
+++ b/src/render/pseudoRoadCanvas.ts
@@ -277,6 +277,8 @@ const ROADSIDE_SPRITE_STYLES: Record<string, RoadsideSpriteStyle> = {
   marina_signs: { kind: "sign", widthToHeight: 0.45, heightRoadFactor: 0.85, minHeight: 8 },
   guardrail: { kind: "fence", widthToHeight: 0.32, heightRoadFactor: 0.5, minHeight: 5 },
   water_wall: { kind: "rock", widthToHeight: 1.2, heightRoadFactor: 0.42, minHeight: 5 },
+  rock_spire: { kind: "rock", widthToHeight: 0.62, heightRoadFactor: 0.95, minHeight: 9 },
+  heat_sign: { kind: "sign", widthToHeight: 0.58, heightRoadFactor: 0.8, minHeight: 8 },
 };
 
 const DEFAULT_RECOLOUR_IN_FLIGHT = new Set<string>();


### PR DESCRIPTION
## GDD sections
- §9 Track design
- §22 Data schemas
- §24 Content plan

## Requirement inventory
- Adds all four §24 Ember Steppe World Tour tracks: Redglass Straight, Mesa Coil, Dustbreak Causeway, and Cinder Gate.
- Registers the tracks in the browser-safe `TRACK_RAW` catalogue.
- Tightens track and championship content tests so authored tracks through Ember Steppe must resolve.
- Adds `GDD-24-EMBER-STEPPE-TRACK-SET` to the machine-checkable coverage ledger.

Nearby requirements left for later:
- The remaining five v1.0 World Tour regions still need authored track JSON before strict 32-track championship resolution can be enabled.
- Online leaderboard production storage remains blocked by Q-011.

## Progress log
- `docs/PROGRESS_LOG.md`: `2026-04-30: Slice: Ember Steppe track set`

## Test plan
- [x] `npx vitest run src/data/__tests__/tracks-content.test.ts src/data/__tests__/championship-content.test.ts src/data/regions/__tests__/regions-content.test.ts src/data/__tests__/content-budget.test.ts src/road/__tests__/trackCompiler.test.ts src/road/__tests__/trackCompiler.golden.test.ts`
- [x] `npx vitest run src/data/__tests__/hazards-content.test.ts src/data/__tests__/tracks-content.test.ts src/data/__tests__/championship-content.test.ts`
- [x] `npx playwright test e2e/world-tour.spec.ts e2e/tour-flow.spec.ts --project=chromium`
- [x] `npm run content-lint`
- [x] `npm run verify`

## Followups
None.
