### PR TITLE
test(playtest): automate release fun checklist

### DIFF
--- a/docs/FOLLOWUPS.md
+++ b/docs/FOLLOWUPS.md
@@ -13,12 +13,18 @@ or `obsolete` so the trail is preserved.
 ## F-076: Automate the release-fun playtest checklist
 **Created:** 2026-05-02
 **Priority:** blocks-release
-**Status:** open
+**Status:** done (2026-05-02)
 **Notes:** `docs/RELEASE_FUN_PLAYTEST.md` defines the manual release-fun
 gate, but it is not yet an agent-runnable command. Implement the checklist
 as browser automation with screenshot or trace evidence, deployed-smoke
 coverage, and normal race HUD telemetry for grip and weather when available.
 Dot: `VibeGear2-feat-playtest-automate-9d148438`.
+
+Closed by `feat/release-fun-playtest-automation`. `npm run playtest:release-fun`
+runs a gated Playwright checklist for first 90 seconds, full Quick Race,
+first-tour handoff, upgrade purchase, weather prep, AI pressure, pickup
+feedback, finish routing, and optional production smoke through
+`RELEASE_FUN_PRODUCTION_URL`.
 
 ## F-075: Add pass and rival-pressure HUD moments
 **Created:** 2026-05-02

--- a/docs/GDD_COVERAGE.json
+++ b/docs/GDD_COVERAGE.json
@@ -335,8 +335,14 @@
         "src/app/race/page.tsx",
         "src/data/tracks/velvet-coast-harbor-run.json"
       ],
-      "testRefs": ["e2e/first-race-fun.spec.ts"],
-      "followupRefs": ["VibeGear2-feat-tuning-first-74ba5505"]
+      "testRefs": [
+        "e2e/first-race-fun.spec.ts",
+        "e2e/release-fun-playtest.spec.ts"
+      ],
+      "followupRefs": [
+        "VibeGear2-feat-tuning-first-74ba5505",
+        "F-076"
+      ]
     },
     {
       "id": "GDD-06-PRACTICE-MODE",
@@ -1615,7 +1621,8 @@
       "testRefs": [
         "src/road/__tests__/segmentProjector.test.ts",
         "src/render/__tests__/pseudoRoadCanvas.test.ts",
-        "e2e/projection-readability.spec.ts"
+        "e2e/projection-readability.spec.ts",
+        "e2e/release-fun-playtest.spec.ts"
       ],
       "followupRefs": ["VibeGear2-fix-cpu-opponent-009867d7", "F-073"]
     },

--- a/docs/PROGRESS_LOG.md
+++ b/docs/PROGRESS_LOG.md
@@ -6,6 +6,50 @@ Correct them by adding a new entry that references the old one.
 
 ---
 
+## 2026-05-02: Slice: Release-fun playtest automation
+
+**GDD sections touched:** §4, §5, §16, and §20.
+**Branch / PR:** `feat/release-fun-playtest-automation`, PR pending.
+**Status:** Implemented.
+
+### Done
+- Added `npm run playtest:release-fun`, a gated Playwright command for the
+  release-fun checklist.
+- Added `e2e/release-fun-playtest.spec.ts`, covering the first 90 seconds,
+  full Quick Race to garage, first-tour handoff, upgrade purchase, weather
+  prep, AI pressure, pickup feedback, finish routing, and optional production
+  smoke.
+- Updated the release-fun checklist, script catalogue, followups, and coverage
+  ledger so future agents run the checklist before calling race-feel work done.
+
+### Verified
+- `npm run typecheck` green.
+- `npm run lint` green.
+- `npm run playtest:release-fun` green, 5 passed and 1 skipped because
+  production smoke env vars were not supplied.
+
+### Decisions and assumptions
+- The release-fun checklist is gated behind its own npm script instead of the
+  default CI suite because it duplicates several long browser flows and should
+  be run for release candidates and major race-feel changes.
+- Production smoke is part of the same spec, but remains opt-in locally through
+  `RELEASE_FUN_PRODUCTION_URL` and `RELEASE_FUN_EXPECTED_VERSION`.
+
+### Coverage ledger
+- Updated `GDD-04-FIRST-RACE-FUN-LOOP`.
+- Updated `GDD-16-OPPONENT-HILL-PROJECTION`.
+- Closes F-076.
+- Uncovered adjacent requirements: F-075 still tracks richer pass and
+  rival-pressure telemetry for a stronger Script F assertion.
+
+### Followups created
+None.
+
+### GDD edits
+None.
+
+---
+
 ## 2026-05-02: Slice: Projection readability playtest checks
 
 **GDD sections touched:** §4, §15, and §16.

--- a/docs/RELEASE_FUN_PLAYTEST.md
+++ b/docs/RELEASE_FUN_PLAYTEST.md
@@ -19,6 +19,25 @@ Every run records:
 - Screenshot or video path for any visual failure.
 - Any manual observation that automation cannot yet assert.
 
+## Automated Command
+
+Run:
+
+```bash
+npm run playtest:release-fun
+```
+
+The command runs `e2e/release-fun-playtest.spec.ts` with
+`RELEASE_FUN_PLAYTEST=1` against a production Next.js build. It covers scripts
+A through H and skips the deployed production smoke unless these optional env
+vars are supplied:
+
+- `RELEASE_FUN_PRODUCTION_URL`: production or preview base URL to smoke.
+- `RELEASE_FUN_EXPECTED_VERSION`: expected `/api/version` value.
+
+When the production vars are set, Script I also verifies `/api/version`, title
+screen boot, Quick Race start, and nonblank race canvas paint.
+
 ## Script A: First 90 Seconds
 
 Route:
@@ -220,9 +239,11 @@ Do not call the game releasable if any of these occur:
 
 ## Automation Backlog
 
-- `VibeGear2-feat-playtest-automate-9d148438`: implement the full checklist
-  runner tracked by F-076.
-- `VibeGear2-feat-playtest-add-4ba02811`: add projection and opponent
-  readability checks to the runner.
+- `VibeGear2-feat-playtest-automate-9d148438`: shipped
+  `npm run playtest:release-fun`, covering scripts A through H locally and
+  Script I when production env vars are supplied.
+- `VibeGear2-feat-playtest-add-4ba02811`: shipped projection and opponent
+  readability checks through `e2e/projection-readability.spec.ts`, and the
+  release-fun runner now samples road and opponent stability in Script A.
 - `VibeGear2-feat-feedback-add-880f1fd2`: add pass and rival-pressure telemetry
   that the AI pass script can assert.

--- a/docs/SCRIPTS.md
+++ b/docs/SCRIPTS.md
@@ -20,6 +20,7 @@ Run commands from the repository root.
 | `quality:lighthouse` | Starts the production build and runs Lighthouse on core routes, retrying each route to smooth CI scoring noise. | After `npm run build`, before release or performance PRs. | Performance, accessibility, or best-practices score fell below the release gate on every attempt. |
 | `quality:gates` | Runs bundle and Lighthouse quality gates. | In CI after the production build. | Bundle budget or Lighthouse release gate failed. |
 | `release:media` | Captures the v1.0 screenshot pack and trailer source clip from a running build. | After `npm run build && npm run start`, before release notes or store copy. | The app is not running, a release route failed to boot, or Playwright video capture failed. |
+| `playtest:release-fun` | Runs the gated release-fun Playwright checklist against a production build. | Before release candidates and after major race feel, AI, track, HUD, or garage-flow changes. | The default game loop no longer proves visible AI, pickups, nitro, finish routing, tour handoff, upgrade, or weather prep. |
 | `bench:render` | Runs the render benchmark suite. | Renderer, sprite, parallax, road, HUD, or VFX PRs. | Perf harness failure or a large frame-time regression. |
 | `art:generate` | Regenerates placeholder art assets. | Only when intentionally refreshing generated art. | Art generator or manifest contract changed. |
 | `art:check` | Validates art manifest coverage. | Before PRs that touch art. | Missing manifest entry, bad path, or invalid art metadata. |
@@ -39,6 +40,7 @@ Run commands from the repository root.
 | Cross-browser hardening | `npm run test:e2e:cross-browser` |
 | Release quality gates | `npm run build && npm run quality:gates` |
 | Release screenshots and trailer source | `npm run build`, `npm run start`, then `npm run release:media` |
+| Release-fun checklist | `npm run playtest:release-fun` |
 | Renderer change | `npm run verify && npm run bench:render` |
 | Docs-only change | `npm run docs:check && npm run content-lint` |
 | Art change | `npm run art:check` |

--- a/e2e/release-fun-playtest.spec.ts
+++ b/e2e/release-fun-playtest.spec.ts
@@ -81,16 +81,14 @@ test.describe("release-fun playtest checklist", () => {
       ...samples.map((sample) => sample.collectedPickups),
     );
     const maxSpeed = Math.max(...samples.map((sample) => sample.speed));
-    const roadJumps = adjacentMaxRatio(
-      samples
-        .map((sample) => sample.roadHalfWidth)
-        .filter((value): value is number => value !== null && value > 0),
-    );
-    const aiScaleJumps = adjacentMaxRatio(
-      samples
-        .map((sample) => sample.aiWidthDepth)
-        .filter((value): value is number => value !== null && value > 0),
-    );
+    const roadHalfWidthSamples = samples
+      .map((sample) => sample.roadHalfWidth)
+      .filter((value): value is number => value !== null && value > 0);
+    const aiWidthDepthSamples = samples
+      .map((sample) => sample.aiWidthDepth)
+      .filter((value): value is number => value !== null && value > 0);
+    const roadJumps = adjacentMaxRatio(roadHalfWidthSamples);
+    const aiScaleJumps = adjacentMaxRatio(aiWidthDepthSamples);
 
     await attachEvidence(testInfo, "script-a-first-90-seconds", {
       route: "/quick-race",
@@ -103,6 +101,8 @@ test.describe("release-fun playtest checklist", () => {
         maxVisiblePickups,
         maxCollectedPickups,
         maxSpeed,
+        roadSampleCount: roadHalfWidthSamples.length,
+        aiScaleSampleCount: aiWidthDepthSamples.length,
         roadJumps,
         aiScaleJumps,
         endedOnResults: page.url().includes("/race/results"),
@@ -114,6 +114,8 @@ test.describe("release-fun playtest checklist", () => {
     expect(maxVisiblePickups).toBeGreaterThan(0);
     expect(maxCollectedPickups).toBeGreaterThan(0);
     expect(maxSpeed).toBeGreaterThan(120);
+    expect(roadHalfWidthSamples.length).toBeGreaterThanOrEqual(4);
+    expect(aiWidthDepthSamples.length).toBeGreaterThanOrEqual(2);
     expect(roadJumps).toBeLessThan(1.6);
     expect(aiScaleJumps).toBeLessThan(1.8);
   });

--- a/e2e/release-fun-playtest.spec.ts
+++ b/e2e/release-fun-playtest.spec.ts
@@ -1,0 +1,456 @@
+import { expect, test, type Page, type TestInfo } from "@playwright/test";
+
+const SAVE_KEY = "vibegear2:save:v4";
+const ENABLED = process.env.RELEASE_FUN_PLAYTEST === "1";
+const PRODUCTION_URL = process.env.RELEASE_FUN_PRODUCTION_URL;
+const EXPECTED_VERSION = process.env.RELEASE_FUN_EXPECTED_VERSION;
+
+interface Evidence {
+  route: string;
+  viewport: { width: number; height: number } | null;
+  browser: string;
+  checkpoints: Record<string, boolean | number | string | null>;
+}
+
+test.describe("release-fun playtest checklist", () => {
+  test.skip(!ENABLED, "Set RELEASE_FUN_PLAYTEST=1 to run the release-fun checklist.");
+
+  test("script A records first 90-second quick race evidence", async ({
+    browserName,
+    page,
+  }, testInfo) => {
+    test.setTimeout(160_000);
+
+    await page.setViewportSize({ width: 1280, height: 900 });
+    await page.goto("/quick-race");
+    await expect(page.getByTestId("quick-race-page")).toBeVisible();
+    await expect(page.getByTestId("quick-race-track")).toHaveValue(
+      "velvet-coast/harbor-run",
+    );
+
+    await page.getByTestId("quick-race-start").click();
+    await expect(page.getByTestId("race-phase")).toHaveText("racing", {
+      timeout: 10_000,
+    });
+    const track = await page.getByTestId("race-canvas").getAttribute("data-track");
+    const mode = await page.getByTestId("race-canvas").getAttribute("data-mode");
+    const canvas = page.getByTestId("race-canvas-element");
+    await canvas.focus();
+    await page.keyboard.down("ArrowUp");
+    await page.keyboard.down("Space");
+    await expect(page.getByTestId("race-player-nitro-active")).toHaveText(
+      "yes",
+      { timeout: 5_000 },
+    );
+    await page.keyboard.up("Space");
+
+    const samples: Array<{
+      elapsedMs: number;
+      visibleAi: number;
+      visiblePickups: number;
+      collectedPickups: number;
+      speed: number;
+      aiWidthDepth: number | null;
+      roadHalfWidth: number | null;
+      url: string;
+    }> = [];
+    const startedAt = Date.now();
+    const stopAt = startedAt + 90_000;
+    while (Date.now() < stopAt && !page.url().includes("/race/results")) {
+      samples.push({
+        elapsedMs: Date.now() - startedAt,
+        visibleAi: await numberText(page, "race-visible-ai-count", 0),
+        visiblePickups: await numberText(page, "race-visible-pickup-count", 0),
+        collectedPickups: await numberText(
+          page,
+          "race-collected-pickup-count",
+          0,
+        ),
+        speed: await numberText(page, "hud-speed", 0),
+        aiWidthDepth: await optionalNumberText(page, "race-ai-width-depth-product"),
+        roadHalfWidth: await optionalNumberText(page, "race-road-near-half-width"),
+        url: page.url(),
+      });
+      await page.waitForTimeout(2_000);
+    }
+    await page.keyboard.up("ArrowUp");
+
+    const firstAiAt = samples.find((sample) => sample.visibleAi > 0)?.elapsedMs;
+    const maxVisiblePickups = Math.max(...samples.map((sample) => sample.visiblePickups));
+    const maxCollectedPickups = Math.max(
+      ...samples.map((sample) => sample.collectedPickups),
+    );
+    const maxSpeed = Math.max(...samples.map((sample) => sample.speed));
+    const roadJumps = adjacentMaxRatio(
+      samples
+        .map((sample) => sample.roadHalfWidth)
+        .filter((value): value is number => value !== null && value > 0),
+    );
+    const aiScaleJumps = adjacentMaxRatio(
+      samples
+        .map((sample) => sample.aiWidthDepth)
+        .filter((value): value is number => value !== null && value > 0),
+    );
+
+    await attachEvidence(testInfo, "script-a-first-90-seconds", {
+      route: "/quick-race",
+      viewport: page.viewportSize(),
+      browser: browserName,
+      checkpoints: {
+        track,
+        mode,
+        firstAiAt: firstAiAt ?? null,
+        maxVisiblePickups,
+        maxCollectedPickups,
+        maxSpeed,
+        roadJumps,
+        aiScaleJumps,
+        endedOnResults: page.url().includes("/race/results"),
+      },
+    });
+
+    expect(firstAiAt).not.toBeUndefined();
+    expect(firstAiAt ?? Number.POSITIVE_INFINITY).toBeLessThanOrEqual(25_000);
+    expect(maxVisiblePickups).toBeGreaterThan(0);
+    expect(maxCollectedPickups).toBeGreaterThan(0);
+    expect(maxSpeed).toBeGreaterThan(120);
+    expect(roadJumps).toBeLessThan(1.6);
+    expect(aiScaleJumps).toBeLessThan(1.8);
+  });
+
+  test("script B drives a full quick race into the garage", async ({
+    browserName,
+    page,
+  }, testInfo) => {
+    test.setTimeout(120_000);
+
+    await page.goto("/quick-race");
+    await page.getByTestId("quick-race-start").click();
+    await expect(page.getByTestId("race-phase")).toHaveText("racing", {
+      timeout: 10_000,
+    });
+
+    const canvas = page.getByTestId("race-canvas-element");
+    await canvas.focus();
+    await page.keyboard.down("ArrowUp");
+    await expect(page).toHaveURL(/\/race\/results/, { timeout: 90_000 });
+    await page.keyboard.up("ArrowUp");
+
+    await expect(page.getByTestId("race-results")).toBeVisible();
+    await expect(page.getByTestId("results-placement")).toBeVisible();
+    await expect(page.getByTestId("results-rewards-panel")).toBeVisible();
+    await expect(page.getByTestId("results-fastest-lap")).toBeVisible();
+    await expect(page.getByTestId("results-cta-continue")).toBeVisible();
+
+    await attachEvidence(testInfo, "script-b-full-quick-race", {
+      route: "/quick-race",
+      viewport: page.viewportSize(),
+      browser: browserName,
+      checkpoints: {
+        placement: await textContent(page, "results-placement"),
+        cash: await textContent(page, "results-cash"),
+        credits: await textContent(page, "results-credits-awarded"),
+        ctaVisible: true,
+      },
+    });
+
+    await page.getByTestId("results-cta-continue").click();
+    await expect(page).toHaveURL(/\/garage$/);
+    await expect(page.getByTestId("garage-page")).toBeVisible();
+  });
+
+  test("script C proves first tour handoff does not strand the player", async ({
+    browserName,
+    page,
+  }, testInfo) => {
+    test.setTimeout(80_000);
+
+    await seedSave(page, buildSave({ credits: 5000 }));
+    await page.goto("/world");
+    await page.getByTestId("world-tour-enter-velvet-coast").click();
+    await expect(page.getByTestId("pre-race-page")).toBeVisible();
+    await expect(page.getByTestId("pre-race-tour")).toContainText("Velvet Coast");
+    await page.getByTestId("pre-race-start-link").click();
+
+    await finishRace(page, 45_000);
+    await expect(page.getByTestId("results-standings-panel")).toBeVisible();
+    await expect(page.getByTestId("results-cta-continue-tour")).toBeVisible();
+    await attachEvidence(testInfo, "script-c-first-tour-chain", {
+      route: "/world",
+      viewport: page.viewportSize(),
+      browser: browserName,
+      checkpoints: {
+        resultTrack: await page.getByTestId("race-results").getAttribute("data-track"),
+        standingsVisible: true,
+        continueTourText: await textContent(page, "results-cta-continue-tour"),
+      },
+    });
+
+    await page.getByTestId("results-cta-continue-tour").click();
+    await expect(page).toHaveURL(/raceIndex=1$/);
+  });
+
+  test("scripts D and E cover upgrade purchase and weather prep", async ({
+    browserName,
+    page,
+  }, testInfo) => {
+    await seedSave(page, buildSave({ credits: 3500 }));
+
+    await page.goto("/garage/upgrade");
+    await expect(page.getByTestId("garage-upgrade-page")).toBeVisible();
+    await page.getByTestId("buy-upgrade-engine").click();
+    await expect(page.getByTestId("garage-upgrade-status")).toContainText(
+      "Installed Street Engine",
+    );
+    const persisted = await readSave(page);
+    expect(persisted?.garage?.installedUpgrades?.["sparrow-gt"]?.engine).toBe(1);
+
+    await page.goto(
+      "/race/prep?track=velvet-coast%2Fharbor-run&tour=velvet-coast&raceIndex=0&weather=rain",
+    );
+    await expect(page.getByTestId("pre-race-weather")).toHaveText("Rain");
+    await expect(page.getByTestId("pre-race-recommended-tire")).toContainText(
+      "wet",
+    );
+    await expect(page.getByTestId("pre-race-tire-wet")).toHaveAttribute(
+      "aria-pressed",
+      "true",
+    );
+    await page.getByTestId("pre-race-start-link").click();
+    await expect(page).toHaveURL(/weather=rain/);
+    await expect(page).toHaveURL(/tire=wet/);
+    await expect(page.getByTestId("race-canvas")).toBeVisible();
+
+    await attachEvidence(testInfo, "scripts-d-e-upgrade-weather-prep", {
+      route: "/garage/upgrade and /race/prep",
+      viewport: page.viewportSize(),
+      browser: browserName,
+      checkpoints: {
+        engineTier: persisted?.garage?.installedUpgrades?.["sparrow-gt"]?.engine ?? null,
+        weather: "rain",
+        selectedTire: "wet",
+      },
+    });
+  });
+
+  test("scripts F, G, and H cover AI pressure, pickup feedback, and finish routing", async ({
+    browserName,
+    page,
+  }, testInfo) => {
+    test.setTimeout(90_000);
+
+    await page.goto("/race?track=test/straight&mode=quickRace");
+    await expect(page.getByTestId("race-phase")).toHaveText("racing", {
+      timeout: 10_000,
+    });
+    const canvas = page.getByTestId("race-canvas-element");
+    await canvas.focus();
+    await page.keyboard.down("ArrowUp");
+
+    await expect
+      .poll(async () => numberText(page, "race-visible-ai-count", 0), {
+        timeout: 25_000,
+      })
+      .toBeGreaterThan(0);
+    await expect
+      .poll(async () => numberText(page, "race-visible-pickup-count", 0), {
+        timeout: 10_000,
+      })
+      .toBeGreaterThan(0);
+    await expect
+      .poll(async () => numberText(page, "race-collected-pickup-count", 0), {
+        timeout: 25_000,
+      })
+      .toBeGreaterThan(0);
+    await expect(page.getByTestId("race-last-pickup-kind")).toHaveText("cash", {
+      timeout: 25_000,
+    });
+    await expect(page).toHaveURL(/\/race\/results/, { timeout: 45_000 });
+    await page.keyboard.up("ArrowUp");
+    await expect(page.getByTestId("race-results")).toBeVisible();
+
+    await attachEvidence(testInfo, "scripts-f-g-h-ai-pickup-finish", {
+      route: "/race?track=test/straight&mode=quickRace",
+      viewport: page.viewportSize(),
+      browser: browserName,
+      checkpoints: {
+        pickupKind: "cash",
+        resultsVisible: true,
+        resultTrack: await page.getByTestId("race-results").getAttribute("data-track"),
+      },
+    });
+  });
+
+  test("script I smokes production when configured", async ({
+    browserName,
+    page,
+  }, testInfo) => {
+    test.skip(!PRODUCTION_URL, "Set RELEASE_FUN_PRODUCTION_URL for production smoke.");
+
+    const base = PRODUCTION_URL!.replace(/\/$/, "");
+    const versionResponse = await page.request.get(`${base}/api/version`);
+    expect(versionResponse.ok()).toBe(true);
+    const version = (await versionResponse.json()) as { version?: string };
+    if (EXPECTED_VERSION) {
+      expect(version.version).toBe(EXPECTED_VERSION);
+    }
+
+    await page.goto(base);
+    await expect(page.getByTestId("game-title")).toBeVisible();
+    await page.goto(`${base}/quick-race`);
+    await page.getByTestId("quick-race-start").click();
+    await expect(page.getByTestId("race-canvas-element")).toBeVisible();
+    await expect.poll(() => canvasHasPaint(page), { timeout: 10_000 }).toBe(true);
+
+    await attachEvidence(testInfo, "script-i-production-smoke", {
+      route: base,
+      viewport: page.viewportSize(),
+      browser: browserName,
+      checkpoints: {
+        version: version.version ?? null,
+        expectedVersion: EXPECTED_VERSION ?? null,
+        canvasPainted: true,
+      },
+    });
+  });
+});
+
+async function attachEvidence(
+  testInfo: TestInfo,
+  name: string,
+  evidence: Evidence,
+): Promise<void> {
+  await testInfo.attach(name, {
+    body: JSON.stringify(evidence, null, 2),
+    contentType: "application/json",
+  });
+}
+
+async function finishRace(page: Page, timeout: number): Promise<void> {
+  const canvas = page.getByTestId("race-canvas-element");
+  await expect(canvas).toBeVisible();
+  await expect(page.getByTestId("race-phase")).toHaveText("racing", {
+    timeout: 10_000,
+  });
+  await canvas.focus();
+  await page.keyboard.down("ArrowUp");
+  await expect(page).toHaveURL(/\/race\/results/, { timeout });
+  await page.keyboard.up("ArrowUp");
+  await expect(page.getByTestId("race-results")).toBeVisible();
+}
+
+async function numberText(
+  page: Page,
+  testId: string,
+  fallback: number,
+): Promise<number> {
+  const value = await optionalNumberText(page, testId);
+  return value ?? fallback;
+}
+
+async function optionalNumberText(page: Page, testId: string): Promise<number | null> {
+  const text = await textContent(page, testId);
+  if (!text || text === "none") return null;
+  const value = Number(text);
+  return Number.isFinite(value) ? value : null;
+}
+
+async function textContent(page: Page, testId: string): Promise<string | null> {
+  return page.evaluate((id) => {
+    const element = document.querySelector(`[data-testid="${id}"]`);
+    return element?.textContent?.trim() ?? null;
+  }, testId);
+}
+
+function adjacentMaxRatio(values: number[]): number {
+  let maxRatio = 1;
+  for (let index = 1; index < values.length; index += 1) {
+    const previous = values[index - 1];
+    const current = values[index];
+    if (previous === undefined || current === undefined) continue;
+    if (previous <= 0 || current <= 0) continue;
+    maxRatio = Math.max(
+      maxRatio,
+      Math.max(previous, current) / Math.min(previous, current),
+    );
+  }
+  return maxRatio;
+}
+
+async function canvasHasPaint(page: Page): Promise<boolean> {
+  return page.evaluate(() => {
+    const canvas = document.querySelector<HTMLCanvasElement>(
+      '[data-testid="race-canvas-element"]',
+    );
+    if (!canvas) return false;
+    const context = canvas.getContext("2d");
+    if (!context) return false;
+    const { data } = context.getImageData(0, 0, canvas.width, canvas.height);
+    for (let index = 3; index < data.length; index += 4) {
+      if ((data[index] ?? 0) > 0) return true;
+    }
+    return false;
+  });
+}
+
+async function seedSave(page: Page, save: ReturnType<typeof buildSave>): Promise<void> {
+  await page.goto("/");
+  await page.evaluate(
+    ({ key, payload }) => window.localStorage.setItem(key, JSON.stringify(payload)),
+    { key: SAVE_KEY, payload: save },
+  );
+}
+
+async function readSave(page: Page): Promise<ReturnType<typeof buildSave> | null> {
+  return page.evaluate((key) => {
+    const raw = window.localStorage.getItem(key);
+    return raw ? (JSON.parse(raw) as ReturnType<typeof buildSave>) : null;
+  }, SAVE_KEY);
+}
+
+function buildSave({ credits }: { credits: number }) {
+  return {
+    version: 4,
+    profileName: "ReleaseFunTester",
+    settings: {
+      displaySpeedUnit: "kph",
+      assists: {
+        steeringAssist: false,
+        autoNitro: false,
+        weatherVisualReduction: false,
+      },
+      difficultyPreset: "easy",
+      transmissionMode: "auto",
+      audio: { master: 1, music: 1, sfx: 1 },
+      accessibility: {
+        colorBlindMode: "off",
+        reducedMotion: false,
+        largeUiText: false,
+        screenShakeScale: 1,
+      },
+    },
+    garage: {
+      credits,
+      ownedCars: ["sparrow-gt"],
+      activeCarId: "sparrow-gt",
+      installedUpgrades: {
+        "sparrow-gt": {
+          engine: 0,
+          gearbox: 0,
+          dryTires: 0,
+          wetTires: 0,
+          nitro: 0,
+          armor: 0,
+          cooling: 0,
+          aero: 0,
+        },
+      },
+      pendingDamage: {},
+      lastRaceCashEarned: 0,
+    },
+    progress: { unlockedTours: ["velvet-coast"], completedTours: [] },
+    records: {},
+    ghosts: {},
+    writeCounter: 0,
+  };
+}

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "quality:lighthouse": "vite-node --script scripts/check-lighthouse.ts",
     "quality:gates": "npm run quality:bundle && npm run quality:lighthouse",
     "release:media": "vite-node --script scripts/capture-release-media.ts",
-    "playtest:release-fun": "RELEASE_FUN_PLAYTEST=1 playwright test e2e/release-fun-playtest.spec.ts --project=chromium --workers=1",
+    "playtest:release-fun": "node scripts/run-release-fun-playtest.mjs",
     "bench:render": "vitest run --config vitest.bench.config.ts",
     "art:generate": "vite-node --script scripts/generate-placeholder-art.ts",
     "art:check": "vite-node --script scripts/check-art-manifest.ts",

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "quality:lighthouse": "vite-node --script scripts/check-lighthouse.ts",
     "quality:gates": "npm run quality:bundle && npm run quality:lighthouse",
     "release:media": "vite-node --script scripts/capture-release-media.ts",
+    "playtest:release-fun": "RELEASE_FUN_PLAYTEST=1 playwright test e2e/release-fun-playtest.spec.ts --project=chromium --workers=1",
     "bench:render": "vitest run --config vitest.bench.config.ts",
     "art:generate": "vite-node --script scripts/generate-placeholder-art.ts",
     "art:check": "vite-node --script scripts/check-art-manifest.ts",

--- a/scripts/run-release-fun-playtest.mjs
+++ b/scripts/run-release-fun-playtest.mjs
@@ -1,0 +1,25 @@
+import { spawn } from "node:child_process";
+
+const child = spawn(
+  "npx",
+  [
+    "playwright",
+    "test",
+    "e2e/release-fun-playtest.spec.ts",
+    "--project=chromium",
+    "--workers=1",
+  ],
+  {
+    env: { ...process.env, RELEASE_FUN_PLAYTEST: "1" },
+    shell: process.platform === "win32",
+    stdio: "inherit",
+  },
+);
+
+child.on("exit", (code, signal) => {
+  if (signal) {
+    process.kill(process.pid, signal);
+    return;
+  }
+  process.exit(code ?? 1);
+});


### PR DESCRIPTION
## GDD sections
- docs/gdd/04-player-experience-goals.md
- docs/gdd/05-core-gameplay-loop.md
- docs/gdd/16-rendering-and-visual-design.md
- docs/gdd/20-hud-and-ui-ux.md

## Requirement inventory
- Adds an agent-runnable release-fun checklist command for the default first 90 seconds, full Quick Race, tour handoff, upgrade purchase, weather prep, AI pressure, pickup feedback, finish routing, and optional production smoke.
- Updates docs so future race-feel slices know when and how to run it.
- Leaves richer pass and rival-pressure telemetry to F-075.

## Progress log
- docs/PROGRESS_LOG.md: Release-fun playtest automation.

## Followups
- Closes F-076.

## Test plan
- [x] npm run typecheck
- [x] npm run lint
- [x] npm run docs:check
- [x] npm run content-lint
- [x] npm run playtest:release-fun
- [x] banned dash scan on staged files

## Notes
- Production smoke is built into the spec and runs when RELEASE_FUN_PRODUCTION_URL is supplied. Local verification skipped that configured-only case.