### PR TITLE
docs: mark v0.2 release branch active

### DIFF
--- a/docs/PROGRESS_LOG.md
+++ b/docs/PROGRESS_LOG.md
@@ -6,6 +6,43 @@ Correct them by adding a new entry that references the old one.
 
 ---
 
+## 2026-04-30: Slice: v0.2 release branch activation docs
+
+**GDD sections touched:**
+[§25](gdd/25-development-roadmap.md) v1.0 stable release branch.
+**Branch / PR:** `docs/v0.2-release-branch-active`, PR TBD.
+**Status:** Implemented.
+
+### Done
+- Updated `docs/RELEASES.md` so `release/v0.2` is listed as the active stable
+  branch instead of a planned target.
+- Recorded the active branch base as `269f890`, the PR #140 merge commit.
+- Documented that the branch was created after `v0.2.0` production smoke and
+  after release branch CI support landed.
+
+### Verified
+- `npm run docs:check` green.
+- `npm run content-lint` green.
+- `git diff --check` green.
+- Changed-file diff scan for em-dashes and en-dashes clean.
+
+### Decisions and assumptions
+- Kept `v0.2.0` as the release tag while using `269f890` as the branch base,
+  because PR #140 added only release support docs and CI wiring after the tag.
+
+### Coverage ledger
+- GDD-25-STABLE-RELEASE-BRANCH remains the active coverage row for the stable
+  release branch deliverable.
+- Uncovered adjacent requirements: none.
+
+### Followups created
+None.
+
+### GDD edits
+None.
+
+---
+
 ## 2026-04-30: Slice: v0.2 stable release branch
 
 **GDD sections touched:**

--- a/docs/PROGRESS_LOG.md
+++ b/docs/PROGRESS_LOG.md
@@ -10,7 +10,7 @@ Correct them by adding a new entry that references the old one.
 
 **GDD sections touched:**
 [§25](gdd/25-development-roadmap.md) v1.0 stable release branch.
-**Branch / PR:** `docs/v0.2-release-branch-active`, PR TBD.
+**Branch / PR:** `docs/v0.2-release-branch-active`, PR #141.
 **Status:** Implemented.
 
 ### Done

--- a/docs/RELEASES.md
+++ b/docs/RELEASES.md
@@ -4,16 +4,16 @@ This document defines the stable release branch contract required by
 [`docs/gdd/25-development-roadmap.md`](gdd/25-development-roadmap.md) for v1.0
 readiness.
 
-## Current Stable Branch Target
+## Current Stable Branch
 
 | Line | Branch | Tag | Branch base | Status | Purpose |
 | --- | --- | --- | --- | --- | --- |
-| Content-complete World Tour | `release/v0.2` | `v0.2.0` | Post-PR #140 merge commit | Planned | Stable branch for the 32-track World Tour release candidate. |
+| Content-complete World Tour | `release/v0.2` | `v0.2.0` | `269f890` | Active | Stable branch for the 32-track World Tour release candidate. |
 
-The branch is created after the release-refresh PR merges and the tag passes
-production smoke. The branch starts at the first `main` commit after `v0.2.0`
-that adds the release branch CI and support docs, so release-branch PRs have
-pre-merge checks available.
+The branch was created after the release-refresh PR merged, the `v0.2.0` tag
+passed production smoke, and PR #140 added the release branch CI and support
+docs. It starts at `269f890`, the first `main` commit after `v0.2.0` with
+pre-merge checks available for release-branch PRs.
 
 ## Branch Rules
 

--- a/docs/RELEASES.md
+++ b/docs/RELEASES.md
@@ -10,7 +10,7 @@ readiness.
 | --- | --- | --- | --- | --- | --- |
 | Content-complete World Tour | `release/v0.2` | `v0.2.0` | `269f890` | Active | Stable branch for the 32-track World Tour release candidate. |
 
-The branch was created after the release-refresh PR merged, the `v0.2.0` tag
+The branch was created after release-refresh PR #139 merged, the `v0.2.0` tag
 passed production smoke, and PR #140 added the release branch CI and support
 docs. It starts at `269f890`, the first `main` commit after `v0.2.0` with
 pre-merge checks available for release-branch PRs.


### PR DESCRIPTION
## GDD sections
- §25 development roadmap: stable release branch

## Requirement inventory
- Updates `docs/RELEASES.md` so `release/v0.2` is the active stable branch rather than a planned target.
- Records `269f890` as the branch base and explains why it differs from the `v0.2.0` tag.
- Adds the matching progress log entry.

Nearby requirements left to followups or questions: none.

## Progress log
- `docs/PROGRESS_LOG.md`: `2026-04-30: Slice: v0.2 release branch activation docs`

## Test plan
- [x] `npm run docs:check`
- [x] `npm run content-lint`
- [x] `git diff --check`
- [x] changed-file diff scan for em-dashes and en-dashes

## Followups
None.