### PR TITLE
v0.2.0 content-complete release refresh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,23 @@
 All notable changes to VibeGear2 are tracked here. The canonical slice-by-slice
 audit trail remains `docs/PROGRESS_LOG.md`.
 
+## 0.2.0 - 2026-04-30
+
+Content-complete World Tour release candidate.
+
+### Highlights
+
+- Expanded the bundled World Tour catalogue from the original release build to
+  all 32 planned v1.0 tracks across eight regions.
+- Added Ember Steppe, Breakwater Isles, Glass Ridge, Neon Meridian, Moss
+  Frontier, and Crown Circuit track sets after the `v0.1.0` tag.
+- Enforced strict championship track resolution now that every planned World
+  Tour track id resolves in the browser-safe catalogue.
+- Added per-car FX atlas routing for all six playable cars.
+- Added Time Trial downloaded ghost selection, Daily Challenge share text, and
+  pause-menu Settings and Ghosts actions.
+- Kept production verification green on main after every merged content slice.
+
 ## 0.1.0 - 2026-04-30
 
 Initial playable web release candidate.

--- a/docs/GDD_COVERAGE.json
+++ b/docs/GDD_COVERAGE.json
@@ -1858,6 +1858,22 @@
         "scripts/check-lighthouse.ts"
       ],
       "followupRefs": ["VibeGear2-implement-ci-bundle-57af4a04"]
+    },
+    {
+      "id": "GDD-25-V0-2-0-RELEASE-REFRESH",
+      "gddSections": [
+        "docs/gdd/24-content-plan.md",
+        "docs/gdd/25-development-roadmap.md"
+      ],
+      "requirement": "The post-v0.1.0 release metadata reflects the content-complete World Tour build after all 32 planned v1.0 track ids resolve in the bundled catalogue.",
+      "coverage": ["implemented-code"],
+      "implementationRefs": [
+        "package.json",
+        "package-lock.json",
+        "CHANGELOG.md",
+        "docs/PROGRESS_LOG.md"
+      ],
+      "followupRefs": ["VibeGear2-prepare-v0-2-3715851c"]
     }
   ]
 }

--- a/docs/PROGRESS_LOG.md
+++ b/docs/PROGRESS_LOG.md
@@ -36,8 +36,8 @@ Correct them by adding a new entry that references the old one.
 ### Coverage ledger
 - GDD-25-V0-2-0-RELEASE-REFRESH covers the package metadata, changelog, and
   progress log for the content-complete World Tour build.
-- Uncovered adjacent requirements: the `v0.2.0` tag and post-tag production
-  smoke happen after this PR merges.
+- Uncovered adjacent requirements: create the `v0.2.0` tag after this PR
+  merges, then run post-tag production smoke.
 
 ### Followups created
 None.

--- a/docs/PROGRESS_LOG.md
+++ b/docs/PROGRESS_LOG.md
@@ -6,6 +6,47 @@ Correct them by adding a new entry that references the old one.
 
 ---
 
+## 2026-04-30: Slice: v0.2.0 content-complete release refresh
+
+**GDD sections touched:**
+[§24](gdd/24-content-plan.md) full v1.0 content and
+[§25](gdd/25-development-roadmap.md) release packaging.
+**Branch / PR:** `chore/v0.2.0-release-refresh`, PR pending.
+**Status:** Implemented.
+
+### Done
+- Bumped package metadata from `0.1.0` to `0.2.0`.
+- Added a `CHANGELOG.md` section for the content-complete World Tour release
+  candidate after the post-`v0.1.0` track-set work.
+- Documented that all 32 planned World Tour tracks are now bundled and strict
+  championship track resolution is enforced.
+
+### Verified
+- `npm run verify` green, 2737 Vitest tests passed.
+- `npm run build && npm run quality:gates` green; bundle budgets passed and
+  Lighthouse passed for `/`, `/race?mode=practice`, `/garage`, and `/options`.
+
+### Decisions and assumptions
+- Used `0.2.0` rather than moving the existing `v0.1.0` tag, because `v0.1.0`
+  already points at an older main commit and the later full-track content is a
+  new release candidate.
+- Deferred creating the `v0.2.0` git tag until this release-refresh PR merges
+  so the tag points at the exact merge commit on `main`.
+
+### Coverage ledger
+- GDD-25-V0-2-0-RELEASE-REFRESH covers the package metadata, changelog, and
+  progress log for the content-complete World Tour build.
+- Uncovered adjacent requirements: the `v0.2.0` tag and post-tag production
+  smoke happen after this PR merges.
+
+### Followups created
+None.
+
+### GDD edits
+None.
+
+---
+
 ## 2026-04-30: Slice: Crown Circuit track set
 
 **GDD sections touched:**

--- a/docs/PROGRESS_LOG.md
+++ b/docs/PROGRESS_LOG.md
@@ -11,7 +11,7 @@ Correct them by adding a new entry that references the old one.
 **GDD sections touched:**
 [§24](gdd/24-content-plan.md) full v1.0 content and
 [§25](gdd/25-development-roadmap.md) release packaging.
-**Branch / PR:** `chore/v0.2.0-release-refresh`, PR pending.
+**Branch / PR:** `chore/v0.2.0-release-refresh`, PR #139.
 **Status:** Implemented.
 
 ### Done

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vibegear2",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vibegear2",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "license": "MIT",
       "dependencies": {
         "next": "^15.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vibegear2",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "private": true,
   "license": "MIT",
   "description": "Open source spiritual successor to Top Gear 2",


### PR DESCRIPTION
## Summary
- bump package metadata to 0.2.0
- add a changelog entry for the content-complete World Tour release candidate
- add a coverage ledger row and progress log entry for the release refresh

## Test plan
- npm run verify
- npm run build && npm run quality:gates
- npm run docs:check && npm run content-lint
- git diff --check
