### PR TITLE
docs: add release media capture workflow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ node_modules/
 coverage/
 playwright-report/
 test-results/
+artifacts/
 
 # next.js
 .next/

--- a/README.md
+++ b/README.md
@@ -61,6 +61,9 @@ Stable release branches are documented in [`docs/RELEASES.md`](docs/RELEASES.md)
 `release/*` branches run CI for backport confidence, but production deploys
 remain gated to `main`.
 
+Release screenshots and trailer source clips are captured with
+`npm run release:media`; see [`docs/RELEASE_MEDIA.md`](docs/RELEASE_MEDIA.md).
+
 ## Supported Browsers
 
 The current support and release-smoke evidence matrix lives in

--- a/docs/GDD_COVERAGE.json
+++ b/docs/GDD_COVERAGE.json
@@ -1889,6 +1889,23 @@
         "README.md"
       ],
       "followupRefs": ["VibeGear2-implement-v0-2-cdf8bf7a"]
+    },
+    {
+      "id": "GDD-25-RELEASE-MEDIA-KIT",
+      "gddSections": [
+        "docs/gdd/25-development-roadmap.md",
+        "docs/gdd/26-open-source-project-guidance.md"
+      ],
+      "requirement": "The v1.0 release process has a repeatable launch screenshot pack and trailer source capture workflow, including required views, artifact location, and public-release review checks.",
+      "coverage": ["implemented-code"],
+      "implementationRefs": [
+        "scripts/capture-release-media.ts",
+        "docs/RELEASE_MEDIA.md",
+        "docs/SCRIPTS.md",
+        "README.md",
+        "package.json"
+      ],
+      "followupRefs": ["VibeGear2-docs-add-release-ad43a325"]
     }
   ]
 }

--- a/docs/PROGRESS_LOG.md
+++ b/docs/PROGRESS_LOG.md
@@ -32,6 +32,8 @@ and [§26](gdd/26-open-source-project-guidance.md) release packaging.
 - `npm run build` green.
 - `RELEASE_MEDIA_BASE_URL=http://127.0.0.1:3010 npm run release:media`
   captured 6 screenshots and 1 trailer clip from a production server.
+- `RELEASE_MEDIA_OUT=. npm run release:media` failed before deleting output,
+  proving the artifact safety guard rejects unsafe paths.
 
 ### Decisions and assumptions
 - Generated screenshots and WebM clips stay out of git as release artifacts.

--- a/docs/PROGRESS_LOG.md
+++ b/docs/PROGRESS_LOG.md
@@ -11,7 +11,7 @@ Correct them by adding a new entry that references the old one.
 **GDD sections touched:**
 [§25](gdd/25-development-roadmap.md) v1.0 launch trailer and screenshots,
 and [§26](gdd/26-open-source-project-guidance.md) release packaging.
-**Branch / PR:** `docs/release-media-kit`, PR pending.
+**Branch / PR:** `docs/release-media-kit`, PR #143.
 **Status:** Implemented.
 
 ### Done

--- a/docs/PROGRESS_LOG.md
+++ b/docs/PROGRESS_LOG.md
@@ -6,6 +6,52 @@ Correct them by adding a new entry that references the old one.
 
 ---
 
+## 2026-05-01: Slice: Release media capture kit
+
+**GDD sections touched:**
+[§25](gdd/25-development-roadmap.md) v1.0 launch trailer and screenshots,
+and [§26](gdd/26-open-source-project-guidance.md) release packaging.
+**Branch / PR:** `docs/release-media-kit`, PR pending.
+**Status:** Implemented.
+
+### Done
+- Added `scripts/capture-release-media.ts` to capture the required release
+  screenshot pack and a short race-play trailer source clip from a running
+  production build.
+- Added the `release:media` npm script and documented it in the script
+  catalogue.
+- Added `docs/RELEASE_MEDIA.md` with the screenshot set, trailer source
+  contract, artifact location, and release review checklist.
+- Added `GDD-25-RELEASE-MEDIA-KIT` to the coverage ledger so the §25 media
+  deliverable is machine-checkable.
+
+### Verified
+- `npm run docs:check` green.
+- `npm run content-lint` green.
+- `npm run typecheck` green.
+- `npm run build` green.
+- `RELEASE_MEDIA_BASE_URL=http://127.0.0.1:3010 npm run release:media`
+  captured 6 screenshots and 1 trailer clip from a production server.
+
+### Decisions and assumptions
+- Generated screenshots and WebM clips stay out of git as release artifacts.
+  The repo owns the repeatable capture workflow and checklist.
+
+### Coverage ledger
+- GDD-25-RELEASE-MEDIA-KIT covers the v1.0 launch screenshot and trailer source
+  workflow.
+- Uncovered adjacent requirements: final public trailer editing and hosting
+  remain release-operator work outside the repo unless a later PR approves
+  storing those assets here.
+
+### Followups created
+None.
+
+### GDD edits
+None.
+
+---
+
 ## 2026-05-01: Slice: Lighthouse gate retry hotfix
 
 **GDD sections touched:**

--- a/docs/RELEASE_MEDIA.md
+++ b/docs/RELEASE_MEDIA.md
@@ -1,0 +1,47 @@
+# Release Media
+
+The v1.0 release needs a small screenshot pack and a short trailer source
+clip. These files are generated artifacts and stay out of git.
+
+## Capture
+
+Run a production build locally, then capture media from that build:
+
+```bash
+npm run build
+npm run start
+RELEASE_MEDIA_BASE_URL=http://127.0.0.1:3000 npm run release:media
+```
+
+The script writes `artifacts/release-media/manifest.json`, screenshots under
+`artifacts/release-media/screenshots/`, and a WebM race-play clip under
+`artifacts/release-media/trailer/`.
+
+## Required Screenshots
+
+The screenshot pack must include:
+
+- Title screen.
+- World Tour hub.
+- Live race canvas.
+- Garage.
+- Time Trial.
+- Options.
+
+Each capture uses a 1280 x 720 viewport so store listings and README embeds
+can crop from a consistent source.
+
+## Trailer Source
+
+The trailer source clip is a short practice-race drive recorded from the same
+production build. Edit the generated WebM externally for the final public
+trailer. The repo should not commit edited exports unless the file size,
+licence, and hosting target are approved in the release PR.
+
+## Release Checklist
+
+- Capture from the exact tagged build or production URL being announced.
+- Keep the generated `manifest.json` with the release evidence.
+- Verify screenshots do not show debug overlays, local paths, or private data.
+- Verify the trailer uses original game audio or intentionally muted audio.
+- Link the artifact location from the release PR or tag notes.

--- a/docs/RELEASE_MEDIA.md
+++ b/docs/RELEASE_MEDIA.md
@@ -17,6 +17,9 @@ The script writes `artifacts/release-media/manifest.json`, screenshots under
 `artifacts/release-media/screenshots/`, and a WebM race-play clip under
 `artifacts/release-media/trailer/`.
 
+Set `RELEASE_MEDIA_OUT` only to a child directory under `artifacts/`.
+The script rejects other paths before deleting or recreating output.
+
 ## Required Screenshots
 
 The screenshot pack must include:

--- a/docs/SCRIPTS.md
+++ b/docs/SCRIPTS.md
@@ -19,6 +19,7 @@ Run commands from the repository root.
 | `quality:bundle` | Checks route and total static gzip budgets from the Next app build manifest. | After `npm run build`, before release or performance PRs. | A route or total static asset budget regressed. |
 | `quality:lighthouse` | Starts the production build and runs Lighthouse on core routes, retrying each route to smooth CI scoring noise. | After `npm run build`, before release or performance PRs. | Performance, accessibility, or best-practices score fell below the release gate on every attempt. |
 | `quality:gates` | Runs bundle and Lighthouse quality gates. | In CI after the production build. | Bundle budget or Lighthouse release gate failed. |
+| `release:media` | Captures the v1.0 screenshot pack and trailer source clip from a running build. | After `npm run build && npm run start`, before release notes or store copy. | The app is not running, a release route failed to boot, or Playwright video capture failed. |
 | `bench:render` | Runs the render benchmark suite. | Renderer, sprite, parallax, road, HUD, or VFX PRs. | Perf harness failure or a large frame-time regression. |
 | `art:generate` | Regenerates placeholder art assets. | Only when intentionally refreshing generated art. | Art generator or manifest contract changed. |
 | `art:check` | Validates art manifest coverage. | Before PRs that touch art. | Missing manifest entry, bad path, or invalid art metadata. |
@@ -37,6 +38,7 @@ Run commands from the repository root.
 | Browser or route change | `npm run verify:full` |
 | Cross-browser hardening | `npm run test:e2e:cross-browser` |
 | Release quality gates | `npm run build && npm run quality:gates` |
+| Release screenshots and trailer source | `npm run build`, `npm run start`, then `npm run release:media` |
 | Renderer change | `npm run verify && npm run bench:render` |
 | Docs-only change | `npm run docs:check && npm run content-lint` |
 | Art change | `npm run art:check` |

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "quality:bundle": "vite-node --script scripts/check-bundle-budget.ts",
     "quality:lighthouse": "vite-node --script scripts/check-lighthouse.ts",
     "quality:gates": "npm run quality:bundle && npm run quality:lighthouse",
+    "release:media": "vite-node --script scripts/capture-release-media.ts",
     "bench:render": "vitest run --config vitest.bench.config.ts",
     "art:generate": "vite-node --script scripts/generate-placeholder-art.ts",
     "art:check": "vite-node --script scripts/check-art-manifest.ts",

--- a/scripts/capture-release-media.ts
+++ b/scripts/capture-release-media.ts
@@ -1,7 +1,7 @@
 import { mkdir, rm, writeFile } from "node:fs/promises";
-import { join } from "node:path";
+import { isAbsolute, join, relative, resolve } from "node:path";
 
-import { chromium } from "@playwright/test";
+import { chromium, type Browser, type BrowserContext, type Page } from "@playwright/test";
 
 type CaptureTarget = {
   id: string;
@@ -11,7 +11,7 @@ type CaptureTarget = {
 };
 
 const BASE_URL = process.env.RELEASE_MEDIA_BASE_URL ?? "http://127.0.0.1:3000";
-const OUTPUT_DIR = process.env.RELEASE_MEDIA_OUT ?? "artifacts/release-media";
+const OUTPUT_DIR = resolveOutputDir(process.env.RELEASE_MEDIA_OUT);
 const VIEWPORT = { width: 1280, height: 720 };
 
 const screenshotTargets: CaptureTarget[] = [
@@ -23,52 +23,93 @@ const screenshotTargets: CaptureTarget[] = [
   { id: "06-options", path: "/options", readySelector: "body" },
 ];
 
-async function captureScreenshots(): Promise<string[]> {
-  const browser = await chromium.launch();
-  const context = await browser.newContext({ viewport: VIEWPORT });
-  const page = await context.newPage();
-  const files: string[] = [];
-
-  for (const target of screenshotTargets) {
-    await page.goto(new URL(target.path, BASE_URL).toString(), { waitUntil: "networkidle" });
-    await page.locator(target.readySelector).first().waitFor({ state: "visible" });
-    if (target.waitMs) await page.waitForTimeout(target.waitMs);
-    const file = join(OUTPUT_DIR, "screenshots", `${target.id}.png`);
-    await page.screenshot({ path: file, fullPage: false });
-    files.push(file);
+function resolveOutputDir(rawOutputDir: string | undefined): string {
+  const requested = (rawOutputDir ?? "artifacts/release-media").trim();
+  if (requested.length === 0) {
+    throw new Error("RELEASE_MEDIA_OUT must not be empty.");
   }
 
-  await context.close();
-  await browser.close();
-  return files;
+  const repoRoot = process.cwd();
+  const artifactsRoot = resolve(repoRoot, "artifacts");
+  const resolved = resolve(repoRoot, requested);
+  const rel = relative(artifactsRoot, resolved);
+  if (rel.length === 0 || rel.startsWith("..") || isAbsolute(rel)) {
+    throw new Error(
+      "RELEASE_MEDIA_OUT must resolve to a child directory under artifacts/.",
+    );
+  }
+  return resolved;
+}
+
+async function captureScreenshots(): Promise<string[]> {
+  let browser: Browser | undefined;
+  let context: BrowserContext | undefined;
+  let page: Page | undefined;
+  const files: string[] = [];
+
+  try {
+    browser = await chromium.launch();
+    context = await browser.newContext({ viewport: VIEWPORT });
+    page = await context.newPage();
+
+    for (const target of screenshotTargets) {
+      await page.goto(new URL(target.path, BASE_URL).toString(), { waitUntil: "networkidle" });
+      await page.locator(target.readySelector).first().waitFor({ state: "visible" });
+      if (target.waitMs) await page.waitForTimeout(target.waitMs);
+      const file = join(OUTPUT_DIR, "screenshots", `${target.id}.png`);
+      await page.screenshot({ path: file, fullPage: false });
+      files.push(file);
+    }
+
+    return files;
+  } finally {
+    await page?.close();
+    await context?.close();
+    await browser?.close();
+  }
 }
 
 async function captureTrailerClip(): Promise<string> {
-  const browser = await chromium.launch();
-  const context = await browser.newContext({
-    viewport: VIEWPORT,
-    recordVideo: {
-      dir: join(OUTPUT_DIR, "trailer"),
-      size: VIEWPORT,
-    },
-  });
-  const page = await context.newPage();
-  await page.goto(new URL("/race?mode=practice", BASE_URL).toString(), {
-    waitUntil: "networkidle",
-  });
-  await page.locator("canvas").first().waitFor({ state: "visible" });
-  await page.keyboard.down("ArrowUp");
-  await page.waitForTimeout(12_000);
-  await page.keyboard.up("ArrowUp");
+  let browser: Browser | undefined;
+  let context: BrowserContext | undefined;
+  let page: Page | undefined;
 
-  const video = page.video();
-  const file = join(OUTPUT_DIR, "trailer", "raceplay.webm");
-  await page.close();
-  await context.close();
-  await video?.saveAs(file);
-  await video?.delete();
-  await browser.close();
-  return file;
+  try {
+    browser = await chromium.launch();
+    context = await browser.newContext({
+      viewport: VIEWPORT,
+      recordVideo: {
+        dir: join(OUTPUT_DIR, "trailer"),
+        size: VIEWPORT,
+      },
+    });
+    page = await context.newPage();
+    await page.goto(new URL("/race?mode=practice", BASE_URL).toString(), {
+      waitUntil: "networkidle",
+    });
+    await page.locator("canvas").first().waitFor({ state: "visible" });
+    await page.keyboard.down("ArrowUp");
+    await page.waitForTimeout(12_000);
+    await page.keyboard.up("ArrowUp");
+
+    const video = page.video();
+    if (!video) {
+      throw new Error("Trailer capture failed: Playwright did not create a video recording.");
+    }
+
+    const file = join(OUTPUT_DIR, "trailer", "raceplay.webm");
+    await page.close();
+    page = undefined;
+    await context.close();
+    context = undefined;
+    await video.saveAs(file);
+    await video.delete();
+    return file;
+  } finally {
+    await page?.close();
+    await context?.close();
+    await browser?.close();
+  }
 }
 
 async function main(): Promise<void> {

--- a/scripts/capture-release-media.ts
+++ b/scripts/capture-release-media.ts
@@ -1,0 +1,100 @@
+import { mkdir, rm, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+
+import { chromium } from "@playwright/test";
+
+type CaptureTarget = {
+  id: string;
+  path: string;
+  readySelector: string;
+  waitMs?: number;
+};
+
+const BASE_URL = process.env.RELEASE_MEDIA_BASE_URL ?? "http://127.0.0.1:3000";
+const OUTPUT_DIR = process.env.RELEASE_MEDIA_OUT ?? "artifacts/release-media";
+const VIEWPORT = { width: 1280, height: 720 };
+
+const screenshotTargets: CaptureTarget[] = [
+  { id: "01-title", path: "/", readySelector: "body" },
+  { id: "02-world-tour", path: "/world", readySelector: "body" },
+  { id: "03-race", path: "/race?mode=practice", readySelector: "canvas", waitMs: 1_000 },
+  { id: "04-garage", path: "/garage", readySelector: "body" },
+  { id: "05-time-trial", path: "/time-trial", readySelector: "body" },
+  { id: "06-options", path: "/options", readySelector: "body" },
+];
+
+async function captureScreenshots(): Promise<string[]> {
+  const browser = await chromium.launch();
+  const context = await browser.newContext({ viewport: VIEWPORT });
+  const page = await context.newPage();
+  const files: string[] = [];
+
+  for (const target of screenshotTargets) {
+    await page.goto(new URL(target.path, BASE_URL).toString(), { waitUntil: "networkidle" });
+    await page.locator(target.readySelector).first().waitFor({ state: "visible" });
+    if (target.waitMs) await page.waitForTimeout(target.waitMs);
+    const file = join(OUTPUT_DIR, "screenshots", `${target.id}.png`);
+    await page.screenshot({ path: file, fullPage: false });
+    files.push(file);
+  }
+
+  await context.close();
+  await browser.close();
+  return files;
+}
+
+async function captureTrailerClip(): Promise<string> {
+  const browser = await chromium.launch();
+  const context = await browser.newContext({
+    viewport: VIEWPORT,
+    recordVideo: {
+      dir: join(OUTPUT_DIR, "trailer"),
+      size: VIEWPORT,
+    },
+  });
+  const page = await context.newPage();
+  await page.goto(new URL("/race?mode=practice", BASE_URL).toString(), {
+    waitUntil: "networkidle",
+  });
+  await page.locator("canvas").first().waitFor({ state: "visible" });
+  await page.keyboard.down("ArrowUp");
+  await page.waitForTimeout(12_000);
+  await page.keyboard.up("ArrowUp");
+
+  const video = page.video();
+  const file = join(OUTPUT_DIR, "trailer", "raceplay.webm");
+  await page.close();
+  await context.close();
+  await video?.saveAs(file);
+  await video?.delete();
+  await browser.close();
+  return file;
+}
+
+async function main(): Promise<void> {
+  await rm(OUTPUT_DIR, { force: true, recursive: true });
+  await mkdir(join(OUTPUT_DIR, "screenshots"), { recursive: true });
+  await mkdir(join(OUTPUT_DIR, "trailer"), { recursive: true });
+
+  const screenshots = await captureScreenshots();
+  const trailer = await captureTrailerClip();
+  const manifest = {
+    capturedAt: new Date().toISOString(),
+    baseUrl: BASE_URL,
+    viewport: VIEWPORT,
+    screenshots,
+    trailer,
+  };
+  await writeFile(
+    join(OUTPUT_DIR, "manifest.json"),
+    `${JSON.stringify(manifest, null, 2)}\n`,
+    "utf8",
+  );
+
+  console.log(`Captured ${screenshots.length} screenshots and 1 trailer clip in ${OUTPUT_DIR}`);
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exitCode = 1;
+});


### PR DESCRIPTION
## Summary
- Add a repeatable release screenshot and trailer source capture script.
- Document the v1.0 release media checklist and artifact location.
- Add GDD-25-RELEASE-MEDIA-KIT coverage for the §25 launch trailer and screenshots deliverable.

## GDD sections
- docs/gdd/25-development-roadmap.md: v1.0 launch trailer and screenshots
- docs/gdd/26-open-source-project-guidance.md: release packaging and contribution safety

## Requirement inventory
- Handles: production-build screenshot pack capture for title, world, race, garage, time trial, and options.
- Handles: short race-play WebM source clip capture for trailer editing.
- Handles: artifact location and review checklist for release evidence.
- Leaves: final public trailer editing and hosting outside git unless a later release PR approves storing those files here.

## Progress log
- docs/PROGRESS_LOG.md: 2026-05-01 Slice: Release media capture kit

## Test plan
- [x] npm run docs:check
- [x] npm run content-lint
- [x] npm run typecheck
- [x] npm run lint
- [x] npm run build
- [x] RELEASE_MEDIA_BASE_URL=http://127.0.0.1:3010 npm run release:media

## Followups
- None
