### PR TITLE
Enable Upstash leaderboard production backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,9 @@ remain gated to `main`.
 Release screenshots and trailer source clips are captured with
 `npm run release:media`; see [`docs/RELEASE_MEDIA.md`](docs/RELEASE_MEDIA.md).
 
+The production online leaderboard uses Upstash Redis through the Vercel
+Marketplace. See [`docs/LEADERBOARD_BACKEND.md`](docs/LEADERBOARD_BACKEND.md).
+
 ## Supported Browsers
 
 The current support and release-smoke evidence matrix lives in

--- a/docs/FOLLOWUPS.md
+++ b/docs/FOLLOWUPS.md
@@ -1075,7 +1075,7 @@ decision is tracked by Q-011 and the implementation followup is F-069.
 ## F-069: Select Marketplace Redis provider and wire production leaderboard backend
 **Created:** 2026-04-29
 **Priority:** nice-to-have
-**Status:** open
+**Status:** done (2026-05-01)
 **Notes:** Replaces F-030 after the Vercel KV sunset. Once Q-011 is answered,
 provision the selected Redis provider through Vercel Marketplace, install the
 matching SDK or REST client, update the current `store-vercel-kv` naming if
@@ -1083,6 +1083,14 @@ the provider is not Vercel KV-compatible, set the production env vars, and
 verify one signed lap roundtrip through `/api/leaderboard/test%2Fstraight`.
 Do not start this slice until the dev approves the provider, pricing plan,
 and production environment changes.
+
+Closed by `feat/upstash-leaderboard-production`. The Vercel project now has
+an Upstash Redis Marketplace resource named `vibegear2-leaderboard` in `iad1`
+on the Pay As You Go plan. `LEADERBOARD_BACKEND=upstash-redis`,
+`NEXT_PUBLIC_LEADERBOARD_ENABLED=true`, and `LEADERBOARD_SIGNING_KEY` are set
+for production. The app now recognises the `upstash-redis` backend tag through
+`@upstash/redis`, while keeping the old `vercel-kv` tag as a compatibility
+path.
 
 ## F-029: Playwright e2e race-finish spec
 **Created:** 2026-04-26

--- a/docs/GDD_COVERAGE.json
+++ b/docs/GDD_COVERAGE.json
@@ -1297,13 +1297,20 @@
         "docs/gdd/24-content-plan.md"
       ],
       "requirement": "Online leaderboard production storage must use a currently available provider and must not be provisioned until the dev approves the provider, pricing plan, and production environment changes.",
-      "coverage": ["implemented-code", "open-question", "open-followup"],
+      "coverage": ["implemented-code", "automated-test"],
       "implementationRefs": [
+        "src/leaderboard/store.ts",
+        "src/leaderboard/store-upstash-redis.ts",
+        "docs/LEADERBOARD_BACKEND.md",
         "docs/OPEN_QUESTIONS.md",
         "docs/FOLLOWUPS.md",
         "docs/PROGRESS_LOG.md"
       ],
-      "questionRefs": ["Q-011"],
+      "testRefs": [
+        "src/leaderboard/__tests__/store.test.ts",
+        "src/leaderboard/__tests__/store-vercel-kv.test.ts"
+      ],
+      "questionRefs": [],
       "followupRefs": ["F-069"]
     },
     {

--- a/docs/LEADERBOARD_BACKEND.md
+++ b/docs/LEADERBOARD_BACKEND.md
@@ -1,0 +1,47 @@
+# Leaderboard Backend
+
+The online leaderboard uses an optional Redis backend. Local development and
+static mirrors still work with the default noop backend, but the Vercel
+production project is configured to use Upstash Redis through the Vercel
+Marketplace.
+
+## Production Resource
+
+- Provider: Upstash Redis through Vercel Marketplace.
+- Vercel resource name: `vibegear2-leaderboard`.
+- Primary region: `iad1`.
+- Billing plan: `paid` Pay As You Go.
+- Provisioning flags: `prodPack=false`, `autoUpgrade=false`, `eviction=false`.
+- Vercel project: `randroid88s-projects/vibe-gear2`.
+
+## Required Env Vars
+
+The Marketplace integration injects these Redis vars:
+
+- `KV_REST_API_URL`
+- `KV_REST_API_TOKEN`
+- `KV_REST_API_READ_ONLY_TOKEN`
+- `KV_URL`
+- `REDIS_URL`
+
+The app-owned leaderboard flags are:
+
+- `LEADERBOARD_BACKEND=upstash-redis`
+- `NEXT_PUBLIC_LEADERBOARD_ENABLED=true`
+- `LEADERBOARD_SIGNING_KEY=<random secret>`
+
+Production has all three app-owned vars set. Development has the same backend
+flag and client flag plus a non-sensitive local signing key. Preview branch
+vars should be added after pushing the feature branch because Vercel only
+accepts branch-scoped preview vars for branches that already exist in the
+connected Git repository.
+
+## Runtime Path
+
+`src/leaderboard/store.ts` resolves `LEADERBOARD_BACKEND=upstash-redis` to
+`src/leaderboard/store-upstash-redis.ts`. The Upstash store validates
+`KV_REST_API_URL` and `KV_REST_API_TOKEN`, constructs `Redis.fromEnv()`, and
+reuses the existing Redis command contract in `store-vercel-kv.ts`.
+
+The legacy `vercel-kv` backend tag remains available for compatibility, but new
+Vercel projects should use `upstash-redis`.

--- a/docs/LEADERBOARD_BACKEND.md
+++ b/docs/LEADERBOARD_BACKEND.md
@@ -31,10 +31,9 @@ The app-owned leaderboard flags are:
 - `LEADERBOARD_SIGNING_KEY=<random secret>`
 
 Production has all three app-owned vars set. Development has the same backend
-flag and client flag plus a non-sensitive local signing key. Preview branch
-vars should be added after pushing the feature branch because Vercel only
-accepts branch-scoped preview vars for branches that already exist in the
-connected Git repository.
+flag and client flag plus a non-sensitive local signing key. The
+`feat/upstash-leaderboard-production` preview branch also has branch-scoped
+copies of all three app-owned vars so the PR preview exercises the Redis path.
 
 ## Runtime Path
 

--- a/docs/LEADERBOARD_BACKEND.md
+++ b/docs/LEADERBOARD_BACKEND.md
@@ -14,17 +14,17 @@ Marketplace.
 - Provisioning flags: `prodPack=false`, `autoUpgrade=false`, `eviction=false`.
 - Vercel project: `randroid88s-projects/vibe-gear2`.
 
-## Required Env Vars
+## Injected Env Vars
 
 The Marketplace integration injects these Redis vars:
 
-- `KV_REST_API_URL`
-- `KV_REST_API_TOKEN`
+- `KV_REST_API_URL` (required by the runtime store)
+- `KV_REST_API_TOKEN` (required by the runtime store)
 - `KV_REST_API_READ_ONLY_TOKEN`
 - `KV_URL`
 - `REDIS_URL`
 
-The app-owned leaderboard flags are:
+The app-owned leaderboard flags required to enable production submissions are:
 
 - `LEADERBOARD_BACKEND=upstash-redis`
 - `NEXT_PUBLIC_LEADERBOARD_ENABLED=true`

--- a/docs/OPEN_QUESTIONS.md
+++ b/docs/OPEN_QUESTIONS.md
@@ -47,8 +47,9 @@ future opt-in slice only after this question is answered.
 **GDD reference:** [§21](gdd/21-technical-design-for-web-implementation.md)
 "leaderboard back end concept", [§24](gdd/24-content-plan.md) "Online
 leaderboard".
-**Status:** open
+**Status:** answered (2026-05-01)
 **Asked in loop:** 2026-04-29
+**Answered in loop:** 2026-05-01
 
 **Question.** F-030 asked the agent to provision Vercel KV and flip
 `LEADERBOARD_BACKEND=vercel-kv` in production. Current Vercel docs say
@@ -79,6 +80,13 @@ chosen provider and update the current `vercel-kv` adapter name if needed.
 **Blocking?** Yes for replacing F-030. It is not blocking local gameplay
 because the noop leaderboard path still deploys and the client remains
 feature-flagged off.
+
+**Answer.** Use Upstash Redis through Vercel Marketplace. The agent provisioned
+`vibegear2-leaderboard` in region `iad1` on the Pay As You Go plan with
+`autoUpgrade=false`, `prodPack=false`, and `eviction=false`, then connected it
+to the `vibe-gear2` Vercel project. The app-owned production env vars are
+`LEADERBOARD_BACKEND=upstash-redis`, `NEXT_PUBLIC_LEADERBOARD_ENABLED=true`,
+and `LEADERBOARD_SIGNING_KEY`.
 
 ## Q-010: `tourTierScale` table for the §12 repair-cost formula
 

--- a/docs/PROGRESS_LOG.md
+++ b/docs/PROGRESS_LOG.md
@@ -21,6 +21,7 @@ concept and [§24](gdd/24-content-plan.md) online leaderboard.
   while keeping the legacy `vercel-kv` tag available.
 - Set production Vercel env vars for the Redis backend, public leaderboard
   enablement, and signed lap submissions.
+- Set matching branch-scoped preview env vars after pushing the branch.
 - Documented the selected provider, env contract, and runtime path in
   `docs/LEADERBOARD_BACKEND.md`.
 - Marked Q-011 answered and F-069 done.
@@ -37,8 +38,8 @@ concept and [§24](gdd/24-content-plan.md) online leaderboard.
 - Chose `iad1` to match the Vercel deploy region.
 - Set `autoUpgrade=false` and `prodPack=false` to keep spend bounded until the
   dev changes the plan intentionally.
-- Preview branch env vars will be added after the branch is pushed because the
-  Vercel CLI rejects preview vars for branches that do not exist in GitHub yet.
+- Vercel requires branch-scoped preview env vars to reference a branch that
+  already exists in the connected GitHub repository.
 
 ### Coverage ledger
 - GDD-21-LEADERBOARD-STORAGE-GATE now covers the approved provider, production

--- a/docs/PROGRESS_LOG.md
+++ b/docs/PROGRESS_LOG.md
@@ -6,6 +6,55 @@ Correct them by adding a new entry that references the old one.
 
 ---
 
+## 2026-05-01: Slice: Upstash leaderboard production backend
+
+**GDD sections touched:**
+[§21](gdd/21-technical-design-for-web-implementation.md) leaderboard backend
+concept and [§24](gdd/24-content-plan.md) online leaderboard.
+**Branch / PR:** `feat/upstash-leaderboard-production`, PR pending.
+**Status:** Implemented.
+
+### Done
+- Provisioned the `vibegear2-leaderboard` Upstash Redis resource through the
+  Vercel Marketplace CLI and connected it to the `vibe-gear2` project.
+- Added the `upstash-redis` leaderboard backend tag backed by `@upstash/redis`
+  while keeping the legacy `vercel-kv` tag available.
+- Set production Vercel env vars for the Redis backend, public leaderboard
+  enablement, and signed lap submissions.
+- Documented the selected provider, env contract, and runtime path in
+  `docs/LEADERBOARD_BACKEND.md`.
+- Marked Q-011 answered and F-069 done.
+
+### Verified
+- `npm run typecheck` green.
+- `npx vitest run src/leaderboard/__tests__/store.test.ts src/leaderboard/__tests__/store-vercel-kv.test.ts`
+  green, 30 tests passed.
+
+### Decisions and assumptions
+- Used Upstash Redis through Vercel Marketplace because the dev approved using
+  Vercel and GitHub CLIs to complete setup, and Q-011 recommended Upstash as
+  the closest successor to the obsolete Vercel KV path.
+- Chose `iad1` to match the Vercel deploy region.
+- Set `autoUpgrade=false` and `prodPack=false` to keep spend bounded until the
+  dev changes the plan intentionally.
+- Preview branch env vars will be added after the branch is pushed because the
+  Vercel CLI rejects preview vars for branches that do not exist in GitHub yet.
+
+### Coverage ledger
+- GDD-21-LEADERBOARD-STORAGE-GATE now covers the approved provider, production
+  resource, app-owned env flags, runtime backend tag, and regression tests.
+- Uncovered adjacent requirements: production signed-lap roundtrip after this
+  PR deploys.
+
+### Followups created
+None.
+
+### GDD edits
+- Updated `docs/gdd/21-technical-design-for-web-implementation.md` to name the
+  Upstash Redis production backend and the app-owned env flags.
+
+---
+
 ## 2026-05-01: Slice: Release media capture kit
 
 **GDD sections touched:**

--- a/docs/gdd/21-technical-design-for-web-implementation.md
+++ b/docs/gdd/21-technical-design-for-web-implementation.md
@@ -152,6 +152,19 @@ served on every page load by the production host.
 
 The current repo already stores controls and tuning in local storage and uses backend persistence for tracks and leaderboards. VibeGear2 should extend that pattern into a versioned local save with optional cloud sync later. [24]
 
+### Online leaderboard backend
+
+The production leaderboard backend is Upstash Redis provisioned through the
+Vercel Marketplace. The resource is connected to the `vibe-gear2` Vercel
+project and uses the injected `KV_REST_API_URL` and `KV_REST_API_TOKEN` vars.
+The app enables it with `LEADERBOARD_BACKEND=upstash-redis`,
+`NEXT_PUBLIC_LEADERBOARD_ENABLED=true`, and `LEADERBOARD_SIGNING_KEY`.
+
+The noop backend remains the default when `LEADERBOARD_BACKEND` is unset, so
+local development and static mirrors can still run without Redis. The old
+`vercel-kv` backend tag is kept as a compatibility alias only; new production
+projects should use `upstash-redis`.
+
 ### Cross-tab consistency
 
 Two browser tabs of the deployed build can each load and persist the same `SaveGame`. The MVP rule is **last-write-wins with a monotonic `writeCounter` advisory**, not leader-tab election. `saveSave` increments `writeCounter` (a per-write counter independent of the schema `version`) before serialising. `subscribeToSaveChanges` wires a `storage` event listener so the title and garage screens hot-reload the displayed save when a foreign tab writes; the browser does not deliver the event to the originating tab, so same-tab writes never echo back. `reloadIfNewer(currentInMemory)` compares counters on `focus` / `visibilitychange` and returns the on-disk save when its counter is strictly greater, so a long-lived in-memory reference can revalidate before the next UI mutation. The race loop is intentionally excluded: `RaceState` is independent of `SaveGame` until the race ends, so a foreign-tab write cannot corrupt live race state. See `src/persistence/save.ts` and the cross-tab tests in `src/persistence/save.test.ts`.

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.2.0",
       "license": "MIT",
       "dependencies": {
+        "@upstash/redis": "^1.37.0",
         "next": "^15.0.0",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
@@ -3702,6 +3703,15 @@
       "os": [
         "win32"
       ]
+    },
+    "node_modules/@upstash/redis": {
+      "version": "1.37.0",
+      "resolved": "https://registry.npmjs.org/@upstash/redis/-/redis-1.37.0.tgz",
+      "integrity": "sha512-LqOJ3+XWPLSZ2rGSed5DYG3ixybxb8EhZu3yQqF7MdZX1wLBG/FRcI6xcUZXHy/SS7mmXWyadrud0HJHkOc+uw==",
+      "license": "MIT",
+      "dependencies": {
+        "uncrypto": "^0.1.3"
+      }
     },
     "node_modules/@vitejs/plugin-react": {
       "version": "4.7.0",
@@ -9716,6 +9726,12 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/uncrypto": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/uncrypto/-/uncrypto-0.1.3.tgz",
+      "integrity": "sha512-Ql87qFHB3s/De2ClA9e0gsnS6zXG27SkTiSJwjCc9MebbfapQfuPzumMIUMi38ezPZVNFcHI9sUIepeQfw8J8Q==",
+      "license": "MIT"
     },
     "node_modules/undici-types": {
       "version": "6.21.0",

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "verify:full": "npm run verify && npm run test:e2e"
   },
   "dependencies": {
+    "@upstash/redis": "^1.37.0",
     "next": "^15.0.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",

--- a/src/leaderboard/__tests__/store.test.ts
+++ b/src/leaderboard/__tests__/store.test.ts
@@ -6,9 +6,9 @@
  *
  *   - Unset / empty / case-insensitive `"noop"` values pick the noop
  *     store.
- *   - `"vercel-kv"` is a recognised tag (the store factory itself is
- *     not exercised here; the dynamic import requires a configured
- *     `@vercel/kv` package, which is the FOLLOWUPS task).
+ *   - `"upstash-redis"` is a recognised tag and rejects loudly when
+ *     the required Marketplace env vars are missing.
+ *   - `"vercel-kv"` remains a recognised legacy tag.
  *   - Any unknown value throws (loud failure on misconfigured deploy
  *     per AGENTS.md RULE 7).
  *   - The factory returns a fresh store object on each call so a
@@ -45,6 +45,11 @@ describe("resolveBackendTag", () => {
     expect(resolveBackendTag("  Vercel-KV  ")).toBe("vercel-kv");
   });
 
+  it("returns upstash-redis for the literal 'upstash-redis' (case-insensitive, trimmed)", () => {
+    expect(resolveBackendTag("upstash-redis")).toBe("upstash-redis");
+    expect(resolveBackendTag("  Upstash-Redis  ")).toBe("upstash-redis");
+  });
+
   it("throws on an unknown value rather than falling back silently", () => {
     expect(() => resolveBackendTag("redis")).toThrow(/LEADERBOARD_BACKEND/);
     expect(() => resolveBackendTag("upstash")).toThrow(/LEADERBOARD_BACKEND/);
@@ -69,6 +74,31 @@ describe("resolveLeaderboardStore", () => {
     const a = await resolveLeaderboardStore("noop");
     const b = await resolveLeaderboardStore("noop");
     expect(a).not.toBe(b);
+  });
+});
+
+describe("resolveLeaderboardStore(upstash-redis)", () => {
+  let savedUrl: string | undefined;
+  let savedToken: string | undefined;
+
+  beforeEach(() => {
+    savedUrl = process.env.KV_REST_API_URL;
+    savedToken = process.env.KV_REST_API_TOKEN;
+    delete process.env.KV_REST_API_URL;
+    delete process.env.KV_REST_API_TOKEN;
+  });
+
+  afterEach(() => {
+    if (savedUrl === undefined) delete process.env.KV_REST_API_URL;
+    else process.env.KV_REST_API_URL = savedUrl;
+    if (savedToken === undefined) delete process.env.KV_REST_API_TOKEN;
+    else process.env.KV_REST_API_TOKEN = savedToken;
+  });
+
+  it("rejects with a configuration error when env vars are absent", async () => {
+    await expect(resolveLeaderboardStore("upstash-redis")).rejects.toThrow(
+      /KV_REST_API_URL|KV_REST_API_TOKEN/,
+    );
   });
 });
 

--- a/src/leaderboard/store-upstash-redis.ts
+++ b/src/leaderboard/store-upstash-redis.ts
@@ -18,6 +18,38 @@ import type { LeaderboardStore } from "./types";
 
 export const UPSTASH_REDIS_ENV_VARS = VERCEL_KV_ENV_VARS;
 
+function adaptUpstashRedis(redis: Redis): KvLike {
+  return {
+    hset(key, value) {
+      return redis.hset(key, value);
+    },
+    hgetall(key) {
+      return redis.hgetall(key);
+    },
+    zadd(key, options, member) {
+      if (options === undefined) {
+        return redis.zadd(key, member);
+      }
+      return redis.zadd(key, options, member);
+    },
+    zrange(key, start, stop) {
+      return redis.zrange<string[]>(key, start, stop);
+    },
+    del(...keys) {
+      return redis.del(...keys);
+    },
+    async set(key, value, options) {
+      const result = await redis.set(key, value, options);
+      if (result === null || result === "OK") {
+        return result;
+      }
+      throw new Error(
+        `adaptUpstashRedis: unexpected SET NX result ${String(result)}`,
+      );
+    },
+  };
+}
+
 export function createUpstashRedisStoreFromEnv(): LeaderboardStore {
   const missing = UPSTASH_REDIS_ENV_VARS.filter(
     (name) => !(process.env[name] ?? "").trim(),
@@ -27,5 +59,5 @@ export function createUpstashRedisStoreFromEnv(): LeaderboardStore {
       `createUpstashRedisStoreFromEnv: missing env vars ${missing.join(", ")}`,
     );
   }
-  return createVercelKvStore(Redis.fromEnv() as KvLike);
+  return createVercelKvStore(adaptUpstashRedis(Redis.fromEnv()));
 }

--- a/src/leaderboard/store-upstash-redis.ts
+++ b/src/leaderboard/store-upstash-redis.ts
@@ -1,0 +1,31 @@
+/**
+ * Upstash Redis-backed leaderboard store.
+ *
+ * Vercel Marketplace injects `KV_REST_API_URL` and `KV_REST_API_TOKEN`
+ * for Upstash Redis resources. The command surface matches the narrow
+ * `KvLike` contract used by the legacy Vercel KV store, so this module
+ * only owns env validation and SDK construction.
+ */
+
+import { Redis } from "@upstash/redis";
+
+import {
+  createVercelKvStore,
+  type KvLike,
+  VERCEL_KV_ENV_VARS,
+} from "./store-vercel-kv";
+import type { LeaderboardStore } from "./types";
+
+export const UPSTASH_REDIS_ENV_VARS = VERCEL_KV_ENV_VARS;
+
+export function createUpstashRedisStoreFromEnv(): LeaderboardStore {
+  const missing = UPSTASH_REDIS_ENV_VARS.filter(
+    (name) => !(process.env[name] ?? "").trim(),
+  );
+  if (missing.length > 0) {
+    throw new Error(
+      `createUpstashRedisStoreFromEnv: missing env vars ${missing.join(", ")}`,
+    );
+  }
+  return createVercelKvStore(Redis.fromEnv() as KvLike);
+}

--- a/src/leaderboard/store.ts
+++ b/src/leaderboard/store.ts
@@ -14,13 +14,14 @@
  *     store. This is the documented default in `AGENTS.md` RULE 7
  *     (backend services are optional later phases).
  *
- *   - `"vercel-kv"` (case-insensitive): dynamically imports
- *     `./store-vercel-kv` and returns a Vercel KV-backed store. The
- *     dynamic import keeps `@vercel/kv` out of the bundle on the noop
- *     and static-export deploy shapes per the dot
- *     `VibeGear2-implement-leaderboard-client-48a44048` "loaded
- *     dynamically when LEADERBOARD_BACKEND=vercel-kv so the bundle
- *     stays slim" requirement.
+ *   - `"upstash-redis"` (case-insensitive): dynamically imports
+ *     `./store-upstash-redis` and returns an Upstash Redis-backed
+ *     store. This is the production Vercel Marketplace backend.
+ *
+ *   - `"vercel-kv"` (case-insensitive): legacy alias for the old
+ *     Vercel KV path. It still loads `./store-vercel-kv` for local
+ *     compatibility, but new production projects should use
+ *     `"upstash-redis"`.
  *
  *   - Anything else: throws. A typoed value should fail loudly at
  *     boot rather than silently fall back to the noop store and
@@ -32,20 +33,18 @@
  * caches its connection inside the dynamically loaded module.
  *
  * Why one resolver instead of importing each factory directly: the
- * route handlers stay backend-agnostic. Adding a Redis or Upstash
- * store later means editing this file (and the dot's followup) without
- * touching the route handlers or their tests.
+ * route handlers stay backend-agnostic. Provider swaps edit this file
+ * without touching the route handlers or their tests.
  */
 
 import { createNoopStore } from "./store-noop";
 import type { LeaderboardStore } from "./types";
 
 /**
- * The set of backend tags the resolver recognises today. Adding a tag
- * (e.g. `"upstash-redis"`) requires only extending this union and the
- * switch below; the route handlers stay untouched.
+ * The set of backend tags the resolver recognises today. The route
+ * handlers stay untouched when this list changes.
  */
-export type LeaderboardBackendTag = "noop" | "vercel-kv";
+export type LeaderboardBackendTag = "noop" | "upstash-redis" | "vercel-kv";
 
 /**
  * Resolve which backend tag to use given the raw env value. Exported so
@@ -62,8 +61,11 @@ export function resolveBackendTag(
   if (normalized === "vercel-kv") {
     return "vercel-kv";
   }
+  if (normalized === "upstash-redis") {
+    return "upstash-redis";
+  }
   throw new Error(
-    `resolveBackendTag: unknown LEADERBOARD_BACKEND value "${envValue}". Known values: noop, vercel-kv`,
+    `resolveBackendTag: unknown LEADERBOARD_BACKEND value "${envValue}". Known values: noop, upstash-redis, vercel-kv`,
   );
 }
 
@@ -84,6 +86,10 @@ export async function resolveLeaderboardStore(
   switch (tag) {
     case "noop":
       return createNoopStore();
+    case "upstash-redis": {
+      const mod = await import("./store-upstash-redis");
+      return mod.createUpstashRedisStoreFromEnv();
+    }
     case "vercel-kv": {
       const mod = await import("./store-vercel-kv");
       return mod.createVercelKvStoreFromEnv();


### PR DESCRIPTION
## Summary
- provision Upstash Redis through the Vercel Marketplace for the production leaderboard backend
- add `LEADERBOARD_BACKEND=upstash-redis` runtime support with `@upstash/redis`
- document the provider, env contract, and resolved Q-011/F-069 backlog state

## GDD sections
- docs/gdd/21-technical-design-for-web-implementation.md leaderboard backend concept
- docs/gdd/24-content-plan.md online leaderboard

## Requirement inventory
- Handles GDD-21-LEADERBOARD-STORAGE-GATE by using a currently available Marketplace Redis provider after dev approval.
- Sets production Vercel env vars for `LEADERBOARD_BACKEND`, `NEXT_PUBLIC_LEADERBOARD_ENABLED`, and `LEADERBOARD_SIGNING_KEY`.
- Sets branch-scoped preview env vars for this PR branch.
- Leaves production signed-lap roundtrip verification until this PR deploys and merges, because production currently runs the prior main build.

## Progress log
- docs/PROGRESS_LOG.md slice: 2026-05-01 Upstash leaderboard production backend

## Followups and questions
- Q-011 answered.
- F-069 marked done.
- No new followups created.

## Test plan
- [x] npm run typecheck
- [x] npx vitest run src/leaderboard/__tests__/store.test.ts src/leaderboard/__tests__/store-vercel-kv.test.ts
- [x] npm run docs:check
- [x] npm run lint
- [x] npm run test
- [x] npm run content-lint
- [x] npm run art:check
- [x] npm run audio:check
- [x] npm run build
- [x] git diff --check
- [x] changed-file em-dash and en-dash scan clean