### PR TITLE
fix(ci): raise verify timeout

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
   verify:
     name: Lint, typecheck, unit, e2e
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 45
     steps:
       - uses: actions/checkout@v6
 

--- a/docs/PROGRESS_LOG.md
+++ b/docs/PROGRESS_LOG.md
@@ -6,6 +6,39 @@ Correct them by adding a new entry that references the old one.
 
 ---
 
+## 2026-05-02: Slice: CI cross-browser timeout hotfix
+
+**GDD sections touched:** §21.
+**Branch / PR:** `fix/ci-cross-browser-timeout`, PR pending.
+**Status:** Implemented.
+
+### Done
+- Raised the main CI verify job timeout from 30 minutes to 45 minutes so the
+  required cross-browser smoke has time to install Firefox and WebKit after the
+  full Chromium e2e suite.
+
+### Verified
+- `npm run docs:check` green.
+- `npm run content-lint` green.
+
+### Decisions and assumptions
+- Main deploy was already serving the merged build, but the deploy verification
+  job was skipped because the verify job hit its timeout during browser
+  installation. The immediate fix is to restore a healthy main gate without
+  changing test coverage.
+
+### Coverage ledger
+- Referenced existing ledger id: `GDD-21-CI-DEPLOY-HEALTH`.
+- Uncovered adjacent requirements: none.
+
+### Followups created
+None.
+
+### GDD edits
+None.
+
+---
+
 ## 2026-05-02: Slice: Release-fun playtest automation
 
 **GDD sections touched:** §4, §5, §16, and §20.


### PR DESCRIPTION
## GDD sections
- docs/gdd/21-technical-design-for-web-implementation.md

## Requirement inventory
- Restores healthy main deploy verification by giving the required cross-browser smoke enough time after full Chromium e2e.
- Does not change test coverage or runtime behavior.

## Progress log
- docs/PROGRESS_LOG.md: CI cross-browser timeout hotfix.

## Test plan
- [x] npm run docs:check
- [x] npm run content-lint
- [x] banned dash scan

## Context
Main deploy served 762cf51, but the main CI verify job cancelled at 30 minutes while installing cross-browser smoke browsers, after Chromium e2e and quality gates had passed.