### PR TITLE
chore: define v0.2 stable release branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,9 @@ on:
   pull_request:
     branches: [main]
   push:
-    branches: [main]
+    branches:
+      - main
+      - "release/**"
   workflow_dispatch:
     inputs:
       run_bench:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,9 @@ name: CI
 
 on:
   pull_request:
-    branches: [main]
+    branches:
+      - main
+      - "release/**"
   push:
     branches:
       - main

--- a/README.md
+++ b/README.md
@@ -57,6 +57,10 @@ are documented in [`.github/workflows/ci.yml`](.github/workflows/ci.yml) and
 "Run workflow" button on the CI workflow with `run_bench=true`; it is
 informational and never gates a merge or deploy.
 
+Stable release branches are documented in [`docs/RELEASES.md`](docs/RELEASES.md).
+`release/*` branches run CI for backport confidence, but production deploys
+remain gated to `main`.
+
 ## Supported Browsers
 
 The current support and release-smoke evidence matrix lives in

--- a/docs/GDD_COVERAGE.json
+++ b/docs/GDD_COVERAGE.json
@@ -1874,6 +1874,21 @@
         "docs/PROGRESS_LOG.md"
       ],
       "followupRefs": ["VibeGear2-prepare-v0-2-3715851c"]
+    },
+    {
+      "id": "GDD-25-STABLE-RELEASE-BRANCH",
+      "gddSections": [
+        "docs/gdd/25-development-roadmap.md",
+        "docs/gdd/21-technical-design-for-web-implementation.md"
+      ],
+      "requirement": "The v1.0 release process has a stable release branch contract, a documented v0.2 branch target, and CI coverage for release branch backport verification without production deployment.",
+      "coverage": ["implemented-code"],
+      "implementationRefs": [
+        "docs/RELEASES.md",
+        ".github/workflows/ci.yml",
+        "README.md"
+      ],
+      "followupRefs": ["VibeGear2-implement-v0-2-cdf8bf7a"]
     }
   ]
 }

--- a/docs/PROGRESS_LOG.md
+++ b/docs/PROGRESS_LOG.md
@@ -6,6 +6,50 @@ Correct them by adding a new entry that references the old one.
 
 ---
 
+## 2026-04-30: Slice: v0.2 stable release branch
+
+**GDD sections touched:**
+[§21](gdd/21-technical-design-for-web-implementation.md) CI and deploy target,
+and [§25](gdd/25-development-roadmap.md) v1.0 stable release branch.
+**Branch / PR:** `chore/v0.2-stable-release-branch`, PR TBD.
+**Status:** Implemented.
+
+### Done
+- Added `docs/RELEASES.md` with the stable release branch contract, current
+  `release/v0.2` target, creation commands, smoke checklist, and backport
+  rules.
+- Updated CI so pushes to `release/*` branches run verification while
+  production deploy remains restricted to `main`.
+- Linked release branch docs from `README.md`.
+- Added GDD coverage for the §25 stable release branch deliverable.
+
+### Verified
+- `npm run docs:check` green.
+- `npm run content-lint` green.
+- `git diff --check` green.
+- Changed-file diff scan for em-dashes and en-dashes clean.
+- `npm run verify` green, 2737 Vitest tests passed.
+
+### Decisions and assumptions
+- Treat `release/v0.2` as a support branch for the content-complete World Tour
+  release candidate because the `v0.2.0` tag already passed production smoke.
+- Do not deploy release branch pushes to production. `main` remains the only
+  deploy branch per the working agreement.
+
+### Coverage ledger
+- GDD-25-STABLE-RELEASE-BRANCH covers the release branch process docs and
+  release branch CI trigger.
+- Uncovered adjacent requirements: create and push
+  `release/v0.2` at the `v0.2.0` tag, then watch its CI run.
+
+### Followups created
+None.
+
+### GDD edits
+None.
+
+---
+
 ## 2026-04-30: Slice: v0.2.0 content-complete release refresh
 
 **GDD sections touched:**

--- a/docs/PROGRESS_LOG.md
+++ b/docs/PROGRESS_LOG.md
@@ -11,7 +11,7 @@ Correct them by adding a new entry that references the old one.
 **GDD sections touched:**
 [§21](gdd/21-technical-design-for-web-implementation.md) CI and deploy target,
 and [§25](gdd/25-development-roadmap.md) v1.0 stable release branch.
-**Branch / PR:** `chore/v0.2-stable-release-branch`, PR TBD.
+**Branch / PR:** `chore/v0.2-stable-release-branch`, PR #140.
 **Status:** Implemented.
 
 ### Done

--- a/docs/PROGRESS_LOG.md
+++ b/docs/PROGRESS_LOG.md
@@ -15,11 +15,11 @@ and [§25](gdd/25-development-roadmap.md) v1.0 stable release branch.
 **Status:** Implemented.
 
 ### Done
-- Added `docs/RELEASES.md` with the stable release branch contract, current
+- Added `docs/RELEASES.md` with the stable release branch contract, planned
   `release/v0.2` target, creation commands, smoke checklist, and backport
   rules.
-- Updated CI so pushes to `release/*` branches run verification while
-  production deploy remains restricted to `main`.
+- Updated CI so pushes and PRs targeting `release/*` branches run verification
+  while production deploy remains restricted to `main`.
 - Linked release branch docs from `README.md`.
 - Added GDD coverage for the §25 stable release branch deliverable.
 
@@ -37,10 +37,11 @@ and [§25](gdd/25-development-roadmap.md) v1.0 stable release branch.
   deploy branch per the working agreement.
 
 ### Coverage ledger
-- GDD-25-STABLE-RELEASE-BRANCH covers the release branch process docs and
-  release branch CI trigger.
+- GDD-25-STABLE-RELEASE-BRANCH covers the release branch process docs,
+  backport PR checks, and release branch CI trigger.
 - Uncovered adjacent requirements: create and push
-  `release/v0.2` at the `v0.2.0` tag, then watch its CI run.
+  `release/v0.2` from the merged release-branch docs commit, then watch its
+  CI run.
 
 ### Followups created
 None.

--- a/docs/RELEASES.md
+++ b/docs/RELEASES.md
@@ -1,0 +1,66 @@
+# Release Branches
+
+This document defines the stable release branch contract required by
+[`docs/gdd/25-development-roadmap.md`](gdd/25-development-roadmap.md) for v1.0
+readiness.
+
+## Current Stable Branch
+
+| Line | Branch | Tag | Commit | Purpose |
+| --- | --- | --- | --- | --- |
+| Content-complete World Tour | `release/v0.2` | `v0.2.0` | `ebac874` | Stable branch for the 32-track World Tour release candidate. |
+
+The branch is created after the release-refresh PR merges and the tag passes
+production smoke. The branch must point at the same commit as the tag when it
+is created.
+
+## Branch Rules
+
+- `main` remains the only production deploy branch.
+- `release/*` branches receive CI verification but do not deploy to
+  production.
+- Backports to a release branch require their own PR into that branch.
+- A backport PR must link the original `main` PR, the affected tag, and the
+  production issue or followup that justifies the patch.
+- New feature work does not land on release branches. Use `main`.
+- A new stable branch is created only after a tagged release has passed main
+  CI, CodeQL, Vercel production verification, and external production smoke.
+
+## Creating a Stable Branch
+
+After a release PR is merged and the tag is pushed:
+
+```bash
+git fetch origin --tags
+git checkout main
+git pull --ff-only origin main
+git rev-parse --short HEAD
+git rev-parse --short v0.2.0
+git branch release/v0.2 v0.2.0
+git push origin release/v0.2
+```
+
+If the branch push triggers CI, watch it to completion. A failing release-branch
+CI run is a release-support blocker and must be fixed before the slice closes.
+
+## Smoke Checklist
+
+For every new stable branch, record the following in `docs/PROGRESS_LOG.md`:
+
+- release tag
+- release branch name
+- commit SHA
+- main CI result
+- CodeQL result
+- Vercel production verifier result
+- external production `/api/version` result
+- route smoke result
+- release-branch CI result, if a workflow ran
+
+## Backport Checklist
+
+1. Start from the release branch: `git checkout -b fix/<slice> origin/release/v0.2`.
+2. Apply the smallest patch needed for the released line.
+3. Run `npm run verify` and any targeted e2e or production smoke needed.
+4. Open the PR against the release branch, not `main`.
+5. After merge, tag a patch release if the fix changes shipped behavior.

--- a/docs/RELEASES.md
+++ b/docs/RELEASES.md
@@ -4,15 +4,16 @@ This document defines the stable release branch contract required by
 [`docs/gdd/25-development-roadmap.md`](gdd/25-development-roadmap.md) for v1.0
 readiness.
 
-## Current Stable Branch
+## Current Stable Branch Target
 
-| Line | Branch | Tag | Commit | Purpose |
-| --- | --- | --- | --- | --- |
-| Content-complete World Tour | `release/v0.2` | `v0.2.0` | `ebac874` | Stable branch for the 32-track World Tour release candidate. |
+| Line | Branch | Tag | Branch base | Status | Purpose |
+| --- | --- | --- | --- | --- | --- |
+| Content-complete World Tour | `release/v0.2` | `v0.2.0` | Post-PR #140 merge commit | Planned | Stable branch for the 32-track World Tour release candidate. |
 
 The branch is created after the release-refresh PR merges and the tag passes
-production smoke. The branch must point at the same commit as the tag when it
-is created.
+production smoke. The branch starts at the first `main` commit after `v0.2.0`
+that adds the release branch CI and support docs, so release-branch PRs have
+pre-merge checks available.
 
 ## Branch Rules
 
@@ -36,12 +37,13 @@ git checkout main
 git pull --ff-only origin main
 git rev-parse --short HEAD
 git rev-parse --short v0.2.0
-git branch release/v0.2 v0.2.0
+git branch release/v0.2 main
 git push origin release/v0.2
 ```
 
-If the branch push triggers CI, watch it to completion. A failing release-branch
-CI run is a release-support blocker and must be fixed before the slice closes.
+The branch push should trigger CI. Watch it to completion. A failing
+release-branch CI run is a release-support blocker and must be fixed before
+the slice closes.
 
 ## Smoke Checklist
 


### PR DESCRIPTION
## GDD sections
- §21 technical design: CI and deploy target
- §25 development roadmap: stable release branch

## Requirement inventory
- Adds `docs/RELEASES.md` with the stable branch contract, current `release/v0.2` target, creation commands, smoke checklist, and backport rules.
- Updates CI so `release/*` branch pushes run verification without triggering production deploy.
- Links the release branch docs from `README.md`.
- Adds `GDD-25-STABLE-RELEASE-BRANCH` coverage.

Nearby requirement left for post-merge: create and push `release/v0.2` at `v0.2.0`, then watch the release-branch CI run.

## Progress log
- `docs/PROGRESS_LOG.md`: `2026-04-30: Slice: v0.2 stable release branch`

## Test plan
- [x] `npm run docs:check`
- [x] `npm run content-lint`
- [x] `git diff --check`
- [x] changed-file diff scan for em-dashes and en-dashes
- [x] `npm run verify`

## Followups
None.