### PR TITLE
feat(feedback): add race story HUD moments

### DIFF
--- a/docs/FOLLOWUPS.md
+++ b/docs/FOLLOWUPS.md
@@ -29,12 +29,17 @@ feedback, finish routing, and optional production smoke through
 ## F-075: Add pass and rival-pressure HUD moments
 **Created:** 2026-05-02
 **Priority:** polish
-**Status:** open
+**Status:** done (2026-05-02)
 **Notes:** The arcade racer priority research found that AI personality needs
 player-facing feedback after the behavior lands. Add short HUD or canvas
 moments for clean passes, being challenged by a rival, and losing a position
 so AI pressure reads as a race story instead of background traffic. Dot:
 `VibeGear2-feat-feedback-add-880f1fd2`.
+
+Closed by `feat/pass-rival-hud-moments`. Live race HUD moments now announce
+position gains, lost positions, and close trailing rival pressure from the same
+ranked car snapshot as the HUD. Pure tests pin each story case, and browser
+coverage verifies a visible position-change moment in a live race.
 
 ## F-074: Make first tour standings pressure visible between races
 **Created:** 2026-05-02

--- a/docs/GDD_COVERAGE.json
+++ b/docs/GDD_COVERAGE.json
@@ -1041,6 +1041,24 @@
       ]
     },
     {
+      "id": "GDD-20-RACE-STORY-MOMENTS",
+      "gddSections": [
+        "docs/gdd/15-cpu-opponents-and-ai.md",
+        "docs/gdd/20-hud-and-ui-ux.md"
+      ],
+      "requirement": "Live races surface short HUD story moments for player position gains, lost positions, and close trailing rival pressure so the CPU field reads as active race pressure.",
+      "coverage": ["implemented-code", "automated-test"],
+      "implementationRefs": [
+        "src/game/raceMoments.ts",
+        "src/app/race/page.tsx"
+      ],
+      "testRefs": [
+        "src/game/__tests__/raceMoments.test.ts",
+        "e2e/race-story-moments.spec.ts"
+      ],
+      "followupRefs": ["F-075"]
+    },
+    {
       "id": "GDD-24-MVP-TRACK-SET",
       "gddSections": [
         "docs/gdd/09-track-design.md",

--- a/docs/PROGRESS_LOG.md
+++ b/docs/PROGRESS_LOG.md
@@ -6,6 +6,50 @@ Correct them by adding a new entry that references the old one.
 
 ---
 
+## 2026-05-02: Slice: Pass and rival-pressure HUD moments
+
+**GDD sections touched:** §15 and §20.
+**Branch / PR:** `feat/pass-rival-hud-moments`, PR pending.
+**Status:** Implemented.
+
+### Done
+- Added a pure race-story moment helper that compares previous and current
+  ranked car snapshots for clean passes, lost positions, and close trailing
+  rival pressure.
+- Wired the race page to show those story moments through the existing
+  center-screen race moment overlay, with cooldown gating so lap and finish
+  moments stay readable.
+- Added hidden last-story-moment telemetry for deterministic browser coverage.
+
+### Verified
+- `npx vitest run src/game/__tests__/raceMoments.test.ts src/game/__tests__/hudState.test.ts` green, 57 passed.
+- `npx playwright test e2e/race-story-moments.spec.ts` green, 1 passed.
+- `npm run typecheck` green.
+- `npm run lint` green.
+- `npm run docs:check` green.
+- `npm run content-lint` green.
+
+### Decisions and assumptions
+- Derived the moments from the HUD-ranked car snapshot instead of duplicating
+  race-order logic. This keeps pass and pressure feedback aligned with the
+  visible position number.
+- Browser coverage asserts a live position-change moment. The pure helper
+  covers the exact clean-pass, lost-position, and rival-pressure cases.
+
+### Coverage ledger
+- Added `GDD-20-RACE-STORY-MOMENTS`.
+- Closes F-075.
+- Uncovered adjacent requirements: richer rival identity labels and audio
+  callouts remain separate polish.
+
+### Followups created
+None.
+
+### GDD edits
+None.
+
+---
+
 ## 2026-05-02: Slice: Readable AI archetype cues
 
 **GDD sections touched:** §15, §20, and §27.

--- a/e2e/race-story-moments.spec.ts
+++ b/e2e/race-story-moments.spec.ts
@@ -1,0 +1,38 @@
+import { expect, test } from "@playwright/test";
+
+test.describe("race story HUD moments", () => {
+  test("announces a position change in the live race overlay", async ({
+    page,
+  }) => {
+    test.setTimeout(45_000);
+
+    await page.goto("/race?track=test/straight");
+
+    const canvas = page.getByTestId("race-canvas-element");
+    await expect(canvas).toBeVisible();
+    await expect(page.getByTestId("race-phase")).toHaveText("racing", {
+      timeout: 10_000,
+    });
+    await expect(page.getByTestId("race-field-size")).not.toHaveText("1");
+
+    await canvas.focus();
+    await page.keyboard.down("ArrowUp");
+    const moment = page.getByTestId("race-moment");
+    await expect(moment).toHaveAttribute(
+      "data-kind",
+      /clean-pass|lost-position/,
+      {
+        timeout: 25_000,
+      },
+    );
+    const momentKind = await moment.getAttribute("data-kind");
+    expect(momentKind).toMatch(/clean-pass|lost-position/);
+    await expect(moment).toContainText(
+      momentKind === "clean-pass" ? "Pass" : "Position lost",
+    );
+    await expect(page.getByTestId("race-story-moment-kind")).toHaveText(
+      momentKind ?? "",
+    );
+    await page.keyboard.up("ArrowUp");
+  });
+});

--- a/src/app/race/page.tsx
+++ b/src/app/race/page.tsx
@@ -1558,6 +1558,7 @@ function RaceCanvas({
       setPickupFeedback(null);
       previousRaceStoryCarsRef.current = null;
       lastRaceStoryMomentMsRef.current = 0;
+      setLastRaceStoryMoment(null);
       sessionRef.current = createRaceSession(config);
       resetTimeTrialRuntime();
       tunnelState = OPEN_TUNNEL_STATE;

--- a/src/app/race/page.tsx
+++ b/src/app/race/page.tsx
@@ -59,11 +59,7 @@ import {
   carAtlasMetaForVisualProfile,
   carSpriteSetForVisualProfile,
 } from "@/data/atlas/carSprites";
-import {
-  TrackSchema,
-  type AudioSettings,
-  type Track,
-} from "@/data/schemas";
+import { TrackSchema, type AudioSettings, type Track } from "@/data/schemas";
 import {
   applyTimeTrialResult,
   buildFinalCarInputsFromSession,
@@ -75,6 +71,7 @@ import {
   createTimeTrialRecorder,
   damageDeltaFromState,
   deriveHudState,
+  deriveRaceStoryMoment,
   deriveSplitsState,
   pendingDamageForActiveCar,
   applyRaceDamageToGarage,
@@ -101,6 +98,7 @@ import {
   type GhostDriver,
   type GhostOverlay,
   type AIReadabilityCue,
+  type RaceStoryMoment,
   type TimeTrialRecorder,
 } from "@/game";
 import { DEFAULT_TOUCH_LAYOUT, type TouchLayout } from "@/game/inputTouch";
@@ -175,10 +173,7 @@ import {
   type EngineAudioContextLike,
   type EngineRuntimeInput,
 } from "@/audio/engineRuntime";
-import {
-  ProceduralSfxRuntime,
-  type SfxAudioContextLike,
-} from "@/audio/sfx";
+import { ProceduralSfxRuntime, type SfxAudioContextLike } from "@/audio/sfx";
 import {
   MusicRuntime,
   raceMusicCue,
@@ -193,6 +188,9 @@ const TOUR_PLACEHOLDER_TRACK_ID = "test/straight";
 const WORLD_TOUR_CHAMPIONSHIP_ID = "world-tour-standard";
 const PLAYER_ID = "player";
 const LAP_MOMENT_MS = 900;
+const RACE_STORY_MOMENT_MS = 1000;
+const RACE_STORY_MOMENT_COOLDOWN_MS = 1600;
+const RIVAL_PRESSURE_DISTANCE_METERS = SEGMENT_LENGTH * 8;
 const FINISH_MOMENT_MS = 1250;
 const AI_FALLBACK_FILLS = Object.freeze([
   "#ff6b5f",
@@ -214,10 +212,18 @@ const EMPTY_COLLECTED_PICKUP_SET: ReadonlySet<string> = new Set<string>();
 const MINIMAP_PADDING = 16;
 const MINIMAP_SIZE = 120;
 
-function minimapBoxFor(viewport: Viewport): { x: number; y: number; w: number; h: number } {
+function minimapBoxFor(viewport: Viewport): {
+  x: number;
+  y: number;
+  w: number;
+  h: number;
+} {
   return {
     x: MINIMAP_PADDING,
-    y: Math.max(MINIMAP_PADDING, viewport.height - MINIMAP_PADDING - MINIMAP_SIZE),
+    y: Math.max(
+      MINIMAP_PADDING,
+      viewport.height - MINIMAP_PADDING - MINIMAP_SIZE,
+    ),
     w: MINIMAP_SIZE,
     h: MINIMAP_SIZE,
   };
@@ -231,7 +237,10 @@ function resizeCanvasBackingStore(
   const rect = canvas.getBoundingClientRect();
   const width = Math.max(1, Math.round(rect.width || VIEWPORT_WIDTH));
   const height = Math.max(1, Math.round(rect.height || VIEWPORT_HEIGHT));
-  const dpr = clampDevicePixelRatio(window.devicePixelRatio || 1, pixelRatioCap);
+  const dpr = clampDevicePixelRatio(
+    window.devicePixelRatio || 1,
+    pixelRatioCap,
+  );
   const backingWidth = Math.max(1, Math.round(width * dpr));
   const backingHeight = Math.max(1, Math.round(height * dpr));
   if (canvas.width !== backingWidth) canvas.width = backingWidth;
@@ -317,7 +326,7 @@ function playRaceSfxEvents(
 }
 
 interface RaceMoment {
-  kind: "lap" | "finish";
+  kind: "lap" | "finish" | RaceStoryMoment["kind"];
   title: string;
   detail: string;
 }
@@ -389,7 +398,9 @@ function createLayerCanvas(
   return canvas;
 }
 
-function createTemperateParallaxLayers(viewport: Viewport): readonly ParallaxLayer[] {
+function createTemperateParallaxLayers(
+  viewport: Viewport,
+): readonly ParallaxLayer[] {
   const sky = createLayerCanvas(512, 256, (ctx, width, height) => {
     const gradient = ctx.createLinearGradient(0, 0, 0, height);
     gradient.addColorStop(0, "#0e1730");
@@ -415,8 +426,18 @@ function createTemperateParallaxLayers(viewport: Viewport): readonly ParallaxLay
     ctx.fillStyle = "#265c2d";
     ctx.beginPath();
     ctx.moveTo(0, height);
-    ctx.quadraticCurveTo(width * 0.18, height * 0.3, width * 0.36, height * 0.7);
-    ctx.quadraticCurveTo(width * 0.58, height * 1.05, width * 0.78, height * 0.45);
+    ctx.quadraticCurveTo(
+      width * 0.18,
+      height * 0.3,
+      width * 0.36,
+      height * 0.7,
+    );
+    ctx.quadraticCurveTo(
+      width * 0.58,
+      height * 1.05,
+      width * 0.78,
+      height * 0.45,
+    );
     ctx.quadraticCurveTo(width * 0.9, height * 0.18, width, height * 0.5);
     ctx.lineTo(width, height);
     ctx.closePath();
@@ -429,7 +450,13 @@ function createTemperateParallaxLayers(viewport: Viewport): readonly ParallaxLay
   });
 
   return [
-    { id: "sky", image: sky, scrollX: 0, bandHeight: viewport.height, yAnchor: 0 },
+    {
+      id: "sky",
+      image: sky,
+      scrollX: 0,
+      bandHeight: viewport.height,
+      yAnchor: 0,
+    },
     {
       id: "mountains",
       image: mountains,
@@ -511,10 +538,17 @@ function resolveTrack(
     requestedId !== null &&
     tourContext !== null &&
     requestedId === tourContext.plannedTrackId;
-  const runtimeId = knownId ?? (useTourPlaceholder ? TOUR_PLACEHOLDER_TRACK_ID : DEFAULT_TRACK_ID);
+  const runtimeId =
+    knownId ??
+    (useTourPlaceholder ? TOUR_PLACEHOLDER_TRACK_ID : DEFAULT_TRACK_ID);
   const id = useTourPlaceholder ? requestedId : runtimeId;
   const parsed = TrackSchema.parse(TRACK_RAW[runtimeId]);
-  return { id, runtimeId, version: parsed.version, compiled: loadTrack(runtimeId) };
+  return {
+    id,
+    runtimeId,
+    version: parsed.version,
+    compiled: loadTrack(runtimeId),
+  };
 }
 
 type RaceMode = "race" | "timeTrial" | "quickRace" | "practice";
@@ -536,7 +570,9 @@ function resolveRaceWeather(
 ): RaceSessionConfig["weather"] {
   const parsed = WeatherOptionSchema.safeParse(raw);
   if (!parsed.success) return undefined;
-  return track.compiled.weatherOptions.includes(parsed.data) ? parsed.data : undefined;
+  return track.compiled.weatherOptions.includes(parsed.data)
+    ? parsed.data
+    : undefined;
 }
 
 function resolveDailyChallengeMarker(input: {
@@ -616,10 +652,9 @@ function resolveRaceAIDrivers(
   tourContext: TourRaceContext | null,
 ): readonly AIDriver[] {
   if (tourContext === null) return AI_DRIVERS.slice(0, 1);
-  const tourRoster =
-    tourContext.aiDriverIds
-      .map((driverId) => getAIDriver(driverId))
-      .filter((driver): driver is AIDriver => driver !== undefined);
+  const tourRoster = tourContext.aiDriverIds
+    .map((driverId) => getAIDriver(driverId))
+    .filter((driver): driver is AIDriver => driver !== undefined);
   return tourRoster.length > 0 ? tourRoster : AI_DRIVERS.slice(0, 11);
 }
 
@@ -637,7 +672,8 @@ function toMinimapCar(
   totalLength: number,
   isPlayer: boolean,
 ): MinimapCar {
-  const wrappedZ = totalLength > 0 ? ((carZ % totalLength) + totalLength) % totalLength : 0;
+  const wrappedZ =
+    totalLength > 0 ? ((carZ % totalLength) + totalLength) % totalLength : 0;
   const continuousIndex = wrappedZ / SEGMENT_LENGTH;
   const segmentIndex = Math.floor(continuousIndex) % Math.max(1, totalSegments);
   const progress = continuousIndex - Math.floor(continuousIndex);
@@ -663,9 +699,11 @@ function projectOpponentCar(input: {
   damageTotal: number;
 }): NonNullable<DrawRoadOptions["aiCars"]>[number] | null {
   const depthMeters = input.carZ - input.camera.z;
-  if (!Number.isFinite(depthMeters) || depthMeters < input.camera.depth) return null;
+  if (!Number.isFinite(depthMeters) || depthMeters < input.camera.depth)
+    return null;
   if (depthMeters > 200) return null;
-  if (!Number.isFinite(input.trackLength) || input.trackLength <= 0) return null;
+  if (!Number.isFinite(input.trackLength) || input.trackLength <= 0)
+    return null;
 
   const projection = projectGhostCar(
     input.segments,
@@ -846,7 +884,10 @@ function commitRaceCredits(input: {
   baseTrackReward: number;
   damageAfter?: Readonly<DamageState>;
   activeCarId?: string | null;
-  transformCommit?: (save: SaveGame, result: RaceResult) => {
+  transformCommit?: (
+    save: SaveGame,
+    result: RaceResult,
+  ) => {
     readonly save: SaveGame;
     readonly result: RaceResult;
   };
@@ -902,11 +943,10 @@ function commitRaceCredits(input: {
     ...result,
     creditsAwarded: award.cashEarned ?? 0,
   };
-  const transformed =
-    transformCommit?.(nextSave, creditedResult) ?? {
-      save: nextSave,
-      result: creditedResult,
-    };
+  const transformed = transformCommit?.(nextSave, creditedResult) ?? {
+    save: nextSave,
+    result: creditedResult,
+  };
   saveSave(transformed.save);
 
   return transformed.result;
@@ -1047,7 +1087,9 @@ function RaceCanvas({
   const lastBrakeRef = useRef<number>(0);
   const pauseInputHeldRef = useRef<boolean>(false);
   const carAtlasRef = useRef<LoadedAtlas | null>(null);
-  const aiCarAtlasesRef = useRef<Partial<Record<CarSpriteSetId, LoadedAtlas>>>({});
+  const aiCarAtlasesRef = useRef<Partial<Record<CarSpriteSetId, LoadedAtlas>>>(
+    {},
+  );
   const carSpriteSetRef = useRef<CarSpriteSet>(
     carSpriteSetForVisualProfile("sparrow_gt"),
   );
@@ -1063,6 +1105,8 @@ function RaceCanvas({
   const raceMomentTimeoutRef = useRef<number | null>(null);
   const finishRouteTimeoutRef = useRef<number | null>(null);
   const pickupFeedbackRef = useRef<PickupFeedbackSnapshot | null>(null);
+  const previousRaceStoryCarsRef = useRef<readonly RankedCar[] | null>(null);
+  const lastRaceStoryMomentMsRef = useRef<number>(0);
   const observedAiCuesRef = useRef<Set<AIReadabilityCue>>(new Set());
   // Per-mount guard for the natural finish wiring. The render callback
   // fires every frame, so without this latch a `phase === "finished"`
@@ -1097,8 +1141,9 @@ function RaceCanvas({
   } | null>(null);
   const [fieldSize, setFieldSize] = useState<number>(1);
   const [aiVisibleCount, setAiVisibleCount] = useState<number>(0);
-  const [aiProjection, setAiProjection] =
-    useState<AiProjectionSnapshot | null>(null);
+  const [aiProjection, setAiProjection] = useState<AiProjectionSnapshot | null>(
+    null,
+  );
   const [aiReadability, setAiReadability] =
     useState<AiReadabilitySnapshot | null>(null);
   const [roadProjection, setRoadProjection] =
@@ -1113,6 +1158,8 @@ function RaceCanvas({
   );
   const [resultMs, setResultMs] = useState<number | null>(null);
   const [raceMoment, setRaceMoment] = useState<RaceMoment | null>(null);
+  const [lastRaceStoryMoment, setLastRaceStoryMoment] =
+    useState<RaceStoryMoment | null>(null);
 
   const clearRaceMomentTimeout = useCallback(() => {
     if (raceMomentTimeoutRef.current === null) return;
@@ -1261,7 +1308,9 @@ function RaceCanvas({
     const noCampaignMode = recordsOnlyMode || practiceMode;
     const economyEnabled = mode === "race";
     const sessionCar = resolveSessionCar(sessionSave, selectedCarId);
-    carSpriteSetRef.current = carSpriteSetForVisualProfile(sessionCar.spriteSet);
+    carSpriteSetRef.current = carSpriteSetForVisualProfile(
+      sessionCar.spriteSet,
+    );
     const playerStats = sessionCar.stats;
     const initialPlayerDamage = noCampaignMode
       ? PRISTINE_DAMAGE_STATE
@@ -1269,17 +1318,18 @@ function RaceCanvas({
     const raceSeed = 1;
     let timeTrialSaveSnapshot = sessionSave;
     const aiDriverRoster = resolveRaceAIDrivers(tourContext);
-    const spawnedAi = ghostEnabled || practiceMode
-      ? []
-      : spawnGrid({
-          trackSpawn: track.compiled.spawn,
-          laneCount: track.compiled.laneCount,
-          aiDrivers: aiDriverRoster.map((driver) => ({
-            driver,
-            stats: playerStats,
-          })),
-          seed: raceSeed,
-        });
+    const spawnedAi =
+      ghostEnabled || practiceMode
+        ? []
+        : spawnGrid({
+            trackSpawn: track.compiled.spawn,
+            laneCount: track.compiled.laneCount,
+            aiDrivers: aiDriverRoster.map((driver) => ({
+              driver,
+              stats: playerStats,
+            })),
+            seed: raceSeed,
+          });
 
     const config: RaceSessionConfig = {
       track: track.compiled,
@@ -1309,8 +1359,8 @@ function RaceCanvas({
       }
       const currentGhost =
         ghostSource === "downloaded"
-          ? timeTrialSaveSnapshot.downloadedGhosts?.[track.id] ?? null
-          : timeTrialSaveSnapshot.ghosts?.[track.id] ?? null;
+          ? (timeTrialSaveSnapshot.downloadedGhosts?.[track.id] ?? null)
+          : (timeTrialSaveSnapshot.ghosts?.[track.id] ?? null);
       const ghostCarStats =
         currentGhost === null
           ? playerStats
@@ -1366,7 +1416,11 @@ function RaceCanvas({
       z: 0,
       depth: CAMERA_DEPTH,
     };
-    let viewport = resizeCanvasBackingStore(canvas, ctx, graphics.pixelRatioCap);
+    let viewport = resizeCanvasBackingStore(
+      canvas,
+      ctx,
+      graphics.pixelRatioCap,
+    );
     setTouchLayout(touchLayoutFor(viewport));
     let parallaxLayers = createTemperateParallaxLayers(viewport);
 
@@ -1429,7 +1483,11 @@ function RaceCanvas({
     let cachedCollectedPickups: ReadonlyArray<string> | null = null;
     let cachedCollectedPickupSet: ReadonlySet<string> = new Set<string>();
     const tryStartEngineAudio = (): void => {
-      if (engineAudioTeardown || engineStartPending || engineAudio.isRunning()) {
+      if (
+        engineAudioTeardown ||
+        engineStartPending ||
+        engineAudio.isRunning()
+      ) {
         return;
       }
       engineStartPending = true;
@@ -1476,6 +1534,8 @@ function RaceCanvas({
       raceMusic.stop();
       handleRef.current = null;
       sessionRef.current = null;
+      previousRaceStoryCarsRef.current = null;
+      lastRaceStoryMomentMsRef.current = 0;
       inputManager.dispose();
     };
 
@@ -1496,6 +1556,8 @@ function RaceCanvas({
       setRaceMoment(null);
       pickupFeedbackRef.current = null;
       setPickupFeedback(null);
+      previousRaceStoryCarsRef.current = null;
+      lastRaceStoryMomentMsRef.current = 0;
       sessionRef.current = createRaceSession(config);
       resetTimeTrialRuntime();
       tunnelState = OPEN_TUNNEL_STATE;
@@ -1540,8 +1602,7 @@ function RaceCanvas({
         totalLaps: retired.race.totalLaps,
         cars: buildFinalCarInputsFromSession(retired),
       });
-      const save =
-        persisted.kind === "loaded" ? persisted.save : defaultSave();
+      const save = persisted.kind === "loaded" ? persisted.save : defaultSave();
       // `buildRaceResult` reads `track.id` and `track.difficulty` from
       // the Track shape; pass a minimal stand-in cast to `Track` so we
       // do not have to re-parse the bundled JSON just to satisfy the
@@ -1698,7 +1759,11 @@ function RaceCanvas({
         }
         if (lastRaceSfxTick !== session.tick) {
           lastRaceSfxTick = session.tick;
-          playRaceSfxEvents(raceSfx, session.audioEvents, persistedSettings.audio);
+          playRaceSfxEvents(
+            raceSfx,
+            session.audioEvents,
+            persistedSettings.audio,
+          );
           const pickupFeedbackFromTick = playerPickupFeedbackFromEvents(
             session.audioEvents,
             performance.now(),
@@ -1712,6 +1777,7 @@ function RaceCanvas({
             session.race.totalLaps,
           );
           if (playerMoment !== null) {
+            lastRaceStoryMomentMsRef.current = performance.now();
             showRaceMoment(
               playerMoment,
               playerMoment.kind === "finish" ? 0 : LAP_MOMENT_MS,
@@ -1737,7 +1803,11 @@ function RaceCanvas({
             : performance.now() - pickupFeedbackRef.current.createdAtMs;
         const playerFrameIndex = playerCarFrameIndex(
           lastSteerRef.current,
-          upcomingCurvature(track.compiled.segments, camera.z, SEGMENT_LENGTH * 5),
+          upcomingCurvature(
+            track.compiled.segments,
+            camera.z,
+            SEGMENT_LENGTH * 5,
+          ),
         );
         const aiCars = session.ai
           .map((entry, index) => {
@@ -1817,7 +1887,10 @@ function RaceCanvas({
           pickupFeedback:
             pickupFeedbackRef.current !== null &&
             pickupFeedbackAgeMs < PICKUP_FEEDBACK_TTL_MS
-              ? { kind: pickupFeedbackRef.current.kind, ageMs: pickupFeedbackAgeMs }
+              ? {
+                  kind: pickupFeedbackRef.current.kind,
+                  ageMs: pickupFeedbackAgeMs,
+                }
               : null,
           aiCars,
           ghostCar: ghostOverlayRef.current
@@ -1864,6 +1937,27 @@ function RaceCanvas({
             };
           }),
         ];
+        if (session.race.phase === "racing") {
+          const raceStoryMoment = deriveRaceStoryMoment({
+            playerId: PLAYER_ID,
+            previousCars: previousRaceStoryCarsRef.current,
+            currentCars: cars,
+            threatDistanceMeters: RIVAL_PRESSURE_DISTANCE_METERS,
+          });
+          const nowMs = performance.now();
+          if (
+            raceStoryMoment !== null &&
+            nowMs - lastRaceStoryMomentMsRef.current >=
+              RACE_STORY_MOMENT_COOLDOWN_MS
+          ) {
+            lastRaceStoryMomentMsRef.current = nowMs;
+            setLastRaceStoryMoment(raceStoryMoment);
+            showRaceMoment(raceStoryMoment, RACE_STORY_MOMENT_MS);
+          }
+          previousRaceStoryCarsRef.current = cars;
+        } else if (session.race.phase === "countdown") {
+          previousRaceStoryCarsRef.current = null;
+        }
 
         const nitroUpgradeTier = nitroUpgradeTierForUpgrades(
           config.player.upgrades ?? null,
@@ -1911,11 +2005,23 @@ function RaceCanvas({
         const minimapCars: MinimapCar[] = [];
         if (totalSegments > 0 && totalLength > 0) {
           minimapCars.push(
-            toMinimapCar(minimapPoints, session.player.car.z, totalSegments, totalLength, true),
+            toMinimapCar(
+              minimapPoints,
+              session.player.car.z,
+              totalSegments,
+              totalLength,
+              true,
+            ),
           );
           for (const entry of session.ai) {
             minimapCars.push(
-              toMinimapCar(minimapPoints, entry.car.z, totalSegments, totalLength, false),
+              toMinimapCar(
+                minimapPoints,
+                entry.car.z,
+                totalSegments,
+                totalLength,
+                false,
+              ),
             );
           }
         }
@@ -1985,8 +2091,7 @@ function RaceCanvas({
               playerStartPosition: 1,
               damageBefore: damageDeltaFromState(initialPlayerDamage),
               damageAfter: damageDeltaFromState(session.player.damage),
-              recordPBs:
-                !practiceMode && session.player.status === "finished",
+              recordPBs: !practiceMode && session.player.status === "finished",
               championship: tourContext?.championship,
               tourId: tourContext?.tourId,
               currentTrackIndex: tourContext?.raceIndex,
@@ -2041,6 +2146,7 @@ function RaceCanvas({
               },
               0,
             );
+            lastRaceStoryMomentMsRef.current = performance.now();
             stopRaceRuntime({ stopSfx: false });
             finishRouteTimeoutRef.current = window.setTimeout(() => {
               finishRouteTimeoutRef.current = null;
@@ -2180,6 +2286,10 @@ function RaceCanvas({
         </dd>
         <dt>Position:</dt>
         <dd data-testid="hud-position">{hudSnapshot.position}</dd>
+        <dt>Race story moment:</dt>
+        <dd data-testid="race-story-moment-kind">
+          {lastRaceStoryMoment?.kind ?? "none"}
+        </dd>
         <dt>Field size:</dt>
         <dd data-testid="race-field-size">{fieldSize}</dd>
         <dt>Visible AI:</dt>

--- a/src/game/__tests__/raceMoments.test.ts
+++ b/src/game/__tests__/raceMoments.test.ts
@@ -72,6 +72,17 @@ describe("deriveRaceStoryMoment", () => {
     ).toBeNull();
   });
 
+  it("returns null when the current field does not contain the player", () => {
+    expect(
+      deriveRaceStoryMoment({
+        playerId: PLAYER,
+        previousCars: [car(PLAYER, 200), car("ai-a", 180)],
+        currentCars: [car("ai-a", 230), car("ai-b", 210)],
+        threatDistanceMeters: 25,
+      }),
+    ).toBeNull();
+  });
+
   it("ignores distant trailing opponents", () => {
     expect(
       deriveRaceStoryMoment({

--- a/src/game/__tests__/raceMoments.test.ts
+++ b/src/game/__tests__/raceMoments.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from "vitest";
+
+import { deriveRaceStoryMoment } from "@/game/raceMoments";
+import type { RankedCar } from "@/game/hudState";
+
+const PLAYER = "player";
+
+function car(id: string, totalProgress: number): RankedCar {
+  return { id, totalProgress };
+}
+
+describe("deriveRaceStoryMoment", () => {
+  it("announces a clean pass when the player gains position", () => {
+    const previousCars = [car("ai-a", 120), car(PLAYER, 100), car("ai-b", 80)];
+    const currentCars = [car(PLAYER, 130), car("ai-a", 128), car("ai-b", 80)];
+
+    expect(
+      deriveRaceStoryMoment({
+        playerId: PLAYER,
+        previousCars,
+        currentCars,
+        threatDistanceMeters: 45,
+      }),
+    ).toEqual({
+      kind: "clean-pass",
+      title: "Pass",
+      detail: "P1",
+    });
+  });
+
+  it("announces a lost position when the player drops back", () => {
+    const previousCars = [car(PLAYER, 150), car("ai-a", 140), car("ai-b", 80)];
+    const currentCars = [car("ai-a", 170), car(PLAYER, 160), car("ai-b", 80)];
+
+    expect(
+      deriveRaceStoryMoment({
+        playerId: PLAYER,
+        previousCars,
+        currentCars,
+        threatDistanceMeters: 45,
+      }),
+    ).toEqual({
+      kind: "lost-position",
+      title: "Position lost",
+      detail: "P2",
+    });
+  });
+
+  it("announces rival pressure when a trailing opponent is close", () => {
+    expect(
+      deriveRaceStoryMoment({
+        playerId: PLAYER,
+        previousCars: [car(PLAYER, 200), car("ai-a", 160)],
+        currentCars: [car(PLAYER, 220), car("ai-a", 199.6), car("ai-b", 40)],
+        threatDistanceMeters: 25,
+      }),
+    ).toEqual({
+      kind: "rival-pressure",
+      title: "Rival close",
+      detail: "20 m back",
+    });
+  });
+
+  it("does not treat equal start-line progress as pressure", () => {
+    expect(
+      deriveRaceStoryMoment({
+        playerId: PLAYER,
+        previousCars: null,
+        currentCars: [car(PLAYER, 0), car("ai-a", 0)],
+        threatDistanceMeters: 25,
+      }),
+    ).toBeNull();
+  });
+
+  it("ignores distant trailing opponents", () => {
+    expect(
+      deriveRaceStoryMoment({
+        playerId: PLAYER,
+        previousCars: [car(PLAYER, 200), car("ai-a", 100)],
+        currentCars: [car(PLAYER, 230), car("ai-a", 175)],
+        threatDistanceMeters: 25,
+      }),
+    ).toBeNull();
+  });
+});

--- a/src/game/index.ts
+++ b/src/game/index.ts
@@ -26,6 +26,7 @@ export * from "./assists";
 export * from "./difficultyPresets";
 export * from "./raceDamagePersistence";
 export * from "./preRaceCard";
+export * from "./raceMoments";
 // `raceBonuses` is the owner of the §5 bonus pipeline; `raceResult` is
 // the §20 results-screen builder that consumes it. The two re-export the
 // same `RaceBonus` / `RaceBonusKind` and the four bonus constants, so

--- a/src/game/raceMoments.ts
+++ b/src/game/raceMoments.ts
@@ -1,0 +1,91 @@
+import { rankPosition, type RankedCar } from "./hudState";
+
+export type RaceStoryMomentKind =
+  | "clean-pass"
+  | "rival-pressure"
+  | "lost-position";
+
+export interface RaceStoryMoment {
+  readonly kind: RaceStoryMomentKind;
+  readonly title: string;
+  readonly detail: string;
+}
+
+export interface RaceStoryMomentInput {
+  readonly playerId: string;
+  readonly previousCars: readonly RankedCar[] | null;
+  readonly currentCars: readonly RankedCar[];
+  readonly threatDistanceMeters: number;
+}
+
+function sortedByProgress(cars: readonly RankedCar[]): RankedCar[] {
+  return [...cars].sort((a, b) => {
+    if (b.totalProgress !== a.totalProgress)
+      return b.totalProgress - a.totalProgress;
+    return a.id < b.id ? -1 : a.id > b.id ? 1 : 0;
+  });
+}
+
+function nearestTrailingGap(input: {
+  readonly playerId: string;
+  readonly cars: readonly RankedCar[];
+}): number | null {
+  const player = input.cars.find((car) => car.id === input.playerId);
+  if (player === undefined) return null;
+
+  let closestGap = Number.POSITIVE_INFINITY;
+  for (const car of input.cars) {
+    if (car.id === input.playerId) continue;
+    const gap = player.totalProgress - car.totalProgress;
+    if (gap > 0.5 && gap < closestGap) {
+      closestGap = gap;
+    }
+  }
+
+  return Number.isFinite(closestGap) ? closestGap : null;
+}
+
+export function deriveRaceStoryMoment(
+  input: RaceStoryMomentInput,
+): RaceStoryMoment | null {
+  const currentPosition = rankPosition(input.playerId, input.currentCars);
+  if (input.previousCars !== null) {
+    const previousHasPlayer = input.previousCars.some(
+      (car) => car.id === input.playerId,
+    );
+    if (previousHasPlayer) {
+      const previousPosition = rankPosition(input.playerId, input.previousCars);
+      if (currentPosition < previousPosition) {
+        return {
+          kind: "clean-pass",
+          title: "Pass",
+          detail: `P${currentPosition}`,
+        };
+      }
+      if (currentPosition > previousPosition) {
+        return {
+          kind: "lost-position",
+          title: "Position lost",
+          detail: `P${currentPosition}`,
+        };
+      }
+    }
+  }
+
+  const trailingGap = nearestTrailingGap({
+    playerId: input.playerId,
+    cars: sortedByProgress(input.currentCars),
+  });
+  if (
+    trailingGap !== null &&
+    trailingGap <= Math.max(1, input.threatDistanceMeters)
+  ) {
+    return {
+      kind: "rival-pressure",
+      title: "Rival close",
+      detail: `${Math.round(trailingGap)} m back`,
+    };
+  }
+
+  return null;
+}

--- a/src/game/raceMoments.ts
+++ b/src/game/raceMoments.ts
@@ -18,14 +18,6 @@ export interface RaceStoryMomentInput {
   readonly threatDistanceMeters: number;
 }
 
-function sortedByProgress(cars: readonly RankedCar[]): RankedCar[] {
-  return [...cars].sort((a, b) => {
-    if (b.totalProgress !== a.totalProgress)
-      return b.totalProgress - a.totalProgress;
-    return a.id < b.id ? -1 : a.id > b.id ? 1 : 0;
-  });
-}
-
 function nearestTrailingGap(input: {
   readonly playerId: string;
   readonly cars: readonly RankedCar[];
@@ -48,6 +40,11 @@ function nearestTrailingGap(input: {
 export function deriveRaceStoryMoment(
   input: RaceStoryMomentInput,
 ): RaceStoryMoment | null {
+  const currentHasPlayer = input.currentCars.some(
+    (car) => car.id === input.playerId,
+  );
+  if (!currentHasPlayer) return null;
+
   const currentPosition = rankPosition(input.playerId, input.currentCars);
   if (input.previousCars !== null) {
     const previousHasPlayer = input.previousCars.some(
@@ -74,7 +71,7 @@ export function deriveRaceStoryMoment(
 
   const trailingGap = nearestTrailingGap({
     playerId: input.playerId,
-    cars: sortedByProgress(input.currentCars),
+    cars: input.currentCars,
   });
   if (
     trailingGap !== null &&


### PR DESCRIPTION
## Summary
- Add pure race-story moment derivation for clean passes, lost positions, and close trailing rival pressure
- Route story moments through the existing race overlay with cooldown gating
- Add unit and browser coverage, plus progress log, followup, and coverage ledger updates

## GDD
- docs/gdd/15-cpu-opponents-and-ai.md
- docs/gdd/20-hud-and-ui-ux.md
- docs/PROGRESS_LOG.md entry: 2026-05-02 Pass and rival-pressure HUD moments
- Coverage ledger: GDD-20-RACE-STORY-MOMENTS

## Test plan
- npx vitest run src/game/__tests__/raceMoments.test.ts src/game/__tests__/hudState.test.ts
- npx playwright test e2e/race-story-moments.spec.ts
- npm run typecheck
- npm run lint
- npm run docs:check
- npm run content-lint

## Followups
- Closes F-075

## Review process
- I will check and respond to inline and threaded PR review comments before merge.