### PR TITLE
Breakwater Isles track set

### DIFF
--- a/docs/GDD_COVERAGE.json
+++ b/docs/GDD_COVERAGE.json
@@ -1008,6 +1008,32 @@
       "followupRefs": ["VibeGear2-implement-ember-steppe-5d879662"]
     },
     {
+      "id": "GDD-24-BREAKWATER-ISLES-TRACK-SET",
+      "gddSections": [
+        "docs/gdd/09-track-design.md",
+        "docs/gdd/22-data-schemas.md",
+        "docs/gdd/24-content-plan.md"
+      ],
+      "requirement": "The Breakwater Isles World Tour region has four registered, schema-valid, compiler-valid bundled track JSON files matching the §24 track list, region weather profile, and wet hazard palette.",
+      "coverage": ["implemented-code", "automated-test"],
+      "implementationRefs": [
+        "src/data/tracks/index.ts",
+        "src/data/tracks/breakwater-isles-tidewire.json",
+        "src/data/tracks/breakwater-isles-storm-span.json",
+        "src/data/tracks/breakwater-isles-gull-point.json",
+        "src/data/tracks/breakwater-isles-sealight-shelf.json"
+      ],
+      "testRefs": [
+        "src/data/__tests__/tracks-content.test.ts",
+        "src/data/__tests__/championship-content.test.ts",
+        "src/data/regions/__tests__/regions-content.test.ts",
+        "src/data/__tests__/content-budget.test.ts",
+        "src/road/__tests__/trackCompiler.test.ts",
+        "src/road/__tests__/trackCompiler.golden.test.ts"
+      ],
+      "followupRefs": ["VibeGear2-implement-breakwater-isles-c55d6f60"]
+    },
+    {
       "id": "GDD-19-MOBILE-RACE-INPUT",
       "gddSections": [
         "docs/gdd/19-controls-and-input.md",

--- a/docs/PROGRESS_LOG.md
+++ b/docs/PROGRESS_LOG.md
@@ -12,7 +12,7 @@ Correct them by adding a new entry that references the old one.
 [§9](gdd/09-track-design.md) track design,
 [§22](gdd/22-data-schemas.md) track schema, and
 [§24](gdd/24-content-plan.md) full v1.0 content.
-**Branch / PR:** `feat/breakwater-isles-tracks`, PR pending.
+**Branch / PR:** `feat/breakwater-isles-tracks`, PR #134.
 **Status:** Implemented.
 
 ### Done

--- a/docs/PROGRESS_LOG.md
+++ b/docs/PROGRESS_LOG.md
@@ -6,6 +6,56 @@ Correct them by adding a new entry that references the old one.
 
 ---
 
+## 2026-04-30: Slice: Breakwater Isles track set
+
+**GDD sections touched:**
+[§9](gdd/09-track-design.md) track design,
+[§22](gdd/22-data-schemas.md) track schema, and
+[§24](gdd/24-content-plan.md) full v1.0 content.
+**Branch / PR:** `feat/breakwater-isles-tracks`, PR pending.
+**Status:** Implemented.
+
+### Done
+- Added the four planned Breakwater Isles tracks from the §24 World Tour
+  list: Tidewire, Storm Span, Gull Point, and Sealight Shelf.
+- Registered the new tracks in the browser-safe track catalogue.
+- Tightened content tests so the authored World Tour set through
+  Breakwater Isles must resolve in both the track catalogue and
+  championship cross-reference tests.
+- Added machine-checkable coverage for the Breakwater Isles track set.
+
+### Verified
+- `npx vitest run src/data/__tests__/tracks-content.test.ts src/data/__tests__/championship-content.test.ts src/data/regions/__tests__/regions-content.test.ts src/data/__tests__/content-budget.test.ts src/road/__tests__/trackCompiler.test.ts src/road/__tests__/trackCompiler.golden.test.ts`
+  green, 133 tests passed.
+- `npm run content-lint` green.
+- `npm run docs:check` green.
+- `npm run verify` green, 2698 Vitest tests passed.
+- `npx playwright test e2e/world-tour.spec.ts e2e/tour-flow.spec.ts --project=chromium`
+  green, 3 tests passed.
+
+### Decisions and assumptions
+- Kept Breakwater Isles weather to the region profile values already in
+  `src/data/regions/breakwater-isles.json`: `rain`, `heavy_rain`, and
+  `overcast`.
+- Used the existing wet hazard palette (`puddle` and `slick_paint`) plus
+  existing renderer-supported coastal roadside ids so this slice stays
+  content-only.
+
+### Coverage ledger
+- GDD-24-BREAKWATER-ISLES-TRACK-SET covers the four fourth-tour bundled
+  track JSON files, catalogue registration, and content validation.
+- Uncovered adjacent requirements: the remaining four v1.0 World Tour
+  regions still need authored track JSON before strict championship
+  track resolution can be enabled.
+
+### Followups created
+None.
+
+### GDD edits
+None.
+
+---
+
 ## 2026-04-30: Slice: WebKit keyboard smoke hotfix
 
 **GDD sections touched:**

--- a/docs/PROGRESS_LOG.md
+++ b/docs/PROGRESS_LOG.md
@@ -32,6 +32,11 @@ Correct them by adding a new entry that references the old one.
 - `npm run verify` green, 2698 Vitest tests passed.
 - `npx playwright test e2e/world-tour.spec.ts e2e/tour-flow.spec.ts --project=chromium`
   green, 3 tests passed.
+- `CI=1 PLAYWRIGHT_CROSS_BROWSER=1 npx playwright test e2e/cross-browser-smoke.spec.ts --project=cross-browser-webkit -g "keyboard-only" --repeat-each=3`
+  green, 3 WebKit runs passed after the PR CI exposed the modal
+  focus path as the flaky step.
+- `CI=1 npm run test:e2e:cross-browser` green, 12 tests passed across
+  Chromium, Firefox, and WebKit.
 
 ### Decisions and assumptions
 - Kept Breakwater Isles weather to the region profile values already in

--- a/e2e/cross-browser-smoke.spec.ts
+++ b/e2e/cross-browser-smoke.spec.ts
@@ -27,6 +27,20 @@ async function focusByTab(page: Page, testId: string, maxTabs = 40): Promise<voi
   throw new Error(`Could not focus ${testId} with Tab`);
 }
 
+async function focusByTestId(page: Page, testId: string): Promise<void> {
+  const target = page.getByTestId(testId);
+  await expect(target).toBeVisible();
+  await target.focus();
+  await expect
+    .poll(() =>
+      page.evaluate(() => {
+        const active = document.activeElement;
+        return active instanceof HTMLElement ? active.dataset.testid ?? null : null;
+      }),
+    )
+    .toBe(testId);
+}
+
 async function canvasHasSpatialVariation(page: Page): Promise<boolean> {
   return page.getByTestId("race-canvas-element").evaluate((node) => {
     const canvas = node as HTMLCanvasElement;
@@ -110,7 +124,7 @@ test.describe("cross-browser compatibility smoke", () => {
 
     await page.keyboard.press("Escape");
     await expect(page.getByTestId("pause-overlay")).toBeVisible();
-    await focusByTab(page, "pause-exit");
+    await focusByTestId(page, "pause-exit");
     await page.keyboard.press("Enter");
     await expect(page).toHaveURL(/\/$/);
     await expect(page.getByTestId("menu-garage")).toBeVisible();

--- a/src/data/__tests__/championship-content.test.ts
+++ b/src/data/__tests__/championship-content.test.ts
@@ -143,8 +143,8 @@ describe("world-tour-standard track id cross-references", () => {
       expect(unresolved).toEqual([]);
     });
   } else {
-    it("resolves every authored §24 track id through Ember Steppe", () => {
-      const authoredTrackIds = wt.tours.slice(0, 3).flatMap((t) => t.tracks);
+    it("resolves every authored §24 track id through Breakwater Isles", () => {
+      const authoredTrackIds = wt.tours.slice(0, 4).flatMap((t) => t.tracks);
       expect(authoredTrackIds.filter((id) => !hasBundledTrack(id))).toEqual([]);
     });
 

--- a/src/data/__tests__/tracks-content.test.ts
+++ b/src/data/__tests__/tracks-content.test.ts
@@ -33,9 +33,17 @@ const EXPECTED_AUTHORED_TOUR_TRACK_IDS = [
   "ember-steppe/mesa-coil",
   "ember-steppe/dustbreak-causeway",
   "ember-steppe/cinder-gate",
+  "breakwater-isles/tidewire",
+  "breakwater-isles/storm-span",
+  "breakwater-isles/gull-point",
+  "breakwater-isles/sealight-shelf",
 ];
 
 const EXPECTED_IDS = [
+  "breakwater-isles/gull-point",
+  "breakwater-isles/sealight-shelf",
+  "breakwater-isles/storm-span",
+  "breakwater-isles/tidewire",
   "ember-steppe/cinder-gate",
   "ember-steppe/dustbreak-causeway",
   "ember-steppe/mesa-coil",
@@ -58,7 +66,7 @@ describe("track catalogue", () => {
     expect([...TRACK_IDS].sort()).toEqual(EXPECTED_IDS);
   });
 
-  it("registers the authored World Tour track set through Ember Steppe", () => {
+  it("registers the authored World Tour track set through Breakwater Isles", () => {
     for (const id of EXPECTED_AUTHORED_TOUR_TRACK_IDS) {
       expect(TRACK_IDS).toContain(id);
     }
@@ -170,5 +178,43 @@ describe("§24 Ember Steppe track set", () => {
     expect([...weather].sort()).toEqual(["clear", "fog"]);
     expect(hazards.has("gravel_band")).toBe(true);
     expect(hazards.has("traffic_cone")).toBe(true);
+  });
+});
+
+describe("§24 Breakwater Isles track set", () => {
+  const breakwaterTrackIds = EXPECTED_AUTHORED_TOUR_TRACK_IDS.filter((id) =>
+    id.startsWith("breakwater-isles/"),
+  );
+
+  it("covers all four planned Breakwater Isles tracks", () => {
+    expect(breakwaterTrackIds).toEqual([
+      "breakwater-isles/tidewire",
+      "breakwater-isles/storm-span",
+      "breakwater-isles/gull-point",
+      "breakwater-isles/sealight-shelf",
+    ]);
+    for (const id of breakwaterTrackIds) {
+      expect(TRACK_IDS).toContain(id);
+    }
+  });
+
+  it("uses the Breakwater Isles region weather profile and wet hazards", () => {
+    const tracks = breakwaterTrackIds.map((id) =>
+      TrackSchema.parse(TRACK_RAW[id]),
+    );
+    const weather = new Set<string>();
+    const hazards = new Set<string>();
+    for (const track of tracks) {
+      expect(track.tourId).toBe("breakwater-isles");
+      expect(track.laps).toBe(1);
+      expect(track.laneCount).toBe(3);
+      for (const option of track.weatherOptions) weather.add(option);
+      for (const segment of track.segments) {
+        for (const hazard of segment.hazards) hazards.add(hazard);
+      }
+    }
+    expect([...weather].sort()).toEqual(["heavy_rain", "overcast", "rain"]);
+    expect(hazards.has("puddle")).toBe(true);
+    expect(hazards.has("slick_paint")).toBe(true);
   });
 });

--- a/src/data/tracks/breakwater-isles-gull-point.json
+++ b/src/data/tracks/breakwater-isles-gull-point.json
@@ -1,0 +1,27 @@
+{
+  "id": "breakwater-isles/gull-point",
+  "name": "Gull Point",
+  "tourId": "breakwater-isles",
+  "author": "core",
+  "version": 1,
+  "lengthMeters": 1980,
+  "laps": 1,
+  "laneCount": 3,
+  "weatherOptions": ["rain", "overcast"],
+  "difficulty": 4,
+  "segments": [
+    { "len": 260, "curve": 0, "grade": 0.01, "roadsideLeft": "marina_signs", "roadsideRight": "light_pole", "hazards": [] },
+    { "len": 240, "curve": 0.14, "grade": 0.03, "roadsideLeft": "guardrail", "roadsideRight": "water_wall", "hazards": ["puddle"] },
+    { "len": 260, "curve": -0.1, "grade": -0.02, "roadsideLeft": "water_wall", "roadsideRight": "guardrail", "hazards": [] },
+    { "len": 280, "curve": 0.18, "grade": 0.04, "roadsideLeft": "light_pole", "roadsideRight": "marina_signs", "hazards": ["slick_paint"] },
+    { "len": 260, "curve": -0.2, "grade": -0.03, "roadsideLeft": "guardrail", "roadsideRight": "water_wall", "hazards": ["puddle"] },
+    { "len": 300, "curve": 0.08, "grade": 0.01, "roadsideLeft": "marina_signs", "roadsideRight": "light_pole", "hazards": [] },
+    { "len": 380, "curve": 0, "grade": 0, "roadsideLeft": "water_wall", "roadsideRight": "guardrail", "hazards": [] }
+  ],
+  "checkpoints": [
+    { "segmentIndex": 0, "label": "start" },
+    { "segmentIndex": 2, "label": "point-rise" },
+    { "segmentIndex": 5, "label": "gull-run" }
+  ],
+  "spawn": { "gridSlots": 12 }
+}

--- a/src/data/tracks/breakwater-isles-sealight-shelf.json
+++ b/src/data/tracks/breakwater-isles-sealight-shelf.json
@@ -1,0 +1,27 @@
+{
+  "id": "breakwater-isles/sealight-shelf",
+  "name": "Sealight Shelf",
+  "tourId": "breakwater-isles",
+  "author": "core",
+  "version": 1,
+  "lengthMeters": 2120,
+  "laps": 1,
+  "laneCount": 3,
+  "weatherOptions": ["heavy_rain", "overcast"],
+  "difficulty": 5,
+  "segments": [
+    { "len": 280, "curve": 0.04, "grade": 0.02, "roadsideLeft": "light_pole", "roadsideRight": "marina_signs", "hazards": [] },
+    { "len": 260, "curve": -0.16, "grade": 0.05, "roadsideLeft": "guardrail", "roadsideRight": "water_wall", "hazards": ["puddle"] },
+    { "len": 300, "curve": 0.12, "grade": -0.04, "roadsideLeft": "water_wall", "roadsideRight": "guardrail", "hazards": ["slick_paint"] },
+    { "len": 280, "curve": 0.2, "grade": 0.03, "roadsideLeft": "marina_signs", "roadsideRight": "light_pole", "hazards": [] },
+    { "len": 280, "curve": -0.22, "grade": -0.05, "roadsideLeft": "guardrail", "roadsideRight": "water_wall", "hazards": ["puddle"] },
+    { "len": 320, "curve": 0.1, "grade": 0.01, "roadsideLeft": "light_pole", "roadsideRight": "guardrail", "hazards": ["traffic_cone"] },
+    { "len": 400, "curve": 0, "grade": 0, "roadsideLeft": "water_wall", "roadsideRight": "marina_signs", "hazards": [] }
+  ],
+  "checkpoints": [
+    { "segmentIndex": 0, "label": "start" },
+    { "segmentIndex": 2, "label": "shelf-drop" },
+    { "segmentIndex": 5, "label": "sealight" }
+  ],
+  "spawn": { "gridSlots": 12 }
+}

--- a/src/data/tracks/breakwater-isles-storm-span.json
+++ b/src/data/tracks/breakwater-isles-storm-span.json
@@ -1,0 +1,27 @@
+{
+  "id": "breakwater-isles/storm-span",
+  "name": "Storm Span",
+  "tourId": "breakwater-isles",
+  "author": "core",
+  "version": 1,
+  "lengthMeters": 2040,
+  "laps": 1,
+  "laneCount": 3,
+  "weatherOptions": ["heavy_rain", "rain"],
+  "difficulty": 4,
+  "segments": [
+    { "len": 260, "curve": 0, "grade": 0, "roadsideLeft": "light_pole", "roadsideRight": "light_pole", "hazards": [] },
+    { "len": 260, "curve": -0.12, "grade": 0.02, "roadsideLeft": "guardrail", "roadsideRight": "water_wall", "hazards": ["puddle"] },
+    { "len": 280, "curve": 0, "grade": 0.04, "roadsideLeft": "water_wall", "roadsideRight": "guardrail", "hazards": [] },
+    { "len": 260, "curve": 0.16, "grade": -0.03, "roadsideLeft": "marina_signs", "roadsideRight": "light_pole", "hazards": ["slick_paint"] },
+    { "len": 280, "curve": -0.18, "grade": 0.03, "roadsideLeft": "guardrail", "roadsideRight": "water_wall", "hazards": ["puddle"] },
+    { "len": 320, "curve": 0.08, "grade": -0.02, "roadsideLeft": "light_pole", "roadsideRight": "marina_signs", "hazards": ["traffic_cone"] },
+    { "len": 380, "curve": 0, "grade": 0, "roadsideLeft": "water_wall", "roadsideRight": "guardrail", "hazards": [] }
+  ],
+  "checkpoints": [
+    { "segmentIndex": 0, "label": "start" },
+    { "segmentIndex": 2, "label": "main-span" },
+    { "segmentIndex": 5, "label": "storm-gate" }
+  ],
+  "spawn": { "gridSlots": 12 }
+}

--- a/src/data/tracks/breakwater-isles-tidewire.json
+++ b/src/data/tracks/breakwater-isles-tidewire.json
@@ -1,0 +1,27 @@
+{
+  "id": "breakwater-isles/tidewire",
+  "name": "Tidewire",
+  "tourId": "breakwater-isles",
+  "author": "core",
+  "version": 1,
+  "lengthMeters": 1880,
+  "laps": 1,
+  "laneCount": 3,
+  "weatherOptions": ["rain", "overcast"],
+  "difficulty": 3,
+  "segments": [
+    { "len": 280, "curve": 0, "grade": 0, "roadsideLeft": "marina_signs", "roadsideRight": "light_pole", "hazards": [] },
+    { "len": 220, "curve": 0.1, "grade": 0.01, "roadsideLeft": "guardrail", "roadsideRight": "water_wall", "hazards": ["puddle"] },
+    { "len": 240, "curve": -0.08, "grade": 0.03, "roadsideLeft": "water_wall", "roadsideRight": "guardrail", "hazards": [] },
+    { "len": 240, "curve": 0.14, "grade": -0.02, "roadsideLeft": "light_pole", "roadsideRight": "marina_signs", "hazards": ["slick_paint"] },
+    { "len": 260, "curve": -0.16, "grade": 0.02, "roadsideLeft": "guardrail", "roadsideRight": "water_wall", "hazards": ["puddle"] },
+    { "len": 300, "curve": 0.04, "grade": -0.01, "roadsideLeft": "marina_signs", "roadsideRight": "light_pole", "hazards": [] },
+    { "len": 340, "curve": 0, "grade": 0, "roadsideLeft": "water_wall", "roadsideRight": "guardrail", "hazards": [] }
+  ],
+  "checkpoints": [
+    { "segmentIndex": 0, "label": "start" },
+    { "segmentIndex": 2, "label": "tidewire" },
+    { "segmentIndex": 5, "label": "harbor-return" }
+  ],
+  "spawn": { "gridSlots": 12 }
+}

--- a/src/data/tracks/index.ts
+++ b/src/data/tracks/index.ts
@@ -14,6 +14,10 @@
 import testCurve from "./test-curve.json";
 import testElevation from "./test-elevation.json";
 import testStraight from "./test-straight.json";
+import breakwaterIslesGullPoint from "./breakwater-isles-gull-point.json";
+import breakwaterIslesSealightShelf from "./breakwater-isles-sealight-shelf.json";
+import breakwaterIslesStormSpan from "./breakwater-isles-storm-span.json";
+import breakwaterIslesTidewire from "./breakwater-isles-tidewire.json";
 import ironBoroughFoundryMile from "./iron-borough-foundry-mile.json";
 import ironBoroughFreightlineRing from "./iron-borough-freightline-ring.json";
 import ironBoroughOuterExchange from "./iron-borough-outer-exchange.json";
@@ -31,6 +35,10 @@ export const TRACK_RAW: Readonly<Record<string, unknown>> = Object.freeze({
   "test/straight": testStraight,
   "test/curve": testCurve,
   "test/elevation": testElevation,
+  "breakwater-isles/tidewire": breakwaterIslesTidewire,
+  "breakwater-isles/storm-span": breakwaterIslesStormSpan,
+  "breakwater-isles/gull-point": breakwaterIslesGullPoint,
+  "breakwater-isles/sealight-shelf": breakwaterIslesSealightShelf,
   "velvet-coast/harbor-run": velvetCoastHarborRun,
   "velvet-coast/sunpier-loop": velvetCoastSunpierLoop,
   "velvet-coast/cliffline-arc": velvetCoastClifflineArc,


### PR DESCRIPTION
## Summary
- Add the four Breakwater Isles World Tour tracks from GDD §24: Tidewire, Storm Span, Gull Point, and Sealight Shelf.
- Register the tracks in the bundled catalogue and extend content tests so authored championship tracks resolve through tour four.
- Add GDD coverage and a progress log entry for the slice.
- Stabilize the WebKit pause-modal keyboard smoke after PR CI exposed that focus step as flaky.

## GDD sections
- docs/gdd/09-track-design.md
- docs/gdd/22-data-schemas.md
- docs/gdd/24-content-plan.md
- docs/gdd/19-controls-and-input.md
- docs/gdd/21-technical-design-for-web-implementation.md

## Requirement inventory
- Handles the Breakwater Isles §24 track list with four schema-valid bundled track files.
- Keeps each track on the Breakwater Isles region weather profile: rain, heavy_rain, and overcast.
- Verifies wet hazard coverage with puddle and slick_paint hazards.
- Keeps the cross-browser keyboard smoke route covered after PR CI exposed a WebKit modal focus timeout.
- Leaves the remaining v1.0 World Tour regions for later content slices before strict championship track resolution is enabled.

## Progress log
- docs/PROGRESS_LOG.md: 2026-04-30, Slice: Breakwater Isles track set.

## Test plan
- [x] npx vitest run src/data/__tests__/tracks-content.test.ts src/data/__tests__/championship-content.test.ts src/data/regions/__tests__/regions-content.test.ts src/data/__tests__/content-budget.test.ts src/road/__tests__/trackCompiler.test.ts src/road/__tests__/trackCompiler.golden.test.ts
- [x] npm run content-lint
- [x] npm run docs:check
- [x] npm run verify
- [x] npx playwright test e2e/world-tour.spec.ts e2e/tour-flow.spec.ts --project=chromium
- [x] CI=1 PLAYWRIGHT_CROSS_BROWSER=1 npx playwright test e2e/cross-browser-smoke.spec.ts --project=cross-browser-webkit -g "keyboard-only" --repeat-each=3
- [x] CI=1 npm run test:e2e:cross-browser

## Followups
- None.
