### PR TITLE
feat(pickups): render collection feedback

### DIFF
--- a/docs/FOLLOWUPS.md
+++ b/docs/FOLLOWUPS.md
@@ -13,12 +13,19 @@ or `obsolete` so the trail is preserved.
 ## F-072: Render pickups and collection feedback in the race view
 **Created:** 2026-05-01
 **Priority:** blocks-release
-**Status:** open
+**Status:** done (2026-05-01)
 **Notes:** The pickup runtime slice collects authored cash and nitro
 pickups, hides already collected ids from session state, pays pickup cash
 with the race result, and emits pickup events. Add visible pickup sprites,
 collection burst feedback, HUD cash and nitro feedback, and Playwright
 coverage that proves a visible pickup disappears after collection.
+
+Closed by `feat/pickups-render-feedback`. The race renderer now projects
+visible uncollected pickups from compiled strip metadata, paints cash and
+nitro pickup sprites in the canvas world, emits a short collection burst,
+and exposes pickup telemetry for E2E coverage. `test/straight` now places
+the first pickup far enough from the spawn point to prove the sprite is
+visible before collection and disappears after pickup.
 
 ## F-071: Route pickup collection events into race SFX
 **Created:** 2026-05-01

--- a/docs/GDD_COVERAGE.json
+++ b/docs/GDD_COVERAGE.json
@@ -668,6 +668,29 @@
       "followupRefs": []
     },
     {
+      "id": "GDD-09-PICKUP-RENDER-FEEDBACK",
+      "gddSections": [
+        "docs/gdd/09-track-design.md",
+        "docs/gdd/10-driving-model-and-physics.md",
+        "docs/gdd/16-rendering-and-visual-design.md",
+        "docs/gdd/20-hud-and-ui-ux.md"
+      ],
+      "requirement": "Authored cash and nitro pickups are visible in the live race view before collection, disappear after collection, and emit player-facing collection feedback.",
+      "coverage": ["implemented-code", "automated-test"],
+      "implementationRefs": [
+        "src/render/pickupSprites.ts",
+        "src/render/pseudoRoadCanvas.ts",
+        "src/app/race/page.tsx",
+        "src/data/tracks/test-straight.json"
+      ],
+      "testRefs": [
+        "src/render/__tests__/pickupSprites.test.ts",
+        "src/render/__tests__/pseudoRoadCanvas.test.ts",
+        "e2e/race-pickups.spec.ts"
+      ],
+      "followupRefs": ["F-072"]
+    },
+    {
       "id": "GDD-20-GAME-UI-SELECTION",
       "gddSections": [
         "docs/gdd/20-hud-and-ui-ux.md",

--- a/docs/PROGRESS_LOG.md
+++ b/docs/PROGRESS_LOG.md
@@ -6,6 +6,59 @@ Correct them by adding a new entry that references the old one.
 
 ---
 
+## 2026-05-01: Slice: Pickup render and feedback
+
+**GDD sections touched:**
+[§9](gdd/09-track-design.md) track pickups,
+[§10](gdd/10-driving-model-and-physics.md) mid-race resources,
+[§16](gdd/16-rendering-and-visual-design.md) race readability, and
+[§20](gdd/20-hud-and-ui-ux.md) race feedback.
+**Branch / PR:** `feat/pickups-render-feedback`, PR pending.
+**Status:** Implemented.
+
+### Done
+- Added pure pickup sprite projection from visible road strips, compiled
+  pickup metadata, lap, and collected pickup ids.
+- Added canvas pickup sprites for cash and nitro pickups.
+- Added a short collection burst driven by the deterministic player pickup
+  event.
+- Added race metrics for visible pickups, collected pickups, and last pickup
+  kind so browser tests can prove the runtime loop.
+- Moved `test/straight` pickups away from spawn so the first pickup is visible
+  before collection and disappears after the player drives into it.
+
+### Verified
+- `npx vitest run src/render/__tests__/pickupSprites.test.ts
+  src/render/__tests__/pseudoRoadCanvas.test.ts
+  src/game/__tests__/pickups.test.ts src/game/__tests__/raceSession.test.ts
+  src/road/__tests__/trackCompiler.test.ts` green, 219 tests passed.
+- `npm run typecheck` green.
+- `npm run lint` green.
+- `npx playwright test e2e/race-pickups.spec.ts --project=chromium` green.
+- `npm run verify` green, 142 files and 2758 tests passed.
+
+### Decisions and assumptions
+- Pickup sprites are projected from the same strip array as the road so they
+  inherit hill and curve visibility without adding a second projection path.
+- Collection feedback is visual only in this slice. Pickup SFX remains F-071.
+- The `test/straight` pickup placement changed only to support the visible
+  before collection browser proof.
+
+### Coverage ledger
+- Added `GDD-09-PICKUP-RENDER-FEEDBACK` to cover visible pickup sprites,
+  collection disappearance, and collection feedback.
+- Closes F-072.
+- Uncovered adjacent requirements: pickup SFX in F-071 and richer pickup art
+  beyond the procedural placeholder sprites.
+
+### Followups created
+None.
+
+### GDD edits
+- `docs/GDD_COVERAGE.json`: added pickup render and feedback coverage.
+
+---
+
 ## 2026-05-01: Slice: Pickup runtime collection
 
 **GDD sections touched:**

--- a/e2e/race-pickups.spec.ts
+++ b/e2e/race-pickups.spec.ts
@@ -1,0 +1,44 @@
+import { expect, test } from "@playwright/test";
+
+function metricNumber(text: string | null): number {
+  return Number.parseInt(text ?? "0", 10);
+}
+
+test.describe("race pickups", () => {
+  test("renders pickups, collects one, and reports feedback", async ({ page }) => {
+    await page.goto("/race?track=test/straight");
+
+    const canvas = page.getByTestId("race-canvas-element");
+    await expect(canvas).toBeVisible();
+    await expect(page.getByTestId("race-phase")).toHaveText("racing", {
+      timeout: 10_000,
+    });
+
+    const visiblePickups = page.getByTestId("race-visible-pickup-count");
+    await expect
+      .poll(
+        async () => metricNumber(await visiblePickups.textContent()),
+        { timeout: 5_000 },
+      )
+      .toBeGreaterThan(0);
+
+    const initialVisible = metricNumber(await visiblePickups.textContent());
+    await canvas.focus();
+    await page.keyboard.down("ArrowUp");
+    await expect
+      .poll(
+        async () =>
+          metricNumber(
+            await page.getByTestId("race-collected-pickup-count").textContent(),
+          ),
+        { timeout: 20_000 },
+      )
+      .toBeGreaterThan(0);
+    await page.keyboard.up("ArrowUp");
+
+    await expect(page.getByTestId("race-last-pickup-kind")).toHaveText("cash");
+    await expect
+      .poll(async () => metricNumber(await visiblePickups.textContent()))
+      .toBeLessThan(initialVisible);
+  });
+});

--- a/src/app/race/page.tsx
+++ b/src/app/race/page.tsx
@@ -133,6 +133,7 @@ import {
   type Viewport,
 } from "@/road";
 import { drawRoad, type DrawRoadOptions } from "@/render/pseudoRoadCanvas";
+import { projectPickupSprites } from "@/render/pickupSprites";
 import { playerCarFrameIndex } from "@/render/carFrame";
 import type { CarSpriteSet } from "@/render/carSpriteCompositor";
 import {
@@ -187,6 +188,7 @@ const WORLD_TOUR_CHAMPIONSHIP_ID = "world-tour-standard";
 const PLAYER_ID = "player";
 const LAP_MOMENT_MS = 900;
 const FINISH_MOMENT_MS = 1250;
+const PICKUP_FEEDBACK_MS = 900;
 const AI_FALLBACK_FILLS = Object.freeze([
   "#ff6b5f",
   "#63d471",
@@ -307,6 +309,12 @@ interface RaceMoment {
   detail: string;
 }
 
+interface PickupFeedbackSnapshot {
+  kind: "cash" | "nitro";
+  value: number;
+  createdAtMs: number;
+}
+
 function playerMomentFromEvents(
   events: ReadonlyArray<RaceSessionAudioEvent>,
   totalLaps: number,
@@ -328,6 +336,23 @@ function playerMomentFromEvents(
         detail: "Saving results",
       };
     }
+  }
+  return latest;
+}
+
+function playerPickupFeedbackFromEvents(
+  events: ReadonlyArray<RaceSessionAudioEvent>,
+  nowMs: number,
+): PickupFeedbackSnapshot | null {
+  let latest: PickupFeedbackSnapshot | null = null;
+  for (const event of events) {
+    if (event.carId !== PLAYER_ID) continue;
+    if (event.kind !== "pickupCollected") continue;
+    latest = {
+      kind: event.pickupKind,
+      value: event.value,
+      createdAtMs: nowMs,
+    };
   }
   return latest;
 }
@@ -901,6 +926,7 @@ function RaceCanvas({
   const ghostsFnRef = useRef<(() => void) | null>(null);
   const raceMomentTimeoutRef = useRef<number | null>(null);
   const finishRouteTimeoutRef = useRef<number | null>(null);
+  const pickupFeedbackRef = useRef<PickupFeedbackSnapshot | null>(null);
   // Per-mount guard for the natural finish wiring. The render callback
   // fires every frame, so without this latch a `phase === "finished"`
   // tick would call `saveRaceResult` and `router.push` on every frame
@@ -934,6 +960,10 @@ function RaceCanvas({
   } | null>(null);
   const [fieldSize, setFieldSize] = useState<number>(1);
   const [aiVisibleCount, setAiVisibleCount] = useState<number>(0);
+  const [visiblePickupCount, setVisiblePickupCount] = useState<number>(0);
+  const [collectedPickupCount, setCollectedPickupCount] = useState<number>(0);
+  const [pickupFeedback, setPickupFeedback] =
+    useState<PickupFeedbackSnapshot | null>(null);
   const [touchLayout, setTouchLayout] = useState<TouchLayout>(() =>
     touchLayoutFor({ width: VIEWPORT_WIDTH, height: VIEWPORT_HEIGHT }),
   );
@@ -1174,6 +1204,8 @@ function RaceCanvas({
       });
     };
 
+    pickupFeedbackRef.current = null;
+    setPickupFeedback(null);
     sessionRef.current = createRaceSession(config);
     resetTimeTrialRuntime();
     // Re-arm the natural-finish guard on every fresh mount. The
@@ -1313,6 +1345,8 @@ function RaceCanvas({
       clearRaceMomentTimeout();
       clearFinishRouteTimeout();
       setRaceMoment(null);
+      pickupFeedbackRef.current = null;
+      setPickupFeedback(null);
       sessionRef.current = createRaceSession(config);
       resetTimeTrialRuntime();
       tunnelState = OPEN_TUNNEL_STATE;
@@ -1344,6 +1378,8 @@ function RaceCanvas({
       clearRaceMomentTimeout();
       clearFinishRouteTimeout();
       setRaceMoment(null);
+      pickupFeedbackRef.current = null;
+      setPickupFeedback(null);
       const retired = retireRaceSession(session);
       sessionRef.current = retired;
       // Build the §20 results payload from the post-retire session
@@ -1432,6 +1468,8 @@ function RaceCanvas({
       clearRaceMomentTimeout();
       clearFinishRouteTimeout();
       setRaceMoment(null);
+      pickupFeedbackRef.current = null;
+      setPickupFeedback(null);
       stopRaceRuntime();
       router.push("/");
     };
@@ -1440,6 +1478,8 @@ function RaceCanvas({
       clearRaceMomentTimeout();
       clearFinishRouteTimeout();
       setRaceMoment(null);
+      pickupFeedbackRef.current = null;
+      setPickupFeedback(null);
       stopRaceRuntime();
       router.push("/options");
     };
@@ -1448,6 +1488,8 @@ function RaceCanvas({
       clearRaceMomentTimeout();
       clearFinishRouteTimeout();
       setRaceMoment(null);
+      pickupFeedbackRef.current = null;
+      setPickupFeedback(null);
       stopRaceRuntime();
       router.push("/time-trial");
     };
@@ -1508,6 +1550,14 @@ function RaceCanvas({
         if (lastRaceSfxTick !== session.tick) {
           lastRaceSfxTick = session.tick;
           playRaceSfxEvents(raceSfx, session.audioEvents, persistedSettings.audio);
+          const pickupFeedbackFromTick = playerPickupFeedbackFromEvents(
+            session.audioEvents,
+            performance.now(),
+          );
+          if (pickupFeedbackFromTick !== null) {
+            pickupFeedbackRef.current = pickupFeedbackFromTick;
+            setPickupFeedback(pickupFeedbackFromTick);
+          }
           const playerMoment = playerMomentFromEvents(
             session.audioEvents,
             session.race.totalLaps,
@@ -1522,6 +1572,18 @@ function RaceCanvas({
         const strips = project(track.compiled.segments, camera, viewport, {
           drawDistance: graphics.drawDistanceSegments,
         });
+        const pickupSprites = projectPickupSprites({
+          strips,
+          pickupsById: track.compiled.pickupsById,
+          lap: session.race.lap,
+          collectedPickups: session.collectedPickups,
+        });
+        setVisiblePickupCount(pickupSprites.length);
+        setCollectedPickupCount(session.collectedPickups.length);
+        const pickupFeedbackAgeMs =
+          pickupFeedbackRef.current === null
+            ? Number.POSITIVE_INFINITY
+            : performance.now() - pickupFeedbackRef.current.createdAtMs;
         const playerFrameIndex = playerCarFrameIndex(
           lastSteerRef.current,
           upcomingCurvature(track.compiled.segments, camera.z, SEGMENT_LENGTH * 5),
@@ -1598,6 +1660,12 @@ function RaceCanvas({
             intensityScale: tunnelOcclusion(tunnelState),
           },
           spriteDensityFactor: graphics.spriteDensityFactor,
+          pickupSprites,
+          pickupFeedback:
+            pickupFeedbackRef.current !== null &&
+            pickupFeedbackAgeMs < PICKUP_FEEDBACK_MS
+              ? { kind: pickupFeedbackRef.current.kind, ageMs: pickupFeedbackAgeMs }
+              : null,
           aiCars,
           ghostCar: ghostOverlayRef.current
             ? {
@@ -1939,6 +2007,16 @@ function RaceCanvas({
         <dd data-testid="race-field-size">{fieldSize}</dd>
         <dt>Visible AI:</dt>
         <dd data-testid="race-visible-ai-count">{aiVisibleCount}</dd>
+        <dt>Visible pickups:</dt>
+        <dd data-testid="race-visible-pickup-count">{visiblePickupCount}</dd>
+        <dt>Collected pickups:</dt>
+        <dd data-testid="race-collected-pickup-count">
+          {collectedPickupCount}
+        </dd>
+        <dt>Last pickup:</dt>
+        <dd data-testid="race-last-pickup-kind">
+          {pickupFeedback?.kind ?? "none"}
+        </dd>
         <dt>Touch active:</dt>
         <dd data-testid="race-touch-active">
           {inputSnapshot.touchActive ? "yes" : "no"}

--- a/src/app/race/page.tsx
+++ b/src/app/race/page.tsx
@@ -132,7 +132,11 @@ import {
   type MinimapPoint,
   type Viewport,
 } from "@/road";
-import { drawRoad, type DrawRoadOptions } from "@/render/pseudoRoadCanvas";
+import {
+  PICKUP_FEEDBACK_TTL_MS,
+  drawRoad,
+  type DrawRoadOptions,
+} from "@/render/pseudoRoadCanvas";
 import { projectPickupSprites } from "@/render/pickupSprites";
 import { playerCarFrameIndex } from "@/render/carFrame";
 import type { CarSpriteSet } from "@/render/carSpriteCompositor";
@@ -188,7 +192,6 @@ const WORLD_TOUR_CHAMPIONSHIP_ID = "world-tour-standard";
 const PLAYER_ID = "player";
 const LAP_MOMENT_MS = 900;
 const FINISH_MOMENT_MS = 1250;
-const PICKUP_FEEDBACK_MS = 900;
 const AI_FALLBACK_FILLS = Object.freeze([
   "#ff6b5f",
   "#63d471",
@@ -197,6 +200,7 @@ const AI_FALLBACK_FILLS = Object.freeze([
   "#d980ff",
   "#ff9f43",
 ]);
+const EMPTY_COLLECTED_PICKUP_SET: ReadonlySet<string> = new Set<string>();
 
 /**
  * §20 minimap layout. The wireframe places the minimap in the bottom-left
@@ -1279,6 +1283,8 @@ function RaceCanvas({
     let lastEngineAudioUpdateMs = 0;
     let lastCountdownSfxStep: number | null = null;
     let lastRaceSfxTick: number | null = null;
+    let cachedCollectedPickups: ReadonlyArray<string> | null = null;
+    let cachedCollectedPickupSet: ReadonlySet<string> = new Set<string>();
     const tryStartEngineAudio = (): void => {
       if (engineAudioTeardown || engineStartPending || engineAudio.isRunning()) {
         return;
@@ -1576,7 +1582,7 @@ function RaceCanvas({
           strips,
           pickupsById: track.compiled.pickupsById,
           lap: session.race.lap,
-          collectedPickups: session.collectedPickups,
+          collectedPickups: collectedPickupSetForRender(),
         });
         setVisiblePickupCount(pickupSprites.length);
         setCollectedPickupCount(session.collectedPickups.length);
@@ -1663,7 +1669,7 @@ function RaceCanvas({
           pickupSprites,
           pickupFeedback:
             pickupFeedbackRef.current !== null &&
-            pickupFeedbackAgeMs < PICKUP_FEEDBACK_MS
+            pickupFeedbackAgeMs < PICKUP_FEEDBACK_TTL_MS
               ? { kind: pickupFeedbackRef.current.kind, ageMs: pickupFeedbackAgeMs }
               : null,
           aiCars,
@@ -1930,6 +1936,19 @@ function RaceCanvas({
         }
       },
     });
+
+    function collectedPickupSetForRender(): ReadonlySet<string> {
+      if (sessionRef.current === null) return cachedCollectedPickupSet;
+      if (sessionRef.current.collectedPickups === cachedCollectedPickups) {
+        return cachedCollectedPickupSet;
+      }
+      cachedCollectedPickups = sessionRef.current.collectedPickups;
+      cachedCollectedPickupSet =
+        cachedCollectedPickups.length === 0
+          ? EMPTY_COLLECTED_PICKUP_SET
+          : new Set(cachedCollectedPickups);
+      return cachedCollectedPickupSet;
+    }
 
     return () => {
       window.removeEventListener("resize", resize);

--- a/src/data/tracks/test-straight.json
+++ b/src/data/tracks/test-straight.json
@@ -10,18 +10,30 @@
   "weatherOptions": ["clear"],
   "difficulty": 1,
   "segments": [
+    { "len": 120, "curve": 0, "grade": 0, "roadsideLeft": "default", "roadsideRight": "default", "hazards": [] },
     {
-      "len": 1200,
+      "len": 160,
       "curve": 0,
       "grade": 0,
       "roadsideLeft": "default",
       "roadsideRight": "default",
       "hazards": [],
       "pickups": [
-        { "id": "test-straight-cash", "kind": "cash", "laneOffset": 0, "value": 100 },
+        { "id": "test-straight-cash", "kind": "cash", "laneOffset": 0, "value": 100 }
+      ]
+    },
+    {
+      "len": 200,
+      "curve": 0,
+      "grade": 0,
+      "roadsideLeft": "default",
+      "roadsideRight": "default",
+      "hazards": [],
+      "pickups": [
         { "id": "test-straight-nitro", "kind": "nitro", "laneOffset": 0.35, "value": 25 }
       ]
-    }
+    },
+    { "len": 720, "curve": 0, "grade": 0, "roadsideLeft": "default", "roadsideRight": "default", "hazards": [] }
   ],
   "checkpoints": [
     { "segmentIndex": 0, "label": "start" }

--- a/src/game/__tests__/pickups.test.ts
+++ b/src/game/__tests__/pickups.test.ts
@@ -4,11 +4,15 @@ import { loadTrack } from "@/data";
 import { evaluatePickups } from "@/game/pickups";
 import { INITIAL_CAR_STATE } from "@/game/physics";
 
+const CASH_PICKUP_Z = 120;
+const NITRO_PICKUP_Z = 282;
+const NITRO_PICKUP_X = 1.575;
+
 describe("evaluatePickups", () => {
   it("collects a matching pickup once per lap", () => {
     const track = loadTrack("test/straight");
     const first = evaluatePickups({
-      car: { ...INITIAL_CAR_STATE, x: 0, z: 0 },
+      car: { ...INITIAL_CAR_STATE, x: 0, z: CASH_PICKUP_Z },
       track,
       lap: 1,
     });
@@ -16,7 +20,7 @@ describe("evaluatePickups", () => {
       {
         key: "1:test-straight-cash",
         pickupId: "test-straight-cash",
-        segmentIndex: 0,
+        segmentIndex: 20,
         lap: 1,
         kind: "cash",
         value: 100,
@@ -24,7 +28,7 @@ describe("evaluatePickups", () => {
     ]);
 
     const sameLap = evaluatePickups({
-      car: { ...INITIAL_CAR_STATE, x: 0, z: 6 },
+      car: { ...INITIAL_CAR_STATE, x: 0, z: CASH_PICKUP_Z + 6 },
       track,
       lap: 1,
       collectedPickups: first.collectedPickups,
@@ -32,7 +36,7 @@ describe("evaluatePickups", () => {
     expect(sameLap.events).toHaveLength(0);
 
     const nextLap = evaluatePickups({
-      car: { ...INITIAL_CAR_STATE, x: 0, z: 0 },
+      car: { ...INITIAL_CAR_STATE, x: 0, z: CASH_PICKUP_Z },
       track,
       lap: 2,
       collectedPickups: sameLap.collectedPickups,
@@ -45,7 +49,7 @@ describe("evaluatePickups", () => {
   it("uses normalized lane offset against road-space car x", () => {
     const track = loadTrack("test/straight");
     const result = evaluatePickups({
-      car: { ...INITIAL_CAR_STATE, x: 1.575, z: 0 },
+      car: { ...INITIAL_CAR_STATE, x: NITRO_PICKUP_X, z: NITRO_PICKUP_Z },
       track,
       lap: 1,
     });
@@ -57,7 +61,7 @@ describe("evaluatePickups", () => {
   it("falls back to lap 1 when lap state is corrupted", () => {
     const track = loadTrack("test/straight");
     const result = evaluatePickups({
-      car: { ...INITIAL_CAR_STATE, x: 0, z: 0 },
+      car: { ...INITIAL_CAR_STATE, x: 0, z: CASH_PICKUP_Z },
       track,
       lap: Number.NaN,
     });

--- a/src/game/__tests__/raceSession.test.ts
+++ b/src/game/__tests__/raceSession.test.ts
@@ -810,6 +810,10 @@ describe("stepRaceSession (pickups)", () => {
   it("collects cash pickups into the player race cash delta once", () => {
     const config = buildConfig({
       track: loadTrack("test/straight"),
+      player: {
+        stats: STARTER_STATS,
+        initial: { z: 120 },
+      },
       ai: [],
       countdownSec: 0,
     });
@@ -834,7 +838,7 @@ describe("stepRaceSession (pickups)", () => {
       track: loadTrack("test/straight"),
       player: {
         stats: STARTER_STATS,
-        initial: { x: 1.575 },
+        initial: { x: 1.575, z: 282 },
       },
       ai: [],
       countdownSec: 0,

--- a/src/render/__tests__/pickupSprites.test.ts
+++ b/src/render/__tests__/pickupSprites.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, it } from "vitest";
+
+import type { TrackPickup } from "@/data/schemas";
+import type { Strip } from "@/road/types";
+import { projectPickupSprites } from "../pickupSprites";
+
+const pickupsById: Readonly<Record<string, TrackPickup>> = {
+  cash: { id: "cash", kind: "cash", laneOffset: 0, value: 100 },
+  nitro: { id: "nitro", kind: "nitro", laneOffset: 0.5, value: 25 },
+};
+
+describe("projectPickupSprites", () => {
+  it("projects uncollected pickup ids from visible strips", () => {
+    const sprites = projectPickupSprites({
+      strips: [
+        strip({ index: 0, pickupIds: [] }),
+        strip({ index: 1, pickupIds: ["cash", "nitro"], screenW: 100 }),
+      ],
+      pickupsById,
+      lap: 1,
+    });
+
+    expect(sprites).toMatchObject([
+      {
+        key: "1:cash",
+        pickupId: "cash",
+        kind: "cash",
+        value: 100,
+        screenX: 400,
+        screenY: 240,
+        depthMeters: 6,
+      },
+      {
+        key: "1:nitro",
+        pickupId: "nitro",
+        kind: "nitro",
+        value: 25,
+        screenX: 450,
+        screenY: 240,
+        depthMeters: 6,
+      },
+    ]);
+    expect(sprites[0]?.screenW).toBeCloseTo(14, 6);
+    expect(sprites[1]?.screenW).toBeCloseTo(14, 6);
+  });
+
+  it("skips collected and far pickups", () => {
+    const sprites = projectPickupSprites({
+      strips: [
+        strip({ index: 0, pickupIds: [] }),
+        strip({ index: 1, pickupIds: ["cash"] }),
+        strip({ index: 40, pickupIds: ["nitro"] }),
+      ],
+      pickupsById,
+      lap: 1,
+      collectedPickups: ["1:cash"],
+      maxDistanceMeters: 6,
+    });
+
+    expect(sprites).toEqual([]);
+  });
+
+  it("uses lap 1 for corrupted lap values", () => {
+    const sprites = projectPickupSprites({
+      strips: [strip({ index: 1, pickupIds: ["cash"] })],
+      pickupsById,
+      lap: Number.NaN,
+    });
+
+    expect(sprites.map((sprite) => sprite.key)).toEqual([]);
+
+    const visibleSprites = projectPickupSprites({
+      strips: [
+        strip({ index: 0, pickupIds: [] }),
+        strip({ index: 1, pickupIds: ["cash"] }),
+      ],
+      pickupsById,
+      lap: Number.NaN,
+    });
+    expect(visibleSprites.map((sprite) => sprite.key)).toEqual(["1:cash"]);
+  });
+});
+
+function strip(input: {
+  index: number;
+  pickupIds: readonly string[];
+  screenW?: number;
+}): Strip {
+  return {
+    segment: {
+      index: input.index,
+      worldZ: input.index * 6,
+      curve: 0,
+      grade: 0,
+      authoredIndex: 0,
+      roadsideLeftId: "default",
+      roadsideRightId: "default",
+      hazardIds: [],
+      pickupIds: input.pickupIds,
+    },
+    visible: true,
+    screenX: 400,
+    screenY: 240,
+    screenW: input.screenW ?? 80,
+    scale: 1,
+    worldX: 0,
+    worldY: 0,
+  };
+}

--- a/src/render/__tests__/pseudoRoadCanvas.test.ts
+++ b/src/render/__tests__/pseudoRoadCanvas.test.ts
@@ -33,6 +33,9 @@ import {
   HEAT_SHIMMER_BAND_COUNT,
   HEAT_SHIMMER_FILL,
   HEAT_SHIMMER_MAX_ALPHA,
+  PICKUP_CASH_FILL,
+  PICKUP_FEEDBACK_TTL_MS,
+  PICKUP_NITRO_FILL,
   PLAYER_CAR_DEFAULT_FILL,
   PLAYER_CAR_DEFAULT_SHADOW,
   PLAYER_CAR_DEFAULT_SPRITE_ID,
@@ -555,6 +558,62 @@ describe("drawRoad ghost car overlay", () => {
         c.type === "fillRect" && c.w === 40 && c.h === 20,
     );
     expect(ghostRect).toBeUndefined();
+  });
+});
+
+describe("drawRoad pickup overlays", () => {
+  it("paints cash and nitro pickup sprites above road strips", () => {
+    const spy = makeCanvasSpy();
+    drawRoad(spy.ctx, WEATHER_STRIPS, VIEWPORT, {
+      pickupSprites: [
+        {
+          key: "1:cash",
+          pickupId: "cash",
+          kind: "cash",
+          value: 100,
+          screenX: 410,
+          screenY: 260,
+          screenW: 18,
+          depthMeters: 12,
+        },
+        {
+          key: "1:nitro",
+          pickupId: "nitro",
+          kind: "nitro",
+          value: 25,
+          screenX: 430,
+          screenY: 260,
+          screenW: 18,
+          depthMeters: 18,
+        },
+      ],
+    });
+
+    expect(
+      spy.calls.some((c) => c.type === "fill" && c.fillStyle === PICKUP_CASH_FILL),
+    ).toBe(true);
+    expect(
+      spy.calls.some(
+        (c) => c.type === "fillRect" && c.fillStyle === PICKUP_NITRO_FILL,
+      ),
+    ).toBe(true);
+  });
+
+  it("paints and fades collection feedback without leaking alpha", () => {
+    const spy = makeCanvasSpy();
+    drawRoad(spy.ctx, WEATHER_STRIPS, VIEWPORT, {
+      pickupFeedback: { kind: "cash", ageMs: PICKUP_FEEDBACK_TTL_MS / 2 },
+    });
+
+    const feedbackCalls = spy.calls.filter(
+      (c): c is FillRectCall =>
+        c.type === "fillRect" &&
+        c.fillStyle === PICKUP_CASH_FILL &&
+        c.globalAlpha > 0 &&
+        c.globalAlpha < 1,
+    );
+    expect(feedbackCalls.length).toBeGreaterThan(0);
+    expect(spy.finalAlpha()).toBeCloseTo(1, 6);
   });
 });
 

--- a/src/render/pickupSprites.ts
+++ b/src/render/pickupSprites.ts
@@ -1,0 +1,103 @@
+import type { TrackPickup } from "@/data/schemas";
+import type { Strip } from "@/road/types";
+import { SEGMENT_LENGTH } from "@/road/constants";
+
+export interface ProjectedPickupSprite {
+  readonly key: string;
+  readonly pickupId: string;
+  readonly kind: TrackPickup["kind"];
+  readonly value: number;
+  readonly screenX: number;
+  readonly screenY: number;
+  readonly screenW: number;
+  readonly depthMeters: number;
+}
+
+export interface ProjectPickupSpritesInput {
+  readonly strips: readonly Strip[];
+  readonly pickupsById: Readonly<Record<string, TrackPickup>>;
+  readonly lap: number;
+  readonly collectedPickups?: ReadonlySet<string> | readonly string[];
+  readonly maxDistanceMeters?: number;
+}
+
+const DEFAULT_MAX_PICKUP_DISTANCE_METERS = 180;
+const MIN_PICKUP_SCREEN_WIDTH = 8;
+const MAX_PICKUP_SCREEN_WIDTH = 34;
+
+export function projectPickupSprites(
+  input: ProjectPickupSpritesInput,
+): readonly ProjectedPickupSprite[] {
+  const maxDistanceMeters =
+    Number.isFinite(input.maxDistanceMeters) && input.maxDistanceMeters != null
+      ? Math.max(0, input.maxDistanceMeters)
+      : DEFAULT_MAX_PICKUP_DISTANCE_METERS;
+  if (maxDistanceMeters <= 0) return [];
+
+  const collected = normalizeCollected(input.collectedPickups);
+  const lap = sanitizeLap(input.lap);
+  const sprites: ProjectedPickupSprite[] = [];
+
+  for (let stripIndex = 0; stripIndex < input.strips.length; stripIndex += 1) {
+    const strip = input.strips[stripIndex];
+    if (!strip?.visible) continue;
+    if (!isFinitePickupProjection(strip.screenX, strip.screenY, strip.screenW)) {
+      continue;
+    }
+    const depthMeters = stripIndex * SEGMENT_LENGTH;
+    if (depthMeters <= 0 || depthMeters > maxDistanceMeters) continue;
+
+    for (const pickupId of strip.segment.pickupIds) {
+      const pickup = input.pickupsById[pickupId];
+      if (!pickup) continue;
+      const key = `${lap}:${pickup.id}`;
+      if (collected?.has(key)) continue;
+      sprites.push({
+        key,
+        pickupId: pickup.id,
+        kind: pickup.kind,
+        value: pickup.value,
+        screenX: strip.screenX + strip.screenW * pickup.laneOffset,
+        screenY: strip.screenY,
+        screenW: clamp(
+          strip.screenW * 0.14,
+          MIN_PICKUP_SCREEN_WIDTH,
+          MAX_PICKUP_SCREEN_WIDTH,
+        ),
+        depthMeters,
+      });
+    }
+  }
+
+  return sprites.sort((a, b) => b.depthMeters - a.depthMeters);
+}
+
+function normalizeCollected(
+  collected: ReadonlySet<string> | readonly string[] | undefined,
+): ReadonlySet<string> | null {
+  if (collected === undefined) return null;
+  if ("has" in collected) return collected;
+  return new Set(collected);
+}
+
+function sanitizeLap(lap: number): number {
+  if (!Number.isFinite(lap)) return 1;
+  return Math.max(1, Math.floor(lap));
+}
+
+function isFinitePickupProjection(
+  screenX: number,
+  screenY: number,
+  screenW: number,
+): boolean {
+  return (
+    Number.isFinite(screenX) &&
+    Number.isFinite(screenY) &&
+    Number.isFinite(screenW) &&
+    screenW > 0
+  );
+}
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.max(min, Math.min(max, value));
+}

--- a/src/render/pickupSprites.ts
+++ b/src/render/pickupSprites.ts
@@ -24,6 +24,7 @@ export interface ProjectPickupSpritesInput {
 const DEFAULT_MAX_PICKUP_DISTANCE_METERS = 180;
 const MIN_PICKUP_SCREEN_WIDTH = 8;
 const MAX_PICKUP_SCREEN_WIDTH = 34;
+const EMPTY_COLLECTED_PICKUP_SET: ReadonlySet<string> = new Set<string>();
 
 export function projectPickupSprites(
   input: ProjectPickupSpritesInput,
@@ -77,6 +78,7 @@ function normalizeCollected(
 ): ReadonlySet<string> | null {
   if (collected === undefined) return null;
   if ("has" in collected) return collected;
+  if (collected.length === 0) return EMPTY_COLLECTED_PICKUP_SET;
   return new Set(collected);
 }
 

--- a/src/render/pseudoRoadCanvas.ts
+++ b/src/render/pseudoRoadCanvas.ts
@@ -34,6 +34,7 @@ import { drawDust, type DustState } from "./dust";
 import type { PaletteCache } from "./paletteCache";
 import { paletteCacheKey, recolourFrameToImageBitmap } from "./paletteRecolour";
 import { drawParallax, type ParallaxLayer } from "./parallax";
+import type { ProjectedPickupSprite } from "./pickupSprites";
 import {
   resolveCarRenderFrames,
   selectCarFramePlan,
@@ -101,6 +102,11 @@ export const RAIN_ROAD_SHEEN_FILL = "#d8f4ff";
 export const RAIN_ROAD_SHEEN_MAX_ALPHA = 0.16;
 export const SNOW_ROADSIDE_WHITENING_FILL = "#edf7ff";
 export const SNOW_ROADSIDE_WHITENING_MAX_ALPHA = 0.2;
+export const PICKUP_CASH_FILL = "#ffd84a";
+export const PICKUP_CASH_SHADOW = "#7a4b00";
+export const PICKUP_NITRO_FILL = "#55d8ff";
+export const PICKUP_NITRO_SHADOW = "#173f82";
+export const PICKUP_FEEDBACK_TTL_MS = 900;
 const LANE_DASH_CYCLE_METERS = LANE_STRIPE_LEN * SEGMENT_LENGTH;
 const LANE_DASH_VISIBLE_METERS = SEGMENT_LENGTH * 2;
 
@@ -206,6 +212,11 @@ export interface DrawRoadOptions {
     inFlight?: Set<string>;
     failed?: Set<string>;
     onRecolourError?: (key: string, error: unknown) => void;
+  } | null;
+  pickupSprites?: readonly ProjectedPickupSprite[] | null;
+  pickupFeedback?: {
+    kind: "cash" | "nitro";
+    ageMs: number;
   } | null;
   /**
    * Optional ghost car overlay per F-022. The §6 Time Trial flow drives
@@ -400,6 +411,7 @@ export function drawRoad(
         options.spriteDensityFactor,
         options.roadsideAtlas,
       );
+      drawPickupSprites(ctx, options.pickupSprites);
       ctx.restore();
     } else {
       drawStrips(ctx, strips, viewport, colors, markingCameraZFrom(options));
@@ -411,6 +423,7 @@ export function drawRoad(
         options.spriteDensityFactor,
         options.roadsideAtlas,
       );
+      drawPickupSprites(ctx, options.pickupSprites);
     }
   }
 
@@ -445,6 +458,129 @@ export function drawRoad(
 
   if (options.playerCar) {
     drawPlayerCar(ctx, options.playerCar, viewport);
+  }
+
+  drawPickupFeedback(ctx, viewport, options.pickupFeedback);
+}
+
+function drawPickupSprites(
+  ctx: CanvasRenderingContext2D,
+  sprites: readonly ProjectedPickupSprite[] | null | undefined,
+): void {
+  if (!sprites || sprites.length === 0) return;
+  for (const sprite of sprites) {
+    drawPickupSprite(ctx, sprite);
+  }
+}
+
+function drawPickupSprite(
+  ctx: CanvasRenderingContext2D,
+  sprite: ProjectedPickupSprite,
+): void {
+  if (
+    !Number.isFinite(sprite.screenX) ||
+    !Number.isFinite(sprite.screenY) ||
+    !Number.isFinite(sprite.screenW) ||
+    sprite.screenW <= 0
+  ) {
+    return;
+  }
+
+  if (sprite.kind === "nitro") {
+    drawNitroPickupSprite(ctx, sprite.screenX, sprite.screenY, sprite.screenW);
+  } else {
+    drawCashPickupSprite(ctx, sprite.screenX, sprite.screenY, sprite.screenW);
+  }
+}
+
+function drawCashPickupSprite(
+  ctx: CanvasRenderingContext2D,
+  centerX: number,
+  baseY: number,
+  size: number,
+): void {
+  const half = size / 2;
+  const y = baseY - size * 0.82;
+  const prevFill = ctx.fillStyle;
+  try {
+    ctx.fillStyle = PICKUP_CASH_SHADOW;
+    ctx.beginPath();
+    ctx.moveTo(centerX, y + size * 0.12);
+    ctx.lineTo(centerX + half, y + half + size * 0.12);
+    ctx.lineTo(centerX, y + size + size * 0.12);
+    ctx.lineTo(centerX - half, y + half + size * 0.12);
+    ctx.closePath();
+    ctx.fill();
+    ctx.fillStyle = PICKUP_CASH_FILL;
+    ctx.beginPath();
+    ctx.moveTo(centerX, y);
+    ctx.lineTo(centerX + half, y + half);
+    ctx.lineTo(centerX, y + size);
+    ctx.lineTo(centerX - half, y + half);
+    ctx.closePath();
+    ctx.fill();
+    ctx.fillStyle = "#fff7a8";
+    ctx.fillRect(centerX - size * 0.08, y + size * 0.24, size * 0.16, size * 0.52);
+    ctx.fillRect(centerX - size * 0.23, y + size * 0.42, size * 0.46, size * 0.14);
+  } finally {
+    ctx.fillStyle = prevFill;
+  }
+}
+
+function drawNitroPickupSprite(
+  ctx: CanvasRenderingContext2D,
+  centerX: number,
+  baseY: number,
+  size: number,
+): void {
+  const y = baseY - size * 0.9;
+  const prevFill = ctx.fillStyle;
+  try {
+    ctx.fillStyle = PICKUP_NITRO_SHADOW;
+    ctx.fillRect(centerX - size * 0.4, y + size * 0.16, size * 0.8, size * 0.78);
+    ctx.fillStyle = PICKUP_NITRO_FILL;
+    ctx.fillRect(centerX - size * 0.34, y, size * 0.68, size * 0.78);
+    ctx.fillStyle = "#f7fbff";
+    ctx.fillRect(centerX - size * 0.22, y + size * 0.12, size * 0.44, size * 0.12);
+    ctx.fillStyle = "#2f7dff";
+    ctx.fillRect(centerX - size * 0.14, y + size * 0.32, size * 0.28, size * 0.34);
+  } finally {
+    ctx.fillStyle = prevFill;
+  }
+}
+
+function drawPickupFeedback(
+  ctx: CanvasRenderingContext2D,
+  viewport: Viewport,
+  feedback: DrawRoadOptions["pickupFeedback"],
+): void {
+  if (!feedback) return;
+  if (viewport.width <= 0 || viewport.height <= 0) return;
+  if (!Number.isFinite(feedback.ageMs)) return;
+  const t = Math.max(0, Math.min(1, feedback.ageMs / PICKUP_FEEDBACK_TTL_MS));
+  if (t >= 1) return;
+
+  const prevFill = ctx.fillStyle;
+  const prevAlpha = ctx.globalAlpha;
+  try {
+    ctx.globalAlpha = 1 - t;
+    ctx.fillStyle = feedback.kind === "nitro" ? PICKUP_NITRO_FILL : PICKUP_CASH_FILL;
+    const centerX = viewport.width / 2;
+    const centerY = viewport.height * 0.78;
+    const radius = 22 + t * 32;
+    const size = 5;
+    for (let i = 0; i < 8; i += 1) {
+      const angle = (Math.PI * 2 * i) / 8;
+      ctx.fillRect(
+        centerX + Math.cos(angle) * radius - size / 2,
+        centerY + Math.sin(angle) * radius - size / 2,
+        size,
+        size,
+      );
+    }
+  } finally {
+    ctx.fillStyle = prevFill;
+    ctx.globalAlpha = prevAlpha;
   }
 }
 


### PR DESCRIPTION
## Summary
- project authored pickup ids into live race canvas sprites
- draw cash and nitro pickup placeholders plus collection burst feedback
- add pickup telemetry and Playwright coverage for visible pickup disappearance after collection
- close F-072 and add GDD-09-PICKUP-RENDER-FEEDBACK coverage

## GDD
- docs/gdd/09-track-design.md
- docs/gdd/10-driving-model-and-physics.md
- docs/gdd/16-rendering-and-visual-design.md
- docs/gdd/20-hud-and-ui-ux.md

## Progress Log
- docs/PROGRESS_LOG.md: 2026-05-01: Slice: Pickup render and feedback

## Test Plan
- npx vitest run src/render/__tests__/pickupSprites.test.ts src/render/__tests__/pseudoRoadCanvas.test.ts src/game/__tests__/pickups.test.ts src/game/__tests__/raceSession.test.ts src/road/__tests__/trackCompiler.test.ts
- npm run typecheck
- npm run lint
- npx playwright test e2e/race-pickups.spec.ts --project=chromium
- npm run verify