### PR TITLE
feat(race): add finish-line moment

### DIFF
--- a/docs/PROGRESS_LOG.md
+++ b/docs/PROGRESS_LOG.md
@@ -23,6 +23,8 @@ Correct them by adding a new entry that references the old one.
   screen route takes over.
 - Delayed the natural-finish route handoff briefly so the final stinger and
   finish feedback register while preserving the existing saved-results flow.
+- Kept one-shot finish SFX alive during the finish hold, then stopped it at
+  the results route handoff.
 - Added Playwright coverage that waits for the finish moment before asserting
   the route reaches `/race/results`.
 
@@ -34,6 +36,8 @@ Correct them by adding a new entry that references the old one.
   green, 134 tests passed.
 - `npx playwright test e2e/race-finish.spec.ts --project=chromium --grep
   "natural finish on test/straight"` green.
+- `PLAYWRIGHT_CROSS_BROWSER=1 npx playwright test
+  e2e/cross-browser-smoke.spec.ts --project=cross-browser-webkit` green.
 - `git diff --check` green.
 
 ### Decisions and assumptions
@@ -42,6 +46,8 @@ Correct them by adding a new entry that references the old one.
 - Used a short page-layer hold before navigation instead of changing race
   physics after finish. This keeps the saved result snapshot and route handoff
   stable while making the finish feel intentional.
+- Addressed Copilot PR review by splitting finish teardown so the visual hold
+  does not cut off the finish stinger.
 
 ### Coverage ledger
 - Extends `GDD-18-PROCEDURAL-RACE-MILESTONE-SFX` and

--- a/docs/PROGRESS_LOG.md
+++ b/docs/PROGRESS_LOG.md
@@ -6,6 +6,58 @@ Correct them by adding a new entry that references the old one.
 
 ---
 
+## 2026-05-01: Slice: Finish-line moment and lap rollover polish
+
+**GDD sections touched:**
+[§7](gdd/07-race-rules-and-structure.md) race finish,
+[§18](gdd/18-sound-and-music-design.md) lap and results stingers,
+[§20](gdd/20-hud-and-ui-ux.md) race HUD feedback, and
+[§25](gdd/25-development-roadmap.md) roadmap.
+**Branch / PR:** `feat/race-finish-moment`, PR pending.
+**Status:** Implemented.
+
+### Done
+- Added an in-race lap-complete callout driven by the existing
+  `lapComplete` race-session event.
+- Added a centered finish moment with place-aware copy before the results
+  screen route takes over.
+- Delayed the natural-finish route handoff briefly so the final stinger and
+  finish feedback register while preserving the existing saved-results flow.
+- Added Playwright coverage that waits for the finish moment before asserting
+  the route reaches `/race/results`.
+
+### Verified
+- `grep -n $'\u2014\|\u2013'` on changed files returned no matches.
+- `npm run typecheck` green.
+- `npm run lint` green.
+- `npx vitest run src/game/__tests__/raceSession.test.ts src/audio/sfx.test.ts`
+  green, 134 tests passed.
+- `npx playwright test e2e/race-finish.spec.ts --project=chromium --grep
+  "natural finish on test/straight"` green.
+- `git diff --check` green.
+
+### Decisions and assumptions
+- Kept the deterministic race-session reducer unchanged because it already
+  emits `lapComplete` and `raceFinish` events at the right boundary.
+- Used a short page-layer hold before navigation instead of changing race
+  physics after finish. This keeps the saved result snapshot and route handoff
+  stable while making the finish feel intentional.
+
+### Coverage ledger
+- Extends `GDD-18-PROCEDURAL-RACE-MILESTONE-SFX` and
+  `GDD-16-VFX-FLASH-SHAKE` with user-visible lap and finish feedback.
+- Uncovered adjacent requirements: pickups, readable AI archetype behavior,
+  race audio emphasis, production car art, first-tour authored events, and
+  automated release-fun checklist remain in Dots.
+
+### Followups created
+None.
+
+### GDD edits
+None.
+
+---
+
 ## 2026-05-01: Slice: Top Gear 2 fun-factor gap audit
 
 **GDD sections touched:**
@@ -14,7 +66,7 @@ Correct them by adding a new entry that references the old one.
 [§15](gdd/15-cpu-opponents-and-ai.md) CPU opponents,
 [§18](gdd/18-sound-and-music-design.md) sound and music,
 and [§25](gdd/25-development-roadmap.md) roadmap.
-**Branch / PR:** `docs/top-gear-fun-gap-audit`, PR pending.
+**Branch / PR:** `docs/top-gear-fun-gap-audit`, PR #146.
 **Status:** Implemented.
 
 ### Done

--- a/e2e/race-finish.spec.ts
+++ b/e2e/race-finish.spec.ts
@@ -42,6 +42,12 @@ test.describe("race-finish wiring (F-038)", () => {
       await canvas.focus();
       await page.keyboard.down("ArrowUp");
 
+      const finishMoment = page.getByTestId("race-moment");
+      await expect(finishMoment).toHaveAttribute("data-kind", "finish", {
+        timeout: 45_000,
+      });
+      await expect(finishMoment).toContainText(/Victory|Podium|Finished/);
+
       // The natural-finish wiring tears down the loop and pushes the
       // router to /race/results once the player crosses the line. The
       // URL assertion is the load-bearing contract per the F-038

--- a/src/app/race/page.tsx
+++ b/src/app/race/page.tsx
@@ -185,6 +185,8 @@ const DEFAULT_TRACK_ID = "test/elevation";
 const TOUR_PLACEHOLDER_TRACK_ID = "test/straight";
 const WORLD_TOUR_CHAMPIONSHIP_ID = "world-tour-standard";
 const PLAYER_ID = "player";
+const LAP_MOMENT_MS = 900;
+const FINISH_MOMENT_MS = 1250;
 const AI_FALLBACK_FILLS = Object.freeze([
   "#ff6b5f",
   "#63d471",
@@ -297,6 +299,43 @@ function playRaceSfxEvents(
       });
     }
   }
+}
+
+interface RaceMoment {
+  kind: "lap" | "finish";
+  title: string;
+  detail: string;
+}
+
+function playerMomentFromEvents(
+  events: ReadonlyArray<RaceSessionAudioEvent>,
+  totalLaps: number,
+): RaceMoment | null {
+  let latest: RaceMoment | null = null;
+  for (const event of events) {
+    if (event.carId !== PLAYER_ID) continue;
+    if (event.kind === "lapComplete") {
+      const nextLap = Math.min(totalLaps, event.lap + 1);
+      latest = {
+        kind: "lap",
+        title: `Lap ${event.lap} complete`,
+        detail: `Next lap ${nextLap} / ${totalLaps}`,
+      };
+    } else if (event.kind === "raceFinish") {
+      latest = {
+        kind: "finish",
+        title: "Finish",
+        detail: "Saving results",
+      };
+    }
+  }
+  return latest;
+}
+
+function finishMomentTitle(place: number): string {
+  if (place === 1) return "Victory";
+  if (place <= 3) return "Podium";
+  return "Finished";
 }
 
 function createLayerCanvas(
@@ -860,6 +899,8 @@ function RaceCanvas({
   const exitFnRef = useRef<(() => void) | null>(null);
   const settingsFnRef = useRef<(() => void) | null>(null);
   const ghostsFnRef = useRef<(() => void) | null>(null);
+  const raceMomentTimeoutRef = useRef<number | null>(null);
+  const finishRouteTimeoutRef = useRef<number | null>(null);
   // Per-mount guard for the natural finish wiring. The render callback
   // fires every frame, so without this latch a `phase === "finished"`
   // tick would call `saveRaceResult` and `router.push` on every frame
@@ -897,6 +938,33 @@ function RaceCanvas({
     touchLayoutFor({ width: VIEWPORT_WIDTH, height: VIEWPORT_HEIGHT }),
   );
   const [resultMs, setResultMs] = useState<number | null>(null);
+  const [raceMoment, setRaceMoment] = useState<RaceMoment | null>(null);
+
+  const clearRaceMomentTimeout = useCallback(() => {
+    if (raceMomentTimeoutRef.current === null) return;
+    window.clearTimeout(raceMomentTimeoutRef.current);
+    raceMomentTimeoutRef.current = null;
+  }, []);
+
+  const clearFinishRouteTimeout = useCallback(() => {
+    if (finishRouteTimeoutRef.current === null) return;
+    window.clearTimeout(finishRouteTimeoutRef.current);
+    finishRouteTimeoutRef.current = null;
+  }, []);
+
+  const showRaceMoment = useCallback(
+    (next: RaceMoment, durationMs: number) => {
+      clearRaceMomentTimeout();
+      setRaceMoment(next);
+      if (durationMs > 0) {
+        raceMomentTimeoutRef.current = window.setTimeout(() => {
+          raceMomentTimeoutRef.current = null;
+          setRaceMoment((current) => (current === next ? null : current));
+        }, durationMs);
+      }
+    },
+    [clearRaceMomentTimeout],
+  );
 
   useEffect(() => {
     let active = true;
@@ -1214,6 +1282,7 @@ function RaceCanvas({
       unbindAudioVisibility();
     };
     const stopRaceRuntime = (): void => {
+      clearFinishRouteTimeout();
       engineAudioTeardown = true;
       unbindEngineAudio();
       handleRef.current?.stop();
@@ -1237,6 +1306,9 @@ function RaceCanvas({
     restartFnRef.current = (): void => {
       const handle = handleRef.current;
       if (!handle) return;
+      clearRaceMomentTimeout();
+      clearFinishRouteTimeout();
+      setRaceMoment(null);
       sessionRef.current = createRaceSession(config);
       resetTimeTrialRuntime();
       tunnelState = OPEN_TUNNEL_STATE;
@@ -1265,6 +1337,9 @@ function RaceCanvas({
     retireFnRef.current = (): void => {
       const session = sessionRef.current;
       if (!session) return;
+      clearRaceMomentTimeout();
+      clearFinishRouteTimeout();
+      setRaceMoment(null);
       const retired = retireRaceSession(session);
       sessionRef.current = retired;
       // Build the §20 results payload from the post-retire session
@@ -1349,16 +1424,25 @@ function RaceCanvas({
     };
 
     exitFnRef.current = (): void => {
+      clearRaceMomentTimeout();
+      clearFinishRouteTimeout();
+      setRaceMoment(null);
       stopRaceRuntime();
       router.push("/");
     };
 
     settingsFnRef.current = (): void => {
+      clearRaceMomentTimeout();
+      clearFinishRouteTimeout();
+      setRaceMoment(null);
       stopRaceRuntime();
       router.push("/options");
     };
 
     ghostsFnRef.current = (): void => {
+      clearRaceMomentTimeout();
+      clearFinishRouteTimeout();
+      setRaceMoment(null);
       stopRaceRuntime();
       router.push("/time-trial");
     };
@@ -1419,6 +1503,16 @@ function RaceCanvas({
         if (lastRaceSfxTick !== session.tick) {
           lastRaceSfxTick = session.tick;
           playRaceSfxEvents(raceSfx, session.audioEvents, persistedSettings.audio);
+          const playerMoment = playerMomentFromEvents(
+            session.audioEvents,
+            session.race.totalLaps,
+          );
+          if (playerMoment !== null) {
+            showRaceMoment(
+              playerMoment,
+              playerMoment.kind === "finish" ? 0 : LAP_MOMENT_MS,
+            );
+          }
         }
         const strips = project(track.compiled.segments, camera, viewport, {
           drawDistance: graphics.drawDistanceSegments,
@@ -1710,9 +1804,21 @@ function RaceCanvas({
                   });
             saveRaceResult(committed);
             // Tear down the loop, input, and audio bindings before the
-            // route hop. Mirrors the retire branch tear-down ordering.
+            // route hop. Keep the finish moment on screen briefly so the
+            // player gets a clear payoff before the results route takes over.
+            showRaceMoment(
+              {
+                kind: "finish",
+                title: finishMomentTitle(rankPosition(PLAYER_ID, cars)),
+                detail: `Total ${session.race.elapsed.toFixed(2)} s`,
+              },
+              0,
+            );
             stopRaceRuntime();
-            router.push("/race/results");
+            finishRouteTimeoutRef.current = window.setTimeout(() => {
+              finishRouteTimeoutRef.current = null;
+              router.push("/race/results");
+            }, FINISH_MOMENT_MS);
           }
         } else if (lastCountdownSfxStep !== 0) {
           lastCountdownSfxStep = 0;
@@ -1753,6 +1859,8 @@ function RaceCanvas({
     return () => {
       window.removeEventListener("resize", resize);
       window.visualViewport?.removeEventListener("resize", resize);
+      clearRaceMomentTimeout();
+      clearFinishRouteTimeout();
       stopRaceRuntime();
     };
   }, [
@@ -1768,6 +1876,9 @@ function RaceCanvas({
     selectedCarId,
     dailyChallenge,
     ghostSource,
+    showRaceMoment,
+    clearRaceMomentTimeout,
+    clearFinishRouteTimeout,
   ]);
 
   return (
@@ -1786,6 +1897,16 @@ function RaceCanvas({
         style={canvasStyle}
       />
       <TouchControls layout={touchLayout} />
+      {raceMoment !== null ? (
+        <div
+          data-testid="race-moment"
+          data-kind={raceMoment.kind}
+          style={raceMomentStyle}
+        >
+          <strong style={raceMomentTitleStyle}>{raceMoment.title}</strong>
+          <span style={raceMomentDetailStyle}>{raceMoment.detail}</span>
+        </div>
+      ) : null}
       <dl
         style={metricsStyle}
         data-testid="race-metrics"
@@ -1923,10 +2044,45 @@ const metricsStyle: CSSProperties = {
 };
 
 const resultStyle: CSSProperties = {
+  position: "absolute",
+  left: "50%",
+  bottom: "8rem",
+  transform: "translateX(-50%)",
   padding: "0.75rem 1rem",
   border: "1px solid var(--muted, #888)",
   borderRadius: "6px",
   background: "rgba(255,255,255,0.05)",
+};
+
+const raceMomentStyle: CSSProperties = {
+  position: "absolute",
+  left: "50%",
+  top: "50%",
+  transform: "translate(-50%, -50%)",
+  display: "grid",
+  justifyItems: "center",
+  gap: "0.35rem",
+  minWidth: "min(22rem, calc(100vw - 2rem))",
+  padding: "0.9rem 1.15rem",
+  border: "2px solid rgba(255, 238, 120, 0.92)",
+  borderRadius: "6px",
+  background: "rgba(8, 13, 24, 0.78)",
+  color: "#fff6b0",
+  textAlign: "center",
+  textShadow: "0 2px 0 rgba(0, 0, 0, 0.8)",
+  boxShadow: "0 0 0 3px rgba(0, 0, 0, 0.44)",
+  pointerEvents: "none",
+};
+
+const raceMomentTitleStyle: CSSProperties = {
+  fontSize: "3rem",
+  lineHeight: 1,
+  textTransform: "uppercase",
+};
+
+const raceMomentDetailStyle: CSSProperties = {
+  fontSize: "1rem",
+  color: "#ffffff",
 };
 
 const practicePanelStyle: CSSProperties = {

--- a/src/app/race/page.tsx
+++ b/src/app/race/page.tsx
@@ -1281,13 +1281,17 @@ function RaceCanvas({
       window.removeEventListener("keydown", tryStartEngineAudio);
       unbindAudioVisibility();
     };
-    const stopRaceRuntime = (): void => {
+    const stopRaceRuntime = ({
+      stopSfx = true,
+    }: { stopSfx?: boolean } = {}): void => {
       clearFinishRouteTimeout();
       engineAudioTeardown = true;
       unbindEngineAudio();
       handleRef.current?.stop();
       engineAudio.stop();
-      raceSfx.stopAll();
+      if (stopSfx) {
+        raceSfx.stopAll();
+      }
       raceMusic.stop();
       handleRef.current = null;
       sessionRef.current = null;
@@ -1803,9 +1807,9 @@ function RaceCanvas({
                             }),
                   });
             saveRaceResult(committed);
-            // Tear down the loop, input, and audio bindings before the
-            // route hop. Keep the finish moment on screen briefly so the
-            // player gets a clear payoff before the results route takes over.
+            // Tear down the loop, input, engine, and music before the
+            // route hop. Keep one-shot SFX alive during the hold so the
+            // finish stinger can land with the moment.
             showRaceMoment(
               {
                 kind: "finish",
@@ -1814,9 +1818,10 @@ function RaceCanvas({
               },
               0,
             );
-            stopRaceRuntime();
+            stopRaceRuntime({ stopSfx: false });
             finishRouteTimeoutRef.current = window.setTimeout(() => {
               finishRouteTimeoutRef.current = null;
+              raceSfx.stopAll();
               router.push("/race/results");
             }, FINISH_MOMENT_MS);
           }


### PR DESCRIPTION
## Summary
- Adds in-race lap and finish moments driven by existing race-session audio events.
- Holds the final frame briefly before routing to results so the finish stinger and payoff are visible.
- Updates the natural-finish Playwright spec to assert the finish moment before results.

## GDD
- docs/gdd/07-race-rules-and-structure.md
- docs/gdd/18-sound-and-music-design.md
- docs/gdd/20-hud-and-ui-ux.md
- docs/gdd/25-development-roadmap.md

## Requirement inventory
- Handles lap-complete feedback, finish feedback, and the existing saved-results handoff.
- Leaves pickups, AI archetypes, race-audio emphasis, car art, first-tour authored events, and release-fun automation to existing Dots.

## Progress log
- docs/PROGRESS_LOG.md: 2026-05-01 Slice: Finish-line moment and lap rollover polish.

## Test plan
- [x] grep for U+2014 and U+2013 on changed files
- [x] npm run typecheck
- [x] npm run lint
- [x] npx vitest run src/game/__tests__/raceSession.test.ts src/audio/sfx.test.ts
- [x] npx playwright test e2e/race-finish.spec.ts --project=chromium --grep "natural finish on test/straight"
- [x] npm run docs:check
- [x] npm run content-lint
- [x] npm run verify
- [x] git diff --check

## Followups
- None.