### PR TITLE
Glass Ridge track set

### DIFF
--- a/docs/GDD_COVERAGE.json
+++ b/docs/GDD_COVERAGE.json
@@ -1034,6 +1034,32 @@
       "followupRefs": ["VibeGear2-implement-breakwater-isles-c55d6f60"]
     },
     {
+      "id": "GDD-24-GLASS-RIDGE-TRACK-SET",
+      "gddSections": [
+        "docs/gdd/09-track-design.md",
+        "docs/gdd/22-data-schemas.md",
+        "docs/gdd/24-content-plan.md"
+      ],
+      "requirement": "The Glass Ridge World Tour region has four registered, schema-valid, compiler-valid bundled track JSON files matching the §24 track list, region weather profile, and alpine hazard palette.",
+      "coverage": ["implemented-code", "automated-test"],
+      "implementationRefs": [
+        "src/data/tracks/index.ts",
+        "src/data/tracks/glass-ridge-whitepass.json",
+        "src/data/tracks/glass-ridge-frostrelay.json",
+        "src/data/tracks/glass-ridge-hollow-crest.json",
+        "src/data/tracks/glass-ridge-summit-echo.json"
+      ],
+      "testRefs": [
+        "src/data/__tests__/tracks-content.test.ts",
+        "src/data/__tests__/championship-content.test.ts",
+        "src/data/regions/__tests__/regions-content.test.ts",
+        "src/data/__tests__/content-budget.test.ts",
+        "src/road/__tests__/trackCompiler.test.ts",
+        "src/road/__tests__/trackCompiler.golden.test.ts"
+      ],
+      "followupRefs": ["VibeGear2-implement-glass-ridge-1dfc8d6b"]
+    },
+    {
       "id": "GDD-19-MOBILE-RACE-INPUT",
       "gddSections": [
         "docs/gdd/19-controls-and-input.md",

--- a/docs/PROGRESS_LOG.md
+++ b/docs/PROGRESS_LOG.md
@@ -6,6 +6,55 @@ Correct them by adding a new entry that references the old one.
 
 ---
 
+## 2026-04-30: Slice: Glass Ridge track set
+
+**GDD sections touched:**
+[§9](gdd/09-track-design.md) track design,
+[§22](gdd/22-data-schemas.md) track schema, and
+[§24](gdd/24-content-plan.md) full v1.0 content.
+**Branch / PR:** `feat/glass-ridge-tracks`, PR pending.
+**Status:** Implemented.
+
+### Done
+- Added the four planned Glass Ridge tracks from the §24 World Tour list:
+  Whitepass, Frostrelay, Hollow Crest, and Summit Echo.
+- Registered the new tracks in the browser-safe track catalogue.
+- Tightened content tests so the authored World Tour set through
+  Glass Ridge must resolve in both the track catalogue and championship
+  cross-reference tests.
+- Added machine-checkable coverage for the Glass Ridge track set.
+
+### Verified
+- `npx vitest run src/data/__tests__/tracks-content.test.ts src/data/__tests__/championship-content.test.ts src/data/regions/__tests__/regions-content.test.ts src/data/__tests__/content-budget.test.ts src/road/__tests__/trackCompiler.test.ts src/road/__tests__/trackCompiler.golden.test.ts`
+  green, 143 tests passed.
+- `npm run content-lint` green.
+- `npm run docs:check` green.
+- `npm run verify` green, 2708 Vitest tests passed.
+- `npx playwright test e2e/world-tour.spec.ts e2e/tour-flow.spec.ts --project=chromium`
+  green, 3 tests passed.
+
+### Decisions and assumptions
+- Kept Glass Ridge weather to the region profile values already in
+  `src/data/regions/glass-ridge.json`: `snow`, `fog`, and `dusk`.
+- Used the existing alpine hazard palette (`snow_buildup`, `tunnel`, and
+  occasional `traffic_cone`) plus existing renderer-supported roadside ids
+  so this slice stays content-only.
+
+### Coverage ledger
+- GDD-24-GLASS-RIDGE-TRACK-SET covers the four fifth-tour bundled track
+  JSON files, catalogue registration, and content validation.
+- Uncovered adjacent requirements: the remaining three v1.0 World Tour
+  regions still need authored track JSON before strict championship track
+  resolution can be enabled.
+
+### Followups created
+None.
+
+### GDD edits
+None.
+
+---
+
 ## 2026-04-30: Slice: Breakwater Isles track set
 
 **GDD sections touched:**

--- a/docs/PROGRESS_LOG.md
+++ b/docs/PROGRESS_LOG.md
@@ -12,7 +12,7 @@ Correct them by adding a new entry that references the old one.
 [§9](gdd/09-track-design.md) track design,
 [§22](gdd/22-data-schemas.md) track schema, and
 [§24](gdd/24-content-plan.md) full v1.0 content.
-**Branch / PR:** `feat/glass-ridge-tracks`, PR pending.
+**Branch / PR:** `feat/glass-ridge-tracks`, PR #135.
 **Status:** Implemented.
 
 ### Done

--- a/src/data/__tests__/championship-content.test.ts
+++ b/src/data/__tests__/championship-content.test.ts
@@ -143,8 +143,8 @@ describe("world-tour-standard track id cross-references", () => {
       expect(unresolved).toEqual([]);
     });
   } else {
-    it("resolves every authored §24 track id through Breakwater Isles", () => {
-      const authoredTrackIds = wt.tours.slice(0, 4).flatMap((t) => t.tracks);
+    it("resolves every authored §24 track id through Glass Ridge", () => {
+      const authoredTrackIds = wt.tours.slice(0, 5).flatMap((t) => t.tracks);
       expect(authoredTrackIds.filter((id) => !hasBundledTrack(id))).toEqual([]);
     });
 

--- a/src/data/__tests__/tracks-content.test.ts
+++ b/src/data/__tests__/tracks-content.test.ts
@@ -37,6 +37,10 @@ const EXPECTED_AUTHORED_TOUR_TRACK_IDS = [
   "breakwater-isles/storm-span",
   "breakwater-isles/gull-point",
   "breakwater-isles/sealight-shelf",
+  "glass-ridge/whitepass",
+  "glass-ridge/frostrelay",
+  "glass-ridge/hollow-crest",
+  "glass-ridge/summit-echo",
 ];
 
 const EXPECTED_IDS = [
@@ -48,6 +52,10 @@ const EXPECTED_IDS = [
   "ember-steppe/dustbreak-causeway",
   "ember-steppe/mesa-coil",
   "ember-steppe/redglass-straight",
+  "glass-ridge/frostrelay",
+  "glass-ridge/hollow-crest",
+  "glass-ridge/summit-echo",
+  "glass-ridge/whitepass",
   "iron-borough/foundry-mile",
   "iron-borough/freightline-ring",
   "iron-borough/outer-exchange",
@@ -66,7 +74,7 @@ describe("track catalogue", () => {
     expect([...TRACK_IDS].sort()).toEqual(EXPECTED_IDS);
   });
 
-  it("registers the authored World Tour track set through Breakwater Isles", () => {
+  it("registers the authored World Tour track set through Glass Ridge", () => {
     for (const id of EXPECTED_AUTHORED_TOUR_TRACK_IDS) {
       expect(TRACK_IDS).toContain(id);
     }
@@ -216,5 +224,43 @@ describe("§24 Breakwater Isles track set", () => {
     expect([...weather].sort()).toEqual(["heavy_rain", "overcast", "rain"]);
     expect(hazards.has("puddle")).toBe(true);
     expect(hazards.has("slick_paint")).toBe(true);
+  });
+});
+
+describe("§24 Glass Ridge track set", () => {
+  const glassRidgeTrackIds = EXPECTED_AUTHORED_TOUR_TRACK_IDS.filter((id) =>
+    id.startsWith("glass-ridge/"),
+  );
+
+  it("covers all four planned Glass Ridge tracks", () => {
+    expect(glassRidgeTrackIds).toEqual([
+      "glass-ridge/whitepass",
+      "glass-ridge/frostrelay",
+      "glass-ridge/hollow-crest",
+      "glass-ridge/summit-echo",
+    ]);
+    for (const id of glassRidgeTrackIds) {
+      expect(TRACK_IDS).toContain(id);
+    }
+  });
+
+  it("uses the Glass Ridge region weather profile and alpine hazards", () => {
+    const tracks = glassRidgeTrackIds.map((id) =>
+      TrackSchema.parse(TRACK_RAW[id]),
+    );
+    const weather = new Set<string>();
+    const hazards = new Set<string>();
+    for (const track of tracks) {
+      expect(track.tourId).toBe("glass-ridge");
+      expect(track.laps).toBe(1);
+      expect(track.laneCount).toBe(3);
+      for (const option of track.weatherOptions) weather.add(option);
+      for (const segment of track.segments) {
+        for (const hazard of segment.hazards) hazards.add(hazard);
+      }
+    }
+    expect([...weather].sort()).toEqual(["dusk", "fog", "snow"]);
+    expect(hazards.has("snow_buildup")).toBe(true);
+    expect(hazards.has("tunnel")).toBe(true);
   });
 });

--- a/src/data/tracks/glass-ridge-frostrelay.json
+++ b/src/data/tracks/glass-ridge-frostrelay.json
@@ -1,0 +1,27 @@
+{
+  "id": "glass-ridge/frostrelay",
+  "name": "Frostrelay",
+  "tourId": "glass-ridge",
+  "author": "core",
+  "version": 1,
+  "lengthMeters": 1980,
+  "laps": 1,
+  "laneCount": 3,
+  "weatherOptions": ["dusk", "snow"],
+  "difficulty": 4,
+  "segments": [
+    { "len": 260, "curve": 0.08, "grade": 0.01, "roadsideLeft": "light_pole", "roadsideRight": "fence_post", "hazards": [] },
+    { "len": 240, "curve": 0.18, "grade": 0.05, "roadsideLeft": "tree_pine", "roadsideRight": "rock_boulder", "hazards": ["snow_buildup"] },
+    { "len": 260, "curve": -0.2, "grade": 0.02, "roadsideLeft": "sign_marker", "roadsideRight": "tree_pine", "hazards": [] },
+    { "len": 280, "curve": 0.06, "grade": -0.04, "roadsideLeft": "rock_boulder", "roadsideRight": "light_pole", "hazards": ["traffic_cone"] },
+    { "len": 240, "curve": -0.14, "grade": 0.06, "roadsideLeft": "fence_post", "roadsideRight": "sign_marker", "hazards": ["snow_buildup"] },
+    { "len": 320, "curve": 0.12, "grade": -0.03, "roadsideLeft": "tree_pine", "roadsideRight": "fence_post", "hazards": [] },
+    { "len": 380, "curve": 0, "grade": 0, "roadsideLeft": "light_pole", "roadsideRight": "tree_pine", "hazards": [] }
+  ],
+  "checkpoints": [
+    { "segmentIndex": 0, "label": "start" },
+    { "segmentIndex": 2, "label": "relay-rise" },
+    { "segmentIndex": 5, "label": "frost-runout" }
+  ],
+  "spawn": { "gridSlots": 12 }
+}

--- a/src/data/tracks/glass-ridge-hollow-crest.json
+++ b/src/data/tracks/glass-ridge-hollow-crest.json
@@ -1,0 +1,27 @@
+{
+  "id": "glass-ridge/hollow-crest",
+  "name": "Hollow Crest",
+  "tourId": "glass-ridge",
+  "author": "core",
+  "version": 1,
+  "lengthMeters": 2040,
+  "laps": 1,
+  "laneCount": 3,
+  "weatherOptions": ["fog", "dusk"],
+  "difficulty": 5,
+  "segments": [
+    { "len": 260, "curve": -0.06, "grade": 0.03, "roadsideLeft": "rock_boulder", "roadsideRight": "tree_pine", "hazards": [] },
+    { "len": 260, "curve": 0.16, "grade": 0.07, "roadsideLeft": "fence_post", "roadsideRight": "sign_marker", "hazards": ["snow_buildup"] },
+    { "len": 300, "curve": -0.1, "grade": 0.04, "roadsideLeft": "light_pole", "roadsideRight": "rock_boulder", "hazards": ["tunnel"], "inTunnel": true, "tunnelMaterial": "cold-concrete" },
+    { "len": 280, "curve": 0.2, "grade": -0.05, "roadsideLeft": "rock_boulder", "roadsideRight": "light_pole", "hazards": ["tunnel"], "inTunnel": true, "tunnelMaterial": "blue-safety-lighting" },
+    { "len": 260, "curve": -0.18, "grade": -0.03, "roadsideLeft": "tree_pine", "roadsideRight": "fence_post", "hazards": [] },
+    { "len": 300, "curve": 0.12, "grade": 0.02, "roadsideLeft": "sign_marker", "roadsideRight": "tree_pine", "hazards": ["snow_buildup"] },
+    { "len": 380, "curve": 0, "grade": 0, "roadsideLeft": "fence_post", "roadsideRight": "rock_boulder", "hazards": [] }
+  ],
+  "checkpoints": [
+    { "segmentIndex": 0, "label": "start" },
+    { "segmentIndex": 2, "label": "hollow-tunnel" },
+    { "segmentIndex": 5, "label": "crest-exit" }
+  ],
+  "spawn": { "gridSlots": 12 }
+}

--- a/src/data/tracks/glass-ridge-summit-echo.json
+++ b/src/data/tracks/glass-ridge-summit-echo.json
@@ -1,0 +1,27 @@
+{
+  "id": "glass-ridge/summit-echo",
+  "name": "Summit Echo",
+  "tourId": "glass-ridge",
+  "author": "core",
+  "version": 1,
+  "lengthMeters": 2100,
+  "laps": 1,
+  "laneCount": 3,
+  "weatherOptions": ["snow", "fog", "dusk"],
+  "difficulty": 5,
+  "segments": [
+    { "len": 280, "curve": 0, "grade": 0.06, "roadsideLeft": "sign_marker", "roadsideRight": "tree_pine", "hazards": ["snow_buildup"] },
+    { "len": 260, "curve": -0.18, "grade": 0.08, "roadsideLeft": "rock_boulder", "roadsideRight": "fence_post", "hazards": [] },
+    { "len": 280, "curve": 0.22, "grade": -0.02, "roadsideLeft": "tree_pine", "roadsideRight": "light_pole", "hazards": ["snow_buildup"] },
+    { "len": 300, "curve": -0.16, "grade": -0.07, "roadsideLeft": "fence_post", "roadsideRight": "rock_boulder", "hazards": [] },
+    { "len": 260, "curve": 0.12, "grade": 0.04, "roadsideLeft": "light_pole", "roadsideRight": "sign_marker", "hazards": ["traffic_cone"] },
+    { "len": 340, "curve": -0.08, "grade": -0.04, "roadsideLeft": "tree_pine", "roadsideRight": "fence_post", "hazards": [] },
+    { "len": 380, "curve": 0, "grade": 0, "roadsideLeft": "rock_boulder", "roadsideRight": "tree_pine", "hazards": [] }
+  ],
+  "checkpoints": [
+    { "segmentIndex": 0, "label": "start" },
+    { "segmentIndex": 2, "label": "summit-call" },
+    { "segmentIndex": 5, "label": "echo-descent" }
+  ],
+  "spawn": { "gridSlots": 12 }
+}

--- a/src/data/tracks/glass-ridge-whitepass.json
+++ b/src/data/tracks/glass-ridge-whitepass.json
@@ -1,0 +1,27 @@
+{
+  "id": "glass-ridge/whitepass",
+  "name": "Whitepass",
+  "tourId": "glass-ridge",
+  "author": "core",
+  "version": 1,
+  "lengthMeters": 1920,
+  "laps": 1,
+  "laneCount": 3,
+  "weatherOptions": ["snow", "fog"],
+  "difficulty": 4,
+  "segments": [
+    { "len": 260, "curve": 0, "grade": 0.02, "roadsideLeft": "tree_pine", "roadsideRight": "sign_marker", "hazards": [] },
+    { "len": 220, "curve": -0.12, "grade": 0.06, "roadsideLeft": "fence_post", "roadsideRight": "tree_pine", "hazards": ["snow_buildup"] },
+    { "len": 240, "curve": 0.14, "grade": 0.08, "roadsideLeft": "rock_boulder", "roadsideRight": "fence_post", "hazards": [] },
+    { "len": 260, "curve": -0.08, "grade": -0.03, "roadsideLeft": "sign_marker", "roadsideRight": "rock_boulder", "hazards": ["snow_buildup"] },
+    { "len": 260, "curve": 0.18, "grade": 0.04, "roadsideLeft": "tree_pine", "roadsideRight": "light_pole", "hazards": [] },
+    { "len": 300, "curve": -0.1, "grade": -0.05, "roadsideLeft": "fence_post", "roadsideRight": "tree_pine", "hazards": [] },
+    { "len": 380, "curve": 0, "grade": 0, "roadsideLeft": "rock_boulder", "roadsideRight": "sign_marker", "hazards": [] }
+  ],
+  "checkpoints": [
+    { "segmentIndex": 0, "label": "start" },
+    { "segmentIndex": 2, "label": "white-wall" },
+    { "segmentIndex": 5, "label": "pass-descent" }
+  ],
+  "spawn": { "gridSlots": 12 }
+}

--- a/src/data/tracks/index.ts
+++ b/src/data/tracks/index.ts
@@ -18,6 +18,10 @@ import breakwaterIslesGullPoint from "./breakwater-isles-gull-point.json";
 import breakwaterIslesSealightShelf from "./breakwater-isles-sealight-shelf.json";
 import breakwaterIslesStormSpan from "./breakwater-isles-storm-span.json";
 import breakwaterIslesTidewire from "./breakwater-isles-tidewire.json";
+import glassRidgeFrostrelay from "./glass-ridge-frostrelay.json";
+import glassRidgeHollowCrest from "./glass-ridge-hollow-crest.json";
+import glassRidgeSummitEcho from "./glass-ridge-summit-echo.json";
+import glassRidgeWhitepass from "./glass-ridge-whitepass.json";
 import ironBoroughFoundryMile from "./iron-borough-foundry-mile.json";
 import ironBoroughFreightlineRing from "./iron-borough-freightline-ring.json";
 import ironBoroughOuterExchange from "./iron-borough-outer-exchange.json";
@@ -39,6 +43,10 @@ export const TRACK_RAW: Readonly<Record<string, unknown>> = Object.freeze({
   "breakwater-isles/storm-span": breakwaterIslesStormSpan,
   "breakwater-isles/gull-point": breakwaterIslesGullPoint,
   "breakwater-isles/sealight-shelf": breakwaterIslesSealightShelf,
+  "glass-ridge/whitepass": glassRidgeWhitepass,
+  "glass-ridge/frostrelay": glassRidgeFrostrelay,
+  "glass-ridge/hollow-crest": glassRidgeHollowCrest,
+  "glass-ridge/summit-echo": glassRidgeSummitEcho,
   "velvet-coast/harbor-run": velvetCoastHarborRun,
   "velvet-coast/sunpier-loop": velvetCoastSunpierLoop,
   "velvet-coast/cliffline-arc": velvetCoastClifflineArc,


### PR DESCRIPTION
## Summary
- Adds the four planned Glass Ridge World Tour tracks: Whitepass, Frostrelay, Hollow Crest, and Summit Echo.
- Registers the tracks in the browser-safe track catalogue.
- Extends catalogue and championship coverage so authored World Tour tracks resolve through Glass Ridge.
- Adds GDD coverage and progress-log entries for the fifth tour track set.

## GDD
- docs/gdd/09-track-design.md
- docs/gdd/22-data-schemas.md
- docs/gdd/24-content-plan.md
- docs/PROGRESS_LOG.md, 2026-04-30 Glass Ridge track set

## Verification
- npx vitest run src/data/__tests__/tracks-content.test.ts src/data/__tests__/championship-content.test.ts src/data/regions/__tests__/regions-content.test.ts src/data/__tests__/content-budget.test.ts src/road/__tests__/trackCompiler.test.ts src/road/__tests__/trackCompiler.golden.test.ts
- npm run content-lint
- npm run docs:check
- npm run verify
- npx playwright test e2e/world-tour.spec.ts e2e/tour-flow.spec.ts --project=chromium

## Notes
- The first full verify attempt collided with a concurrent Playwright build rewriting .next source maps. Re-running verify by itself passed cleanly.