### PR TITLE
feat(ai): render visible opponents

### DIFF
--- a/docs/PROGRESS_LOG.md
+++ b/docs/PROGRESS_LOG.md
@@ -12,7 +12,7 @@ Correct them by adding a new entry that references the old one.
 [§15](gdd/15-cpu-opponents-and-ai.md) CPU opponents,
 [§16](gdd/16-rendering-and-visual-design.md) billboard cars, and
 [§20](gdd/20-hud-and-ui-ux.md) race HUD observability.
-**Branch / PR:** `feat/ai-visible-opponents`, PR pending.
+**Branch / PR:** `feat/ai-visible-opponents`, PR #145.
 **Status:** Implemented.
 
 ### Done
@@ -28,6 +28,9 @@ Correct them by adding a new entry that references the old one.
   the player shifts laterally toward a pass lane with a 2 m target margin.
 - Added desktop and mobile Playwright coverage that waits for a real race to
   render at least one visible AI opponent.
+- Addressed Copilot review by tightening AI car viewport culling and moving
+  opponent screen projection onto the direct car projector path to avoid
+  current-segment pop-in.
 
 ### Verified
 - `npx vitest run src/game/__tests__/raceSession.test.ts src/game/__tests__/ai.test.ts src/render/__tests__/pseudoRoadCanvas.test.ts`

--- a/docs/PROGRESS_LOG.md
+++ b/docs/PROGRESS_LOG.md
@@ -6,6 +6,63 @@ Correct them by adding a new entry that references the old one.
 
 ---
 
+## 2026-05-01: Slice: Visible AI opponents
+
+**GDD sections touched:**
+[§15](gdd/15-cpu-opponents-and-ai.md) CPU opponents,
+[§16](gdd/16-rendering-and-visual-design.md) billboard cars, and
+[§20](gdd/20-hud-and-ui-ux.md) race HUD observability.
+**Branch / PR:** `feat/ai-visible-opponents`, PR pending.
+**Status:** Implemented.
+
+### Done
+- Added a projected `aiCars` overlay contract to the pseudo-3D canvas
+  renderer so opponent cars paint over road strips and under the fixed
+  player car.
+- Projected live `/race` AI cars from the same camera and strip list that
+  renders the road, with a 200 m z-cull and a visible opponent count for
+  browser verification.
+- Routed opponent overlays through the existing per-car sprite-set registry
+  and atlas loader, with distinct fallback fills while sheets load.
+- Added deterministic overtake intent to `tickAI`: a trailing AI that reaches
+  the player shifts laterally toward a pass lane with a 2 m target margin.
+- Added desktop and mobile Playwright coverage that waits for a real race to
+  render at least one visible AI opponent.
+
+### Verified
+- `npx vitest run src/game/__tests__/raceSession.test.ts src/game/__tests__/ai.test.ts src/render/__tests__/pseudoRoadCanvas.test.ts`
+  green, 213 tests passed.
+- `npm run verify` green, 2744 Vitest tests passed.
+- `npm run typecheck` green.
+- `npm run lint` green.
+- `npm run docs:check` green.
+- `npm run content-lint` green.
+- `git diff --check` green.
+- `npx playwright test e2e/race-ai-visible.spec.ts` green, 2 tests passed.
+
+### Decisions and assumptions
+- Used screen-space projected opponent overlays instead of adding a separate
+  renderer transform. The projection source remains the road strip list from
+  `segmentProjector.project`, so cars and road share one camera contract.
+- Used a 200 m opponent draw cutoff to match the active dot and keep distant
+  sprite scale readable without increasing the road draw window.
+- Assigned AI car sprite sets by grid index until the GDD gains explicit
+  per-driver car selections.
+
+### Coverage ledger
+- GDD-15-AI-VISIBLE-OPPONENTS now covers rendered CPU cars, projected
+  opponent z-culling, visible overtake lane intent, and browser coverage.
+- Uncovered adjacent requirements: per-driver car ownership and full
+  hand-authored production car art remain covered by the existing art dot.
+
+### Followups created
+None.
+
+### GDD edits
+None.
+
+---
+
 ## 2026-05-01: Slice: Upstash leaderboard production backend
 
 **GDD sections touched:**

--- a/e2e/race-ai-visible.spec.ts
+++ b/e2e/race-ai-visible.spec.ts
@@ -1,0 +1,30 @@
+import { expect, test } from "@playwright/test";
+
+async function expectVisibleAi(page: import("@playwright/test").Page): Promise<void> {
+  await page.goto("/race?track=test/straight");
+  await expect(page.getByTestId("race-phase")).toHaveText("racing", {
+    timeout: 8_000,
+  });
+  await expect
+    .poll(
+      async () => {
+        const text = await page.getByTestId("race-visible-ai-count").textContent();
+        return Number.parseInt(text ?? "0", 10);
+      },
+      { timeout: 25_000 },
+    )
+    .toBeGreaterThan(0);
+  await expect(page.getByTestId("race-field-size")).not.toHaveText("1");
+}
+
+test.describe("race AI visibility", () => {
+  test("renders an opponent car on desktop", async ({ page }) => {
+    await page.setViewportSize({ width: 1280, height: 900 });
+    await expectVisibleAi(page);
+  });
+
+  test("renders an opponent car on mobile", async ({ page }) => {
+    await page.setViewportSize({ width: 390, height: 844 });
+    await expectVisibleAi(page);
+  });
+});

--- a/src/app/race/page.tsx
+++ b/src/app/race/page.tsx
@@ -120,16 +120,16 @@ import type { DailyChallengeSelection } from "@/game/modes/dailyChallenge";
 import {
   CAMERA_DEPTH,
   CAMERA_HEIGHT,
-  ROAD_WIDTH,
   SEGMENT_LENGTH,
   fitToBox,
   project,
   projectCar,
+  projectGhostCar,
   upcomingCurvature,
   type Camera,
+  type CompiledSegment,
   type CompiledTrack,
   type MinimapPoint,
-  type Strip,
   type Viewport,
 } from "@/road";
 import { drawRoad, type DrawRoadOptions } from "@/render/pseudoRoadCanvas";
@@ -572,7 +572,8 @@ function projectOpponentCar(input: {
   carX: number;
   carZ: number;
   camera: Camera;
-  strips: readonly Strip[];
+  segments: readonly CompiledSegment[];
+  viewport: Viewport;
   trackLength: number;
   atlas: LoadedAtlas | null;
   spriteSet: CarSpriteSet;
@@ -588,19 +589,19 @@ function projectOpponentCar(input: {
   if (depthMeters > 200) return null;
   if (!Number.isFinite(input.trackLength) || input.trackLength <= 0) return null;
 
-  const wrappedZ = ((input.carZ % input.trackLength) + input.trackLength) % input.trackLength;
-  const segmentIndex = Math.floor(wrappedZ / SEGMENT_LENGTH);
-  const strip = input.strips.find(
-    (candidate) => candidate.visible && candidate.segment.index === segmentIndex,
+  const projection = projectGhostCar(
+    input.segments,
+    input.camera,
+    input.viewport,
+    input.carZ,
+    input.carX,
   );
-  if (!strip || strip.screenW <= 0) return null;
+  if (!projection.visible || projection.screenW <= 0) return null;
 
-  const lateral = input.carX / ROAD_WIDTH;
-  const screenX = strip.screenX + lateral * strip.screenW;
-  const screenW = Math.max(16, Math.min(92, strip.screenW * 0.3));
+  const screenW = Math.max(16, Math.min(92, projection.screenW * 0.3));
   return {
-    screenX,
-    screenY: strip.screenY,
+    screenX: projection.screenX,
+    screenY: projection.screenY,
     screenW,
     depthMeters,
     atlas: input.atlas,
@@ -1433,7 +1434,8 @@ function RaceCanvas({
               carX: entry.car.x,
               carZ: entry.car.z,
               camera,
-              strips,
+              segments: track.compiled.segments,
+              viewport,
               trackLength: track.compiled.totalLengthMeters,
               atlas: aiCarAtlasesRef.current[aiSpriteSetId] ?? null,
               spriteSet: carSpriteSetForVisualProfile(aiSpriteSetId),

--- a/src/app/race/page.tsx
+++ b/src/app/race/page.tsx
@@ -54,6 +54,8 @@ import {
   loadTrack,
 } from "@/data";
 import {
+  CAR_SPRITE_SET_IDS,
+  type CarSpriteSetId,
   carAtlasMetaForVisualProfile,
   carSpriteSetForVisualProfile,
 } from "@/data/atlas/carSprites";
@@ -118,6 +120,7 @@ import type { DailyChallengeSelection } from "@/game/modes/dailyChallenge";
 import {
   CAMERA_DEPTH,
   CAMERA_HEIGHT,
+  ROAD_WIDTH,
   SEGMENT_LENGTH,
   fitToBox,
   project,
@@ -126,9 +129,10 @@ import {
   type Camera,
   type CompiledTrack,
   type MinimapPoint,
+  type Strip,
   type Viewport,
 } from "@/road";
-import { drawRoad } from "@/render/pseudoRoadCanvas";
+import { drawRoad, type DrawRoadOptions } from "@/render/pseudoRoadCanvas";
 import { playerCarFrameIndex } from "@/render/carFrame";
 import type { CarSpriteSet } from "@/render/carSpriteCompositor";
 import {
@@ -181,6 +185,14 @@ const DEFAULT_TRACK_ID = "test/elevation";
 const TOUR_PLACEHOLDER_TRACK_ID = "test/straight";
 const WORLD_TOUR_CHAMPIONSHIP_ID = "world-tour-standard";
 const PLAYER_ID = "player";
+const AI_FALLBACK_FILLS = Object.freeze([
+  "#ff6b5f",
+  "#63d471",
+  "#5fb6ff",
+  "#f7d154",
+  "#d980ff",
+  "#ff9f43",
+]);
 
 /**
  * §20 minimap layout. The wireframe places the minimap in the bottom-left
@@ -556,6 +568,57 @@ function toMinimapCar(
   return { x, y, isPlayer };
 }
 
+function projectOpponentCar(input: {
+  carX: number;
+  carZ: number;
+  camera: Camera;
+  strips: readonly Strip[];
+  trackLength: number;
+  atlas: LoadedAtlas | null;
+  spriteSet: CarSpriteSet;
+  fill?: string;
+  frameIndex: number;
+  braking: boolean;
+  nitroActive: boolean;
+  speedMetersPerSecond: number;
+  damageTotal: number;
+}): NonNullable<DrawRoadOptions["aiCars"]>[number] | null {
+  const depthMeters = input.carZ - input.camera.z;
+  if (!Number.isFinite(depthMeters) || depthMeters < input.camera.depth) return null;
+  if (depthMeters > 200) return null;
+  if (!Number.isFinite(input.trackLength) || input.trackLength <= 0) return null;
+
+  const wrappedZ = ((input.carZ % input.trackLength) + input.trackLength) % input.trackLength;
+  const segmentIndex = Math.floor(wrappedZ / SEGMENT_LENGTH);
+  const strip = input.strips.find(
+    (candidate) => candidate.visible && candidate.segment.index === segmentIndex,
+  );
+  if (!strip || strip.screenW <= 0) return null;
+
+  const lateral = input.carX / ROAD_WIDTH;
+  const screenX = strip.screenX + lateral * strip.screenW;
+  const screenW = Math.max(16, Math.min(92, strip.screenW * 0.3));
+  return {
+    screenX,
+    screenY: strip.screenY,
+    screenW,
+    depthMeters,
+    atlas: input.atlas,
+    spriteSet: input.spriteSet,
+    fill: input.fill,
+    frameIndex: input.frameIndex,
+    braking: input.braking,
+    nitroActive: input.nitroActive,
+    speedMetersPerSecond: input.speedMetersPerSecond,
+    damageTotal: input.damageTotal,
+  };
+}
+
+function aiSpriteSetIdForGridIndex(index: number): CarSpriteSetId {
+  const offset = index + 1;
+  return CAR_SPRITE_SET_IDS[offset % CAR_SPRITE_SET_IDS.length]!;
+}
+
 /**
  * Race-finish wallet commit per F-034. Credits the §12 reward (placement
  * payout + §5 bonuses) into the persisted save, persists the new save
@@ -783,6 +846,7 @@ function RaceCanvas({
   const lastBrakeRef = useRef<number>(0);
   const pauseInputHeldRef = useRef<boolean>(false);
   const carAtlasRef = useRef<LoadedAtlas | null>(null);
+  const aiCarAtlasesRef = useRef<Partial<Record<CarSpriteSetId, LoadedAtlas>>>({});
   const carSpriteSetRef = useRef<CarSpriteSet>(
     carSpriteSetForVisualProfile("sparrow_gt"),
   );
@@ -827,6 +891,7 @@ function RaceCanvas({
     checkpointReady: boolean;
   } | null>(null);
   const [fieldSize, setFieldSize] = useState<number>(1);
+  const [aiVisibleCount, setAiVisibleCount] = useState<number>(0);
   const [touchLayout, setTouchLayout] = useState<TouchLayout>(() =>
     touchLayoutFor({ width: VIEWPORT_WIDTH, height: VIEWPORT_HEIGHT }),
   );
@@ -846,6 +911,15 @@ function RaceCanvas({
         if (active) carAtlasRef.current = atlas;
       },
     );
+    aiCarAtlasesRef.current = {};
+    void Promise.all(
+      CAR_SPRITE_SET_IDS.map(async (id) => {
+        const atlas = await loadAtlas(carAtlasMetaForVisualProfile(id));
+        return [id, atlas] as const;
+      }),
+    ).then((entries) => {
+      if (active) aiCarAtlasesRef.current = Object.fromEntries(entries);
+    });
     return () => {
       active = false;
     };
@@ -1352,6 +1426,37 @@ function RaceCanvas({
           lastSteerRef.current,
           upcomingCurvature(track.compiled.segments, camera.z, SEGMENT_LENGTH * 5),
         );
+        const aiCars = session.ai
+          .map((entry, index) => {
+            const aiSpriteSetId = aiSpriteSetIdForGridIndex(index);
+            return projectOpponentCar({
+              carX: entry.car.x,
+              carZ: entry.car.z,
+              camera,
+              strips,
+              trackLength: track.compiled.totalLengthMeters,
+              atlas: aiCarAtlasesRef.current[aiSpriteSetId] ?? null,
+              spriteSet: carSpriteSetForVisualProfile(aiSpriteSetId),
+              fill: AI_FALLBACK_FILLS[index % AI_FALLBACK_FILLS.length],
+              frameIndex: playerCarFrameIndex(
+                0,
+                upcomingCurvature(
+                  track.compiled.segments,
+                  entry.car.z,
+                  SEGMENT_LENGTH * 5,
+                ),
+              ),
+              braking: entry.state.targetSpeed < entry.car.speed - 1,
+              nitroActive: entry.nitro.activeRemainingSec > 0,
+              speedMetersPerSecond: entry.car.speed,
+              damageTotal: entry.damage.total,
+            });
+          })
+          .filter(
+            (car): car is NonNullable<DrawRoadOptions["aiCars"]>[number] =>
+              car !== null,
+          );
+        setAiVisibleCount(aiCars.length);
         if (
           ghostEnabled &&
           session.race.phase === "racing" &&
@@ -1392,6 +1497,7 @@ function RaceCanvas({
             intensityScale: tunnelOcclusion(tunnelState),
           },
           spriteDensityFactor: graphics.spriteDensityFactor,
+          aiCars,
           ghostCar: ghostOverlayRef.current
             ? {
                 ...ghostOverlayRef.current,
@@ -1701,6 +1807,8 @@ function RaceCanvas({
         <dd data-testid="hud-position">{hudSnapshot.position}</dd>
         <dt>Field size:</dt>
         <dd data-testid="race-field-size">{fieldSize}</dd>
+        <dt>Visible AI:</dt>
+        <dd data-testid="race-visible-ai-count">{aiVisibleCount}</dd>
         <dt>Touch active:</dt>
         <dd data-testid="race-touch-active">
           {inputSnapshot.touchActive ? "yes" : "no"}

--- a/src/game/__tests__/ai.test.ts
+++ b/src/game/__tests__/ai.test.ts
@@ -356,7 +356,7 @@ describe("tickAI (§15 archetype behaviours)", () => {
     const bully = archetypeDriver("aggressive", { aggression: 1 });
     const aiCar = freshCar({ x: 0, z: 300, speed: 30 });
     const playerNearbyRight: PlayerView = {
-      car: freshCar({ x: 3, z: 312, speed: 30 }),
+      car: freshCar({ x: 3, z: 300, speed: 30 }),
     };
     const cleanTick = tickAI(
       clean,
@@ -385,7 +385,7 @@ describe("tickAI (§15 archetype behaviours)", () => {
     const bully = archetypeDriver("aggressive", { aggression: 1 });
     const aiCar = freshCar({ x: 1, z: 300, speed: 30 });
     const playerNearbyLeft: PlayerView = {
-      car: freshCar({ x: 0.5, z: 312, speed: 30 }),
+      car: freshCar({ x: 0.5, z: 300, speed: 30 }),
     };
     const cleanTick = tickAI(
       clean,
@@ -461,6 +461,44 @@ describe("tickAI (§15 archetype behaviours)", () => {
     expect(countSteeringMistakes(chaotic)).toBeGreaterThan(
       countSteeringMistakes(enduro),
     );
+  });
+});
+
+describe("tickAI (visible overtake intent)", () => {
+  it("moves laterally when a trailing AI reaches the player", () => {
+    const playerAhead: PlayerView = {
+      car: freshCar({ x: 0, z: 112, speed: 28 }),
+    };
+    const result = tickAI(
+      CLEAN_LINE_DRIVER,
+      freshAi(),
+      freshCar({ x: 0, z: 100, speed: 30 }),
+      playerAhead,
+      STRAIGHT_TRACK,
+      RACING,
+      STARTER_STATS,
+    );
+
+    expect(result.nextAiState.intent).toBe("overtake");
+    expect(result.input.steer).toBeGreaterThan(0);
+  });
+
+  it("keeps a 2 m target margin from the player line during a pass", () => {
+    const playerAheadLeft: PlayerView = {
+      car: freshCar({ x: -1, z: 112, speed: 28 }),
+    };
+    const result = tickAI(
+      CLEAN_LINE_DRIVER,
+      freshAi(),
+      freshCar({ x: -1, z: 100, speed: 30 }),
+      playerAheadLeft,
+      STRAIGHT_TRACK,
+      RACING,
+      STARTER_STATS,
+    );
+
+    expect(result.nextAiState.intent).toBe("overtake");
+    expect(result.input.steer).toBe(1);
   });
 });
 

--- a/src/game/__tests__/raceSession.test.ts
+++ b/src/game/__tests__/raceSession.test.ts
@@ -2082,20 +2082,21 @@ describe("stepRaceSession (§28 difficulty preset wiring, F-042)", () => {
     // cars run their own controller without scalar bias. Two sessions
     // with different player presets should leave the AI car at the
     // same lateral position after a short on-road burst.
-    const STEER_GENTLE: Input = { ...NEUTRAL_INPUT, throttle: 1, steer: 0.2 };
     const cfgEasy = buildConfig({
       countdownSec: 0,
       player: { stats: STARTER_STATS, difficultyPreset: "easy" },
+      ai: [{ driver: TEST_DRIVER, stats: STARTER_STATS, initial: { z: -80 } }],
     });
     const cfgHard = buildConfig({
       countdownSec: 0,
       player: { stats: STARTER_STATS, difficultyPreset: "hard" },
+      ai: [{ driver: TEST_DRIVER, stats: STARTER_STATS, initial: { z: -80 } }],
     });
     let easy = createRaceSession(cfgEasy);
     let hard = createRaceSession(cfgHard);
     for (let i = 0; i < 30; i += 1) {
-      easy = stepRaceSession(easy, STEER_GENTLE, cfgEasy, DT);
-      hard = stepRaceSession(hard, STEER_GENTLE, cfgHard, DT);
+      easy = stepRaceSession(easy, NEUTRAL_INPUT, cfgEasy, DT);
+      hard = stepRaceSession(hard, NEUTRAL_INPUT, cfgHard, DT);
     }
     expect(easy.ai[0]?.car.x).toBeCloseTo(hard.ai[0]?.car.x ?? Number.NaN, 6);
     expect(easy.ai[0]?.car.z).toBeCloseTo(hard.ai[0]?.car.z ?? Number.NaN, 6);

--- a/src/game/ai.ts
+++ b/src/game/ai.ts
@@ -197,6 +197,12 @@ export const AI_TUNING = Object.freeze({
   ROCKET_FADE_FRACTION: 0.72,
   /** Player gap where archetype lane pressure can engage. */
   TRAFFIC_PRESSURE_WINDOW_METERS: 36,
+  /** Gap where a trailing AI can start a visible lane move. */
+  OVERTAKE_WINDOW_METERS: 28,
+  /** Lateral overtake target in meters. */
+  OVERTAKE_LANE_SHIFT_METERS: 3,
+  /** Minimum lateral space from the player target line during a pass. */
+  OVERTAKE_PLAYER_MARGIN_METERS: 2,
 });
 
 /**
@@ -290,7 +296,12 @@ export function tickAI(
     player.car,
     context.roadHalfWidth,
   );
-  const idealOffsetWithTraffic = rawIdealOffset + trafficLaneOffset;
+  const overtake = overtakeOffset(
+    aiCar,
+    player.car,
+    context.roadHalfWidth,
+  );
+  const idealOffsetWithTraffic = rawIdealOffset + trafficLaneOffset + overtake.offset;
   const baseIdealLateralOffset = clamp(
     idealOffsetWithTraffic === 0 ? 0 : idealOffsetWithTraffic,
     -context.roadHalfWidth,
@@ -385,7 +396,7 @@ export function tickAI(
     progress: aiCar.z / SEGMENT_LENGTH,
     laneOffset: aiCar.x,
     speed: aiCar.speed,
-    intent: aiState.intent,
+    intent: overtake.active ? "overtake" : aiState.intent === "overtake" ? "recover" : aiState.intent,
     targetSpeed,
     seed: nextSeed,
   };
@@ -486,6 +497,38 @@ function trafficPressureOffset(
     1,
   );
   return direction * pressure * clamp(aggression, 0, 1) * closeness;
+}
+
+function overtakeOffset(
+  aiCar: Readonly<CarState>,
+  playerCar: Readonly<CarState>,
+  roadHalfWidth: number,
+): { active: boolean; offset: number } {
+  const gap = playerCar.z - aiCar.z;
+  if (gap <= 0 || gap > AI_TUNING.OVERTAKE_WINDOW_METERS) {
+    return { active: false, offset: 0 };
+  }
+  if (aiCar.speed + 1 < playerCar.speed) {
+    return { active: false, offset: 0 };
+  }
+  const passSide = playerCar.x <= 0 ? 1 : -1;
+  const desiredTarget =
+    playerCar.x + passSide * AI_TUNING.OVERTAKE_PLAYER_MARGIN_METERS;
+  const boundedTarget = clamp(
+    desiredTarget,
+    -roadHalfWidth + AI_TUNING.OVERTAKE_PLAYER_MARGIN_METERS,
+    roadHalfWidth - AI_TUNING.OVERTAKE_PLAYER_MARGIN_METERS,
+  );
+  const directionalTarget =
+    passSide * Math.min(AI_TUNING.OVERTAKE_LANE_SHIFT_METERS, roadHalfWidth);
+  const target =
+    Math.abs(boundedTarget - playerCar.x) >= AI_TUNING.OVERTAKE_PLAYER_MARGIN_METERS
+      ? boundedTarget
+      : directionalTarget;
+  return {
+    active: true,
+    offset: clamp(target - aiCar.x, -AI_TUNING.OVERTAKE_LANE_SHIFT_METERS, AI_TUNING.OVERTAKE_LANE_SHIFT_METERS),
+  };
 }
 
 // Numeric helpers ----------------------------------------------------------

--- a/src/render/__tests__/pseudoRoadCanvas.test.ts
+++ b/src/render/__tests__/pseudoRoadCanvas.test.ts
@@ -26,6 +26,8 @@ import { PaletteCache } from "../paletteCache";
 import type { LoadedAtlas } from "../spriteAtlas";
 
 import {
+  AI_CAR_DEFAULT_ALPHA,
+  AI_CAR_DEFAULT_FILL,
   GHOST_CAR_DEFAULT_ALPHA,
   GHOST_CAR_DEFAULT_FILL,
   HEAT_SHIMMER_BAND_COUNT,
@@ -548,6 +550,79 @@ describe("drawRoad ghost car overlay", () => {
         c.type === "fillRect" && c.w === 40 && c.h === 20,
     );
     expect(ghostRect).toBeUndefined();
+  });
+});
+
+describe("drawRoad AI car overlays", () => {
+  it("draws projected AI fallback cars from far to near", () => {
+    const spy = makeCanvasSpy();
+    drawRoad(spy.ctx, EMPTY_STRIPS, VIEWPORT, {
+      aiCars: [
+        { screenX: 430, screenY: 300, screenW: 50, depthMeters: 24, fill: "#00ff00" },
+        { screenX: 410, screenY: 210, screenW: 30, depthMeters: 80 },
+      ],
+    });
+
+    const carBodies = spy.calls.filter(
+      (c): c is FillCall =>
+        c.type === "fill" &&
+        (c.fillStyle === AI_CAR_DEFAULT_FILL || c.fillStyle === "#00ff00"),
+    );
+    expect(carBodies).toHaveLength(2);
+    expect(carBodies[0]!.fillStyle).toBe(AI_CAR_DEFAULT_FILL);
+    expect(carBodies[0]!.globalAlpha).toBeCloseTo(AI_CAR_DEFAULT_ALPHA, 6);
+    expect(carBodies[1]!.fillStyle).toBe("#00ff00");
+  });
+
+  it("draws projected AI cars from the loaded atlas when available", () => {
+    const spy = makeCanvasSpy();
+    drawRoad(spy.ctx, EMPTY_STRIPS, VIEWPORT, {
+      aiCars: [
+        {
+          screenX: 220,
+          screenY: 260,
+          screenW: 64,
+          depthMeters: 60,
+          atlas: loadedCustomCarAtlas(),
+          spriteSet: {
+            clean: "custom_clean",
+            damage1: "custom_dented",
+            damage2: "custom_battered",
+            damage3: "custom_totaled",
+            brake: "custom_brake",
+            nitro: "custom_nitro",
+            wetTrail: "custom_wet_trail",
+            snowTrail: "custom_snow_trail",
+          },
+          frameIndex: 1,
+          braking: true,
+          speedMetersPerSecond: 20,
+        },
+      ],
+    });
+
+    const draws = spy.calls.filter((c): c is DrawImageCall => c.type === "drawImage");
+    expect(draws.length).toBeGreaterThanOrEqual(2);
+    expect(draws[0]!.sx).toBe(11);
+    expect(draws[0]!.sy).toBe(0);
+    expect(draws[0]!.globalAlpha).toBeCloseTo(AI_CAR_DEFAULT_ALPHA, 6);
+    expect(draws.some((draw) => draw.sx === 40)).toBe(true);
+  });
+
+  it("skips projected AI cars outside the viewport contract", () => {
+    const spy = makeCanvasSpy();
+    drawRoad(spy.ctx, EMPTY_STRIPS, VIEWPORT, {
+      aiCars: [
+        { screenX: Number.NaN, screenY: 200, screenW: 40, depthMeters: 20 },
+        { screenX: 100, screenY: 200, screenW: 0, depthMeters: 20 },
+        { screenX: 100, screenY: 200, screenW: 40, depthMeters: -1 },
+      ],
+    });
+
+    const carBodies = spy.calls.filter(
+      (c): c is FillCall => c.type === "fill" && c.fillStyle === AI_CAR_DEFAULT_FILL,
+    );
+    expect(carBodies).toHaveLength(0);
   });
 });
 

--- a/src/render/__tests__/pseudoRoadCanvas.test.ts
+++ b/src/render/__tests__/pseudoRoadCanvas.test.ts
@@ -616,6 +616,7 @@ describe("drawRoad AI car overlays", () => {
         { screenX: Number.NaN, screenY: 200, screenW: 40, depthMeters: 20 },
         { screenX: 100, screenY: 200, screenW: 0, depthMeters: 20 },
         { screenX: 100, screenY: 200, screenW: 40, depthMeters: -1 },
+        { screenX: VIEWPORT.width + 30, screenY: 200, screenW: 40, depthMeters: 20 },
       ],
     });
 

--- a/src/render/pseudoRoadCanvas.ts
+++ b/src/render/pseudoRoadCanvas.ts
@@ -466,19 +466,27 @@ function isDrawableProjectedCar(
   car: NonNullable<DrawRoadOptions["aiCars"]>[number],
   viewport: Viewport,
 ): boolean {
+  if (
+    !(
+      viewport.width > 0 &&
+      viewport.height > 0 &&
+      Number.isFinite(car.screenX) &&
+      Number.isFinite(car.screenY) &&
+      Number.isFinite(car.screenW) &&
+      car.screenW > 0 &&
+      Number.isFinite(car.depthMeters) &&
+      car.depthMeters > 0
+    )
+  ) {
+    return false;
+  }
+
+  const halfW = car.screenW / 2;
   return (
-    viewport.width > 0 &&
-    viewport.height > 0 &&
-    Number.isFinite(car.screenX) &&
-    Number.isFinite(car.screenY) &&
-    Number.isFinite(car.screenW) &&
-    car.screenW > 0 &&
-    Number.isFinite(car.depthMeters) &&
-    car.depthMeters > 0 &&
     car.screenY >= -viewport.height * 0.2 &&
     car.screenY <= viewport.height * 1.15 &&
-    car.screenX + car.screenW >= 0 &&
-    car.screenX - car.screenW <= viewport.width
+    car.screenX + halfW >= 0 &&
+    car.screenX - halfW <= viewport.width
   );
 }
 

--- a/src/render/pseudoRoadCanvas.ts
+++ b/src/render/pseudoRoadCanvas.ts
@@ -79,6 +79,9 @@ export const PLAYER_CAR_DEFAULT_SHADOW = "rgba(0, 0, 0, 0.55)";
 export const PLAYER_CAR_DEFAULT_WINDSHIELD = "#18243d";
 export const PLAYER_CAR_DEFAULT_TIRE = "#10151f";
 export const PLAYER_CAR_DEFAULT_TAIL_LIGHT = "#ff3d38";
+export const AI_CAR_DEFAULT_ALPHA = 0.95;
+export const AI_CAR_DEFAULT_FILL = "#ff6b5f";
+export const AI_CAR_DEFAULT_SHADOW = "rgba(0, 0, 0, 0.45)";
 
 /**
  * Standard player-car footprint. §16 pins the player car at 16 to 22
@@ -233,6 +236,26 @@ export interface DrawRoadOptions {
     spriteId?: string;
     frameIndex?: number;
   } | null;
+  /**
+   * Optional opponent car overlays. Callers project these with the same
+   * camera and strips as the road, then the drawer paints them in depth
+   * order over the road and under the fixed player car.
+   */
+  aiCars?: readonly {
+    screenX: number;
+    screenY: number;
+    screenW: number;
+    depthMeters: number;
+    alpha?: number;
+    fill?: string;
+    atlas?: LoadedAtlas | null;
+    frameIndex?: number;
+    braking?: boolean;
+    nitroActive?: boolean;
+    speedMetersPerSecond?: number;
+    damageTotal?: number;
+    spriteSet?: CarSpriteSet;
+  }[] | null;
   /**
    * Optional live player car overlay. Pseudo-3D road strips represent the
    * world moving under a chase camera, so the player car is drawn as a
@@ -391,6 +414,10 @@ export function drawRoad(
     }
   }
 
+  if (options.aiCars && options.aiCars.length > 0) {
+    drawAICars(ctx, options.aiCars, viewport);
+  }
+
   // Ghost car paints over the road strips so the player sees their best
   // line, but BEFORE the dust pool so off-road dust the live car kicks
   // up still occludes the ghost rather than the ghost showing through
@@ -418,6 +445,110 @@ export function drawRoad(
 
   if (options.playerCar) {
     drawPlayerCar(ctx, options.playerCar, viewport);
+  }
+}
+
+function drawAICars(
+  ctx: CanvasRenderingContext2D,
+  cars: NonNullable<DrawRoadOptions["aiCars"]>,
+  viewport: Viewport,
+): void {
+  const ordered = cars
+    .filter((car) => isDrawableProjectedCar(car, viewport))
+    .slice()
+    .sort((a, b) => b.depthMeters - a.depthMeters);
+  for (const car of ordered) {
+    drawProjectedAICar(ctx, car);
+  }
+}
+
+function isDrawableProjectedCar(
+  car: NonNullable<DrawRoadOptions["aiCars"]>[number],
+  viewport: Viewport,
+): boolean {
+  return (
+    viewport.width > 0 &&
+    viewport.height > 0 &&
+    Number.isFinite(car.screenX) &&
+    Number.isFinite(car.screenY) &&
+    Number.isFinite(car.screenW) &&
+    car.screenW > 0 &&
+    Number.isFinite(car.depthMeters) &&
+    car.depthMeters > 0 &&
+    car.screenY >= -viewport.height * 0.2 &&
+    car.screenY <= viewport.height * 1.15 &&
+    car.screenX + car.screenW >= 0 &&
+    car.screenX - car.screenW <= viewport.width
+  );
+}
+
+function drawProjectedAICar(
+  ctx: CanvasRenderingContext2D,
+  car: NonNullable<DrawRoadOptions["aiCars"]>[number],
+): void {
+  const alpha =
+    typeof car.alpha === "number" && Number.isFinite(car.alpha)
+      ? Math.max(0, Math.min(1, car.alpha))
+      : AI_CAR_DEFAULT_ALPHA;
+  if (alpha <= 0) return;
+
+  if (car.atlas?.image) {
+    const frames = resolveCarRenderFrames(
+      car.atlas,
+      selectCarFramePlan({
+        frameIndex: car.frameIndex ?? 0,
+        braking: car.braking === true,
+        nitroActive: car.nitroActive === true,
+        speedMetersPerSecond: car.speedMetersPerSecond ?? 0,
+        damageTotal: car.damageTotal ?? 0,
+        spriteSet: car.spriteSet,
+      }),
+    );
+    if (frames) {
+      drawAtlasCarFrame(ctx, car.atlas.image, frames.base, car.screenX, car.screenY, car.screenW, alpha);
+      if (frames.trailOverlay) {
+        drawAtlasCarFrame(ctx, car.atlas.image, frames.trailOverlay, car.screenX, car.screenY, car.screenW, alpha);
+      }
+      if (frames.brakeOverlay) {
+        drawAtlasCarFrame(ctx, car.atlas.image, frames.brakeOverlay, car.screenX, car.screenY, car.screenW, alpha);
+      }
+      if (frames.nitroOverlay) {
+        drawAtlasCarFrame(ctx, car.atlas.image, frames.nitroOverlay, car.screenX, car.screenY, car.screenW, alpha);
+      }
+      if (frames.damageOverlay) {
+        drawAtlasCarFrame(ctx, car.atlas.image, frames.damageOverlay, car.screenX, car.screenY, car.screenW, alpha);
+      }
+      return;
+    }
+  }
+
+  const height = car.screenW * 0.52;
+  const halfW = car.screenW / 2;
+  const bottomY = car.screenY;
+  const topY = bottomY - height;
+  const prevAlpha = ctx.globalAlpha;
+  const prevFill = ctx.fillStyle;
+  try {
+    ctx.globalAlpha = alpha;
+    ctx.fillStyle = AI_CAR_DEFAULT_SHADOW;
+    ctx.fillRect(car.screenX - halfW * 0.72, bottomY - height * 0.08, car.screenW * 0.72, height * 0.16);
+    ctx.fillStyle = car.fill ?? AI_CAR_DEFAULT_FILL;
+    ctx.beginPath();
+    ctx.moveTo(car.screenX, topY);
+    ctx.lineTo(car.screenX + halfW * 0.82, bottomY - height * 0.22);
+    ctx.lineTo(car.screenX + halfW * 0.62, bottomY);
+    ctx.lineTo(car.screenX - halfW * 0.62, bottomY);
+    ctx.lineTo(car.screenX - halfW * 0.82, bottomY - height * 0.22);
+    ctx.closePath();
+    ctx.fill();
+    ctx.fillStyle = PLAYER_CAR_DEFAULT_WINDSHIELD;
+    ctx.fillRect(car.screenX - halfW * 0.28, topY + height * 0.35, halfW * 0.56, height * 0.24);
+    ctx.fillStyle = PLAYER_CAR_DEFAULT_TAIL_LIGHT;
+    ctx.fillRect(car.screenX - halfW * 0.46, bottomY - height * 0.18, halfW * 0.28, height * 0.08);
+    ctx.fillRect(car.screenX + halfW * 0.18, bottomY - height * 0.18, halfW * 0.28, height * 0.08);
+  } finally {
+    ctx.globalAlpha = prevAlpha;
+    ctx.fillStyle = prevFill;
   }
 }
 


### PR DESCRIPTION
## Summary
- Render live CPU opponents on the pseudo-3D road using the same projected strip camera as the road.
- Add deterministic overtake lane intent so trailing AI shifts visibly when it reaches the player.
- Add desktop and mobile e2e coverage for visible AI in a real race.

## GDD links
- docs/gdd/15-cpu-opponents-and-ai.md
- docs/gdd/16-rendering-and-visual-design.md
- docs/gdd/20-hud-and-ui-ux.md

## Requirement inventory
- Handles rendered CPU cars in /race.
- Handles 200 m opponent z-culling.
- Handles visible overtake lane motion with a 2 m target margin.
- Leaves per-driver car ownership and final production car art to the existing art dot.

## Progress log
- docs/PROGRESS_LOG.md: Visible AI opponents

## Test plan
- [x] npx vitest run src/game/__tests__/raceSession.test.ts src/game/__tests__/ai.test.ts src/render/__tests__/pseudoRoadCanvas.test.ts
- [x] npm run verify
- [x] npx playwright test e2e/race-ai-visible.spec.ts
- [x] git diff --check
- [x] changed-file dash scan for U+2014 and U+2013

## Followups
- None created.
