### PR TITLE
WebKit keyboard smoke hotfix

### DIFF
--- a/docs/PROGRESS_LOG.md
+++ b/docs/PROGRESS_LOG.md
@@ -6,6 +6,43 @@ Correct them by adding a new entry that references the old one.
 
 ---
 
+## 2026-04-30: Slice: WebKit keyboard smoke hotfix
+
+**GDD sections touched:**
+[§19](gdd/19-controls-and-accessibility.md) keyboard controls and
+[§21](gdd/21-technical-design-for-web-implementation.md) CI verification.
+**Branch / PR:** `fix/webkit-keyboard-smoke`, PR pending.
+**Status:** Implemented.
+
+### Done
+- Hardened the cross-browser keyboard smoke after the PR #132 post-merge
+  main CI failed in WebKit with the page closing at the 30 second test
+  timeout.
+- Made the Tab helper check the current focused element before sending the
+  next Tab key so it does no extra focus cycling.
+- Gave only the keyboard navigation smoke a 60 second timeout and reduced
+  motion media state so the race canvas does less work during the route
+  navigation check.
+
+### Verified
+- `CI=1 PLAYWRIGHT_CROSS_BROWSER=1 npx playwright test e2e/cross-browser-smoke.spec.ts --project=cross-browser-webkit --repeat-each=3`
+  green, 12 WebKit runs passed.
+- `CI=1 npm run test:e2e:cross-browser` green, 12 tests passed across
+  Chromium, Firefox, and WebKit.
+
+### Decisions and assumptions
+- Treated this as a CI stability hotfix, not a gameplay change. The
+  failure log showed Playwright closing the page after the test timeout,
+  while the same keyboard flow passed locally when isolated.
+
+### Followups created
+None.
+
+### GDD edits
+None.
+
+---
+
 ## 2026-04-30: Slice: Ember Steppe track set
 
 **GDD sections touched:**

--- a/docs/PROGRESS_LOG.md
+++ b/docs/PROGRESS_LOG.md
@@ -35,6 +35,12 @@ Correct them by adding a new entry that references the old one.
   failure log showed Playwright closing the page after the test timeout,
   while the same keyboard flow passed locally when isolated.
 
+### Coverage ledger
+- GDD-27-CROSS-BROWSER-SMOKE covers the automated Chromium, Firefox, and
+  WebKit smoke, including keyboard-only title to race to garage navigation.
+- Uncovered adjacent requirements: none. This hotfix keeps the existing
+  cross-browser smoke coverage stable.
+
 ### Followups created
 None.
 

--- a/docs/PROGRESS_LOG.md
+++ b/docs/PROGRESS_LOG.md
@@ -9,7 +9,7 @@ Correct them by adding a new entry that references the old one.
 ## 2026-04-30: Slice: WebKit keyboard smoke hotfix
 
 **GDD sections touched:**
-[§19](gdd/19-controls-and-accessibility.md) keyboard controls and
+[§19](gdd/19-controls-and-input.md) keyboard controls and
 [§21](gdd/21-technical-design-for-web-implementation.md) CI verification.
 **Branch / PR:** `fix/webkit-keyboard-smoke`, PR pending.
 **Status:** Implemented.

--- a/e2e/cross-browser-smoke.spec.ts
+++ b/e2e/cross-browser-smoke.spec.ts
@@ -13,12 +13,12 @@ const CORE_ROUTES: ReadonlyArray<{
 
 async function focusByTab(page: Page, testId: string, maxTabs = 40): Promise<void> {
   for (let i = 0; i < maxTabs; i += 1) {
-    await page.keyboard.press("Tab");
     const activeTestId = await page.evaluate(() => {
       const active = document.activeElement;
       return active instanceof HTMLElement ? active.dataset.testid ?? null : null;
     });
     if (activeTestId === testId) return;
+    await page.keyboard.press("Tab");
   }
   throw new Error(`Could not focus ${testId} with Tab`);
 }
@@ -93,6 +93,8 @@ test.describe("cross-browser compatibility smoke", () => {
   test("supports keyboard-only title to race to garage navigation", async ({
     page,
   }) => {
+    test.setTimeout(60_000);
+    await page.emulateMedia({ reducedMotion: "reduce" });
     await page.goto("/");
     await expect(page.getByTestId("menu-start-race")).toBeVisible();
     await focusByTab(page, "menu-start-race");

--- a/e2e/cross-browser-smoke.spec.ts
+++ b/e2e/cross-browser-smoke.spec.ts
@@ -12,13 +12,17 @@ const CORE_ROUTES: ReadonlyArray<{
 ];
 
 async function focusByTab(page: Page, testId: string, maxTabs = 40): Promise<void> {
-  for (let i = 0; i < maxTabs; i += 1) {
-    const activeTestId = await page.evaluate(() => {
+  const focusedTestId = async (): Promise<string | null> =>
+    page.evaluate(() => {
       const active = document.activeElement;
       return active instanceof HTMLElement ? active.dataset.testid ?? null : null;
     });
-    if (activeTestId === testId) return;
+
+  if ((await focusedTestId()) === testId) return;
+
+  for (let i = 0; i < maxTabs; i += 1) {
     await page.keyboard.press("Tab");
+    if ((await focusedTestId()) === testId) return;
   }
   throw new Error(`Could not focus ${testId} with Tab`);
 }


### PR DESCRIPTION
## Summary
- harden the cross-browser keyboard smoke after main CI timed out in WebKit
- check existing focus before sending an extra Tab key
- run the keyboard route smoke in reduced-motion mode with a local 60 second timeout

## GDD
- §19 controls and accessibility
- §21 CI verification

## Progress log
- docs/PROGRESS_LOG.md: WebKit keyboard smoke hotfix

## Test plan
- [x] CI=1 PLAYWRIGHT_CROSS_BROWSER=1 npx playwright test e2e/cross-browser-smoke.spec.ts --project=cross-browser-webkit --repeat-each=3
- [x] CI=1 npm run test:e2e:cross-browser
- [x] npm run docs:check
- [x] npm run lint

## Followups
- None