### PR TITLE
feat(tracks): first-tour authored event pass

### DIFF
--- a/docs/GDD_COVERAGE.json
+++ b/docs/GDD_COVERAGE.json
@@ -737,6 +737,29 @@
       "followupRefs": ["F-072"]
     },
     {
+      "id": "GDD-09-FIRST-TOUR-AUTHORED-EVENTS",
+      "gddSections": [
+        "docs/gdd/09-track-design.md",
+        "docs/gdd/14-weather-and-environmental-systems.md",
+        "docs/gdd/16-rendering-and-visual-design.md",
+        "docs/gdd/20-hud-and-ui-ux.md",
+        "docs/gdd/22-data-schemas.md"
+      ],
+      "requirement": "Every Velvet Coast race has at least one visible authored pickup line and at least one authored physical hazard, giving the first tour readable non-curve decisions with content validation and browser route coverage.",
+      "coverage": ["implemented-code", "automated-test"],
+      "implementationRefs": [
+        "src/data/tracks/velvet-coast-harbor-run.json",
+        "src/data/tracks/velvet-coast-sunpier-loop.json",
+        "src/data/tracks/velvet-coast-cliffline-arc.json",
+        "src/data/tracks/velvet-coast-lighthouse-fall.json"
+      ],
+      "testRefs": [
+        "src/data/__tests__/tracks-content.test.ts",
+        "e2e/first-tour-authored-events.spec.ts"
+      ],
+      "followupRefs": ["VibeGear2-feat-tracks-first-10ebfec0"]
+    },
+    {
       "id": "GDD-20-GAME-UI-SELECTION",
       "gddSections": [
         "docs/gdd/20-hud-and-ui-ux.md",

--- a/docs/PROGRESS_LOG.md
+++ b/docs/PROGRESS_LOG.md
@@ -6,6 +6,52 @@ Correct them by adding a new entry that references the old one.
 
 ---
 
+## 2026-05-02: Slice: First-tour authored events
+
+**GDD sections touched:** §9, §14, §16, §20, and §22.
+**Branch / PR:** `feat/first-tour-authored-events`, PR pending.
+**Status:** Implemented.
+
+### Done
+- Added visible authored pickup lines to Sunpier Loop, Cliffline Arc, and
+  Lighthouse Fall so every Velvet Coast race now has at least one readable
+  non-curve decision point.
+- Kept the existing first-tour physical hazards in place so each race combines
+  pickup routing with a shared-rule road condition that applies through the
+  hazard runtime.
+- Added content coverage that enforces first-tour pickup coverage, shared-rule
+  hazard coverage, pickup id uniqueness, nitro value consistency, and cash
+  pickup budget limits.
+- Added browser coverage that boots every Velvet Coast race route and verifies
+  a live authored pickup becomes visible from the race camera.
+
+### Verified
+- `npx vitest run src/data/__tests__/tracks-content.test.ts` green, 91 passed.
+- `npx playwright test e2e/first-tour-authored-events.spec.ts --project=chromium`
+  green, 4 passed.
+
+### Decisions and assumptions
+- Treated pickups as the visible authored player decision because the GDD
+  explicitly documents that AI ignores pickups in v1. Hazards remain the
+  shared-rule event surface for player and AI physics.
+- Limited first-tour cash pickups to 150 credits per race so authored rewards
+  stay below a meaningful race-payout budget.
+
+### Coverage ledger
+- Added `GDD-09-FIRST-TOUR-AUTHORED-EVENTS`.
+- Closes `VibeGear2-feat-tracks-first-10ebfec0`.
+- Uncovered adjacent requirements: richer visible hazard sprites, AI hazard
+  avoidance steering, and second-tour authored event passes remain separate
+  backlog work.
+
+### Followups created
+None.
+
+### GDD edits
+None.
+
+---
+
 ## 2026-05-02: Slice: First-tour standings pressure
 
 **GDD sections touched:** §8, §12, and §20.

--- a/e2e/first-tour-authored-events.spec.ts
+++ b/e2e/first-tour-authored-events.spec.ts
@@ -28,16 +28,21 @@ test.describe("first-tour authored event pass", () => {
       await expect(canvas).toBeVisible();
       await canvas.focus();
       await page.keyboard.down("ArrowUp");
-      await expect
-        .poll(
-          async () =>
-            metricNumber(
-              await page.getByTestId("race-visible-pickup-count").textContent(),
-            ),
-          { timeout: 20_000 },
-        )
-        .toBeGreaterThan(0);
-      await page.keyboard.up("ArrowUp");
+      try {
+        await expect
+          .poll(
+            async () =>
+              metricNumber(
+                await page
+                  .getByTestId("race-visible-pickup-count")
+                  .textContent(),
+              ),
+            { timeout: 20_000 },
+          )
+          .toBeGreaterThan(0);
+      } finally {
+        await page.keyboard.up("ArrowUp");
+      }
     });
   }
 });

--- a/e2e/first-tour-authored-events.spec.ts
+++ b/e2e/first-tour-authored-events.spec.ts
@@ -1,0 +1,43 @@
+import { expect, test } from "@playwright/test";
+
+const FIRST_TOUR_TRACKS = [
+  "velvet-coast/harbor-run",
+  "velvet-coast/sunpier-loop",
+  "velvet-coast/cliffline-arc",
+  "velvet-coast/lighthouse-fall",
+];
+
+function metricNumber(text: string | null): number {
+  return Number.parseInt(text ?? "0", 10);
+}
+
+test.describe("first-tour authored event pass", () => {
+  for (const trackId of FIRST_TOUR_TRACKS) {
+    test(`${trackId} boots and exposes an authored pickup`, async ({ page }) => {
+      await page.goto(`/race?track=${encodeURIComponent(trackId)}&mode=practice`);
+
+      await expect(page.getByTestId("race-canvas")).toHaveAttribute(
+        "data-track",
+        trackId,
+      );
+      await expect(page.getByTestId("race-phase")).toHaveText("racing", {
+        timeout: 10_000,
+      });
+
+      const canvas = page.getByTestId("race-canvas-element");
+      await expect(canvas).toBeVisible();
+      await canvas.focus();
+      await page.keyboard.down("ArrowUp");
+      await expect
+        .poll(
+          async () =>
+            metricNumber(
+              await page.getByTestId("race-visible-pickup-count").textContent(),
+            ),
+          { timeout: 20_000 },
+        )
+        .toBeGreaterThan(0);
+      await page.keyboard.up("ArrowUp");
+    });
+  }
+});

--- a/src/data/__tests__/tracks-content.test.ts
+++ b/src/data/__tests__/tracks-content.test.ts
@@ -27,6 +27,13 @@ const EXPECTED_MVP_TRACK_IDS = [
   "iron-borough/outer-exchange",
 ];
 
+const EXPECTED_VELVET_COAST_TRACK_IDS = [
+  "velvet-coast/harbor-run",
+  "velvet-coast/sunpier-loop",
+  "velvet-coast/cliffline-arc",
+  "velvet-coast/lighthouse-fall",
+];
+
 const EXPECTED_AUTHORED_TOUR_TRACK_IDS = [
   ...EXPECTED_MVP_TRACK_IDS,
   "ember-steppe/redglass-straight",
@@ -174,6 +181,50 @@ describe("§24 MVP track set", () => {
         track.segments.some((segment) => segment.grade !== 0),
       ),
     ).toBe(true);
+  });
+});
+
+describe("§9 Velvet Coast authored events", () => {
+  it("gives every first-tour race a visible pickup line and a shared-rule hazard", () => {
+    for (const id of EXPECTED_VELVET_COAST_TRACK_IDS) {
+      const parsed = TrackSchema.parse(TRACK_RAW[id]);
+      const pickups = parsed.segments.flatMap((segment) => segment.pickups ?? []);
+      const hazards = parsed.segments.flatMap((segment) => segment.hazards);
+
+      expect(pickups.length, `${id} pickup count`).toBeGreaterThan(0);
+      expect(hazards.length, `${id} hazard count`).toBeGreaterThan(0);
+      expect(
+        new Set(pickups.map((pickup) => pickup.id)).size,
+        `${id} pickup ids`,
+      ).toBe(pickups.length);
+      expect(
+        pickups.every((pickup) => pickup.kind === "cash" || pickup.value === 25),
+        `${id} nitro pickup values`,
+      ).toBe(true);
+      expect(
+        pickups
+          .filter((pickup) => pickup.kind === "cash")
+          .reduce((total, pickup) => total + pickup.value, 0),
+        `${id} cash pickup budget`,
+      ).toBeLessThanOrEqual(150);
+    }
+  });
+
+  it("mixes pickup decisions and hazard pressure across the first tour", () => {
+    const pickups = new Set<string>();
+    const hazards = new Set<string>();
+    for (const id of EXPECTED_VELVET_COAST_TRACK_IDS) {
+      const parsed = TrackSchema.parse(TRACK_RAW[id]);
+      for (const segment of parsed.segments) {
+        for (const pickup of segment.pickups ?? []) pickups.add(pickup.kind);
+        for (const hazard of segment.hazards) hazards.add(hazard);
+      }
+    }
+
+    expect(pickups.has("cash")).toBe(true);
+    expect(pickups.has("nitro")).toBe(true);
+    expect(hazards.has("puddle")).toBe(true);
+    expect(hazards.has("gravel_band")).toBe(true);
   });
 });
 

--- a/src/data/tracks/velvet-coast-cliffline-arc.json
+++ b/src/data/tracks/velvet-coast-cliffline-arc.json
@@ -11,7 +11,17 @@
   "difficulty": 2,
   "segments": [
     { "len": 240, "curve": 0, "grade": 0.01, "roadsideLeft": "rock_boulder", "roadsideRight": "sign_marker", "hazards": [] },
-    { "len": 240, "curve": 0.14, "grade": 0.04, "roadsideLeft": "rock_boulder", "roadsideRight": "fence_post", "hazards": [] },
+    {
+      "len": 240,
+      "curve": 0.14,
+      "grade": 0.04,
+      "roadsideLeft": "rock_boulder",
+      "roadsideRight": "fence_post",
+      "hazards": [],
+      "pickups": [
+        { "id": "cliffline-arc-climb-nitro", "kind": "nitro", "laneOffset": 0.35, "value": 25 }
+      ]
+    },
     { "len": 180, "curve": 0.06, "grade": -0.03, "roadsideLeft": "tree_pine", "roadsideRight": "rock_boulder", "hazards": [] },
     { "len": 240, "curve": -0.14, "grade": 0, "roadsideLeft": "sign_marker", "roadsideRight": "light_pole", "hazards": ["gravel_band"] },
     { "len": 300, "curve": -0.04, "grade": -0.02, "roadsideLeft": "fence_post", "roadsideRight": "rock_boulder", "hazards": [] },

--- a/src/data/tracks/velvet-coast-lighthouse-fall.json
+++ b/src/data/tracks/velvet-coast-lighthouse-fall.json
@@ -11,7 +11,17 @@
   "difficulty": 2,
   "segments": [
     { "len": 240, "curve": 0, "grade": 0, "roadsideLeft": "sign_marker", "roadsideRight": "light_pole", "hazards": [] },
-    { "len": 180, "curve": -0.1, "grade": 0.05, "roadsideLeft": "rock_boulder", "roadsideRight": "fence_post", "hazards": [] },
+    {
+      "len": 180,
+      "curve": -0.1,
+      "grade": 0.05,
+      "roadsideLeft": "rock_boulder",
+      "roadsideRight": "fence_post",
+      "hazards": [],
+      "pickups": [
+        { "id": "lighthouse-fall-keeper-cash", "kind": "cash", "laneOffset": 0.4, "value": 100 }
+      ]
+    },
     { "len": 240, "curve": -0.08, "grade": -0.06, "roadsideLeft": "tree_pine", "roadsideRight": "rock_boulder", "hazards": ["puddle"] },
     { "len": 240, "curve": 0.12, "grade": 0, "roadsideLeft": "light_pole", "roadsideRight": "sign_marker", "hazards": [] },
     { "len": 324, "curve": 0.06, "grade": 0.03, "roadsideLeft": "fence_post", "roadsideRight": "tree_pine", "hazards": [] },

--- a/src/data/tracks/velvet-coast-sunpier-loop.json
+++ b/src/data/tracks/velvet-coast-sunpier-loop.json
@@ -11,7 +11,17 @@
   "difficulty": 1,
   "segments": [
     { "len": 216, "curve": 0, "grade": 0, "roadsideLeft": "light_pole", "roadsideRight": "sign_marker", "hazards": [] },
-    { "len": 240, "curve": 0.12, "grade": 0, "roadsideLeft": "fence_post", "roadsideRight": "light_pole", "hazards": [] },
+    {
+      "len": 240,
+      "curve": 0.12,
+      "grade": 0,
+      "roadsideLeft": "fence_post",
+      "roadsideRight": "light_pole",
+      "hazards": [],
+      "pickups": [
+        { "id": "sunpier-loop-boardwalk-cash", "kind": "cash", "laneOffset": -0.35, "value": 90 }
+      ]
+    },
     { "len": 180, "curve": 0.08, "grade": 0.03, "roadsideLeft": "tree_pine", "roadsideRight": "fence_post", "hazards": ["puddle"] },
     { "len": 240, "curve": -0.1, "grade": -0.02, "roadsideLeft": "sign_marker", "roadsideRight": "rock_boulder", "hazards": [] },
     { "len": 300, "curve": -0.04, "grade": 0, "roadsideLeft": "light_pole", "roadsideRight": "fence_post", "hazards": [] },


### PR DESCRIPTION
## Summary
- Add authored pickup lines to Sunpier Loop, Cliffline Arc, and Lighthouse Fall so every Velvet Coast race has a visible non-curve decision point.
- Add content coverage for first-tour pickup and hazard coverage, pickup id uniqueness, nitro values, and cash budget limits.
- Add browser coverage that boots every Velvet Coast race and verifies an authored pickup becomes visible.

## GDD
- docs/gdd/09-track-design.md
- docs/gdd/14-weather-and-environmental-systems.md
- docs/gdd/16-rendering-and-visual-design.md
- docs/gdd/20-hud-and-ui-ux.md
- docs/gdd/22-data-schemas.md

## Progress Log
- docs/PROGRESS_LOG.md: 2026-05-02: Slice: First-tour authored events

## Test Plan
- npx vitest run src/data/__tests__/tracks-content.test.ts
- npx playwright test e2e/first-tour-authored-events.spec.ts --project=chromium
- npm run typecheck
- npm run lint
- npm run docs:check
- npm run content-lint
- git diff --check

## Followups
- None
