### PR TITLE
Moss Frontier track set

### DIFF
--- a/docs/GDD_COVERAGE.json
+++ b/docs/GDD_COVERAGE.json
@@ -1086,6 +1086,32 @@
       "followupRefs": ["VibeGear2-implement-neon-meridian-f803dd00"]
     },
     {
+      "id": "GDD-24-MOSS-FRONTIER-TRACK-SET",
+      "gddSections": [
+        "docs/gdd/09-track-design.md",
+        "docs/gdd/22-data-schemas.md",
+        "docs/gdd/24-content-plan.md"
+      ],
+      "requirement": "The Moss Frontier World Tour region has four registered, schema-valid, compiler-valid bundled track JSON files matching the §24 track list, region weather profile, and wet forest hazard palette.",
+      "coverage": ["implemented-code", "automated-test"],
+      "implementationRefs": [
+        "src/data/tracks/index.ts",
+        "src/data/tracks/moss-frontier-pine-switchback.json",
+        "src/data/tracks/moss-frontier-millstream.json",
+        "src/data/tracks/moss-frontier-wetroot-drive.json",
+        "src/data/tracks/moss-frontier-mistbarrow.json"
+      ],
+      "testRefs": [
+        "src/data/__tests__/tracks-content.test.ts",
+        "src/data/__tests__/championship-content.test.ts",
+        "src/data/regions/__tests__/regions-content.test.ts",
+        "src/data/__tests__/content-budget.test.ts",
+        "src/road/__tests__/trackCompiler.test.ts",
+        "src/road/__tests__/trackCompiler.golden.test.ts"
+      ],
+      "followupRefs": ["VibeGear2-implement-moss-frontier-54c8953e"]
+    },
+    {
       "id": "GDD-19-MOBILE-RACE-INPUT",
       "gddSections": [
         "docs/gdd/19-controls-and-input.md",

--- a/docs/PROGRESS_LOG.md
+++ b/docs/PROGRESS_LOG.md
@@ -6,6 +6,55 @@ Correct them by adding a new entry that references the old one.
 
 ---
 
+## 2026-04-30: Slice: Moss Frontier track set
+
+**GDD sections touched:**
+[§9](gdd/09-track-design.md) track design,
+[§22](gdd/22-data-schemas.md) track schema, and
+[§24](gdd/24-content-plan.md) full v1.0 content.
+**Branch / PR:** `feat/moss-frontier-tracks`, PR TBD.
+**Status:** Implemented.
+
+### Done
+- Added the four planned Moss Frontier tracks from the §24 World Tour
+  list: Pine Switchback, Millstream, Wetroot Drive, and Mistbarrow.
+- Registered the new tracks in the browser-safe track catalogue.
+- Tightened content tests so the authored World Tour set through
+  Moss Frontier must resolve in both the track catalogue and championship
+  cross-reference tests.
+- Added machine-checkable coverage for the Moss Frontier track set.
+
+### Verified
+- `npx vitest run src/data/__tests__/tracks-content.test.ts src/data/__tests__/championship-content.test.ts src/data/regions/__tests__/regions-content.test.ts src/data/__tests__/content-budget.test.ts src/road/__tests__/trackCompiler.test.ts src/road/__tests__/trackCompiler.golden.test.ts`
+  green, 163 tests passed.
+- `npm run content-lint` green.
+- `npm run docs:check` green.
+- `npm run verify` green, 2728 Vitest tests passed.
+- `npx playwright test e2e/world-tour.spec.ts e2e/tour-flow.spec.ts --project=chromium`
+  green, 3 tests passed.
+
+### Decisions and assumptions
+- Kept Moss Frontier weather to the region profile values already in
+  `src/data/regions/moss-frontier.json`: `heavy_rain`, `rain`, and `fog`.
+- Used the existing wet forest hazard palette (`puddle`, `gravel_band`,
+  and `slick_paint`) plus existing renderer-supported roadside ids so this
+  slice stays content-only.
+
+### Coverage ledger
+- GDD-24-MOSS-FRONTIER-TRACK-SET covers the four seventh-tour bundled
+  track JSON files, catalogue registration, and content validation.
+- Uncovered adjacent requirements: the final v1.0 World Tour region still
+  needs authored track JSON before strict championship track resolution can
+  be enabled.
+
+### Followups created
+None.
+
+### GDD edits
+None.
+
+---
+
 ## 2026-04-30: Slice: Neon Meridian track set
 
 **GDD sections touched:**

--- a/docs/PROGRESS_LOG.md
+++ b/docs/PROGRESS_LOG.md
@@ -12,7 +12,7 @@ Correct them by adding a new entry that references the old one.
 [§9](gdd/09-track-design.md) track design,
 [§22](gdd/22-data-schemas.md) track schema, and
 [§24](gdd/24-content-plan.md) full v1.0 content.
-**Branch / PR:** `feat/moss-frontier-tracks`, PR TBD.
+**Branch / PR:** `feat/moss-frontier-tracks`, PR #137.
 **Status:** Implemented.
 
 ### Done

--- a/src/data/__tests__/championship-content.test.ts
+++ b/src/data/__tests__/championship-content.test.ts
@@ -143,8 +143,8 @@ describe("world-tour-standard track id cross-references", () => {
       expect(unresolved).toEqual([]);
     });
   } else {
-    it("resolves every authored §24 track id through Neon Meridian", () => {
-      const authoredTrackIds = wt.tours.slice(0, 6).flatMap((t) => t.tracks);
+    it("resolves every authored §24 track id through Moss Frontier", () => {
+      const authoredTrackIds = wt.tours.slice(0, 7).flatMap((t) => t.tracks);
       expect(authoredTrackIds.filter((id) => !hasBundledTrack(id))).toEqual([]);
     });
 

--- a/src/data/__tests__/tracks-content.test.ts
+++ b/src/data/__tests__/tracks-content.test.ts
@@ -45,6 +45,10 @@ const EXPECTED_AUTHORED_TOUR_TRACK_IDS = [
   "neon-meridian/prism-cut",
   "neon-meridian/skyline-drain",
   "neon-meridian/afterglow-run",
+  "moss-frontier/pine-switchback",
+  "moss-frontier/millstream",
+  "moss-frontier/wetroot-drive",
+  "moss-frontier/mistbarrow",
 ];
 
 const EXPECTED_IDS = [
@@ -64,6 +68,10 @@ const EXPECTED_IDS = [
   "iron-borough/freightline-ring",
   "iron-borough/outer-exchange",
   "iron-borough/rivet-tunnel",
+  "moss-frontier/millstream",
+  "moss-frontier/mistbarrow",
+  "moss-frontier/pine-switchback",
+  "moss-frontier/wetroot-drive",
   "neon-meridian/afterglow-run",
   "neon-meridian/arc-boulevard",
   "neon-meridian/prism-cut",
@@ -82,7 +90,7 @@ describe("track catalogue", () => {
     expect([...TRACK_IDS].sort()).toEqual(EXPECTED_IDS);
   });
 
-  it("registers the authored World Tour track set through Neon Meridian", () => {
+  it("registers the authored World Tour track set through Moss Frontier", () => {
     for (const id of EXPECTED_AUTHORED_TOUR_TRACK_IDS) {
       expect(TRACK_IDS).toContain(id);
     }
@@ -309,5 +317,44 @@ describe("§24 Neon Meridian track set", () => {
     expect(hazards.has("slick_paint")).toBe(true);
     expect(hazards.has("puddle")).toBe(true);
     expect(hazards.has("tunnel")).toBe(true);
+  });
+});
+
+describe("§24 Moss Frontier track set", () => {
+  const mossFrontierTrackIds = EXPECTED_AUTHORED_TOUR_TRACK_IDS.filter((id) =>
+    id.startsWith("moss-frontier/"),
+  );
+
+  it("covers all four planned Moss Frontier tracks", () => {
+    expect(mossFrontierTrackIds).toEqual([
+      "moss-frontier/pine-switchback",
+      "moss-frontier/millstream",
+      "moss-frontier/wetroot-drive",
+      "moss-frontier/mistbarrow",
+    ]);
+    for (const id of mossFrontierTrackIds) {
+      expect(TRACK_IDS).toContain(id);
+    }
+  });
+
+  it("uses the Moss Frontier region weather profile and wet forest hazards", () => {
+    const tracks = mossFrontierTrackIds.map((id) =>
+      TrackSchema.parse(TRACK_RAW[id]),
+    );
+    const weather = new Set<string>();
+    const hazards = new Set<string>();
+    for (const track of tracks) {
+      expect(track.tourId).toBe("moss-frontier");
+      expect(track.laps).toBe(1);
+      expect(track.laneCount).toBe(3);
+      for (const option of track.weatherOptions) weather.add(option);
+      for (const segment of track.segments) {
+        for (const hazard of segment.hazards) hazards.add(hazard);
+      }
+    }
+    expect([...weather].sort()).toEqual(["fog", "heavy_rain", "rain"]);
+    expect(hazards.has("puddle")).toBe(true);
+    expect(hazards.has("gravel_band")).toBe(true);
+    expect(hazards.has("slick_paint")).toBe(true);
   });
 });

--- a/src/data/tracks/index.ts
+++ b/src/data/tracks/index.ts
@@ -26,6 +26,10 @@ import neonMeridianAfterglowRun from "./neon-meridian-afterglow-run.json";
 import neonMeridianArcBoulevard from "./neon-meridian-arc-boulevard.json";
 import neonMeridianPrismCut from "./neon-meridian-prism-cut.json";
 import neonMeridianSkylineDrain from "./neon-meridian-skyline-drain.json";
+import mossFrontierMillstream from "./moss-frontier-millstream.json";
+import mossFrontierMistbarrow from "./moss-frontier-mistbarrow.json";
+import mossFrontierPineSwitchback from "./moss-frontier-pine-switchback.json";
+import mossFrontierWetrootDrive from "./moss-frontier-wetroot-drive.json";
 import ironBoroughFoundryMile from "./iron-borough-foundry-mile.json";
 import ironBoroughFreightlineRing from "./iron-borough-freightline-ring.json";
 import ironBoroughOuterExchange from "./iron-borough-outer-exchange.json";
@@ -55,6 +59,10 @@ export const TRACK_RAW: Readonly<Record<string, unknown>> = Object.freeze({
   "neon-meridian/prism-cut": neonMeridianPrismCut,
   "neon-meridian/skyline-drain": neonMeridianSkylineDrain,
   "neon-meridian/afterglow-run": neonMeridianAfterglowRun,
+  "moss-frontier/pine-switchback": mossFrontierPineSwitchback,
+  "moss-frontier/millstream": mossFrontierMillstream,
+  "moss-frontier/wetroot-drive": mossFrontierWetrootDrive,
+  "moss-frontier/mistbarrow": mossFrontierMistbarrow,
   "velvet-coast/harbor-run": velvetCoastHarborRun,
   "velvet-coast/sunpier-loop": velvetCoastSunpierLoop,
   "velvet-coast/cliffline-arc": velvetCoastClifflineArc,

--- a/src/data/tracks/moss-frontier-millstream.json
+++ b/src/data/tracks/moss-frontier-millstream.json
@@ -1,0 +1,27 @@
+{
+  "id": "moss-frontier/millstream",
+  "name": "Millstream",
+  "tourId": "moss-frontier",
+  "author": "core",
+  "version": 1,
+  "lengthMeters": 1980,
+  "laps": 1,
+  "laneCount": 3,
+  "weatherOptions": ["rain", "heavy_rain"],
+  "difficulty": 5,
+  "segments": [
+    { "len": 280, "curve": 0, "grade": 0, "roadsideLeft": "fence_post", "roadsideRight": "sign_marker", "hazards": [] },
+    { "len": 260, "curve": -0.14, "grade": -0.01, "roadsideLeft": "tree_pine", "roadsideRight": "fence_post", "hazards": ["puddle"] },
+    { "len": 240, "curve": 0.16, "grade": 0.02, "roadsideLeft": "sign_marker", "roadsideRight": "tree_pine", "hazards": ["slick_paint"] },
+    { "len": 300, "curve": -0.08, "grade": 0.03, "roadsideLeft": "fence_post", "roadsideRight": "rock_boulder", "hazards": ["puddle"] },
+    { "len": 260, "curve": 0.18, "grade": -0.02, "roadsideLeft": "tree_pine", "roadsideRight": "fence_post", "hazards": [] },
+    { "len": 300, "curve": -0.2, "grade": 0.01, "roadsideLeft": "rock_boulder", "roadsideRight": "sign_marker", "hazards": ["gravel_band"] },
+    { "len": 340, "curve": 0, "grade": 0, "roadsideLeft": "fence_post", "roadsideRight": "tree_pine", "hazards": [] }
+  ],
+  "checkpoints": [
+    { "segmentIndex": 0, "label": "start" },
+    { "segmentIndex": 3, "label": "mill-bridge" },
+    { "segmentIndex": 5, "label": "waterwheel" }
+  ],
+  "spawn": { "gridSlots": 12 }
+}

--- a/src/data/tracks/moss-frontier-mistbarrow.json
+++ b/src/data/tracks/moss-frontier-mistbarrow.json
@@ -1,0 +1,27 @@
+{
+  "id": "moss-frontier/mistbarrow",
+  "name": "Mistbarrow",
+  "tourId": "moss-frontier",
+  "author": "core",
+  "version": 1,
+  "lengthMeters": 2320,
+  "laps": 1,
+  "laneCount": 3,
+  "weatherOptions": ["fog", "heavy_rain"],
+  "difficulty": 5,
+  "segments": [
+    { "len": 300, "curve": 0.02, "grade": 0.02, "roadsideLeft": "sign_marker", "roadsideRight": "tree_pine", "hazards": [] },
+    { "len": 300, "curve": -0.16, "grade": 0.04, "roadsideLeft": "tree_pine", "roadsideRight": "fence_post", "hazards": ["gravel_band"] },
+    { "len": 280, "curve": 0.2, "grade": 0.03, "roadsideLeft": "rock_boulder", "roadsideRight": "tree_pine", "hazards": ["puddle"] },
+    { "len": 300, "curve": -0.12, "grade": -0.04, "roadsideLeft": "fence_post", "roadsideRight": "rock_boulder", "hazards": ["puddle"] },
+    { "len": 320, "curve": 0.18, "grade": 0.01, "roadsideLeft": "tree_pine", "roadsideRight": "sign_marker", "hazards": ["slick_paint"] },
+    { "len": 340, "curve": -0.08, "grade": -0.02, "roadsideLeft": "fence_post", "roadsideRight": "tree_pine", "hazards": ["gravel_band"] },
+    { "len": 480, "curve": 0, "grade": 0, "roadsideLeft": "tree_pine", "roadsideRight": "fence_post", "hazards": [] }
+  ],
+  "checkpoints": [
+    { "segmentIndex": 0, "label": "start" },
+    { "segmentIndex": 2, "label": "barrow-climb" },
+    { "segmentIndex": 5, "label": "mist-gate" }
+  ],
+  "spawn": { "gridSlots": 12 }
+}

--- a/src/data/tracks/moss-frontier-pine-switchback.json
+++ b/src/data/tracks/moss-frontier-pine-switchback.json
@@ -1,0 +1,27 @@
+{
+  "id": "moss-frontier/pine-switchback",
+  "name": "Pine Switchback",
+  "tourId": "moss-frontier",
+  "author": "core",
+  "version": 1,
+  "lengthMeters": 2100,
+  "laps": 1,
+  "laneCount": 3,
+  "weatherOptions": ["fog", "rain"],
+  "difficulty": 5,
+  "segments": [
+    { "len": 260, "curve": 0.04, "grade": 0.01, "roadsideLeft": "tree_pine", "roadsideRight": "fence_post", "hazards": [] },
+    { "len": 240, "curve": 0.2, "grade": 0.03, "roadsideLeft": "tree_pine", "roadsideRight": "sign_marker", "hazards": ["gravel_band"] },
+    { "len": 260, "curve": -0.22, "grade": 0.04, "roadsideLeft": "fence_post", "roadsideRight": "tree_pine", "hazards": ["puddle"] },
+    { "len": 280, "curve": 0.18, "grade": -0.02, "roadsideLeft": "rock_boulder", "roadsideRight": "tree_pine", "hazards": [] },
+    { "len": 300, "curve": -0.16, "grade": -0.03, "roadsideLeft": "tree_pine", "roadsideRight": "fence_post", "hazards": ["gravel_band"] },
+    { "len": 340, "curve": 0.08, "grade": 0.02, "roadsideLeft": "sign_marker", "roadsideRight": "tree_pine", "hazards": ["puddle"] },
+    { "len": 420, "curve": 0, "grade": 0, "roadsideLeft": "fence_post", "roadsideRight": "tree_pine", "hazards": [] }
+  ],
+  "checkpoints": [
+    { "segmentIndex": 0, "label": "start" },
+    { "segmentIndex": 2, "label": "upper-switch" },
+    { "segmentIndex": 5, "label": "pine-fall" }
+  ],
+  "spawn": { "gridSlots": 12 }
+}

--- a/src/data/tracks/moss-frontier-wetroot-drive.json
+++ b/src/data/tracks/moss-frontier-wetroot-drive.json
@@ -1,0 +1,27 @@
+{
+  "id": "moss-frontier/wetroot-drive",
+  "name": "Wetroot Drive",
+  "tourId": "moss-frontier",
+  "author": "core",
+  "version": 1,
+  "lengthMeters": 2200,
+  "laps": 1,
+  "laneCount": 3,
+  "weatherOptions": ["heavy_rain", "fog"],
+  "difficulty": 5,
+  "segments": [
+    { "len": 300, "curve": -0.04, "grade": 0.01, "roadsideLeft": "tree_pine", "roadsideRight": "tree_pine", "hazards": [] },
+    { "len": 260, "curve": 0.18, "grade": 0.02, "roadsideLeft": "fence_post", "roadsideRight": "rock_boulder", "hazards": ["puddle"] },
+    { "len": 260, "curve": -0.2, "grade": 0.04, "roadsideLeft": "tree_pine", "roadsideRight": "fence_post", "hazards": ["gravel_band"] },
+    { "len": 320, "curve": 0.1, "grade": -0.03, "roadsideLeft": "sign_marker", "roadsideRight": "tree_pine", "hazards": ["puddle"] },
+    { "len": 280, "curve": -0.18, "grade": -0.02, "roadsideLeft": "rock_boulder", "roadsideRight": "fence_post", "hazards": ["slick_paint"] },
+    { "len": 320, "curve": 0.16, "grade": 0.02, "roadsideLeft": "tree_pine", "roadsideRight": "sign_marker", "hazards": ["gravel_band"] },
+    { "len": 460, "curve": 0, "grade": 0, "roadsideLeft": "fence_post", "roadsideRight": "tree_pine", "hazards": [] }
+  ],
+  "checkpoints": [
+    { "segmentIndex": 0, "label": "start" },
+    { "segmentIndex": 2, "label": "root-rise" },
+    { "segmentIndex": 5, "label": "bog-exit" }
+  ],
+  "spawn": { "gridSlots": 12 }
+}


### PR DESCRIPTION
## Summary
- Add the four Moss Frontier World Tour tracks from GDD section 24: Pine Switchback, Millstream, Wetroot Drive, and Mistbarrow.
- Register the tracks in the browser-safe catalogue and extend authored World Tour cross-reference coverage through Moss Frontier.
- Add coverage ledger and progress log entries for GDD-24-MOSS-FRONTIER-TRACK-SET.

## GDD
- docs/gdd/09-track-design.md
- docs/gdd/22-data-schemas.md
- docs/gdd/24-content-plan.md

## Progress Log
- docs/PROGRESS_LOG.md: Moss Frontier track set

## Test Plan
- npx vitest run src/data/__tests__/tracks-content.test.ts src/data/__tests__/championship-content.test.ts src/data/regions/__tests__/regions-content.test.ts src/data/__tests__/content-budget.test.ts src/road/__tests__/trackCompiler.test.ts src/road/__tests__/trackCompiler.golden.test.ts
- npm run content-lint
- npm run docs:check
- npm run verify
- npx playwright test e2e/world-tour.spec.ts e2e/tour-flow.spec.ts --project=chromium

## Followups
None.