### PR TITLE
feat(ai): add readable archetype cues

### DIFF
--- a/docs/GDD_COVERAGE.json
+++ b/docs/GDD_COVERAGE.json
@@ -1022,6 +1022,25 @@
       ]
     },
     {
+      "id": "GDD-15-AI-ARCHETYPE-READABILITY",
+      "gddSections": [
+        "docs/gdd/15-cpu-opponents-and-ai.md",
+        "docs/gdd/20-hud-and-ui-ux.md",
+        "docs/gdd/27-risks-and-mitigations.md"
+      ],
+      "requirement": "Live CPU opponents expose readable archetype behavior cues for rocket launch and fade, bully pressure, cautious low-visibility braking, chaotic missed apex events, and enduro consistency.",
+      "coverage": ["implemented-code", "automated-test"],
+      "implementationRefs": [
+        "src/game/ai.ts",
+        "src/game/aiArchetypes.ts",
+        "src/app/race/page.tsx"
+      ],
+      "testRefs": [
+        "src/game/__tests__/ai.test.ts",
+        "e2e/race-ai-archetypes.spec.ts"
+      ]
+    },
+    {
       "id": "GDD-24-MVP-TRACK-SET",
       "gddSections": [
         "docs/gdd/09-track-design.md",

--- a/docs/PROGRESS_LOG.md
+++ b/docs/PROGRESS_LOG.md
@@ -6,6 +6,49 @@ Correct them by adding a new entry that references the old one.
 
 ---
 
+## 2026-05-02: Slice: Readable AI archetype cues
+
+**GDD sections touched:** §15, §20, and §27.
+**Branch / PR:** `feat/readable-ai-archetypes`, PR pending.
+**Status:** Implemented.
+
+### Done
+- Added explicit AI readability cues to the deterministic AI state so live
+  races can report rocket launch and fade, bully pressure, cautious
+  low-visibility braking, chaotic missed apex events, enduro consistency, and
+  overtakes.
+- Made cautious archetypes brake earlier on low-visibility curves instead of
+  relying only on generic weather skill and lane-mistake pressure.
+- Exposed hidden race-window telemetry for AI archetype roster and observed
+  behavior cues, then added a Playwright race check that verifies the cues
+  appear in a real fog race.
+
+### Verified
+- `npx vitest run src/game/__tests__/ai.test.ts` green, 40 passed.
+- `npx playwright test e2e/race-ai-archetypes.spec.ts` green, 1 passed.
+- `npm run typecheck` green.
+- `npm run lint` green.
+- `npm run docs:check` green.
+- `npm run content-lint` green.
+
+### Decisions and assumptions
+- Kept the cues on `AIState` instead of deriving them from screenshots. This
+  gives browser tests a deterministic signal while still coming from the same
+  runtime decisions the player sees.
+
+### Coverage ledger
+- Added `GDD-15-AI-ARCHETYPE-READABILITY`.
+- Uncovered adjacent requirements: AI nitro firing and fuller passing strategy
+  remain separate from this PR-sized slice.
+
+### Followups created
+None.
+
+### GDD edits
+None.
+
+---
+
 ## 2026-05-02: Slice: CI cross-browser timeout hotfix
 
 **GDD sections touched:** §21.

--- a/e2e/race-ai-archetypes.spec.ts
+++ b/e2e/race-ai-archetypes.spec.ts
@@ -1,0 +1,68 @@
+import { expect, test, type Page } from "@playwright/test";
+
+async function csvText(page: Page, testId: string): Promise<Set<string>> {
+  const text = await page.getByTestId(testId).textContent();
+  return new Set(
+    (text ?? "")
+      .split(",")
+      .map((value) => value.trim())
+      .filter((value) => value.length > 0 && value !== "none"),
+  );
+}
+
+test.describe("race AI archetype readability", () => {
+  test("surfaces archetype and behavior cues from the live race window", async ({
+    page,
+  }) => {
+    test.setTimeout(45_000);
+
+    await page.setViewportSize({ width: 1280, height: 900 });
+    await page.goto(
+      "/race?track=moss-frontier/mistbarrow&mode=quickRace&weather=fog&tour=velvet-coast&raceIndex=0",
+    );
+    await expect(page.getByTestId("race-phase")).toHaveText("racing", {
+      timeout: 10_000,
+    });
+
+    await expect
+      .poll(
+        async () => Array.from(await csvText(page, "race-ai-archetype-roster")),
+        { timeout: 10_000 },
+      )
+      .toEqual(
+        expect.arrayContaining([
+          "aggressive",
+          "clean_line",
+          "defender",
+          "endurance",
+          "nitro_burst",
+          "wet_specialist",
+        ]),
+      );
+
+    const observed = new Set<string>();
+    for (let i = 0; i < 100; i += 1) {
+      for (const cue of await csvText(page, "race-ai-observed-cues")) {
+        observed.add(cue);
+      }
+      if (
+        observed.has("rocket-launch") &&
+        observed.has("bully-pressure") &&
+        observed.has("cautious-low-visibility") &&
+        observed.has("enduro-consistent")
+      ) {
+        break;
+      }
+      await page.waitForTimeout(250);
+    }
+
+    expect(Array.from(observed)).toEqual(
+      expect.arrayContaining([
+        "rocket-launch",
+        "bully-pressure",
+        "cautious-low-visibility",
+        "enduro-consistent",
+      ]),
+    );
+  });
+});

--- a/e2e/race-ai-archetypes.spec.ts
+++ b/e2e/race-ai-archetypes.spec.ts
@@ -18,7 +18,7 @@ test.describe("race AI archetype readability", () => {
 
     await page.setViewportSize({ width: 1280, height: 900 });
     await page.goto(
-      "/race?track=moss-frontier/mistbarrow&mode=quickRace&weather=fog&tour=velvet-coast&raceIndex=0",
+      "/race?track=glass-ridge/hollow-crest&mode=quickRace&weather=fog&tour=velvet-coast&raceIndex=0",
     );
     await expect(page.getByTestId("race-phase")).toHaveText("racing", {
       timeout: 10_000,

--- a/src/app/race/page.tsx
+++ b/src/app/race/page.tsx
@@ -100,6 +100,7 @@ import {
   type RankedCar,
   type GhostDriver,
   type GhostOverlay,
+  type AIReadabilityCue,
   type TimeTrialRecorder,
 } from "@/game";
 import { DEFAULT_TOUCH_LAYOUT, type TouchLayout } from "@/game/inputTouch";
@@ -753,6 +754,11 @@ interface RoadProjectionSnapshot {
   readonly horizonY: number;
 }
 
+interface AiReadabilitySnapshot {
+  readonly archetypeRoster: string;
+  readonly observedCueRoster: string;
+}
+
 function roadProjectionSnapshot(
   strips: readonly Strip[],
 ): RoadProjectionSnapshot | null {
@@ -777,6 +783,28 @@ function roadProjectionSnapshot(
     nearY: foreground.screenY,
     nearHalfWidth: foreground.screenW,
     horizonY: horizon.screenY,
+  };
+}
+
+function aiReadabilitySnapshot(input: {
+  config: Readonly<RaceSessionConfig>;
+  session: Readonly<RaceSessionState>;
+  roster: readonly AIDriver[];
+  observedCues: Set<AIReadabilityCue>;
+}): AiReadabilitySnapshot {
+  const archetypes = new Set<string>();
+  for (const driver of input.roster) {
+    archetypes.add(driver.archetype);
+  }
+  for (const entry of input.config.ai) {
+    archetypes.add(entry.driver.archetype);
+  }
+  for (const entry of input.session.ai) {
+    input.observedCues.add(entry.state.readabilityCue);
+  }
+  return {
+    archetypeRoster: Array.from(archetypes).sort().join(","),
+    observedCueRoster: Array.from(input.observedCues).sort().join(","),
   };
 }
 
@@ -1028,6 +1056,7 @@ function RaceCanvas({
   const raceMomentTimeoutRef = useRef<number | null>(null);
   const finishRouteTimeoutRef = useRef<number | null>(null);
   const pickupFeedbackRef = useRef<PickupFeedbackSnapshot | null>(null);
+  const observedAiCuesRef = useRef<Set<AIReadabilityCue>>(new Set());
   // Per-mount guard for the natural finish wiring. The render callback
   // fires every frame, so without this latch a `phase === "finished"`
   // tick would call `saveRaceResult` and `router.push` on every frame
@@ -1063,6 +1092,8 @@ function RaceCanvas({
   const [aiVisibleCount, setAiVisibleCount] = useState<number>(0);
   const [aiProjection, setAiProjection] =
     useState<AiProjectionSnapshot | null>(null);
+  const [aiReadability, setAiReadability] =
+    useState<AiReadabilitySnapshot | null>(null);
   const [roadProjection, setRoadProjection] =
     useState<RoadProjectionSnapshot | null>(null);
   const [visiblePickupCount, setVisiblePickupCount] = useState<number>(0);
@@ -1230,12 +1261,13 @@ function RaceCanvas({
       : pendingDamageForActiveCar(sessionSave);
     const raceSeed = 1;
     let timeTrialSaveSnapshot = sessionSave;
+    const aiDriverRoster = resolveRaceAIDrivers(tourContext);
     const spawnedAi = ghostEnabled || practiceMode
       ? []
       : spawnGrid({
           trackSpawn: track.compiled.spawn,
           laneCount: track.compiled.laneCount,
-          aiDrivers: resolveRaceAIDrivers(tourContext).map((driver) => ({
+          aiDrivers: aiDriverRoster.map((driver) => ({
             driver,
             stats: playerStats,
           })),
@@ -1311,7 +1343,9 @@ function RaceCanvas({
     };
 
     pickupFeedbackRef.current = null;
+    observedAiCuesRef.current = new Set();
     setPickupFeedback(null);
+    setAiReadability(null);
     sessionRef.current = createRaceSession(config);
     resetTimeTrialRuntime();
     // Re-arm the natural-finish guard on every fresh mount. The
@@ -2020,6 +2054,14 @@ function RaceCanvas({
           totalLaps: hud.totalLaps,
           position: hud.position,
         });
+        setAiReadability(
+          aiReadabilitySnapshot({
+            config,
+            session,
+            roster: aiDriverRoster,
+            observedCues: observedAiCuesRef.current,
+          }),
+        );
         setInputSnapshot({
           steer: lastSteerRef.current,
           touchActive: inputManager.hasTouch(),
@@ -2133,6 +2175,14 @@ function RaceCanvas({
         <dd data-testid="race-field-size">{fieldSize}</dd>
         <dt>Visible AI:</dt>
         <dd data-testid="race-visible-ai-count">{aiVisibleCount}</dd>
+        <dt>AI archetypes:</dt>
+        <dd data-testid="race-ai-archetype-roster">
+          {aiReadability?.archetypeRoster ?? "none"}
+        </dd>
+        <dt>AI cues:</dt>
+        <dd data-testid="race-ai-observed-cues">
+          {aiReadability?.observedCueRoster ?? "none"}
+        </dd>
         <dt>Nearest AI depth:</dt>
         <dd data-testid="race-ai-nearest-depth">
           {aiProjection?.nearestDepthMeters.toFixed(2) ?? "none"}

--- a/src/app/race/page.tsx
+++ b/src/app/race/page.tsx
@@ -759,6 +759,15 @@ interface AiReadabilitySnapshot {
   readonly observedCueRoster: string;
 }
 
+function observeAiReadabilityCues(input: {
+  session: Readonly<RaceSessionState>;
+  observedCues: Set<AIReadabilityCue>;
+}): void {
+  for (const entry of input.session.ai) {
+    input.observedCues.add(entry.state.readabilityCue);
+  }
+}
+
 function roadProjectionSnapshot(
   strips: readonly Strip[],
 ): RoadProjectionSnapshot | null {
@@ -788,19 +797,17 @@ function roadProjectionSnapshot(
 
 function aiReadabilitySnapshot(input: {
   config: Readonly<RaceSessionConfig>;
-  session: Readonly<RaceSessionState>;
-  roster: readonly AIDriver[];
-  observedCues: Set<AIReadabilityCue>;
+  observedCues: ReadonlySet<AIReadabilityCue>;
 }): AiReadabilitySnapshot {
-  const archetypes = new Set<string>();
-  for (const driver of input.roster) {
-    archetypes.add(driver.archetype);
+  if (input.config.ai.length === 0) {
+    return {
+      archetypeRoster: "",
+      observedCueRoster: "",
+    };
   }
+  const archetypes = new Set<string>();
   for (const entry of input.config.ai) {
     archetypes.add(entry.driver.archetype);
-  }
-  for (const entry of input.session.ai) {
-    input.observedCues.add(entry.state.readabilityCue);
   }
   return {
     archetypeRoster: Array.from(archetypes).sort().join(","),
@@ -2054,11 +2061,13 @@ function RaceCanvas({
           totalLaps: hud.totalLaps,
           position: hud.position,
         });
+        observeAiReadabilityCues({
+          session,
+          observedCues: observedAiCuesRef.current,
+        });
         setAiReadability(
           aiReadabilitySnapshot({
             config,
-            session,
-            roster: aiDriverRoster,
             observedCues: observedAiCuesRef.current,
           }),
         );

--- a/src/game/__tests__/ai.test.ts
+++ b/src/game/__tests__/ai.test.ts
@@ -349,6 +349,8 @@ describe("tickAI (§15 archetype behaviours)", () => {
     expect(lateRocket.nextAiState.targetSpeed).toBeLessThan(
       lateClean.nextAiState.targetSpeed,
     );
+    expect(earlyRocket.nextAiState.readabilityCue).toBe("rocket-launch");
+    expect(lateRocket.nextAiState.readabilityCue).toBe("rocket-fade");
   });
 
   it("bully drivers pressure toward nearby traffic", () => {
@@ -378,6 +380,7 @@ describe("tickAI (§15 archetype behaviours)", () => {
     );
 
     expect(bullyTick.input.steer).toBeGreaterThan(cleanTick.input.steer);
+    expect(bullyTick.nextAiState.readabilityCue).toBe("bully-pressure");
   });
 
   it("bully pressure uses the player's position relative to the AI", () => {
@@ -438,6 +441,47 @@ describe("tickAI (§15 archetype behaviours)", () => {
     expect(cautiousTick.input.brake).toBeGreaterThan(cleanTick.input.brake);
   });
 
+  it("cautious drivers brake earlier on low-visibility curves", () => {
+    const cautious = archetypeDriver("defender");
+    const aiCar = freshCar({ z: 900, speed: 40 });
+    const clearTick = tickAI(
+      cautious,
+      freshAi(),
+      aiCar,
+      PLAYER_FAR_BEHIND,
+      SWEEPER_TRACK,
+      RACING,
+      STARTER_STATS,
+      DEFAULT_AI_TRACK_CONTEXT,
+      0,
+      IDENTITY_CPU_MODIFIERS,
+      1,
+      1,
+    );
+    const fogTick = tickAI(
+      cautious,
+      freshAi(),
+      aiCar,
+      PLAYER_FAR_BEHIND,
+      SWEEPER_TRACK,
+      RACING,
+      STARTER_STATS,
+      DEFAULT_AI_TRACK_CONTEXT,
+      0,
+      IDENTITY_CPU_MODIFIERS,
+      1,
+      1.5,
+    );
+
+    expect(fogTick.nextAiState.targetSpeed).toBeLessThan(
+      clearTick.nextAiState.targetSpeed,
+    );
+    expect(fogTick.input.brake).toBeGreaterThan(clearTick.input.brake);
+    expect(fogTick.nextAiState.readabilityCue).toBe(
+      "cautious-low-visibility",
+    );
+  });
+
   it("chaotic drivers produce more seeded lane mistakes than enduro drivers", () => {
     const chaotic = archetypeDriver("wet_specialist", { mistakeRate: 0.2 });
     const enduro = archetypeDriver("endurance", { mistakeRate: 0.2 });
@@ -461,6 +505,17 @@ describe("tickAI (§15 archetype behaviours)", () => {
     expect(countSteeringMistakes(chaotic)).toBeGreaterThan(
       countSteeringMistakes(enduro),
     );
+    expect(
+      tickAI(
+        enduro,
+        freshAi(),
+        freshCar({ speed: 20 }),
+        PLAYER_FAR_BEHIND,
+        STRAIGHT_TRACK,
+        RACING,
+        STARTER_STATS,
+      ).nextAiState.readabilityCue,
+    ).toBe("enduro-consistent");
   });
 });
 

--- a/src/game/__tests__/ai.test.ts
+++ b/src/game/__tests__/ai.test.ts
@@ -505,6 +505,20 @@ describe("tickAI (§15 archetype behaviours)", () => {
     expect(countSteeringMistakes(chaotic)).toBeGreaterThan(
       countSteeringMistakes(enduro),
     );
+    const chaoticMistakeCue = Array.from({ length: 160 }, (_, index) => index + 1)
+      .map((seed) =>
+        tickAI(
+          chaotic,
+          freshAi({ seed }),
+          freshCar({ speed: 20, z: seed * 6 }),
+          PLAYER_FAR_BEHIND,
+          STRAIGHT_TRACK,
+          RACING,
+          STARTER_STATS,
+        ).nextAiState.readabilityCue,
+      )
+      .find((cue) => cue === "chaotic-missed-apex");
+    expect(chaoticMistakeCue).toBe("chaotic-missed-apex");
     expect(
       tickAI(
         enduro,
@@ -535,6 +549,7 @@ describe("tickAI (visible overtake intent)", () => {
     );
 
     expect(result.nextAiState.intent).toBe("overtake");
+    expect(result.nextAiState.readabilityCue).toBe("overtake");
     expect(result.input.steer).toBeGreaterThan(0);
   });
 

--- a/src/game/ai.ts
+++ b/src/game/ai.ts
@@ -579,6 +579,7 @@ function readabilityCueFor(input: {
   brilliantPaceBonus: number;
   overtakeActive: boolean;
 }): AIReadabilityCue {
+  if (input.overtakeActive) return "overtake";
   if (input.archetype === "nitro_burst") {
     if (input.launchPaceBonus > 0) return "rocket-launch";
     if (input.fadePacePenalty > 0) return "rocket-fade";
@@ -591,7 +592,8 @@ function readabilityCueFor(input: {
   }
   if (
     input.archetype === "defender" &&
-    input.visibilityRiskScalar > 1.05
+    input.visibilityRiskScalar > 1.05 &&
+    Math.abs(input.authoredCurve) > 0.05
   ) {
     return "cautious-low-visibility";
   }
@@ -600,7 +602,6 @@ function readabilityCueFor(input: {
     if (input.brilliantPaceBonus > 0) return "chaotic-brilliant";
   }
   if (input.archetype === "endurance") return "enduro-consistent";
-  if (input.overtakeActive) return "overtake";
   return "clean-line";
 }
 

--- a/src/game/ai.ts
+++ b/src/game/ai.ts
@@ -65,7 +65,7 @@
  * - Damage-aware rub avoidance and contact fairness scoring.
  */
 
-import type { AIDriver, CarBaseStats } from "@/data/schemas";
+import type { AIArchetype, AIDriver, CarBaseStats } from "@/data/schemas";
 import { CURVATURE_SCALE, ROAD_WIDTH, SEGMENT_LENGTH } from "@/road/constants";
 import type { CompiledSegmentBuffer } from "@/road/trackCompiler";
 import type { CpuDifficultyModifiers } from "./aiDifficulty";
@@ -117,7 +117,19 @@ export interface AIState {
   intent: "defend" | "overtake" | "recover" | "conserve";
   targetSpeed: number;
   seed: number;
+  readabilityCue: AIReadabilityCue;
 }
+
+export type AIReadabilityCue =
+  | "clean-line"
+  | "rocket-launch"
+  | "rocket-fade"
+  | "bully-pressure"
+  | "cautious-low-visibility"
+  | "chaotic-missed-apex"
+  | "chaotic-brilliant"
+  | "enduro-consistent"
+  | "overtake";
 
 /**
  * Initial AI state convenience: stationary at the start of the track
@@ -132,6 +144,7 @@ export const INITIAL_AI_STATE: Readonly<AIState> = Object.freeze({
   intent: "conserve",
   targetSpeed: 0,
   seed: 1,
+  readabilityCue: "clean-line",
 });
 
 /**
@@ -366,7 +379,11 @@ export function tickAI(
   const curvePenalty =
     1 -
     AI_TUNING.CLEAN_LINE_CURVE_DECEL *
-      behaviour.curveBrakeScalar *
+      visibilityCurveBrakeScalar(
+        behaviour.curveBrakeScalar,
+        behaviour.lowVisibilityBrakeScalar,
+        visibilityRiskScalar,
+      ) *
       Math.abs(authoredCurve);
   const lapProgressFraction = lapFraction(track.totalLength, aiCar.z);
   const launchPaceBonus =
@@ -399,6 +416,17 @@ export function tickAI(
     intent: overtake.active ? "overtake" : aiState.intent === "overtake" ? "recover" : aiState.intent,
     targetSpeed,
     seed: nextSeed,
+    readabilityCue: readabilityCueFor({
+      archetype: driver.archetype,
+      launchPaceBonus,
+      fadePacePenalty,
+      trafficLaneOffset,
+      visibilityRiskScalar,
+      authoredCurve,
+      mistakeOffset,
+      brilliantPaceBonus,
+      overtakeActive: overtake.active,
+    }),
   };
 
   // Countdown: do not integrate inputs. Per the dot stress-test item 10
@@ -529,6 +557,51 @@ function overtakeOffset(
     active: true,
     offset: clamp(target - aiCar.x, -AI_TUNING.OVERTAKE_LANE_SHIFT_METERS, AI_TUNING.OVERTAKE_LANE_SHIFT_METERS),
   };
+}
+
+function visibilityCurveBrakeScalar(
+  curveBrakeScalar: number,
+  lowVisibilityBrakeScalar: number,
+  visibilityRiskScalar: number,
+): number {
+  const visibilityPressure = clamp(visibilityRiskScalar - 1, 0, 1);
+  return curveBrakeScalar * (1 + lowVisibilityBrakeScalar * visibilityPressure);
+}
+
+function readabilityCueFor(input: {
+  archetype: AIArchetype;
+  launchPaceBonus: number;
+  fadePacePenalty: number;
+  trafficLaneOffset: number;
+  visibilityRiskScalar: number;
+  authoredCurve: number;
+  mistakeOffset: number;
+  brilliantPaceBonus: number;
+  overtakeActive: boolean;
+}): AIReadabilityCue {
+  if (input.archetype === "nitro_burst") {
+    if (input.launchPaceBonus > 0) return "rocket-launch";
+    if (input.fadePacePenalty > 0) return "rocket-fade";
+  }
+  if (
+    input.archetype === "aggressive" &&
+    Math.abs(input.trafficLaneOffset) > 0.05
+  ) {
+    return "bully-pressure";
+  }
+  if (
+    input.archetype === "defender" &&
+    input.visibilityRiskScalar > 1.05
+  ) {
+    return "cautious-low-visibility";
+  }
+  if (input.archetype === "wet_specialist") {
+    if (input.mistakeOffset !== 0) return "chaotic-missed-apex";
+    if (input.brilliantPaceBonus > 0) return "chaotic-brilliant";
+  }
+  if (input.archetype === "endurance") return "enduro-consistent";
+  if (input.overtakeActive) return "overtake";
+  return "clean-line";
 }
 
 // Numeric helpers ----------------------------------------------------------

--- a/src/game/aiArchetypes.ts
+++ b/src/game/aiArchetypes.ts
@@ -10,6 +10,7 @@ export interface AIBehaviour {
   readonly recoveryScalar: number;
   readonly launchPaceBonus: number;
   readonly fadePacePenalty: number;
+  readonly lowVisibilityBrakeScalar: number;
   readonly brilliantChance: number;
   readonly brilliantPaceBonus: number;
   /**
@@ -31,6 +32,7 @@ export const AI_ARCHETYPE_BEHAVIOURS: Readonly<Record<AIArchetype, AIBehaviour>>
       recoveryScalar: 0.9,
       launchPaceBonus: 0.08,
       fadePacePenalty: 0.04,
+      lowVisibilityBrakeScalar: 0,
       brilliantChance: 0,
       brilliantPaceBonus: 0,
       trafficLanePressure: 0.05,
@@ -45,6 +47,7 @@ export const AI_ARCHETYPE_BEHAVIOURS: Readonly<Record<AIArchetype, AIBehaviour>>
       recoveryScalar: 1,
       launchPaceBonus: 0,
       fadePacePenalty: 0,
+      lowVisibilityBrakeScalar: 0,
       brilliantChance: 0,
       brilliantPaceBonus: 0,
       trafficLanePressure: 0,
@@ -59,6 +62,7 @@ export const AI_ARCHETYPE_BEHAVIOURS: Readonly<Record<AIArchetype, AIBehaviour>>
       recoveryScalar: 1.05,
       launchPaceBonus: 0.02,
       fadePacePenalty: 0,
+      lowVisibilityBrakeScalar: 0,
       brilliantChance: 0,
       brilliantPaceBonus: 0,
       trafficLanePressure: 0.45,
@@ -73,6 +77,7 @@ export const AI_ARCHETYPE_BEHAVIOURS: Readonly<Record<AIArchetype, AIBehaviour>>
       recoveryScalar: 0.75,
       launchPaceBonus: 0,
       fadePacePenalty: 0,
+      lowVisibilityBrakeScalar: 0.28,
       brilliantChance: 0,
       brilliantPaceBonus: 0,
       trafficLanePressure: -0.2,
@@ -87,6 +92,7 @@ export const AI_ARCHETYPE_BEHAVIOURS: Readonly<Record<AIArchetype, AIBehaviour>>
       recoveryScalar: 1,
       launchPaceBonus: 0.01,
       fadePacePenalty: 0,
+      lowVisibilityBrakeScalar: 0,
       brilliantChance: 0.015,
       brilliantPaceBonus: 0.06,
       trafficLanePressure: 0.2,
@@ -101,6 +107,7 @@ export const AI_ARCHETYPE_BEHAVIOURS: Readonly<Record<AIArchetype, AIBehaviour>>
       recoveryScalar: 0.85,
       launchPaceBonus: 0,
       fadePacePenalty: 0,
+      lowVisibilityBrakeScalar: 0,
       brilliantChance: 0,
       brilliantPaceBonus: 0,
       trafficLanePressure: 0,


### PR DESCRIPTION
## Summary
- add deterministic AI readability cues for rocket, bully, cautious, chaotic, enduro, and overtake behavior
- make cautious AI brake earlier on low-visibility curves
- expose hidden race telemetry and add a Playwright race-window check for archetype cues

## GDD
- docs/gdd/15-cpu-opponents-and-ai.md
- docs/gdd/20-hud-and-ui-ux.md
- docs/gdd/27-risks-and-mitigations.md
- docs/PROGRESS_LOG.md: 2026-05-02 Readable AI archetype cues
- docs/GDD_COVERAGE.json: GDD-15-AI-ARCHETYPE-READABILITY

## Test Plan
- npx vitest run src/game/__tests__/ai.test.ts
- npx playwright test e2e/race-ai-archetypes.spec.ts
- npm run typecheck
- npm run lint
- npm run docs:check
- npm run content-lint
