### PR TITLE
fix(render): interpolate opponent hill projection

### DIFF
--- a/docs/GDD_COVERAGE.json
+++ b/docs/GDD_COVERAGE.json
@@ -1600,6 +1600,25 @@
       "followupRefs": ["F-051", "F-059", "F-060"]
     },
     {
+      "id": "GDD-16-OPPONENT-HILL-PROJECTION",
+      "gddSections": [
+        "docs/gdd/15-cpu-opponents-and-ai.md",
+        "docs/gdd/16-rendering-and-visual-design.md"
+      ],
+      "requirement": "Opponent and ghost car sprites scale from projected depth while sampling the road height at their exact track position across hills and crests.",
+      "coverage": ["implemented-code", "automated-test"],
+      "implementationRefs": [
+        "src/road/segmentProjector.ts",
+        "src/app/race/page.tsx",
+        "src/render/pseudoRoadCanvas.ts"
+      ],
+      "testRefs": [
+        "src/road/__tests__/segmentProjector.test.ts",
+        "src/render/__tests__/pseudoRoadCanvas.test.ts"
+      ],
+      "followupRefs": ["VibeGear2-fix-cpu-opponent-009867d7"]
+    },
+    {
       "id": "GDD-16-CAR-WEATHER-VARIANTS",
       "gddSections": [
         "docs/gdd/16-rendering-and-visual-design.md",

--- a/docs/PROGRESS_LOG.md
+++ b/docs/PROGRESS_LOG.md
@@ -6,6 +6,42 @@ Correct them by adding a new entry that references the old one.
 
 ---
 
+## 2026-05-02: Slice: CPU opponent hill scale fix
+
+**GDD sections touched:**
+[§15](gdd/15-cpu-opponents-and-ai.md) CPU opponents and
+[§16](gdd/16-rendering-and-visual-design.md) sprite scaling.
+**Branch / PR:** `fix/cpu-opponent-scale-hills`, PR pending.
+**Status:** Implemented.
+
+### Done
+- Fixed projected car height sampling so opponent and ghost cars interpolate
+  the road's local hill offset at their exact fractional segment position.
+- Added a projector regression test proving a car halfway between two hill
+  segment boundaries lands halfway between their road heights.
+
+### Verified
+- `npx vitest run src/road/__tests__/segmentProjector.test.ts
+  src/render/__tests__/pseudoRoadCanvas.test.ts` green, 95 tests passed.
+
+### Decisions and assumptions
+- The issue was projection math, not car art scale. Cars already scale from
+  projected depth, but they were using segment-boundary hill height even when
+  rendered mid-segment.
+
+### Coverage ledger
+- Added `GDD-16-OPPONENT-HILL-PROJECTION`.
+- Uncovered adjacent requirements: richer AI archetype personality and full
+  passing behavior remain separate backlog items.
+
+### Followups created
+None.
+
+### GDD edits
+None.
+
+---
+
 ## 2026-05-01: Slice: First-race fun pass
 
 **GDD sections touched:**
@@ -15,7 +51,7 @@ Correct them by adding a new entry that references the old one.
 [§12](gdd/12-upgrade-and-economy-system.md) reward clarity,
 [§15](gdd/15-cpu-opponents-and-ai.md) CPU opponents, and
 [§20](gdd/20-hud-and-ui-ux.md) HUD and results flow.
-**Branch / PR:** `feat/first-race-fun-pass`, PR pending.
+**Branch / PR:** `feat/first-race-fun-pass`, PR #152 merged.
 **Status:** Implemented.
 
 ### Done

--- a/src/road/__tests__/segmentProjector.test.ts
+++ b/src/road/__tests__/segmentProjector.test.ts
@@ -460,6 +460,42 @@ describe("projectGhostCar", () => {
     expect(ghost.screenX).toBeCloseTo(strip.screenX, 6);
   });
 
+  it("interpolates a car's hill height between segment boundaries", () => {
+    const segs = flatTrack(48, { grade: 2 });
+    const camera = makeCamera();
+    const start = projectGhostCar(
+      segs,
+      camera,
+      VIEWPORT,
+      SEGMENT_LENGTH * 2,
+      0,
+      { drawDistance: 24 },
+    );
+    const end = projectGhostCar(
+      segs,
+      camera,
+      VIEWPORT,
+      SEGMENT_LENGTH * 3,
+      0,
+      { drawDistance: 24 },
+    );
+    const halfway = projectGhostCar(
+      segs,
+      camera,
+      VIEWPORT,
+      SEGMENT_LENGTH * 2.5,
+      0,
+      { drawDistance: 24 },
+    );
+
+    expect(start.visible).toBe(true);
+    expect(end.visible).toBe(true);
+    expect(halfway.visible).toBe(true);
+    expect(halfway.worldY).toBeCloseTo((start.worldY + end.worldY) / 2, 6);
+    expect(halfway.screenY).toBeGreaterThan(end.screenY);
+    expect(halfway.screenY).toBeLessThan(start.screenY);
+  });
+
   it("wraps cameraZ past the end of the ring so a lap-rolling player still sees a ghost ahead", () => {
     const segs = flatTrack(16);
     const trackLength = 16 * SEGMENT_LENGTH;

--- a/src/road/segmentProjector.ts
+++ b/src/road/segmentProjector.ts
@@ -59,6 +59,22 @@ function smoothStep(t: number): number {
   return t * t * (3 - 2 * t);
 }
 
+function sampleLocalProjectionOffset(
+  offsets: readonly LocalProjectionOffset[],
+  position: number,
+): LocalProjectionOffset {
+  if (position <= 0) return offsets[0] ?? { x: 0, y: 0 };
+
+  const startIndex = Math.floor(position);
+  const start = offsets[startIndex] ?? offsets[offsets.length - 1] ?? { x: 0, y: 0 };
+  const end = offsets[startIndex + 1] ?? start;
+  const t = position - startIndex;
+  return {
+    x: lerp(start.x, end.x, t),
+    y: lerp(start.y, end.y, t),
+  };
+}
+
 /**
  * Project a compiled segment list to screen-space strips.
  *
@@ -438,23 +454,26 @@ export function projectGhostCar(
     return HIDDEN_GHOST_PROJECTION;
   }
 
-  const ghostSegmentOffset = Math.floor(
-    (forwardZ + cameraOffsetWithinSegment) / SEGMENT_LENGTH,
-  );
+  const ghostSegmentPosition =
+    (forwardZ + cameraOffsetWithinSegment) / SEGMENT_LENGTH;
+  const ghostSegmentOffset = Math.floor(ghostSegmentPosition);
   const currentOffsets = buildLocalProjectionOffsets(
     segments,
     baseSegmentIndex,
-    ghostSegmentOffset + 1,
+    ghostSegmentOffset + 2,
   );
   const nextOffsets = buildLocalProjectionOffsets(
     segments,
     (baseSegmentIndex + 1) % totalSegments,
-    ghostSegmentOffset + 1,
+    ghostSegmentOffset + 2,
   );
-  const current = currentOffsets[ghostSegmentOffset] ?? { x: 0, y: 0 };
+  const current = sampleLocalProjectionOffset(
+    currentOffsets,
+    ghostSegmentPosition,
+  );
   const next =
-    ghostSegmentOffset > 0
-      ? nextOffsets[ghostSegmentOffset - 1] ?? current
+    ghostSegmentPosition >= 1
+      ? sampleLocalProjectionOffset(nextOffsets, ghostSegmentPosition - 1)
       : current;
   const worldX = lerp(current.x, next.x, boundaryBlend) + ghostX - camera.x;
   const worldY = lerp(current.y, next.y, boundaryBlend) - camera.y;


### PR DESCRIPTION
## GDD coverage
- docs/gdd/15-cpu-opponents-and-ai.md
- docs/gdd/16-rendering-and-visual-design.md

## Requirement inventory
- Fix opponent and ghost car projection so cars sample road height at their exact fractional track position across hills and crests.
- Preserve depth-based car scaling and existing draw ordering.
- Adjacent behavior left for later: richer AI archetype personality and full passing behavior.

## Progress log
- docs/PROGRESS_LOG.md: 2026-05-02 CPU opponent hill scale fix
- docs/GDD_COVERAGE.json: GDD-16-OPPONENT-HILL-PROJECTION

## Test plan
- [x] npx vitest run src/road/__tests__/segmentProjector.test.ts src/render/__tests__/pseudoRoadCanvas.test.ts
- [x] npm run docs:check
- [x] npm run content-lint
- [x] npm run typecheck
- [x] npm run lint

## Followups
- Closes dot VibeGear2-fix-cpu-opponent-009867d7.