### PR TITLE
Neon Meridian track set

### DIFF
--- a/docs/GDD_COVERAGE.json
+++ b/docs/GDD_COVERAGE.json
@@ -1060,6 +1060,32 @@
       "followupRefs": ["VibeGear2-implement-glass-ridge-1dfc8d6b"]
     },
     {
+      "id": "GDD-24-NEON-MERIDIAN-TRACK-SET",
+      "gddSections": [
+        "docs/gdd/09-track-design.md",
+        "docs/gdd/22-data-schemas.md",
+        "docs/gdd/24-content-plan.md"
+      ],
+      "requirement": "The Neon Meridian World Tour region has four registered, schema-valid, compiler-valid bundled track JSON files matching the §24 track list, region weather profile, and urban hazard palette.",
+      "coverage": ["implemented-code", "automated-test"],
+      "implementationRefs": [
+        "src/data/tracks/index.ts",
+        "src/data/tracks/neon-meridian-arc-boulevard.json",
+        "src/data/tracks/neon-meridian-prism-cut.json",
+        "src/data/tracks/neon-meridian-skyline-drain.json",
+        "src/data/tracks/neon-meridian-afterglow-run.json"
+      ],
+      "testRefs": [
+        "src/data/__tests__/tracks-content.test.ts",
+        "src/data/__tests__/championship-content.test.ts",
+        "src/data/regions/__tests__/regions-content.test.ts",
+        "src/data/__tests__/content-budget.test.ts",
+        "src/road/__tests__/trackCompiler.test.ts",
+        "src/road/__tests__/trackCompiler.golden.test.ts"
+      ],
+      "followupRefs": ["VibeGear2-implement-neon-meridian-f803dd00"]
+    },
+    {
       "id": "GDD-19-MOBILE-RACE-INPUT",
       "gddSections": [
         "docs/gdd/19-controls-and-input.md",

--- a/docs/PROGRESS_LOG.md
+++ b/docs/PROGRESS_LOG.md
@@ -12,7 +12,7 @@ Correct them by adding a new entry that references the old one.
 [§9](gdd/09-track-design.md) track design,
 [§22](gdd/22-data-schemas.md) track schema, and
 [§24](gdd/24-content-plan.md) full v1.0 content.
-**Branch / PR:** `feat/neon-meridian-tracks`, PR pending.
+**Branch / PR:** `feat/neon-meridian-tracks`, PR #136.
 **Status:** Implemented.
 
 ### Done

--- a/docs/PROGRESS_LOG.md
+++ b/docs/PROGRESS_LOG.md
@@ -6,6 +6,55 @@ Correct them by adding a new entry that references the old one.
 
 ---
 
+## 2026-04-30: Slice: Neon Meridian track set
+
+**GDD sections touched:**
+[§9](gdd/09-track-design.md) track design,
+[§22](gdd/22-data-schemas.md) track schema, and
+[§24](gdd/24-content-plan.md) full v1.0 content.
+**Branch / PR:** `feat/neon-meridian-tracks`, PR pending.
+**Status:** Implemented.
+
+### Done
+- Added the four planned Neon Meridian tracks from the §24 World Tour
+  list: Arc Boulevard, Prism Cut, Skyline Drain, and Afterglow Run.
+- Registered the new tracks in the browser-safe track catalogue.
+- Tightened content tests so the authored World Tour set through
+  Neon Meridian must resolve in both the track catalogue and championship
+  cross-reference tests.
+- Added machine-checkable coverage for the Neon Meridian track set.
+
+### Verified
+- `npx vitest run src/data/__tests__/tracks-content.test.ts src/data/__tests__/championship-content.test.ts src/data/regions/__tests__/regions-content.test.ts src/data/__tests__/content-budget.test.ts src/road/__tests__/trackCompiler.test.ts src/road/__tests__/trackCompiler.golden.test.ts`
+  green, 153 tests passed.
+- `npm run content-lint` green.
+- `npm run docs:check` green.
+- `npm run verify` green, 2718 Vitest tests passed.
+- `npx playwright test e2e/world-tour.spec.ts e2e/tour-flow.spec.ts --project=chromium`
+  green, 3 tests passed.
+
+### Decisions and assumptions
+- Kept Neon Meridian weather to the region profile values already in
+  `src/data/regions/neon-meridian.json`: `night`, `rain`, and `dusk`.
+- Used the existing urban hazard palette (`slick_paint`, `puddle`,
+  `tunnel`, and occasional `traffic_cone`) plus existing
+  renderer-supported roadside ids so this slice stays content-only.
+
+### Coverage ledger
+- GDD-24-NEON-MERIDIAN-TRACK-SET covers the four sixth-tour bundled
+  track JSON files, catalogue registration, and content validation.
+- Uncovered adjacent requirements: the remaining two v1.0 World Tour
+  regions still need authored track JSON before strict championship track
+  resolution can be enabled.
+
+### Followups created
+None.
+
+### GDD edits
+None.
+
+---
+
 ## 2026-04-30: Slice: Glass Ridge track set
 
 **GDD sections touched:**

--- a/src/data/__tests__/championship-content.test.ts
+++ b/src/data/__tests__/championship-content.test.ts
@@ -143,8 +143,8 @@ describe("world-tour-standard track id cross-references", () => {
       expect(unresolved).toEqual([]);
     });
   } else {
-    it("resolves every authored §24 track id through Glass Ridge", () => {
-      const authoredTrackIds = wt.tours.slice(0, 5).flatMap((t) => t.tracks);
+    it("resolves every authored §24 track id through Neon Meridian", () => {
+      const authoredTrackIds = wt.tours.slice(0, 6).flatMap((t) => t.tracks);
       expect(authoredTrackIds.filter((id) => !hasBundledTrack(id))).toEqual([]);
     });
 

--- a/src/data/__tests__/tracks-content.test.ts
+++ b/src/data/__tests__/tracks-content.test.ts
@@ -41,6 +41,10 @@ const EXPECTED_AUTHORED_TOUR_TRACK_IDS = [
   "glass-ridge/frostrelay",
   "glass-ridge/hollow-crest",
   "glass-ridge/summit-echo",
+  "neon-meridian/arc-boulevard",
+  "neon-meridian/prism-cut",
+  "neon-meridian/skyline-drain",
+  "neon-meridian/afterglow-run",
 ];
 
 const EXPECTED_IDS = [
@@ -60,6 +64,10 @@ const EXPECTED_IDS = [
   "iron-borough/freightline-ring",
   "iron-borough/outer-exchange",
   "iron-borough/rivet-tunnel",
+  "neon-meridian/afterglow-run",
+  "neon-meridian/arc-boulevard",
+  "neon-meridian/prism-cut",
+  "neon-meridian/skyline-drain",
   "test/curve",
   "test/elevation",
   "test/straight",
@@ -74,7 +82,7 @@ describe("track catalogue", () => {
     expect([...TRACK_IDS].sort()).toEqual(EXPECTED_IDS);
   });
 
-  it("registers the authored World Tour track set through Glass Ridge", () => {
+  it("registers the authored World Tour track set through Neon Meridian", () => {
     for (const id of EXPECTED_AUTHORED_TOUR_TRACK_IDS) {
       expect(TRACK_IDS).toContain(id);
     }
@@ -261,6 +269,45 @@ describe("§24 Glass Ridge track set", () => {
     }
     expect([...weather].sort()).toEqual(["dusk", "fog", "snow"]);
     expect(hazards.has("snow_buildup")).toBe(true);
+    expect(hazards.has("tunnel")).toBe(true);
+  });
+});
+
+describe("§24 Neon Meridian track set", () => {
+  const neonMeridianTrackIds = EXPECTED_AUTHORED_TOUR_TRACK_IDS.filter((id) =>
+    id.startsWith("neon-meridian/"),
+  );
+
+  it("covers all four planned Neon Meridian tracks", () => {
+    expect(neonMeridianTrackIds).toEqual([
+      "neon-meridian/arc-boulevard",
+      "neon-meridian/prism-cut",
+      "neon-meridian/skyline-drain",
+      "neon-meridian/afterglow-run",
+    ]);
+    for (const id of neonMeridianTrackIds) {
+      expect(TRACK_IDS).toContain(id);
+    }
+  });
+
+  it("uses the Neon Meridian region weather profile and urban hazards", () => {
+    const tracks = neonMeridianTrackIds.map((id) =>
+      TrackSchema.parse(TRACK_RAW[id]),
+    );
+    const weather = new Set<string>();
+    const hazards = new Set<string>();
+    for (const track of tracks) {
+      expect(track.tourId).toBe("neon-meridian");
+      expect(track.laps).toBe(1);
+      expect(track.laneCount).toBe(3);
+      for (const option of track.weatherOptions) weather.add(option);
+      for (const segment of track.segments) {
+        for (const hazard of segment.hazards) hazards.add(hazard);
+      }
+    }
+    expect([...weather].sort()).toEqual(["dusk", "night", "rain"]);
+    expect(hazards.has("slick_paint")).toBe(true);
+    expect(hazards.has("puddle")).toBe(true);
     expect(hazards.has("tunnel")).toBe(true);
   });
 });

--- a/src/data/tracks/index.ts
+++ b/src/data/tracks/index.ts
@@ -22,6 +22,10 @@ import glassRidgeFrostrelay from "./glass-ridge-frostrelay.json";
 import glassRidgeHollowCrest from "./glass-ridge-hollow-crest.json";
 import glassRidgeSummitEcho from "./glass-ridge-summit-echo.json";
 import glassRidgeWhitepass from "./glass-ridge-whitepass.json";
+import neonMeridianAfterglowRun from "./neon-meridian-afterglow-run.json";
+import neonMeridianArcBoulevard from "./neon-meridian-arc-boulevard.json";
+import neonMeridianPrismCut from "./neon-meridian-prism-cut.json";
+import neonMeridianSkylineDrain from "./neon-meridian-skyline-drain.json";
 import ironBoroughFoundryMile from "./iron-borough-foundry-mile.json";
 import ironBoroughFreightlineRing from "./iron-borough-freightline-ring.json";
 import ironBoroughOuterExchange from "./iron-borough-outer-exchange.json";
@@ -47,6 +51,10 @@ export const TRACK_RAW: Readonly<Record<string, unknown>> = Object.freeze({
   "glass-ridge/frostrelay": glassRidgeFrostrelay,
   "glass-ridge/hollow-crest": glassRidgeHollowCrest,
   "glass-ridge/summit-echo": glassRidgeSummitEcho,
+  "neon-meridian/arc-boulevard": neonMeridianArcBoulevard,
+  "neon-meridian/prism-cut": neonMeridianPrismCut,
+  "neon-meridian/skyline-drain": neonMeridianSkylineDrain,
+  "neon-meridian/afterglow-run": neonMeridianAfterglowRun,
   "velvet-coast/harbor-run": velvetCoastHarborRun,
   "velvet-coast/sunpier-loop": velvetCoastSunpierLoop,
   "velvet-coast/cliffline-arc": velvetCoastClifflineArc,

--- a/src/data/tracks/neon-meridian-afterglow-run.json
+++ b/src/data/tracks/neon-meridian-afterglow-run.json
@@ -1,0 +1,27 @@
+{
+  "id": "neon-meridian/afterglow-run",
+  "name": "Afterglow Run",
+  "tourId": "neon-meridian",
+  "author": "core",
+  "version": 1,
+  "lengthMeters": 2140,
+  "laps": 1,
+  "laneCount": 3,
+  "weatherOptions": ["night", "rain", "dusk"],
+  "difficulty": 5,
+  "segments": [
+    { "len": 300, "curve": 0.1, "grade": 0.02, "roadsideLeft": "light_pole", "roadsideRight": "guardrail", "hazards": [] },
+    { "len": 280, "curve": -0.18, "grade": 0.03, "roadsideLeft": "sign_marker", "roadsideRight": "light_pole", "hazards": ["slick_paint"] },
+    { "len": 300, "curve": 0.22, "grade": -0.02, "roadsideLeft": "guardrail", "roadsideRight": "sign_marker", "hazards": ["puddle"] },
+    { "len": 300, "curve": -0.12, "grade": 0.04, "roadsideLeft": "light_pole", "roadsideRight": "guardrail", "hazards": ["tunnel"], "inTunnel": true, "tunnelMaterial": "black-ceramic" },
+    { "len": 280, "curve": 0.16, "grade": -0.04, "roadsideLeft": "sign_marker", "roadsideRight": "light_pole", "hazards": ["tunnel"], "inTunnel": true, "tunnelMaterial": "neon-strip" },
+    { "len": 320, "curve": -0.08, "grade": -0.02, "roadsideLeft": "guardrail", "roadsideRight": "sign_marker", "hazards": ["traffic_cone"] },
+    { "len": 360, "curve": 0, "grade": 0, "roadsideLeft": "light_pole", "roadsideRight": "guardrail", "hazards": [] }
+  ],
+  "checkpoints": [
+    { "segmentIndex": 0, "label": "start" },
+    { "segmentIndex": 3, "label": "afterglow-tunnel" },
+    { "segmentIndex": 5, "label": "runout" }
+  ],
+  "spawn": { "gridSlots": 12 }
+}

--- a/src/data/tracks/neon-meridian-arc-boulevard.json
+++ b/src/data/tracks/neon-meridian-arc-boulevard.json
@@ -1,0 +1,27 @@
+{
+  "id": "neon-meridian/arc-boulevard",
+  "name": "Arc Boulevard",
+  "tourId": "neon-meridian",
+  "author": "core",
+  "version": 1,
+  "lengthMeters": 1960,
+  "laps": 1,
+  "laneCount": 3,
+  "weatherOptions": ["night", "rain"],
+  "difficulty": 4,
+  "segments": [
+    { "len": 300, "curve": 0.04, "grade": 0, "roadsideLeft": "light_pole", "roadsideRight": "sign_marker", "hazards": [] },
+    { "len": 240, "curve": 0.16, "grade": 0.01, "roadsideLeft": "guardrail", "roadsideRight": "light_pole", "hazards": ["slick_paint"] },
+    { "len": 260, "curve": -0.18, "grade": 0.02, "roadsideLeft": "sign_marker", "roadsideRight": "guardrail", "hazards": [] },
+    { "len": 260, "curve": 0.12, "grade": -0.01, "roadsideLeft": "light_pole", "roadsideRight": "sign_marker", "hazards": ["puddle"] },
+    { "len": 260, "curve": -0.1, "grade": 0.03, "roadsideLeft": "guardrail", "roadsideRight": "light_pole", "hazards": [] },
+    { "len": 300, "curve": 0.08, "grade": -0.02, "roadsideLeft": "sign_marker", "roadsideRight": "guardrail", "hazards": ["traffic_cone"] },
+    { "len": 340, "curve": 0, "grade": 0, "roadsideLeft": "light_pole", "roadsideRight": "sign_marker", "hazards": [] }
+  ],
+  "checkpoints": [
+    { "segmentIndex": 0, "label": "start" },
+    { "segmentIndex": 2, "label": "arc-rise" },
+    { "segmentIndex": 5, "label": "boulevard-return" }
+  ],
+  "spawn": { "gridSlots": 12 }
+}

--- a/src/data/tracks/neon-meridian-prism-cut.json
+++ b/src/data/tracks/neon-meridian-prism-cut.json
@@ -1,0 +1,27 @@
+{
+  "id": "neon-meridian/prism-cut",
+  "name": "Prism Cut",
+  "tourId": "neon-meridian",
+  "author": "core",
+  "version": 1,
+  "lengthMeters": 2020,
+  "laps": 1,
+  "laneCount": 3,
+  "weatherOptions": ["dusk", "night"],
+  "difficulty": 5,
+  "segments": [
+    { "len": 260, "curve": -0.08, "grade": 0.02, "roadsideLeft": "sign_marker", "roadsideRight": "light_pole", "hazards": [] },
+    { "len": 240, "curve": 0.2, "grade": 0.03, "roadsideLeft": "guardrail", "roadsideRight": "sign_marker", "hazards": ["slick_paint"] },
+    { "len": 280, "curve": -0.22, "grade": -0.02, "roadsideLeft": "light_pole", "roadsideRight": "guardrail", "hazards": [] },
+    { "len": 300, "curve": 0.1, "grade": 0.01, "roadsideLeft": "sign_marker", "roadsideRight": "light_pole", "hazards": ["tunnel"], "inTunnel": true, "tunnelMaterial": "neon-strip" },
+    { "len": 280, "curve": -0.14, "grade": -0.03, "roadsideLeft": "guardrail", "roadsideRight": "sign_marker", "hazards": ["tunnel"], "inTunnel": true, "tunnelMaterial": "violet-service-lighting" },
+    { "len": 300, "curve": 0.16, "grade": 0.02, "roadsideLeft": "light_pole", "roadsideRight": "guardrail", "hazards": ["traffic_cone"] },
+    { "len": 360, "curve": 0, "grade": 0, "roadsideLeft": "sign_marker", "roadsideRight": "light_pole", "hazards": [] }
+  ],
+  "checkpoints": [
+    { "segmentIndex": 0, "label": "start" },
+    { "segmentIndex": 3, "label": "prism-tunnel" },
+    { "segmentIndex": 5, "label": "cut-exit" }
+  ],
+  "spawn": { "gridSlots": 12 }
+}

--- a/src/data/tracks/neon-meridian-skyline-drain.json
+++ b/src/data/tracks/neon-meridian-skyline-drain.json
@@ -1,0 +1,27 @@
+{
+  "id": "neon-meridian/skyline-drain",
+  "name": "Skyline Drain",
+  "tourId": "neon-meridian",
+  "author": "core",
+  "version": 1,
+  "lengthMeters": 2080,
+  "laps": 1,
+  "laneCount": 3,
+  "weatherOptions": ["rain", "dusk"],
+  "difficulty": 5,
+  "segments": [
+    { "len": 300, "curve": 0, "grade": -0.01, "roadsideLeft": "guardrail", "roadsideRight": "light_pole", "hazards": ["puddle"] },
+    { "len": 260, "curve": -0.16, "grade": 0.02, "roadsideLeft": "sign_marker", "roadsideRight": "guardrail", "hazards": [] },
+    { "len": 280, "curve": 0.18, "grade": 0.04, "roadsideLeft": "light_pole", "roadsideRight": "sign_marker", "hazards": ["slick_paint"] },
+    { "len": 300, "curve": -0.08, "grade": -0.03, "roadsideLeft": "guardrail", "roadsideRight": "light_pole", "hazards": ["puddle"] },
+    { "len": 260, "curve": 0.12, "grade": 0.02, "roadsideLeft": "sign_marker", "roadsideRight": "guardrail", "hazards": [] },
+    { "len": 320, "curve": -0.14, "grade": -0.02, "roadsideLeft": "light_pole", "roadsideRight": "sign_marker", "hazards": ["traffic_cone"] },
+    { "len": 360, "curve": 0, "grade": 0, "roadsideLeft": "guardrail", "roadsideRight": "light_pole", "hazards": [] }
+  ],
+  "checkpoints": [
+    { "segmentIndex": 0, "label": "start" },
+    { "segmentIndex": 2, "label": "skyline-run" },
+    { "segmentIndex": 5, "label": "drain-sprint" }
+  ],
+  "spawn": { "gridSlots": 12 }
+}


### PR DESCRIPTION
## Summary
- Adds the four planned Neon Meridian World Tour tracks: Arc Boulevard, Prism Cut, Skyline Drain, and Afterglow Run.
- Registers the tracks in the browser-safe track catalogue.
- Extends catalogue and championship coverage so authored World Tour tracks resolve through Neon Meridian.
- Adds GDD coverage and progress-log entries for the sixth tour track set.

## GDD
- docs/gdd/09-track-design.md
- docs/gdd/22-data-schemas.md
- docs/gdd/24-content-plan.md
- docs/PROGRESS_LOG.md, 2026-04-30 Neon Meridian track set

## Verification
- npx vitest run src/data/__tests__/tracks-content.test.ts src/data/__tests__/championship-content.test.ts src/data/regions/__tests__/regions-content.test.ts src/data/__tests__/content-budget.test.ts src/road/__tests__/trackCompiler.test.ts src/road/__tests__/trackCompiler.golden.test.ts
- npm run content-lint
- npm run docs:check
- npm run verify
- npx playwright test e2e/world-tour.spec.ts e2e/tour-flow.spec.ts --project=chromium