### PR TITLE
Crown Circuit track set

### DIFF
--- a/docs/GDD_COVERAGE.json
+++ b/docs/GDD_COVERAGE.json
@@ -1112,6 +1112,32 @@
       "followupRefs": ["VibeGear2-implement-moss-frontier-54c8953e"]
     },
     {
+      "id": "GDD-24-CROWN-CIRCUIT-TRACK-SET",
+      "gddSections": [
+        "docs/gdd/09-track-design.md",
+        "docs/gdd/22-data-schemas.md",
+        "docs/gdd/24-content-plan.md"
+      ],
+      "requirement": "The Crown Circuit World Tour region has four registered, schema-valid, compiler-valid bundled track JSON files matching the §24 track list, region weather profile, and finale hazard palette.",
+      "coverage": ["implemented-code", "automated-test"],
+      "implementationRefs": [
+        "src/data/tracks/index.ts",
+        "src/data/tracks/crown-circuit-embassy-loop.json",
+        "src/data/tracks/crown-circuit-victory-causeway.json",
+        "src/data/tracks/crown-circuit-grand-meridian.json",
+        "src/data/tracks/crown-circuit-final-horizon.json"
+      ],
+      "testRefs": [
+        "src/data/__tests__/tracks-content.test.ts",
+        "src/data/__tests__/championship-content.test.ts",
+        "src/data/regions/__tests__/regions-content.test.ts",
+        "src/data/__tests__/content-budget.test.ts",
+        "src/road/__tests__/trackCompiler.test.ts",
+        "src/road/__tests__/trackCompiler.golden.test.ts"
+      ],
+      "followupRefs": ["VibeGear2-implement-crown-circuit-0dcaa786"]
+    },
+    {
       "id": "GDD-19-MOBILE-RACE-INPUT",
       "gddSections": [
         "docs/gdd/19-controls-and-input.md",

--- a/docs/PROGRESS_LOG.md
+++ b/docs/PROGRESS_LOG.md
@@ -6,6 +6,54 @@ Correct them by adding a new entry that references the old one.
 
 ---
 
+## 2026-04-30: Slice: Crown Circuit track set
+
+**GDD sections touched:**
+[§9](gdd/09-track-design.md) track design,
+[§22](gdd/22-data-schemas.md) track schema, and
+[§24](gdd/24-content-plan.md) full v1.0 content.
+**Branch / PR:** `feat/crown-circuit-tracks`, PR TBD.
+**Status:** Implemented.
+
+### Done
+- Added the four planned Crown Circuit tracks from the §24 World Tour
+  list: Embassy Loop, Victory Causeway, Grand Meridian, and Final Horizon.
+- Registered the new tracks in the browser-safe track catalogue.
+- Tightened content tests so every World Tour track id must resolve now
+  that the full 32-track v1.0 set is bundled.
+- Added machine-checkable coverage for the Crown Circuit track set.
+
+### Verified
+- `npx vitest run src/data/__tests__/tracks-content.test.ts src/data/__tests__/championship-content.test.ts src/data/regions/__tests__/regions-content.test.ts src/data/__tests__/content-budget.test.ts src/road/__tests__/trackCompiler.test.ts src/road/__tests__/trackCompiler.golden.test.ts`
+  green, 172 tests passed.
+- `npm run content-lint` green.
+- `npm run docs:check` green.
+- `npm run verify` green, 2737 Vitest tests passed.
+- `npx playwright test e2e/world-tour.spec.ts e2e/tour-flow.spec.ts --project=chromium`
+  green, 3 tests passed.
+
+### Decisions and assumptions
+- Kept Crown Circuit weather to the region profile values already in
+  `src/data/regions/crown-circuit.json`: `clear`, `rain`, `fog`, and `snow`.
+- Used the existing finale-compatible hazard palette (`slick_paint`,
+  `puddle`, `snow_buildup`, and occasional `traffic_cone`) plus existing
+  renderer-supported roadside ids so this slice stays content-only.
+
+### Coverage ledger
+- GDD-24-CROWN-CIRCUIT-TRACK-SET covers the four eighth-tour bundled
+  track JSON files, catalogue registration, and content validation.
+- Uncovered adjacent requirements: none for the §24 v1.0 World Tour
+  track list; all 32 planned track ids now resolve in the bundled
+  catalogue.
+
+### Followups created
+None.
+
+### GDD edits
+None.
+
+---
+
 ## 2026-04-30: Slice: Moss Frontier track set
 
 **GDD sections touched:**

--- a/docs/PROGRESS_LOG.md
+++ b/docs/PROGRESS_LOG.md
@@ -12,7 +12,7 @@ Correct them by adding a new entry that references the old one.
 [§9](gdd/09-track-design.md) track design,
 [§22](gdd/22-data-schemas.md) track schema, and
 [§24](gdd/24-content-plan.md) full v1.0 content.
-**Branch / PR:** `feat/crown-circuit-tracks`, PR TBD.
+**Branch / PR:** `feat/crown-circuit-tracks`, PR #138.
 **Status:** Implemented.
 
 ### Done

--- a/src/data/__tests__/championship-content.test.ts
+++ b/src/data/__tests__/championship-content.test.ts
@@ -7,12 +7,7 @@
  *   "Suggested region and track list",
  * - hold monotonic non-increasing `requiredStanding` values across tours
  *   (later tours never raise the bar above an earlier tour),
- * - reference only track ids that resolve in `TRACK_RAW` once the full
- *   32-track content set lands. During the MVP window, the cross-reference
- *   test runs in permissive mode by default (since the track set is being
- *   authored across sibling slices). Set
- *   `STRICT_CHAMPIONSHIP_TRACKS=1` to fail on any unresolved id; remove
- *   the permissive branch entirely once §24 ships.
+ * - reference only track ids that resolve in `TRACK_RAW`.
  *
  * Adding a championship: drop a JSON in `src/data/championships/`,
  * register it in `src/data/championships/index.ts`, and add an
@@ -33,13 +28,6 @@ import { SPONSOR_OBJECTIVES_BY_ID } from "@/data/sponsors";
 import { TRACK_RAW } from "@/data/tracks";
 
 const WORLD_TOUR_ID = "world-tour-standard";
-
-// MVP phase guard: full track set ships across sibling slices. Default to
-// permissive so the suite is green during the content build-out window.
-// Flip via `STRICT_CHAMPIONSHIP_TRACKS=1` to enforce full resolution; the
-// permissive branch goes away once §24 content fully ships.
-const STRICT_TRACK_RESOLUTION =
-  process.env.STRICT_CHAMPIONSHIP_TRACKS === "1";
 
 describe("championship catalogue", () => {
   it("exposes the canonical World Tour championship", () => {
@@ -133,30 +121,13 @@ describe("world-tour-standard structure", () => {
 describe("world-tour-standard track id cross-references", () => {
   const wt = getChampionship(WORLD_TOUR_ID);
   const allTrackIds = wt.tours.flatMap((t) => t.tracks);
-  const mvpTrackIds = wt.tours.slice(0, 2).flatMap((t) => t.tracks);
   const hasBundledTrack = (id: string) =>
     Object.prototype.hasOwnProperty.call(TRACK_RAW, id);
   const unresolved = allTrackIds.filter((id) => !hasBundledTrack(id));
 
-  if (STRICT_TRACK_RESOLUTION) {
-    it("resolves every referenced track id in TRACK_RAW (strict mode)", () => {
-      expect(unresolved).toEqual([]);
-    });
-  } else {
-    it("resolves every authored §24 track id through Moss Frontier", () => {
-      const authoredTrackIds = wt.tours.slice(0, 7).flatMap((t) => t.tracks);
-      expect(authoredTrackIds.filter((id) => !hasBundledTrack(id))).toEqual([]);
-    });
-
-    it("permits unresolved track ids during the MVP content window", () => {
-      // Phase guard: full 32-track set is authored in sibling slices.
-      // The presence of unresolved ids is expected; this assertion still
-      // runs to catch regressions that drop already-authored tracks.
-      const resolvedCount = allTrackIds.length - unresolved.length;
-      expect(resolvedCount).toBeGreaterThanOrEqual(mvpTrackIds.length);
-      expect(allTrackIds.length).toBe(32);
-    });
-  }
+  it("resolves every referenced track id in TRACK_RAW", () => {
+    expect(unresolved).toEqual([]);
+  });
 });
 
 describe("world-tour-standard sponsor roster cross-references", () => {

--- a/src/data/__tests__/content-budget.test.ts
+++ b/src/data/__tests__/content-budget.test.ts
@@ -95,6 +95,11 @@ describe("content budget: tracks", () => {
   const trackJsonFiles = walkJsonFiles(TRACKS_DIR).filter(
     (file) => !file.relPath.startsWith(`_benchmark${path.sep}`),
   );
+  const userFacingTrackJsonFiles = trackJsonFiles.filter(
+    (file) =>
+      !file.relPath.startsWith("test-") &&
+      !file.relPath.includes(`${path.sep}test-`),
+  );
 
   it("counts every shipped track JSON as a valid track", () => {
     const failures: string[] = [];
@@ -116,19 +121,21 @@ describe("content budget: tracks", () => {
     }
   });
 
-  it("does not exceed the v1.0 cap of CONTENT_BUDGET.tracks files", () => {
-    if (trackJsonFiles.length > CONTENT_BUDGET.tracks) {
+  it("does not exceed the v1.0 cap of CONTENT_BUDGET.tracks user-facing files", () => {
+    if (userFacingTrackJsonFiles.length > CONTENT_BUDGET.tracks) {
       throw new Error(
-        `Track count ${trackJsonFiles.length} exceeds the v1.0 budget of ` +
+        `User-facing track count ${userFacingTrackJsonFiles.length} exceeds the v1.0 budget of ` +
           `${CONTENT_BUDGET.tracks}. The §27 scope-creep mitigation hard-caps ` +
           `the bundled track set at ${CONTENT_BUDGET.tracks}. Either remove a ` +
           `track or raise CONTENT_BUDGET.tracks AND the matching GDD §27 row ` +
-          `in the same PR.\nFiles found:\n${trackJsonFiles
+          `in the same PR.\nFiles found:\n${userFacingTrackJsonFiles
             .map((f) => `  - ${f.relPath}`)
             .join("\n")}`,
       );
     }
-    expect(trackJsonFiles.length).toBeLessThanOrEqual(CONTENT_BUDGET.tracks);
+    expect(userFacingTrackJsonFiles.length).toBeLessThanOrEqual(
+      CONTENT_BUDGET.tracks,
+    );
   });
 
   it("meets the MVP minimum once content lands beyond the test stubs", () => {
@@ -136,24 +143,23 @@ describe("content budget: tracks", () => {
     // Once the first MVP track lands, this assertion flips to enforce the
     // §24 minimum. The gate keeps the test green during the build-out and
     // turns into a regression guard the moment real content ships.
-    const realTracks = trackJsonFiles.filter(
-      (f) => !f.relPath.startsWith("test-") && !f.relPath.includes(`${path.sep}test-`),
-    );
-    if (realTracks.length === 0) {
+    if (userFacingTrackJsonFiles.length === 0) {
       // Pre-MVP: no shipped tracks yet, only test stubs. Nothing to enforce.
       expect(trackJsonFiles.length).toBeGreaterThan(0);
       return;
     }
-    if (realTracks.length < CONTENT_BUDGET.mvpTracks) {
+    if (userFacingTrackJsonFiles.length < CONTENT_BUDGET.mvpTracks) {
       throw new Error(
-        `Real track count ${realTracks.length} is below the MVP minimum of ` +
+        `Real track count ${userFacingTrackJsonFiles.length} is below the MVP minimum of ` +
           `${CONTENT_BUDGET.mvpTracks} (per §24 "Suggested region and track ` +
           `list"). Authoring is in progress; once at least ` +
           `${CONTENT_BUDGET.mvpTracks} non-test tracks ship, this assertion ` +
           `holds.`,
       );
     }
-    expect(realTracks.length).toBeGreaterThanOrEqual(CONTENT_BUDGET.mvpTracks);
+    expect(userFacingTrackJsonFiles.length).toBeGreaterThanOrEqual(
+      CONTENT_BUDGET.mvpTracks,
+    );
   });
 
   it("registers every track JSON in the TRACK_RAW barrel", () => {

--- a/src/data/__tests__/content-budget.test.ts
+++ b/src/data/__tests__/content-budget.test.ts
@@ -139,7 +139,7 @@ describe("content budget: tracks", () => {
   });
 
   it("meets the MVP minimum once content lands beyond the test stubs", () => {
-    // During the MVP window only the two `test/*` tracks are authored.
+    // During the MVP window only `test-*` fixture tracks are authored.
     // Once the first MVP track lands, this assertion flips to enforce the
     // §24 minimum. The gate keeps the test green during the build-out and
     // turns into a regression guard the moment real content ships.

--- a/src/data/__tests__/tracks-content.test.ts
+++ b/src/data/__tests__/tracks-content.test.ts
@@ -49,6 +49,10 @@ const EXPECTED_AUTHORED_TOUR_TRACK_IDS = [
   "moss-frontier/millstream",
   "moss-frontier/wetroot-drive",
   "moss-frontier/mistbarrow",
+  "crown-circuit/embassy-loop",
+  "crown-circuit/victory-causeway",
+  "crown-circuit/grand-meridian",
+  "crown-circuit/final-horizon",
 ];
 
 const EXPECTED_IDS = [
@@ -56,6 +60,10 @@ const EXPECTED_IDS = [
   "breakwater-isles/sealight-shelf",
   "breakwater-isles/storm-span",
   "breakwater-isles/tidewire",
+  "crown-circuit/embassy-loop",
+  "crown-circuit/final-horizon",
+  "crown-circuit/grand-meridian",
+  "crown-circuit/victory-causeway",
   "ember-steppe/cinder-gate",
   "ember-steppe/dustbreak-causeway",
   "ember-steppe/mesa-coil",
@@ -90,7 +98,7 @@ describe("track catalogue", () => {
     expect([...TRACK_IDS].sort()).toEqual(EXPECTED_IDS);
   });
 
-  it("registers the authored World Tour track set through Moss Frontier", () => {
+  it("registers the full authored World Tour track set", () => {
     for (const id of EXPECTED_AUTHORED_TOUR_TRACK_IDS) {
       expect(TRACK_IDS).toContain(id);
     }
@@ -356,5 +364,44 @@ describe("§24 Moss Frontier track set", () => {
     expect(hazards.has("puddle")).toBe(true);
     expect(hazards.has("gravel_band")).toBe(true);
     expect(hazards.has("slick_paint")).toBe(true);
+  });
+});
+
+describe("§24 Crown Circuit track set", () => {
+  const crownCircuitTrackIds = EXPECTED_AUTHORED_TOUR_TRACK_IDS.filter((id) =>
+    id.startsWith("crown-circuit/"),
+  );
+
+  it("covers all four planned Crown Circuit tracks", () => {
+    expect(crownCircuitTrackIds).toEqual([
+      "crown-circuit/embassy-loop",
+      "crown-circuit/victory-causeway",
+      "crown-circuit/grand-meridian",
+      "crown-circuit/final-horizon",
+    ]);
+    for (const id of crownCircuitTrackIds) {
+      expect(TRACK_IDS).toContain(id);
+    }
+  });
+
+  it("uses the Crown Circuit region weather profile and finale hazards", () => {
+    const tracks = crownCircuitTrackIds.map((id) =>
+      TrackSchema.parse(TRACK_RAW[id]),
+    );
+    const weather = new Set<string>();
+    const hazards = new Set<string>();
+    for (const track of tracks) {
+      expect(track.tourId).toBe("crown-circuit");
+      expect(track.laps).toBe(1);
+      expect(track.laneCount).toBe(3);
+      for (const option of track.weatherOptions) weather.add(option);
+      for (const segment of track.segments) {
+        for (const hazard of segment.hazards) hazards.add(hazard);
+      }
+    }
+    expect([...weather].sort()).toEqual(["clear", "fog", "rain", "snow"]);
+    expect(hazards.has("slick_paint")).toBe(true);
+    expect(hazards.has("puddle")).toBe(true);
+    expect(hazards.has("snow_buildup")).toBe(true);
   });
 });

--- a/src/data/tracks/crown-circuit-embassy-loop.json
+++ b/src/data/tracks/crown-circuit-embassy-loop.json
@@ -1,0 +1,27 @@
+{
+  "id": "crown-circuit/embassy-loop",
+  "name": "Embassy Loop",
+  "tourId": "crown-circuit",
+  "author": "core",
+  "version": 1,
+  "lengthMeters": 2240,
+  "laps": 1,
+  "laneCount": 3,
+  "weatherOptions": ["clear", "rain"],
+  "difficulty": 5,
+  "segments": [
+    { "len": 320, "curve": 0.04, "grade": 0, "roadsideLeft": "light_pole", "roadsideRight": "sign_marker", "hazards": [] },
+    { "len": 280, "curve": 0.18, "grade": 0.02, "roadsideLeft": "guardrail", "roadsideRight": "light_pole", "hazards": ["slick_paint"] },
+    { "len": 280, "curve": -0.16, "grade": 0.01, "roadsideLeft": "sign_marker", "roadsideRight": "guardrail", "hazards": [] },
+    { "len": 320, "curve": 0.14, "grade": -0.02, "roadsideLeft": "light_pole", "roadsideRight": "sign_marker", "hazards": ["traffic_cone"] },
+    { "len": 300, "curve": -0.18, "grade": 0.03, "roadsideLeft": "guardrail", "roadsideRight": "light_pole", "hazards": [] },
+    { "len": 340, "curve": 0.08, "grade": -0.01, "roadsideLeft": "sign_marker", "roadsideRight": "guardrail", "hazards": ["puddle"] },
+    { "len": 400, "curve": 0, "grade": 0, "roadsideLeft": "light_pole", "roadsideRight": "sign_marker", "hazards": [] }
+  ],
+  "checkpoints": [
+    { "segmentIndex": 0, "label": "start" },
+    { "segmentIndex": 2, "label": "embassy-row" },
+    { "segmentIndex": 5, "label": "flag-rise" }
+  ],
+  "spawn": { "gridSlots": 12 }
+}

--- a/src/data/tracks/crown-circuit-final-horizon.json
+++ b/src/data/tracks/crown-circuit-final-horizon.json
@@ -1,0 +1,27 @@
+{
+  "id": "crown-circuit/final-horizon",
+  "name": "Final Horizon",
+  "tourId": "crown-circuit",
+  "author": "core",
+  "version": 1,
+  "lengthMeters": 2600,
+  "laps": 1,
+  "laneCount": 3,
+  "weatherOptions": ["clear", "rain", "snow", "fog"],
+  "difficulty": 5,
+  "segments": [
+    { "len": 360, "curve": 0, "grade": 0.03, "roadsideLeft": "light_pole", "roadsideRight": "sign_marker", "hazards": [] },
+    { "len": 320, "curve": -0.16, "grade": 0.05, "roadsideLeft": "guardrail", "roadsideRight": "rock_boulder", "hazards": ["slick_paint"] },
+    { "len": 340, "curve": 0.2, "grade": -0.02, "roadsideLeft": "sign_marker", "roadsideRight": "guardrail", "hazards": ["puddle"] },
+    { "len": 360, "curve": -0.18, "grade": 0.04, "roadsideLeft": "light_pole", "roadsideRight": "sign_marker", "hazards": ["snow_buildup"] },
+    { "len": 340, "curve": 0.12, "grade": -0.05, "roadsideLeft": "guardrail", "roadsideRight": "light_pole", "hazards": [] },
+    { "len": 380, "curve": -0.08, "grade": 0.02, "roadsideLeft": "rock_boulder", "roadsideRight": "guardrail", "hazards": ["traffic_cone"] },
+    { "len": 500, "curve": 0, "grade": 0, "roadsideLeft": "sign_marker", "roadsideRight": "light_pole", "hazards": [] }
+  ],
+  "checkpoints": [
+    { "segmentIndex": 0, "label": "start" },
+    { "segmentIndex": 2, "label": "horizon-rise" },
+    { "segmentIndex": 5, "label": "final-gate" }
+  ],
+  "spawn": { "gridSlots": 12 }
+}

--- a/src/data/tracks/crown-circuit-grand-meridian.json
+++ b/src/data/tracks/crown-circuit-grand-meridian.json
@@ -1,0 +1,27 @@
+{
+  "id": "crown-circuit/grand-meridian",
+  "name": "Grand Meridian",
+  "tourId": "crown-circuit",
+  "author": "core",
+  "version": 1,
+  "lengthMeters": 2480,
+  "laps": 1,
+  "laneCount": 3,
+  "weatherOptions": ["fog", "snow"],
+  "difficulty": 5,
+  "segments": [
+    { "len": 340, "curve": 0.02, "grade": 0.02, "roadsideLeft": "light_pole", "roadsideRight": "sign_marker", "hazards": [] },
+    { "len": 320, "curve": 0.18, "grade": 0.05, "roadsideLeft": "guardrail", "roadsideRight": "rock_boulder", "hazards": ["snow_buildup"] },
+    { "len": 300, "curve": -0.2, "grade": 0.03, "roadsideLeft": "sign_marker", "roadsideRight": "guardrail", "hazards": [] },
+    { "len": 340, "curve": 0.14, "grade": -0.04, "roadsideLeft": "rock_boulder", "roadsideRight": "light_pole", "hazards": ["snow_buildup"] },
+    { "len": 320, "curve": -0.16, "grade": -0.02, "roadsideLeft": "guardrail", "roadsideRight": "sign_marker", "hazards": [] },
+    { "len": 360, "curve": 0.1, "grade": 0.02, "roadsideLeft": "light_pole", "roadsideRight": "guardrail", "hazards": ["traffic_cone"] },
+    { "len": 500, "curve": 0, "grade": 0, "roadsideLeft": "sign_marker", "roadsideRight": "light_pole", "hazards": [] }
+  ],
+  "checkpoints": [
+    { "segmentIndex": 0, "label": "start" },
+    { "segmentIndex": 2, "label": "meridian-climb" },
+    { "segmentIndex": 5, "label": "broadcast-row" }
+  ],
+  "spawn": { "gridSlots": 12 }
+}

--- a/src/data/tracks/crown-circuit-victory-causeway.json
+++ b/src/data/tracks/crown-circuit-victory-causeway.json
@@ -1,0 +1,27 @@
+{
+  "id": "crown-circuit/victory-causeway",
+  "name": "Victory Causeway",
+  "tourId": "crown-circuit",
+  "author": "core",
+  "version": 1,
+  "lengthMeters": 2360,
+  "laps": 1,
+  "laneCount": 3,
+  "weatherOptions": ["rain", "fog"],
+  "difficulty": 5,
+  "segments": [
+    { "len": 320, "curve": 0, "grade": 0.01, "roadsideLeft": "guardrail", "roadsideRight": "guardrail", "hazards": [] },
+    { "len": 300, "curve": -0.12, "grade": 0.03, "roadsideLeft": "light_pole", "roadsideRight": "sign_marker", "hazards": ["puddle"] },
+    { "len": 300, "curve": 0.16, "grade": 0.02, "roadsideLeft": "guardrail", "roadsideRight": "light_pole", "hazards": [] },
+    { "len": 340, "curve": -0.18, "grade": -0.03, "roadsideLeft": "sign_marker", "roadsideRight": "guardrail", "hazards": ["slick_paint"] },
+    { "len": 320, "curve": 0.14, "grade": 0.04, "roadsideLeft": "light_pole", "roadsideRight": "sign_marker", "hazards": [] },
+    { "len": 340, "curve": -0.08, "grade": -0.02, "roadsideLeft": "guardrail", "roadsideRight": "light_pole", "hazards": ["puddle"] },
+    { "len": 440, "curve": 0, "grade": 0, "roadsideLeft": "sign_marker", "roadsideRight": "guardrail", "hazards": [] }
+  ],
+  "checkpoints": [
+    { "segmentIndex": 0, "label": "start" },
+    { "segmentIndex": 2, "label": "causeway-crest" },
+    { "segmentIndex": 5, "label": "victory-gate" }
+  ],
+  "spawn": { "gridSlots": 12 }
+}

--- a/src/data/tracks/index.ts
+++ b/src/data/tracks/index.ts
@@ -30,6 +30,10 @@ import mossFrontierMillstream from "./moss-frontier-millstream.json";
 import mossFrontierMistbarrow from "./moss-frontier-mistbarrow.json";
 import mossFrontierPineSwitchback from "./moss-frontier-pine-switchback.json";
 import mossFrontierWetrootDrive from "./moss-frontier-wetroot-drive.json";
+import crownCircuitEmbassyLoop from "./crown-circuit-embassy-loop.json";
+import crownCircuitFinalHorizon from "./crown-circuit-final-horizon.json";
+import crownCircuitGrandMeridian from "./crown-circuit-grand-meridian.json";
+import crownCircuitVictoryCauseway from "./crown-circuit-victory-causeway.json";
 import ironBoroughFoundryMile from "./iron-borough-foundry-mile.json";
 import ironBoroughFreightlineRing from "./iron-borough-freightline-ring.json";
 import ironBoroughOuterExchange from "./iron-borough-outer-exchange.json";
@@ -63,6 +67,10 @@ export const TRACK_RAW: Readonly<Record<string, unknown>> = Object.freeze({
   "moss-frontier/millstream": mossFrontierMillstream,
   "moss-frontier/wetroot-drive": mossFrontierWetrootDrive,
   "moss-frontier/mistbarrow": mossFrontierMistbarrow,
+  "crown-circuit/embassy-loop": crownCircuitEmbassyLoop,
+  "crown-circuit/victory-causeway": crownCircuitVictoryCauseway,
+  "crown-circuit/grand-meridian": crownCircuitGrandMeridian,
+  "crown-circuit/final-horizon": crownCircuitFinalHorizon,
   "velvet-coast/harbor-run": velvetCoastHarborRun,
   "velvet-coast/sunpier-loop": velvetCoastSunpierLoop,
   "velvet-coast/cliffline-arc": velvetCoastClifflineArc,


### PR DESCRIPTION
## Summary
- Add the four Crown Circuit World Tour tracks from GDD section 24: Embassy Loop, Victory Causeway, Grand Meridian, and Final Horizon.
- Register the tracks in the browser-safe catalogue and extend authored World Tour content coverage to the completed 32-track set.
- Remove the temporary permissive championship track-resolution guard now that every World Tour track id resolves.
- Add coverage ledger and progress log entries for GDD-24-CROWN-CIRCUIT-TRACK-SET.

## GDD
- docs/gdd/09-track-design.md
- docs/gdd/22-data-schemas.md
- docs/gdd/24-content-plan.md

## Progress Log
- docs/PROGRESS_LOG.md: Crown Circuit track set

## Test Plan
- npx vitest run src/data/__tests__/tracks-content.test.ts src/data/__tests__/championship-content.test.ts src/data/regions/__tests__/regions-content.test.ts src/data/__tests__/content-budget.test.ts src/road/__tests__/trackCompiler.test.ts src/road/__tests__/trackCompiler.golden.test.ts
- npm run content-lint
- npm run docs:check
- npm run verify
- npx playwright test e2e/world-tour.spec.ts e2e/tour-flow.spec.ts --project=chromium

## Followups
None.