### PR TITLE
docs(research): audit fun factor gaps

### DIFF
--- a/docs/FUN_FACTOR_GAP_AUDIT.md
+++ b/docs/FUN_FACTOR_GAP_AUDIT.md
@@ -1,0 +1,136 @@
+# Fun Factor Gap Audit
+
+Date: 2026-05-01
+
+This audit compares the current VibeGear2 loop against the fun pillars in the
+GDD and the Top Gear 2 reference material. It is a backlog-shaping document,
+not a replacement for the GDD.
+
+## Reference Findings
+
+Top Gear 2 worked because it stacked arcade immediacy with medium-term pressure:
+opponents on screen, weather preparation, upgrade choices, damage pressure, and
+short tour blocks. The SNES manual anchors the tour structure, points economy,
+controls, weather prep, and password progression. The existing GDD already
+captures those lessons in sections 3, 4, 5, 12, 14, 15, 18, 20, and 25.
+
+The strongest external confirmation is that later reviews keep naming the same
+clusters: roughly 64 tracks across 16 countries, cash rewards feeding tires,
+engine, gearbox, armor, and nitro upgrades, weather and visibility changes,
+track obstacles, jumps, pickups, and CPU cars that create traffic instead of
+empty time trials. Sega-16 also calls out weak points we should avoid: cheap
+AI handoffs, unfair obstacle rules, repetition, and audio compromise between
+music and effects.
+
+Sources:
+- Top Gear 2 SNES manual: https://www.retrogames.cz/manualy/SNES/Top_Gear_2_-_SNES_-_Manual.pdf
+- Existing VibeGear2 GDD section 3: `docs/gdd/03-top-gear-2-research-summary.md`
+- Sega-16 review: https://www.sega-16.com/2011/02/top-gear-2/
+- GameFAQs SNES FAQ: https://gamefaqs.gamespot.com/snes/588804-top-gear-2/faqs/7418
+- GameFAQs review: https://gamefaqs.gamespot.com/snes/588804-top-gear-2/reviews/167198
+
+## Current Gap Ranking
+
+### P0: The race must feel like a race
+
+Status: improved by PR #145, but not finished.
+
+What is already present:
+- AI cars now render in live `/race`.
+- AI overtake intent has visible lateral movement.
+- Race results, damage persistence, upgrades, repairs, tire prep, weather
+  rendering, and leaderboards are wired.
+
+Remaining work:
+- AI archetypes need readable personalities.
+- AI must use nitro and weather skill visibly.
+- Finish-line feedback needs a stronger win, pass, and lap-complete moment.
+- Pickups need to make the racing line more tactical.
+
+Implementation dots:
+- `VibeGear2-feat-ai-add-573f4cda`
+- `VibeGear2-feat-race-finish-e3275ad7`
+- `VibeGear2-feat-pickups-on-9f6438bd`
+
+### P1: The first 90 seconds must sell the loop
+
+Problem: the game has many systems, but a new player should understand the
+promise before they read a menu. Within one race they should see a rival,
+spend nitro, collect or miss something, make a visible mistake, finish, earn
+cash, and see why the next garage choice matters.
+
+Implementation dots to add:
+- `feat(tuning): first-race fun pass`
+- `feat(playtest): release-fun checklist automation`
+
+Acceptance shape:
+- Browser test drives the default quick race for 90 seconds.
+- Test or trace confirms visible opponent, nitro use, at least one high-value
+  affordance such as pickup or finish event, and a route from results to garage.
+- Human playtest script records whether the next action is obvious.
+
+### P1: Track texture needs tactical objects, not just scenery
+
+Problem: weather, roadside art, parallax, and tunnels exist, but Top Gear 2's
+extra spice came from pickups, jumps, obstacles, and road furniture that made
+each track feel authored.
+
+Existing dot:
+- `VibeGear2-feat-pickups-on-9f6438bd`
+
+Follow-on candidate:
+- `feat(tracks): first-tour authored event pass`
+
+Acceptance shape:
+- Each Velvet Coast race has one memorable non-curve feature.
+- Features affect player decisions without violating readability.
+- AI and player obey the same visible rule unless the GDD explicitly says not
+  to.
+
+### P1: Production art must replace placeholder feel
+
+Existing dot:
+- `VibeGear2-feat-art-replace-176f701d`
+
+Acceptance shape:
+- All six playable cars have production-grade readable silhouettes.
+- Damage tiers and directional frames remain distinct at race scale.
+- AI cars use distinct looks, not just tint fallbacks.
+
+### P2: Audio must keep momentum without legal risk
+
+Current state: original race music and SFX exist, but the launch bar is higher
+than "sound plays." The mix needs to make nitro, passing, lap completion,
+finish, collisions, weather, and UI confirmation readable together.
+
+Implementation dot to add:
+- `feat(audio): race mix and event emphasis pass`
+
+Acceptance shape:
+- Race music and SFX play together.
+- Nitro, finish, collision, damage warning, and countdown are clearly audible.
+- Weather ambience supports mood without masking engine and event cues.
+
+## Ordered Loop Recommendation
+
+1. Finish-line moment and lap rollover polish.
+2. On-track pickups.
+3. Readable AI archetype behavior.
+4. First-race fun tuning pass.
+5. Race mix and event emphasis pass.
+6. Production car art pass.
+7. First-tour authored event pass.
+8. Release-fun checklist automation.
+
+This order moves the live race from functional to fun before spending large
+time on content and art scale-out.
+
+## Agent Checklist Before Calling A Race Slice Done
+
+- Does the player see at least one opponent or chase target?
+- Does one button create a satisfying acceleration or recovery moment?
+- Does the road ahead read clearly at speed?
+- Does the track ask for at least one decision beyond steering?
+- Does finishing give feedback that feels different from simply stopping?
+- Does the result screen make the next garage or tour action obvious?
+- Did CI, browser e2e, PR comments, main deploy, and production smoke pass?

--- a/docs/PROGRESS_LOG.md
+++ b/docs/PROGRESS_LOG.md
@@ -6,6 +6,60 @@ Correct them by adding a new entry that references the old one.
 
 ---
 
+## 2026-05-01: Slice: Top Gear 2 fun-factor gap audit
+
+**GDD sections touched:**
+[§3](gdd/03-top-gear-2-research-summary.md) research summary,
+[§4](gdd/04-player-experience-goals.md) player goals,
+[§15](gdd/15-cpu-opponents-and-ai.md) CPU opponents,
+[§18](gdd/18-sound-and-music-design.md) sound and music,
+and [§25](gdd/25-development-roadmap.md) roadmap.
+**Branch / PR:** `docs/top-gear-fun-gap-audit`, PR pending.
+**Status:** Implemented.
+
+### Done
+- Added `docs/FUN_FACTOR_GAP_AUDIT.md` to compare the current game loop
+  against the Top Gear 2 reference stack and the current VibeGear2 backlog.
+- Ranked the next release-facing gameplay slices around live race fun:
+  finish-line moment, pickups, readable AI archetypes, first-race tuning,
+  audio mix, car art, first-tour authored events, and release playtest
+  automation.
+- Identified missing implementation dots for first-race tuning, race audio
+  emphasis, first-tour authored events, and release-fun checklist automation.
+
+### Verified
+- Documentation-only slice. Ran `grep -n $'\u2014\|\u2013'` on changed
+  files.
+- `npm run docs:check` green.
+- `npm run content-lint` green.
+- `git diff --check` green.
+
+### Decisions and assumptions
+- Treated the existing GDD as the primary source of truth and used external
+  Top Gear 2 sources only to rank the backlog, not to copy specific content.
+- Recommended live-race fun before large art and content expansion because the
+  current codebase already has most systemic scaffolding wired.
+
+### Coverage ledger
+- GDD-03-FUN-GAP-AUDIT now covers the release-facing gap ranking and the
+  next implementation order for fun-factor work.
+- Uncovered adjacent requirements: the ranked slices remain unimplemented
+  until their dots land, especially pickups, AI archetype behavior, finish-line
+  feedback, race-audio emphasis, production car art, and first-tour authored
+  events.
+
+### Followups created
+- `VibeGear2-feat-tuning-first-74ba5505`: first-race fun pass.
+- `VibeGear2-feat-audio-race-a656eed2`: race mix and event emphasis pass.
+- `VibeGear2-feat-tracks-first-10ebfec0`: first-tour authored event pass.
+- `VibeGear2-feat-playtest-automate-9d148438`: automate release-fun
+  checklist.
+
+### GDD edits
+None.
+
+---
+
 ## 2026-05-01: Slice: Visible AI opponents
 
 **GDD sections touched:**

--- a/docs/PROGRESS_LOG.md
+++ b/docs/PROGRESS_LOG.md
@@ -41,14 +41,19 @@ and [§25](gdd/25-development-roadmap.md) roadmap.
   current codebase already has most systemic scaffolding wired.
 
 ### Coverage ledger
-- GDD-03-FUN-GAP-AUDIT now covers the release-facing gap ranking and the
-  next implementation order for fun-factor work.
+- This slice ranks the release-facing gaps around existing coverage ids
+  `GDD-15-AI-GRID-SPAWNER`, `GDD-18-AUDIO-ENGINE-MIXER-PRIMITIVES`,
+  `GDD-17-PLACEHOLDER-CAR-SPRITES`, `GDD-09-HAZARDS-RUNTIME`, and
+  `GDD-24-MVP-TRACK-SET`, then records the next implementation order for
+  fun-factor work.
 - Uncovered adjacent requirements: the ranked slices remain unimplemented
   until their dots land, especially pickups, AI archetype behavior, finish-line
   feedback, race-audio emphasis, production car art, and first-tour authored
   events.
 
-### Followups created
+### Followups created / tracking note
+- These implementation followups are tracked as Dots backlog slugs, not
+  `docs/FOLLOWUPS.md` entries with `F-NNN` ids.
 - `VibeGear2-feat-tuning-first-74ba5505`: first-race fun pass.
 - `VibeGear2-feat-audio-race-a656eed2`: race mix and event emphasis pass.
 - `VibeGear2-feat-tracks-first-10ebfec0`: first-tour authored event pass.


### PR DESCRIPTION
## Summary
- add docs/FUN_FACTOR_GAP_AUDIT.md as a backlog-shaping audit for Top Gear 2 style fun-factor gaps
- rank the next live-race slices: finish moment, pickups, AI archetypes, first-race tuning, audio mix, car art, first-tour authored events, and playtest automation
- create implementation dots for the missing tuning, audio, track-event, and release checklist slices

## GDD sections
- docs/gdd/03-top-gear-2-research-summary.md
- docs/gdd/04-player-experience-goals.md
- docs/gdd/15-cpu-opponents-and-ai.md
- docs/gdd/18-sound-and-music-design.md
- docs/gdd/25-development-roadmap.md

## Requirement inventory
- Covers backlog ranking and implementation order only.
- Leaves the ranked gameplay work to the new and existing implementation dots.

## Progress log
- docs/PROGRESS_LOG.md: Top Gear 2 fun-factor gap audit

## Followups
- VibeGear2-feat-tuning-first-74ba5505
- VibeGear2-feat-audio-race-a656eed2
- VibeGear2-feat-tracks-first-10ebfec0
- VibeGear2-feat-playtest-automate-9d148438

## Test plan
- [x] grep -n $'\u2014\|\u2013' docs/FUN_FACTOR_GAP_AUDIT.md docs/PROGRESS_LOG.md
- [x] npm run docs:check
- [x] npm run content-lint
- [x] git diff --check