### PR TITLE
feat(tour): show standings pressure between races

### DIFF
--- a/docs/FOLLOWUPS.md
+++ b/docs/FOLLOWUPS.md
@@ -44,11 +44,16 @@ coverage verifies a visible position-change moment in a live race.
 ## F-074: Make first tour standings pressure visible between races
 **Created:** 2026-05-02
 **Priority:** polish
-**Status:** open
+**Status:** done (2026-05-02)
 **Notes:** The arcade racer priority research found that the first tour should
 make standings pressure, cash needs, repair risk, and upgrade thresholds more
 visible between races. Strengthen the Velvet Coast between-race flow and cover
 it with browser evidence. Dot: `VibeGear2-feat-tour-make-ed6387da`.
+
+Closed by `feat/first-tour-standings-pressure`. Garage, pre-race, and results
+surfaces now share a tour-pressure summary for current standing, advancement
+gate, next race, cash after repairs, and next-upgrade shortfall. Unit and
+browser tests cover the in-progress Velvet Coast flow.
 
 ## F-073: Add projection and opponent readability checks to release playtests
 **Created:** 2026-05-02

--- a/docs/GDD_COVERAGE.json
+++ b/docs/GDD_COVERAGE.json
@@ -1456,6 +1456,29 @@
       "followupRefs": []
     },
     {
+      "id": "GDD-20-TOUR-PRESSURE-SURFACES",
+      "gddSections": [
+        "docs/gdd/08-world-and-progression-design.md",
+        "docs/gdd/12-upgrade-and-economy-system.md",
+        "docs/gdd/20-hud-and-ui-ux.md"
+      ],
+      "requirement": "Between World Tour races, garage, pre-race, and results surfaces show current standing pressure, advancement gate, repair room, and next-upgrade affordability so the player understands the next race's stakes.",
+      "coverage": ["implemented-code", "automated-test"],
+      "implementationRefs": [
+        "src/game/tourPressure.ts",
+        "src/app/garage/page.tsx",
+        "src/app/race/prep/page.tsx",
+        "src/app/race/results/page.tsx",
+        "src/game/preRaceCard.ts"
+      ],
+      "testRefs": [
+        "src/game/__tests__/tourPressure.test.ts",
+        "src/game/__tests__/preRaceCard.test.ts",
+        "e2e/tour-pressure.spec.ts"
+      ],
+      "followupRefs": ["F-074"]
+    },
+    {
       "id": "GDD-13-GARAGE-REPAIR-PURCHASE",
       "gddSections": [
         "docs/gdd/05-core-gameplay-loop.md",

--- a/docs/PROGRESS_LOG.md
+++ b/docs/PROGRESS_LOG.md
@@ -6,6 +6,51 @@ Correct them by adding a new entry that references the old one.
 
 ---
 
+## 2026-05-02: Slice: First-tour standings pressure
+
+**GDD sections touched:** §8, §12, and §20.
+**Branch / PR:** `feat/first-tour-standings-pressure`, PR pending.
+**Status:** Implemented.
+
+### Done
+- Added a shared tour-pressure summary for in-progress World Tour state,
+  current standing, advancement gate, next race, full-repair estimate,
+  cash after repairs, and next-upgrade affordability.
+- Rendered the same pressure summary in the garage next-race card, pre-race
+  card, and results screen so the first tour reads as a connected
+  four-race contest instead of isolated race entries.
+- Added browser coverage for a seeded in-progress Velvet Coast tour and unit
+  coverage for the shared pressure derivation.
+
+### Verified
+- `npx vitest run src/game/__tests__/tourPressure.test.ts src/game/__tests__/preRaceCard.test.ts src/components/garage/__tests__/garageSummaryState.test.ts` green, 29 passed.
+- `npx playwright test e2e/tour-pressure.spec.ts` green, 1 passed.
+- `npm run typecheck` green.
+- `npm run lint` green.
+- `npm run docs:check` green.
+- `npm run content-lint` green.
+
+### Decisions and assumptions
+- Kept the pressure model read-only. It explains standing and wallet pressure
+  without changing rewards, repairs, upgrades, or tour progression rules.
+- Chose the cheapest eligible next upgrade as the affordability target so the
+  guidance remains concrete even before richer recommended-upgrade strategy
+  lands.
+
+### Coverage ledger
+- Added `GDD-20-TOUR-PRESSURE-SURFACES`.
+- Closes F-074.
+- Uncovered adjacent requirements: richer recommended-upgrade strategy and
+  named rival standings remain separate polish.
+
+### Followups created
+None.
+
+### GDD edits
+None.
+
+---
+
 ## 2026-05-02: Slice: Pass and rival-pressure HUD moments
 
 **GDD sections touched:** §15 and §20.

--- a/e2e/tour-pressure.spec.ts
+++ b/e2e/tour-pressure.spec.ts
@@ -1,0 +1,115 @@
+import { expect, test } from "@playwright/test";
+
+const SAVE_KEY = "vibegear2:save:v4";
+
+test.describe("first tour pressure surfaces", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto("/");
+    await page.evaluate(
+      ({ key, save }) => window.localStorage.setItem(key, JSON.stringify(save)),
+      { key: SAVE_KEY, save: buildInProgressTourSave() },
+    );
+  });
+
+  test("shows standings and economy pressure in garage and pre-race", async ({
+    page,
+  }) => {
+    await page.goto("/garage");
+    await expect(page.getByTestId("garage-tour-pressure")).toBeVisible();
+    await expect(page.getByTestId("garage-pressure-tour")).toHaveText(
+      "Velvet Coast",
+    );
+    await expect(page.getByTestId("garage-pressure-progress")).toHaveText(
+      "Race 2 of 4, 1 complete",
+    );
+    await expect(page.getByTestId("garage-pressure-gate")).toContainText(
+      "4th or better",
+    );
+    await expect(
+      page.getByTestId("garage-pressure-upgrade-shortfall"),
+    ).toContainText("cr");
+
+    await page.goto(
+      "/race/prep?track=velvet-coast%2Fsunpier-loop&tour=velvet-coast&raceIndex=1",
+    );
+    await expect(page.getByTestId("pre-race-tour-pressure")).toBeVisible();
+    await expect(page.getByTestId("pre-race-pressure-standing")).toContainText(
+      "of",
+    );
+    await expect(page.getByTestId("pre-race-pressure-gate")).toContainText(
+      "4th or better",
+    );
+    await expect(
+      page.getByTestId("pre-race-pressure-next-upgrade"),
+    ).toContainText("Street");
+  });
+});
+
+function buildInProgressTourSave() {
+  return {
+    version: 4,
+    profileName: "TourPressureTester",
+    settings: {
+      displaySpeedUnit: "kph",
+      assists: {
+        steeringAssist: false,
+        autoNitro: false,
+        weatherVisualReduction: false,
+      },
+      difficultyPreset: "normal",
+      transmissionMode: "auto",
+      audio: { master: 1, music: 1, sfx: 1 },
+      accessibility: {
+        colorBlindMode: "off",
+        reducedMotion: false,
+        largeUiText: false,
+        screenShakeScale: 1,
+      },
+    },
+    garage: {
+      credits: 1500,
+      ownedCars: ["sparrow-gt"],
+      activeCarId: "sparrow-gt",
+      installedUpgrades: {
+        "sparrow-gt": {
+          engine: 0,
+          gearbox: 0,
+          dryTires: 0,
+          wetTires: 0,
+          nitro: 0,
+          armor: 0,
+          cooling: 0,
+          aero: 0,
+        },
+      },
+      pendingDamage: {
+        "sparrow-gt": {
+          zones: { engine: 0.1, tires: 0.2, body: 0.05 },
+          total: 0.115,
+          offRoadAccumSeconds: 0,
+        },
+      },
+      lastRaceCashEarned: 700,
+    },
+    progress: {
+      unlockedTours: ["velvet-coast"],
+      completedTours: [],
+      activeTour: {
+        tourId: "velvet-coast",
+        raceIndex: 1,
+        results: [
+          {
+            trackId: "velvet-coast/harbor-run",
+            placement: 6,
+            dnf: false,
+            cashEarned: 700,
+          },
+        ],
+      },
+    },
+    records: {},
+    ghosts: {},
+    downloadedGhosts: {},
+    writeCounter: 0,
+  };
+}

--- a/src/app/garage/page.tsx
+++ b/src/app/garage/page.tsx
@@ -9,7 +9,11 @@ import {
   buildGarageSummaryView,
   selectStarterCar,
 } from "@/components/garage/garageSummaryState";
+import { getChampionship } from "@/data";
+import { buildTourPressureSummary } from "@/game/tourPressure";
 import { defaultSave, loadSave, saveSave } from "@/persistence";
+
+const CHAMPIONSHIP_ID = "world-tour-standard";
 
 interface PageStatus {
   readonly kind: "idle" | "info" | "error";
@@ -41,6 +45,11 @@ export default function GaragePage() {
   const view = useMemo(
     () => (save ? buildGarageSummaryView(save) : null),
     [save],
+  );
+  const championship = useMemo(() => getChampionship(CHAMPIONSHIP_ID), []);
+  const tourPressure = useMemo(
+    () => (save ? buildTourPressureSummary({ save, championship }) : null),
+    [championship, save],
   );
 
   const persist = useCallback((next: SaveGame, message: string) => {
@@ -91,20 +100,37 @@ export default function GaragePage() {
         <div>
           <h1 style={titleStyle}>Garage</h1>
           <p style={mutedTextStyle}>
-            Credits: <strong data-testid="garage-credits">{view.credits}</strong>
+            Credits:{" "}
+            <strong data-testid="garage-credits">{view.credits}</strong>
           </p>
         </div>
         <nav style={navStyle} aria-label="Garage actions">
-          <Link href="/garage/cars" style={linkStyle} data-testid="garage-cars-link">
+          <Link
+            href="/garage/cars"
+            style={linkStyle}
+            data-testid="garage-cars-link"
+          >
             Cars
           </Link>
-          <Link href="/garage/repair" style={linkStyle} data-testid="garage-repair-link">
+          <Link
+            href="/garage/repair"
+            style={linkStyle}
+            data-testid="garage-repair-link"
+          >
             Repairs
           </Link>
-          <Link href="/garage/upgrade" style={linkStyle} data-testid="garage-upgrade-link">
+          <Link
+            href="/garage/upgrade"
+            style={linkStyle}
+            data-testid="garage-upgrade-link"
+          >
             Upgrades
           </Link>
-          <Link href="/world" style={primaryLinkStyle} data-testid="garage-next-race-link">
+          <Link
+            href="/world"
+            style={primaryLinkStyle}
+            data-testid="garage-next-race-link"
+          >
             Next race
           </Link>
         </nav>
@@ -126,12 +152,16 @@ export default function GaragePage() {
         <section style={panelStyle} data-testid="garage-starter-pick">
           <h2 style={sectionTitleStyle}>Pick your starter car</h2>
           <p style={mutedTextStyle}>
-            Your save does not point at an owned active car. Choose an
-            available starter to continue.
+            Your save does not point at an owned active car. Choose an available
+            starter to continue.
           </p>
           <ul style={cardGridStyle}>
             {view.starterCars.map((car) => (
-              <li key={car.id} style={cardStyle} data-testid={`starter-${car.id}`}>
+              <li
+                key={car.id}
+                style={cardStyle}
+                data-testid={`starter-${car.id}`}
+              >
                 <h3 style={cardTitleStyle}>{car.name}</h3>
                 <p style={mutedTextStyle}>Class: {car.class}</p>
                 <button
@@ -191,10 +221,57 @@ export default function GaragePage() {
 
           <aside style={nextRacePanelStyle} data-testid="garage-next-card">
             <h2 style={sectionTitleStyle}>Next race</h2>
-            <p style={nextRaceTextStyle}>
-              Pick the next World Tour event, then return here for repairs and
-              upgrades between races.
-            </p>
+            {tourPressure ? (
+              <dl style={summaryGridStyle} data-testid="garage-tour-pressure">
+                <div style={summaryRowStyle}>
+                  <dt>Tour</dt>
+                  <dd data-testid="garage-pressure-tour">
+                    {tourPressure.tourName}
+                  </dd>
+                </div>
+                <div style={summaryRowStyle}>
+                  <dt>Progress</dt>
+                  <dd data-testid="garage-pressure-progress">
+                    {tourPressure.progressLabel}
+                  </dd>
+                </div>
+                <div style={summaryRowStyle}>
+                  <dt>Standing</dt>
+                  <dd data-testid="garage-pressure-standing">
+                    {tourPressure.standingsLabel}
+                  </dd>
+                </div>
+                <div style={summaryRowStyle}>
+                  <dt>Gate</dt>
+                  <dd data-testid="garage-pressure-gate">
+                    {tourPressure.gateLabel}
+                  </dd>
+                </div>
+                <div style={summaryRowStyle}>
+                  <dt>Plan</dt>
+                  <dd data-testid="garage-pressure-plan">
+                    {tourPressure.pressureLabel}
+                  </dd>
+                </div>
+                <div style={summaryRowStyle}>
+                  <dt>Repair room</dt>
+                  <dd data-testid="garage-pressure-cash-after-repair">
+                    {tourPressure.cashAfterRepair} cr
+                  </dd>
+                </div>
+                <div style={summaryRowStyle}>
+                  <dt>Upgrade gap</dt>
+                  <dd data-testid="garage-pressure-upgrade-shortfall">
+                    {tourPressure.upgradeShortfall} cr
+                  </dd>
+                </div>
+              </dl>
+            ) : (
+              <p style={nextRaceTextStyle}>
+                Pick the next World Tour event, then return here for repairs and
+                upgrades between races.
+              </p>
+            )}
             <Link
               href="/world"
               style={primaryLinkStyle}

--- a/src/app/race/prep/page.tsx
+++ b/src/app/race/prep/page.tsx
@@ -165,8 +165,16 @@ function RacePrepShell(): ReactElement {
               testId="pre-race-difficulty"
               value={`${card.difficulty.value} (${card.difficulty.label})`}
             />
-            <Field label="Base reward" testId="pre-race-base-reward" value={card.baseReward} />
-            <Field label="Standings" testId="pre-race-standings" value={card.standings} />
+            <Field
+              label="Base reward"
+              testId="pre-race-base-reward"
+              value={card.baseReward}
+            />
+            <Field
+              label="Standings"
+              testId="pre-race-standings"
+              value={card.standings}
+            />
           </dl>
         </article>
 
@@ -203,7 +211,11 @@ function RacePrepShell(): ReactElement {
               testId="pre-race-surface-temp"
               value={card.forecast.surfaceTemperatureBand}
             />
-            <Field label="Grip" testId="pre-race-grip" value={card.forecast.gripRating} />
+            <Field
+              label="Grip"
+              testId="pre-race-grip"
+              value={card.forecast.gripRating}
+            />
             <Field
               label="Visibility"
               testId="pre-race-visibility"
@@ -214,7 +226,10 @@ function RacePrepShell(): ReactElement {
 
         <article style={panelStyle}>
           <h2 style={sectionTitleStyle}>Tires</h2>
-          <p style={recommendationStyle} data-testid="pre-race-recommended-tire">
+          <p
+            style={recommendationStyle}
+            data-testid="pre-race-recommended-tire"
+          >
             Recommended: {card.recommendedTire}
           </p>
           <div style={segmentedStyle} role="group" aria-label="Tire choice">
@@ -222,7 +237,9 @@ function RacePrepShell(): ReactElement {
               <button
                 key={tire}
                 type="button"
-                style={selectedTire === tire ? activeSegmentStyle : segmentStyle}
+                style={
+                  selectedTire === tire ? activeSegmentStyle : segmentStyle
+                }
                 aria-pressed={selectedTire === tire}
                 onClick={() => setSelectedTire(tire)}
                 data-testid={`pre-race-tire-${tire}`}
@@ -255,8 +272,16 @@ function RacePrepShell(): ReactElement {
               testId="pre-race-car-class"
               value={card.carSummary.className}
             />
-            <Field label="Setup" testId="pre-race-setup" value={card.setupSummary} />
-            <Field label="Cash" testId="pre-race-cash" value={card.cashOnHand} />
+            <Field
+              label="Setup"
+              testId="pre-race-setup"
+              value={card.setupSummary}
+            />
+            <Field
+              label="Cash"
+              testId="pre-race-cash"
+              value={card.cashOnHand}
+            />
             <Field
               label="Repair estimate"
               testId="pre-race-repair-estimate"
@@ -264,10 +289,56 @@ function RacePrepShell(): ReactElement {
             />
           </dl>
         </article>
+
+        {card.tourPressure ? (
+          <article style={panelStyle} data-testid="pre-race-tour-pressure">
+            <h2 style={sectionTitleStyle}>Tour pressure</h2>
+            <dl style={summaryGridStyle}>
+              <Field
+                label="Standing"
+                testId="pre-race-pressure-standing"
+                value={card.tourPressure.standingsLabel}
+              />
+              <Field
+                label="Gate"
+                testId="pre-race-pressure-gate"
+                value={card.tourPressure.gateLabel}
+              />
+              <Field
+                label="Plan"
+                testId="pre-race-pressure-plan"
+                value={card.tourPressure.pressureLabel}
+              />
+              <Field
+                label="After repairs"
+                testId="pre-race-pressure-cash-after-repair"
+                value={`${card.tourPressure.cashAfterRepair} cr`}
+              />
+              <Field
+                label="Next upgrade"
+                testId="pre-race-pressure-next-upgrade"
+                value={
+                  card.tourPressure.nextUpgradeCost === null
+                    ? card.tourPressure.nextUpgradeLabel
+                    : `${card.tourPressure.nextUpgradeLabel} (${card.tourPressure.nextUpgradeCost} cr)`
+                }
+              />
+              <Field
+                label="Shortfall"
+                testId="pre-race-pressure-upgrade-shortfall"
+                value={`${card.tourPressure.upgradeShortfall} cr`}
+              />
+            </dl>
+          </article>
+        ) : null}
       </section>
 
       <footer style={footerStyle}>
-        <Link href={startHref} style={primaryLinkStyle} data-testid="pre-race-start-link">
+        <Link
+          href={startHref}
+          style={primaryLinkStyle}
+          data-testid="pre-race-start-link"
+        >
           Start race
         </Link>
       </footer>
@@ -320,7 +391,8 @@ function raceHref(input: {
     tire: input.tire,
   });
   if (input.tourId) params.set("tour", input.tourId);
-  if (input.raceIndex !== null) params.set("raceIndex", String(input.raceIndex));
+  if (input.raceIndex !== null)
+    params.set("raceIndex", String(input.raceIndex));
   return `/race?${params.toString()}`;
 }
 

--- a/src/app/race/results/page.tsx
+++ b/src/app/race/results/page.tsx
@@ -48,9 +48,17 @@ import {
   loadRaceResult,
 } from "@/components/results/raceResultStorage";
 import { DailyShareButton } from "@/app/daily/DailyShareButton";
+import { getChampionship } from "@/data";
 import { formatDailyChallengeShareText } from "@/game/modes/dailyChallenge";
 import type { RaceResult } from "@/game/raceResult";
 import type { FinalCarRecord } from "@/game/raceRules";
+import {
+  buildTourPressureSummary,
+  type TourPressureSummary,
+} from "@/game/tourPressure";
+import { loadSave } from "@/persistence/save";
+
+const CHAMPIONSHIP_ID = "world-tour-standard";
 
 export default function RaceResultsPage(): ReactElement {
   return (
@@ -64,11 +72,25 @@ function ResultsShell(): ReactElement {
   const router = useRouter();
   // Hydration-safe pattern: reading sessionStorage at render time would
   // mismatch the SSR snapshot. Defer the read to a client-only effect.
-  const [result, setResult] = useState<RaceResult | null | "loading">("loading");
+  const [result, setResult] = useState<RaceResult | null | "loading">(
+    "loading",
+  );
+  const [tourPressure, setTourPressure] = useState<TourPressureSummary | null>(
+    null,
+  );
   const continueRef = useRef<HTMLAnchorElement>(null);
 
   useEffect(() => {
     setResult(loadRaceResult());
+    const save = loadSave();
+    if (save.kind === "loaded") {
+      setTourPressure(
+        buildTourPressureSummary({
+          save: save.save,
+          championship: getChampionship(CHAMPIONSHIP_ID),
+        }),
+      );
+    }
   }, []);
 
   // Default focus on Continue once the result resolves; mirrors the
@@ -97,17 +119,25 @@ function ResultsShell(): ReactElement {
     return <NoResultFallback />;
   }
 
-  return <ResultsView result={result} onRematch={handleRematch} continueRef={continueRef} />;
+  return (
+    <ResultsView
+      result={result}
+      tourPressure={tourPressure}
+      onRematch={handleRematch}
+      continueRef={continueRef}
+    />
+  );
 }
 
 interface ResultsViewProps {
   result: RaceResult;
+  tourPressure: TourPressureSummary | null;
   onRematch: () => void;
   continueRef: React.Ref<HTMLAnchorElement>;
 }
 
 function ResultsView(props: ResultsViewProps): ReactElement {
-  const { result, onRematch, continueRef } = props;
+  const { result, tourPressure, onRematch, continueRef } = props;
 
   const placementLabel = useMemo(() => {
     if (result.playerPlacement === null) {
@@ -129,9 +159,8 @@ function ResultsView(props: ResultsViewProps): ReactElement {
   // status pill plus the optional top-N. DNF rows skip the network call.
   const playerRow = useMemo<FinalCarRecord | null>(
     () =>
-      result.finishingOrder.find(
-        (row) => row.carId === result.playerCarId,
-      ) ?? null,
+      result.finishingOrder.find((row) => row.carId === result.playerCarId) ??
+      null,
     [result.finishingOrder, result.playerCarId],
   );
   const playerFinished = playerRow?.status === "finished";
@@ -245,6 +274,43 @@ function ResultsView(props: ResultsViewProps): ReactElement {
                 ? ` Unlocked ${formatTourName(tourProgress.unlockedTourId)}.`
                 : ""}
             </p>
+          ) : null}
+          {tourPressure ? (
+            <section
+              style={tourPressurePanelStyle}
+              data-testid="results-tour-pressure"
+              aria-label="Tour pressure"
+            >
+              <h3 style={subHeading}>Tour pressure</h3>
+              <dl style={pressureListStyle}>
+                <dt style={dtStyle}>Standing</dt>
+                <dd data-testid="results-pressure-standing" style={ddStyle}>
+                  {tourPressure.standingsLabel}
+                </dd>
+                <dt style={dtStyle}>Gate</dt>
+                <dd data-testid="results-pressure-gate" style={ddStyle}>
+                  {tourPressure.gateLabel}
+                </dd>
+                <dt style={dtStyle}>Plan</dt>
+                <dd data-testid="results-pressure-plan" style={ddStyle}>
+                  {tourPressure.pressureLabel}
+                </dd>
+                <dt style={dtStyle}>Cash after repairs</dt>
+                <dd
+                  data-testid="results-pressure-cash-after-repair"
+                  style={ddStyle}
+                >
+                  {tourPressure.cashAfterRepair.toLocaleString("en-US")} cr
+                </dd>
+                <dt style={dtStyle}>Upgrade gap</dt>
+                <dd
+                  data-testid="results-pressure-upgrade-shortfall"
+                  style={ddStyle}
+                >
+                  {tourPressure.upgradeShortfall.toLocaleString("en-US")} cr
+                </dd>
+              </dl>
+            </section>
           ) : null}
 
           <LeaderboardPanel
@@ -433,6 +499,19 @@ const rewardsListStyle: CSSProperties = {
   gridTemplateColumns: "max-content 1fr",
   gap: "0.25rem 1rem",
   margin: 0,
+};
+
+const pressureListStyle: CSSProperties = {
+  ...rewardsListStyle,
+};
+
+const tourPressurePanelStyle: CSSProperties = {
+  display: "grid",
+  gap: "0.4rem",
+  border: "1px solid rgba(255, 209, 102, 0.45)",
+  borderRadius: "8px",
+  padding: "0.75rem",
+  background: "rgba(255, 209, 102, 0.07)",
 };
 
 const dtStyle: CSSProperties = {

--- a/src/game/__tests__/preRaceCard.test.ts
+++ b/src/game/__tests__/preRaceCard.test.ts
@@ -35,7 +35,9 @@ describe("pre-race card", () => {
         activeTour: {
           tourId: "velvet-coast",
           raceIndex: 1,
-          results: [{ trackId: "velvet-coast/harbor-run", placement: 2, dnf: false }],
+          results: [
+            { trackId: "velvet-coast/harbor-run", placement: 2, dnf: false },
+          ],
         },
       },
     };
@@ -63,6 +65,8 @@ describe("pre-race card", () => {
     expect(card.cashOnHand).toBe(1250);
     expect(card.repairEstimate).toBeGreaterThan(0);
     expect(card.baseReward).toBe(1000);
+    expect(card.tourPressure?.standingsLabel).toBe("2nd of 2");
+    expect(card.tourPressure?.cashAfterRepair).toBeLessThan(1250);
     expect(card.carSummary.name).toBe("Sparrow GT");
     expect(card.setupSummary).toBe("Stock setup");
   });

--- a/src/game/__tests__/tourPressure.test.ts
+++ b/src/game/__tests__/tourPressure.test.ts
@@ -72,11 +72,12 @@ describe("buildTourPressureSummary", () => {
       tourId: "velvet-coast",
       progressLabel: "Race 2 of 4, 1 complete",
       nextRaceId: "velvet-coast/sunpier-loop",
+      nextRaceLabel: "Sunpier Loop",
       gateLabel: "Need 4th or better to advance",
       playerStanding: 6,
       requiredStanding: 4,
       playerPoints: 8,
-      nextUpgradeLabel: "Cooling Street",
+      nextUpgradeLabel: "Street Cooling",
       nextUpgradeCost: 1000,
     });
     expect(summary?.repairEstimate).toBeGreaterThan(0);

--- a/src/game/__tests__/tourPressure.test.ts
+++ b/src/game/__tests__/tourPressure.test.ts
@@ -1,0 +1,139 @@
+import { describe, expect, it } from "vitest";
+
+import type { Championship, SaveGame } from "@/data/schemas";
+import { defaultSave } from "@/persistence/save";
+
+import { buildTourPressureSummary, estimateFullRepair } from "../tourPressure";
+
+const CHAMPIONSHIP: Championship = {
+  id: "world-tour-standard",
+  name: "World Tour",
+  difficultyPreset: "normal",
+  tours: [
+    {
+      id: "velvet-coast",
+      requiredStanding: 4,
+      tracks: [
+        "velvet-coast/harbor-run",
+        "velvet-coast/sunpier-loop",
+        "velvet-coast/cliffline-arc",
+        "velvet-coast/lighthouse-fall",
+      ],
+    },
+  ],
+};
+
+function saveWithTour(overrides: Partial<SaveGame> = {}): SaveGame {
+  const base = defaultSave();
+  return {
+    ...base,
+    ...overrides,
+    garage: {
+      ...base.garage,
+      credits: 1_500,
+      pendingDamage: {
+        "sparrow-gt": {
+          zones: { engine: 0.1, tires: 0.2, body: 0.05 },
+          total: 0.115,
+          offRoadAccumSeconds: 0,
+        },
+      },
+      ...overrides.garage,
+    },
+    progress: {
+      ...base.progress,
+      unlockedTours: ["velvet-coast"],
+      activeTour: {
+        tourId: "velvet-coast",
+        raceIndex: 1,
+        results: [
+          {
+            trackId: "velvet-coast/harbor-run",
+            placement: 6,
+            dnf: false,
+            cashEarned: 700,
+          },
+        ],
+      },
+      ...overrides.progress,
+    },
+  };
+}
+
+describe("buildTourPressureSummary", () => {
+  it("summarises standings, gate, repair room, and upgrade gap", () => {
+    const save = saveWithTour();
+    const summary = buildTourPressureSummary({
+      save,
+      championship: CHAMPIONSHIP,
+    });
+
+    expect(summary).toMatchObject({
+      tourId: "velvet-coast",
+      progressLabel: "Race 2 of 4, 1 complete",
+      nextRaceId: "velvet-coast/sunpier-loop",
+      gateLabel: "Need 4th or better to advance",
+      playerStanding: 6,
+      requiredStanding: 4,
+      playerPoints: 8,
+      nextUpgradeLabel: "Cooling Street",
+      nextUpgradeCost: 1000,
+    });
+    expect(summary?.repairEstimate).toBeGreaterThan(0);
+    expect(summary?.cashAfterRepair).toBeLessThan(save.garage.credits);
+    expect(summary?.upgradeShortfall).toBeGreaterThanOrEqual(0);
+    expect(summary?.pressureLabel).toContain("Chase");
+  });
+
+  it("returns null when no active tour is stored", () => {
+    const save = defaultSave();
+
+    expect(
+      buildTourPressureSummary({ save, championship: CHAMPIONSHIP }),
+    ).toBeNull();
+  });
+
+  it("handles the opening race without inventing completed standings pressure", () => {
+    const save = saveWithTour({
+      progress: {
+        ...defaultSave().progress,
+        unlockedTours: ["velvet-coast"],
+        activeTour: {
+          tourId: "velvet-coast",
+          raceIndex: 0,
+          results: [],
+        },
+      },
+    });
+
+    const summary = buildTourPressureSummary({
+      save,
+      championship: CHAMPIONSHIP,
+    });
+
+    expect(summary?.progressLabel).toBe("Race 1 of 4, 0 complete");
+    expect(summary?.pressureLabel).toBe(
+      "Opening race: bank points for the top 4 gate",
+    );
+  });
+});
+
+describe("estimateFullRepair", () => {
+  it("uses pending garage damage instead of trusting the stored total", () => {
+    const save = saveWithTour({
+      garage: {
+        ...defaultSave().garage,
+        credits: 1_500,
+        pendingDamage: {
+          "sparrow-gt": {
+            zones: { engine: 0.5, tires: 0, body: 0 },
+            total: 0,
+            offRoadAccumSeconds: 0,
+          },
+        },
+      },
+    });
+
+    expect(estimateFullRepair(save)).toBeGreaterThan(0);
+  });
+});

--- a/src/game/index.ts
+++ b/src/game/index.ts
@@ -27,6 +27,7 @@ export * from "./difficultyPresets";
 export * from "./raceDamagePersistence";
 export * from "./preRaceCard";
 export * from "./raceMoments";
+export * from "./tourPressure";
 // `raceBonuses` is the owner of the §5 bonus pipeline; `raceResult` is
 // the §20 results-screen builder that consumes it. The two re-export the
 // same `RaceBonus` / `RaceBonusKind` and the four bonus constants, so

--- a/src/game/preRaceCard.ts
+++ b/src/game/preRaceCard.ts
@@ -8,17 +8,17 @@ import type {
   WeatherOption,
 } from "@/data/schemas";
 
-import { applyRepairCost, baseRewardForTrackDifficulty } from "./economy";
-import { createDamageState, type DamageState } from "./damage";
+import { baseRewardForTrackDifficulty } from "./economy";
 import {
   visibilityForWeather,
   weatherGripScalar,
   type TireKind,
 } from "./weather";
-
-const REPAIR_ZONES = ["engine", "tires", "body"] as const;
-
-type PendingGarageDamage = NonNullable<SaveGame["garage"]["pendingDamage"]>[string];
+import {
+  buildTourPressureSummary,
+  estimateFullRepair,
+  type TourPressureSummary,
+} from "./tourPressure";
 
 export interface PreRaceCard {
   readonly trackName: string;
@@ -43,6 +43,7 @@ export interface PreRaceCard {
   readonly cashOnHand: number;
   readonly repairEstimate: number;
   readonly baseReward: number;
+  readonly tourPressure: TourPressureSummary | null;
   readonly carSummary: {
     readonly id: string;
     readonly name: string;
@@ -77,7 +78,7 @@ export function buildPreRaceCard(input: BuildPreRaceCardInput): PreRaceCard {
   const selectedTire = input.selectedTire ?? recommendTire(weather);
   const recommendedTire = recommendTire(weather);
   const activeTour = championship
-    ? championship.tours.find((tour) => tour.id === tourId) ?? null
+    ? (championship.tours.find((tour) => tour.id === tourId) ?? null)
     : null;
 
   return {
@@ -101,8 +102,11 @@ export function buildPreRaceCard(input: BuildPreRaceCardInput): PreRaceCard {
     },
     standings: standingsSummary(save, activeTour, raceIndex),
     cashOnHand: save.garage.credits,
-    repairEstimate: repairEstimate(save),
+    repairEstimate: estimateFullRepair(save),
     baseReward: baseRewardForTrackDifficulty(track.difficulty),
+    tourPressure: championship
+      ? buildTourPressureSummary({ save, championship })
+      : null,
     carSummary: carSummary(save.garage.activeCarId, car),
     setupSummary: setupSummary(save.garage.activeCarId, save),
   };
@@ -217,50 +221,18 @@ function standingsSummary(
   raceIndex: number | null,
 ): string {
   const activeTour = save.progress.activeTour;
-  if (!tour || !activeTour || activeTour.tourId !== tour.id) return "No tour standings yet";
+  if (!tour || !activeTour || activeTour.tourId !== tour.id)
+    return "No tour standings yet";
   const completed = activeTour.results.length;
   const total = tour.tracks.length;
   const next = raceIndex === null ? activeTour.raceIndex : raceIndex;
   return `Race ${Math.min(total, next + 1)} of ${total}, ${completed} complete`;
 }
 
-function repairEstimate(save: SaveGame): number {
-  const carId = save.garage.activeCarId;
-  const pending = save.garage.pendingDamage?.[carId];
-  const damage = damageFromPending(pending);
-  const quoteSave: SaveGame = {
-    ...save,
-    garage: {
-      ...save.garage,
-      credits: Number.MAX_SAFE_INTEGER,
-    },
-  };
-  const result = applyRepairCost(quoteSave, {
-    carId,
-    damage,
-    tourTier: 1,
-    zones: REPAIR_ZONES,
-    repairKind: "full",
-    lastRaceCashEarned: save.garage.lastRaceCashEarned ?? 0,
-  });
-  return result.ok ? result.cashSpent ?? 0 : 0;
-}
-
-function damageFromPending(
-  pending: PendingGarageDamage | undefined,
-): DamageState {
-  if (!pending) return createDamageState({});
-  return {
-    ...createDamageState({
-      engine: pending.zones.engine,
-      tires: pending.zones.tires,
-      body: pending.zones.body,
-    }),
-    offRoadAccumSeconds: pending.offRoadAccumSeconds,
-  };
-}
-
-function carSummary(activeCarId: string, car: Car | undefined): PreRaceCard["carSummary"] {
+function carSummary(
+  activeCarId: string,
+  car: Car | undefined,
+): PreRaceCard["carSummary"] {
   if (!car) {
     return {
       id: activeCarId,
@@ -284,8 +256,13 @@ function carSummary(activeCarId: string, car: Car | undefined): PreRaceCard["car
 function setupSummary(activeCarId: string, save: SaveGame): string {
   const upgrades = save.garage.installedUpgrades?.[activeCarId];
   if (!upgrades) return "Stock setup";
-  const totalTiers = Object.values(upgrades).reduce((sum, tier) => sum + tier, 0);
-  return totalTiers === 0 ? "Stock setup" : `${totalTiers} upgrade tiers installed`;
+  const totalTiers = Object.values(upgrades).reduce(
+    (sum, tier) => sum + tier,
+    0,
+  );
+  return totalTiers === 0
+    ? "Stock setup"
+    : `${totalTiers} upgrade tiers installed`;
 }
 
 function displayTourName(tourId: string): string {

--- a/src/game/tourPressure.ts
+++ b/src/game/tourPressure.ts
@@ -1,0 +1,240 @@
+import { getCar } from "@/data/cars";
+import type { Championship, SaveGame, UpgradeCategory } from "@/data/schemas";
+import { UPGRADES } from "@/data/upgrades";
+
+import { tourComplete } from "./championship";
+import { createDamageState, type DamageState } from "./damage";
+import { applyRepairCost } from "./economy";
+
+const REPAIR_ZONES = ["engine", "tires", "body"] as const;
+
+type PendingGarageDamage = NonNullable<
+  SaveGame["garage"]["pendingDamage"]
+>[string];
+
+export interface TourPressureSummary {
+  readonly tourId: string;
+  readonly tourName: string;
+  readonly progressLabel: string;
+  readonly nextRaceId: string | null;
+  readonly nextRaceLabel: string;
+  readonly standingsLabel: string;
+  readonly gateLabel: string;
+  readonly pressureLabel: string;
+  readonly playerStanding: number | null;
+  readonly requiredStanding: number;
+  readonly playerPoints: number;
+  readonly pointsToGate: number;
+  readonly cashOnHand: number;
+  readonly repairEstimate: number;
+  readonly cashAfterRepair: number;
+  readonly nextUpgradeLabel: string;
+  readonly nextUpgradeCost: number | null;
+  readonly upgradeShortfall: number;
+}
+
+export function buildTourPressureSummary(input: {
+  readonly save: SaveGame;
+  readonly championship: Championship;
+}): TourPressureSummary | null {
+  const activeTour = input.save.progress.activeTour;
+  if (!activeTour) return null;
+
+  const tour = input.championship.tours.find(
+    (candidate) => candidate.id === activeTour.tourId,
+  );
+  if (!tour) return null;
+
+  const totalRaces = tour.tracks.length;
+  const completedRaces = Math.min(activeTour.results.length, totalRaces);
+  const nextRaceIndex = Math.min(activeTour.raceIndex, totalRaces - 1);
+  const nextRaceId =
+    activeTour.raceIndex < totalRaces
+      ? (tour.tracks[nextRaceIndex] ?? null)
+      : null;
+  const summary = tourComplete(
+    activeTour,
+    input.championship,
+    input.save.garage.activeCarId,
+  );
+  const playerEntry =
+    summary.standings.find(
+      (entry) => entry.carId === input.save.garage.activeCarId,
+    ) ?? null;
+  const playerStanding = playerEntry
+    ? summary.standings.findIndex(
+        (entry) => entry.carId === playerEntry.carId,
+      ) + 1
+    : null;
+  const gateEntry = summary.standings[tour.requiredStanding - 1] ?? null;
+  const playerPoints = playerEntry?.points ?? 0;
+  const pointsToGate =
+    playerStanding !== null && playerStanding <= tour.requiredStanding
+      ? 0
+      : Math.max(0, (gateEntry?.points ?? 0) - playerPoints);
+  const repairEstimate = estimateFullRepair(input.save);
+  const cashAfterRepair = Math.max(
+    0,
+    input.save.garage.credits - repairEstimate,
+  );
+  const nextUpgrade = cheapestNextUpgrade(input.save);
+  const upgradeShortfall =
+    nextUpgrade === null ? 0 : Math.max(0, nextUpgrade.cost - cashAfterRepair);
+
+  return {
+    tourId: tour.id,
+    tourName: displayTourName(tour.id),
+    progressLabel: `Race ${Math.min(totalRaces, activeTour.raceIndex + 1)} of ${totalRaces}, ${completedRaces} complete`,
+    nextRaceId,
+    nextRaceLabel: nextRaceId ?? "Tour complete",
+    standingsLabel:
+      playerStanding === null
+        ? "No standing yet"
+        : `${ordinal(playerStanding)} of ${Math.max(1, summary.standings.length)}`,
+    gateLabel: `Need ${ordinal(tour.requiredStanding)} or better to advance`,
+    pressureLabel: pressureLabel({
+      completedRaces,
+      playerStanding,
+      requiredStanding: tour.requiredStanding,
+      playerPoints,
+      pointsToGate,
+    }),
+    playerStanding,
+    requiredStanding: tour.requiredStanding,
+    playerPoints,
+    pointsToGate,
+    cashOnHand: input.save.garage.credits,
+    repairEstimate,
+    cashAfterRepair,
+    nextUpgradeLabel: nextUpgrade?.label ?? "No eligible upgrade",
+    nextUpgradeCost: nextUpgrade?.cost ?? null,
+    upgradeShortfall,
+  };
+}
+
+export function estimateFullRepair(save: SaveGame): number {
+  const carId = save.garage.activeCarId;
+  const damage = damageFromPending(save.garage.pendingDamage?.[carId]);
+  const quoteSave: SaveGame = {
+    ...save,
+    garage: {
+      ...save.garage,
+      credits: Number.MAX_SAFE_INTEGER,
+    },
+  };
+  const result = applyRepairCost(quoteSave, {
+    carId,
+    damage,
+    tourTier: 1,
+    zones: REPAIR_ZONES,
+    repairKind: "full",
+    lastRaceCashEarned: save.garage.lastRaceCashEarned ?? 0,
+  });
+  return result.ok ? (result.cashSpent ?? 0) : 0;
+}
+
+function cheapestNextUpgrade(
+  save: SaveGame,
+): { readonly label: string; readonly cost: number } | null {
+  const activeCar = getCar(save.garage.activeCarId);
+  if (!activeCar) return null;
+  const installed = save.garage.installedUpgrades[save.garage.activeCarId];
+  const candidates = UPGRADES.filter((upgrade) => {
+    const currentTier = installed?.[upgrade.category] ?? 0;
+    const cap = activeCar.upgradeCaps[upgrade.category];
+    return upgrade.tier === currentTier + 1 && upgrade.tier <= cap;
+  }).map((upgrade) => ({
+    label: `${upgradeLabel(upgrade.category)} ${tierLabel(upgrade.tier)}`,
+    cost: upgrade.cost,
+  }));
+
+  candidates.sort((a, b) => a.cost - b.cost || a.label.localeCompare(b.label));
+  return candidates[0] ?? null;
+}
+
+function pressureLabel(input: {
+  readonly completedRaces: number;
+  readonly playerStanding: number | null;
+  readonly requiredStanding: number;
+  readonly playerPoints: number;
+  readonly pointsToGate: number;
+}): string {
+  if (input.completedRaces === 0) {
+    return `Opening race: bank points for the top ${input.requiredStanding} gate`;
+  }
+  if (
+    input.playerStanding !== null &&
+    input.playerStanding <= input.requiredStanding
+  ) {
+    return `Inside the gate with ${input.playerPoints} points`;
+  }
+  return `Chase ${input.pointsToGate} points to reach the gate`;
+}
+
+function damageFromPending(
+  pending: PendingGarageDamage | undefined,
+): DamageState {
+  if (!pending) return createDamageState({});
+  return {
+    ...createDamageState({
+      engine: pending.zones.engine,
+      tires: pending.zones.tires,
+      body: pending.zones.body,
+    }),
+    offRoadAccumSeconds: pending.offRoadAccumSeconds,
+  };
+}
+
+function upgradeLabel(category: UpgradeCategory): string {
+  switch (category) {
+    case "dryTires":
+      return "Dry tires";
+    case "wetTires":
+      return "Wet tires";
+    case "nitro":
+      return "Nitro";
+    case "armor":
+      return "Armor";
+    case "aero":
+      return "Aero";
+    default:
+      return `${category.charAt(0).toUpperCase()}${category.slice(1)}`;
+  }
+}
+
+function tierLabel(tier: number): string {
+  switch (tier) {
+    case 1:
+      return "Street";
+    case 2:
+      return "Sport";
+    case 3:
+      return "Factory";
+    case 4:
+      return "Extreme";
+    default:
+      return `Tier ${tier}`;
+  }
+}
+
+function displayTourName(tourId: string): string {
+  return tourId
+    .split("-")
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+    .join(" ");
+}
+
+function ordinal(n: number): string {
+  const last2 = n % 100;
+  if (last2 >= 11 && last2 <= 13) return `${n}th`;
+  switch (n % 10) {
+    case 1:
+      return `${n}st`;
+    case 2:
+      return `${n}nd`;
+    case 3:
+      return `${n}rd`;
+    default:
+      return `${n}th`;
+  }
+}

--- a/src/game/tourPressure.ts
+++ b/src/game/tourPressure.ts
@@ -1,5 +1,6 @@
 import { getCar } from "@/data/cars";
-import type { Championship, SaveGame, UpgradeCategory } from "@/data/schemas";
+import { TrackSchema, type Championship, type SaveGame } from "@/data/schemas";
+import { TRACK_RAW } from "@/data/tracks";
 import { UPGRADES } from "@/data/upgrades";
 
 import { tourComplete } from "./championship";
@@ -86,7 +87,7 @@ export function buildTourPressureSummary(input: {
     tourName: displayTourName(tour.id),
     progressLabel: `Race ${Math.min(totalRaces, activeTour.raceIndex + 1)} of ${totalRaces}, ${completedRaces} complete`,
     nextRaceId,
-    nextRaceLabel: nextRaceId ?? "Tour complete",
+    nextRaceLabel: nextRaceId ? trackName(nextRaceId) : "Tour complete",
     standingsLabel:
       playerStanding === null
         ? "No standing yet"
@@ -144,7 +145,7 @@ function cheapestNextUpgrade(
     const cap = activeCar.upgradeCaps[upgrade.category];
     return upgrade.tier === currentTier + 1 && upgrade.tier <= cap;
   }).map((upgrade) => ({
-    label: `${upgradeLabel(upgrade.category)} ${tierLabel(upgrade.tier)}`,
+    label: upgrade.name,
     cost: upgrade.cost,
   }));
 
@@ -185,38 +186,6 @@ function damageFromPending(
   };
 }
 
-function upgradeLabel(category: UpgradeCategory): string {
-  switch (category) {
-    case "dryTires":
-      return "Dry tires";
-    case "wetTires":
-      return "Wet tires";
-    case "nitro":
-      return "Nitro";
-    case "armor":
-      return "Armor";
-    case "aero":
-      return "Aero";
-    default:
-      return `${category.charAt(0).toUpperCase()}${category.slice(1)}`;
-  }
-}
-
-function tierLabel(tier: number): string {
-  switch (tier) {
-    case 1:
-      return "Street";
-    case 2:
-      return "Sport";
-    case 3:
-      return "Factory";
-    case 4:
-      return "Extreme";
-    default:
-      return `Tier ${tier}`;
-  }
-}
-
 function displayTourName(tourId: string): string {
   return tourId
     .split("-")
@@ -237,4 +206,9 @@ function ordinal(n: number): string {
     default:
       return `${n}th`;
   }
+}
+
+function trackName(trackId: string): string {
+  const parsed = TrackSchema.safeParse(TRACK_RAW[trackId]);
+  return parsed.success ? parsed.data.name : trackId;
 }


### PR DESCRIPTION
## Summary
- Add a shared tour-pressure summary for active World Tour standings, gate, next race, repair room, and next-upgrade shortfall
- Surface the summary in garage, pre-race, and results screens for the first-tour between-race loop
- Add unit and browser coverage plus progress log, followup, and coverage ledger updates

## GDD
- docs/gdd/08-world-and-progression-design.md
- docs/gdd/12-upgrade-and-economy-system.md
- docs/gdd/20-hud-and-ui-ux.md
- docs/PROGRESS_LOG.md entry: 2026-05-02 First-tour standings pressure
- Coverage ledger: GDD-20-TOUR-PRESSURE-SURFACES

## Test plan
- npx vitest run src/game/__tests__/tourPressure.test.ts src/game/__tests__/preRaceCard.test.ts src/components/garage/__tests__/garageSummaryState.test.ts
- npx playwright test e2e/tour-pressure.spec.ts
- npm run typecheck
- npm run lint
- npm run docs:check
- npm run content-lint

## Followups
- Closes F-074

## Review process
- I will check and respond to inline and threaded PR review comments before merge.