### PR TITLE
feat(audio): race mix and event emphasis pass

### DIFF
--- a/docs/GDD_COVERAGE.json
+++ b/docs/GDD_COVERAGE.json
@@ -187,6 +187,30 @@
       "followupRefs": ["VibeGear2-implement-sound-music-1611f9dd"]
     },
     {
+      "id": "GDD-18-RACE-MIX-EVENT-EMPHASIS",
+      "gddSections": [
+        "docs/gdd/10-driving-model-and-physics.md",
+        "docs/gdd/13-damage-repairs-and-risk.md",
+        "docs/gdd/18-sound-and-music-design.md",
+        "docs/gdd/20-hud-and-ui-ux.md"
+      ],
+      "requirement": "Race music, engine, weather, and one-shot SFX share a ducking policy so countdown, nitro, finish, collision, pickup, tire, surface, and damage-warning cues remain readable together.",
+      "coverage": ["implemented-code", "automated-test"],
+      "implementationRefs": [
+        "src/audio/raceMix.ts",
+        "src/audio/sfx.ts",
+        "src/game/raceSession.ts",
+        "src/app/race/page.tsx"
+      ],
+      "testRefs": [
+        "src/audio/raceMix.test.ts",
+        "src/audio/sfx.test.ts",
+        "src/game/__tests__/raceSession.test.ts",
+        "e2e/race-audio-mix.spec.ts"
+      ],
+      "followupRefs": ["VibeGear2-feat-audio-race-a656eed2"]
+    },
+    {
       "id": "GDD-06-DAILY-CHALLENGE-SELECTION",
       "gddSections": [
         "docs/gdd/06-game-modes.md",

--- a/docs/PROGRESS_LOG.md
+++ b/docs/PROGRESS_LOG.md
@@ -6,6 +6,48 @@ Correct them by adding a new entry that references the old one.
 
 ---
 
+## 2026-05-02: Slice: Race mix and event emphasis
+
+**GDD sections touched:** §10, §13, §18, and §20.
+**Branch / PR:** `feat/race-audio-mix-pass`, PR pending.
+**Status:** Implemented.
+
+### Done
+- Added a race-mix ducking policy so countdown, nitro, finish, collision,
+  pickup, tire, surface, and damage-warning cues can sit above race music
+  without muting the music bed.
+- Added a severe-damage warning audio event when the player crosses the
+  75% damage band before the wreck gate.
+- Wired the race route to apply music ducking around countdown and live
+  race SFX events, with hidden telemetry for browser smoke coverage.
+- Added a procedural damage-warning SFX cue and tests for race-mix priority,
+  warning SFX shape, and race-session warning emission.
+
+### Verified
+- `npx vitest run src/audio/raceMix.test.ts src/audio/sfx.test.ts src/game/__tests__/raceSession.test.ts` green, 144 passed.
+- `npx playwright test e2e/race-audio-mix.spec.ts --project=chromium` green, 1 passed.
+
+### Decisions and assumptions
+- Kept this as runtime mix policy and procedural SFX tuning. It does not
+  replace the underlying generated audio assets.
+- Used the existing severe damage band as the warning threshold because it
+  is the first band with heavy power loss and sits below the wreck gate.
+
+### Coverage ledger
+- Added `GDD-18-RACE-MIX-EVENT-EMPHASIS`.
+- Closes `VibeGear2-feat-audio-race-a656eed2`.
+- Uncovered adjacent requirements: production-quality music composition,
+  region-specific mastering, and richer multi-tone warning patterns remain
+  separate polish work.
+
+### Followups created
+None.
+
+### GDD edits
+None.
+
+---
+
 ## 2026-05-02: Slice: First-tour authored events
 
 **GDD sections touched:** §9, §14, §16, §20, and §22.

--- a/e2e/race-audio-mix.spec.ts
+++ b/e2e/race-audio-mix.spec.ts
@@ -1,0 +1,52 @@
+import { expect, test } from "@playwright/test";
+
+function metricNumber(text: string | null): number {
+  return Number.parseFloat(text ?? "1");
+}
+
+test.describe("race audio mix telemetry", () => {
+  test("countdown and live race events duck music without stopping the race", async ({
+    page,
+  }) => {
+    await page.goto("/race?track=test/straight&mode=quickRace");
+
+    await expect(page.getByTestId("race-phase")).toHaveText("countdown", {
+      timeout: 10_000,
+    });
+    await expect(page.getByTestId("race-last-audio-event")).toHaveText(
+      "countdown",
+      { timeout: 5_000 },
+    );
+    expect(
+      metricNumber(await page.getByTestId("race-music-duck-scale").textContent()),
+    ).toBeLessThan(1);
+
+    await expect(page.getByTestId("race-phase")).toHaveText("racing", {
+      timeout: 10_000,
+    });
+
+    const canvas = page.getByTestId("race-canvas-element");
+    await canvas.focus();
+    await page.keyboard.down("ArrowUp");
+    await page.keyboard.down("Space");
+    try {
+      await expect
+        .poll(
+          async () =>
+            (await page
+              .getByTestId("race-observed-audio-events")
+              .textContent()) ?? "none",
+          { timeout: 8_000 },
+        )
+        .toMatch(/impact|pickupCollected|nitroEngage/u);
+      expect(
+        metricNumber(
+          await page.getByTestId("race-music-duck-scale").textContent(),
+        ),
+      ).toBeLessThan(1);
+    } finally {
+      await page.keyboard.up("Space");
+      await page.keyboard.up("ArrowUp");
+    }
+  });
+});

--- a/src/app/race/page.tsx
+++ b/src/app/race/page.tsx
@@ -180,6 +180,11 @@ import {
   raceMusicIntensity,
   weatherMusicStem,
 } from "@/audio/music";
+import {
+  applyRaceMusicDucking,
+  raceMusicDuckingForAudioEvents,
+  raceMusicDuckingForCountdownStep,
+} from "@/audio/raceMix";
 
 const VIEWPORT_WIDTH = 800;
 const VIEWPORT_HEIGHT = 480;
@@ -311,6 +316,8 @@ function playRaceSfxEvents(
       runtime.playLapComplete({ audio });
     } else if (event.kind === "raceFinish") {
       runtime.playResultsStinger({ audio });
+    } else if (event.kind === "damageWarning") {
+      runtime.playDamageWarning({ audio });
     } else if (event.kind === "brakeScrub") {
       runtime.playBrakeScrub({ speedFactor: event.speedFactor, audio });
     } else if (event.kind === "tireSqueal") {
@@ -377,6 +384,17 @@ function playerPickupFeedbackFromEvents(
     };
   }
   return latest;
+}
+
+function mergeObservedAudioEvents(
+  current: string,
+  next: ReadonlyArray<string>,
+): string {
+  const observed = new Set(
+    current === "none" ? [] : current.split(",").filter(Boolean),
+  );
+  for (const event of next) observed.add(event);
+  return observed.size === 0 ? "none" : Array.from(observed).sort().join(",");
 }
 
 function finishMomentTitle(place: number): string {
@@ -1151,6 +1169,11 @@ function RaceCanvas({
   const [visiblePickupCount, setVisiblePickupCount] = useState<number>(0);
   const [collectedPickupCount, setCollectedPickupCount] = useState<number>(0);
   const [playerNitroActive, setPlayerNitroActive] = useState<boolean>(false);
+  const [lastRaceAudioEvent, setLastRaceAudioEvent] = useState<string>("none");
+  const [observedRaceAudioEvents, setObservedRaceAudioEvents] =
+    useState<string>("none");
+  const [raceMusicDuckTelemetry, setRaceMusicDuckTelemetry] =
+    useState<number>(1);
   const [pickupFeedback, setPickupFeedback] =
     useState<PickupFeedbackSnapshot | null>(null);
   const [touchLayout, setTouchLayout] = useState<TouchLayout>(() =>
@@ -1473,6 +1496,8 @@ function RaceCanvas({
       speed: 0,
       topSpeed: playerStats.topSpeed,
     });
+    let raceMusicDuckingScale = 1;
+    let raceMusicDuckingUntilMs = 0;
     let latestWeatherMusicStem = weatherMusicStem(weather);
     let tunnelState = OPEN_TUNNEL_STATE;
     let engineStartPending = false;
@@ -1498,7 +1523,13 @@ function RaceCanvas({
           raceMusic.play(
             raceMusicCueForSession,
             persistedSettings.audio,
-            latestRaceMusicIntensity,
+            {
+              ...latestRaceMusicIntensity,
+              volumeScale: applyRaceMusicDucking(
+                latestRaceMusicIntensity.volumeScale,
+                { volumeScale: raceMusicDuckingScale, holdMs: 0 },
+              ),
+            },
           );
           raceMusic.playWeatherStem(
             latestWeatherMusicStem,
@@ -1559,6 +1590,9 @@ function RaceCanvas({
       previousRaceStoryCarsRef.current = null;
       lastRaceStoryMomentMsRef.current = 0;
       setLastRaceStoryMoment(null);
+      setLastRaceAudioEvent("none");
+      setObservedRaceAudioEvents("none");
+      setRaceMusicDuckTelemetry(1);
       sessionRef.current = createRaceSession(config);
       resetTimeTrialRuntime();
       tunnelState = OPEN_TUNNEL_STATE;
@@ -1749,10 +1783,21 @@ function RaceCanvas({
         const renderWeather = activeWeatherForState(session.weather);
         latestWeatherMusicStem = weatherMusicStem(renderWeather);
         const audioUpdateMs = performance.now();
+        if (audioUpdateMs >= raceMusicDuckingUntilMs) {
+          raceMusicDuckingScale = 1;
+          setRaceMusicDuckTelemetry(1);
+        }
+        const duckedRaceMusicIntensity = {
+          ...latestRaceMusicIntensity,
+          volumeScale: applyRaceMusicDucking(
+            latestRaceMusicIntensity.volumeScale,
+            { volumeScale: raceMusicDuckingScale, holdMs: 0 },
+          ),
+        };
         if (audioUpdateMs - lastEngineAudioUpdateMs >= 50) {
           lastEngineAudioUpdateMs = audioUpdateMs;
           engineAudio.update(latestEngineInput);
-          raceMusic.update(persistedSettings.audio, latestRaceMusicIntensity);
+          raceMusic.update(persistedSettings.audio, duckedRaceMusicIntensity);
           raceMusic.updateWeatherStem(
             latestWeatherMusicStem,
             persistedSettings.audio,
@@ -1760,11 +1805,33 @@ function RaceCanvas({
         }
         if (lastRaceSfxTick !== session.tick) {
           lastRaceSfxTick = session.tick;
+          const ducking = raceMusicDuckingForAudioEvents(session.audioEvents);
+          if (ducking.volumeScale < raceMusicDuckingScale) {
+            raceMusicDuckingScale = ducking.volumeScale;
+            raceMusicDuckingUntilMs = audioUpdateMs + ducking.holdMs;
+            setRaceMusicDuckTelemetry(ducking.volumeScale);
+            raceMusic.update(persistedSettings.audio, {
+              ...latestRaceMusicIntensity,
+              volumeScale: applyRaceMusicDucking(
+                latestRaceMusicIntensity.volumeScale,
+                ducking,
+              ),
+            });
+          }
           playRaceSfxEvents(
             raceSfx,
             session.audioEvents,
             persistedSettings.audio,
           );
+          if (session.audioEvents.length > 0) {
+            setLastRaceAudioEvent(session.audioEvents[0]!.kind);
+            setObservedRaceAudioEvents((current) =>
+              mergeObservedAudioEvents(
+                current,
+                session.audioEvents.map((event) => event.kind),
+              ),
+            );
+          }
           const pickupFeedbackFromTick = playerPickupFeedbackFromEvents(
             session.audioEvents,
             performance.now(),
@@ -2049,6 +2116,21 @@ function RaceCanvas({
           const countdownStep = Math.ceil(session.race.countdownRemainingSec);
           if (countdownStep !== lastCountdownSfxStep) {
             lastCountdownSfxStep = countdownStep;
+            const ducking = raceMusicDuckingForCountdownStep(countdownStep);
+            raceMusicDuckingScale = ducking.volumeScale;
+            raceMusicDuckingUntilMs = performance.now() + ducking.holdMs;
+            setRaceMusicDuckTelemetry(ducking.volumeScale);
+            setLastRaceAudioEvent("countdown");
+            setObservedRaceAudioEvents((current) =>
+              mergeObservedAudioEvents(current, ["countdown"]),
+            );
+            raceMusic.update(persistedSettings.audio, {
+              ...latestRaceMusicIntensity,
+              volumeScale: applyRaceMusicDucking(
+                latestRaceMusicIntensity.volumeScale,
+                ducking,
+              ),
+            });
             raceSfx.playCountdownTick({
               step: countdownStep,
               audio: persistedSettings.audio,
@@ -2157,6 +2239,21 @@ function RaceCanvas({
           }
         } else if (lastCountdownSfxStep !== 0) {
           lastCountdownSfxStep = 0;
+          const ducking = raceMusicDuckingForCountdownStep(0);
+          raceMusicDuckingScale = ducking.volumeScale;
+          raceMusicDuckingUntilMs = performance.now() + ducking.holdMs;
+          setRaceMusicDuckTelemetry(ducking.volumeScale);
+          setLastRaceAudioEvent("countdown");
+          setObservedRaceAudioEvents((current) =>
+            mergeObservedAudioEvents(current, ["countdown"]),
+          );
+          raceMusic.update(persistedSettings.audio, {
+            ...latestRaceMusicIntensity,
+            volumeScale: applyRaceMusicDucking(
+              latestRaceMusicIntensity.volumeScale,
+              ducking,
+            ),
+          });
           raceSfx.playCountdownTick({
             step: 0,
             audio: persistedSettings.audio,
@@ -2348,6 +2445,16 @@ function RaceCanvas({
         <dt>Nitro active:</dt>
         <dd data-testid="race-player-nitro-active">
           {playerNitroActive ? "yes" : "no"}
+        </dd>
+        <dt>Last race audio:</dt>
+        <dd data-testid="race-last-audio-event">{lastRaceAudioEvent}</dd>
+        <dt>Observed race audio:</dt>
+        <dd data-testid="race-observed-audio-events">
+          {observedRaceAudioEvents}
+        </dd>
+        <dt>Music duck:</dt>
+        <dd data-testid="race-music-duck-scale">
+          {raceMusicDuckTelemetry.toFixed(2)}
         </dd>
         <dt>Last pickup:</dt>
         <dd data-testid="race-last-pickup-kind">

--- a/src/audio/raceMix.test.ts
+++ b/src/audio/raceMix.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  NO_RACE_MUSIC_DUCKING,
+  applyRaceMusicDucking,
+  raceMusicDuckingForAudioEvents,
+  raceMusicDuckingForCountdownStep,
+} from "./raceMix";
+
+describe("race music ducking", () => {
+  it("keeps normal mix when there are no race SFX events", () => {
+    expect(raceMusicDuckingForAudioEvents([])).toEqual(NO_RACE_MUSIC_DUCKING);
+  });
+
+  it("ducks deepest for high-priority race moments", () => {
+    expect(
+      raceMusicDuckingForAudioEvents([
+        { kind: "gearShift", carId: "player", fromGear: 1, toGear: 2 },
+        { kind: "nitroEngage", carId: "player" },
+        { kind: "raceFinish", carId: "player" },
+      ]),
+    ).toEqual({ volumeScale: 0.5, holdMs: 900 });
+  });
+
+  it("keeps collisions, warning, and weather cues above the engine", () => {
+    expect(
+      raceMusicDuckingForAudioEvents([
+        {
+          kind: "impact",
+          carId: "player",
+          hitKind: "wallHit",
+          speedFactor: 1,
+        },
+      ]),
+    ).toEqual({ volumeScale: 0.48, holdMs: 360 });
+    expect(
+      raceMusicDuckingForAudioEvents([
+        { kind: "damageWarning", carId: "player", damagePercent: 76 },
+      ]),
+    ).toEqual({ volumeScale: 0.52, holdMs: 720 });
+    expect(
+      raceMusicDuckingForAudioEvents([
+        {
+          kind: "surfaceHush",
+          carId: "player",
+          surface: "wet",
+          speedFactor: 0.7,
+        },
+      ]),
+    ).toEqual({ volumeScale: 0.78, holdMs: 260 });
+  });
+
+  it("ducks countdown and go cues without muting the music", () => {
+    expect(raceMusicDuckingForCountdownStep(3)).toEqual({
+      volumeScale: 0.82,
+      holdMs: 220,
+    });
+    expect(raceMusicDuckingForCountdownStep(0)).toEqual({
+      volumeScale: 0.72,
+      holdMs: 360,
+    });
+  });
+
+  it("applies ducking with defensive clamping", () => {
+    expect(applyRaceMusicDucking(1, { volumeScale: 0.5, holdMs: 100 })).toBe(0.5);
+    expect(applyRaceMusicDucking(2, NO_RACE_MUSIC_DUCKING)).toBe(1.2);
+    expect(
+      applyRaceMusicDucking(Number.NaN, NO_RACE_MUSIC_DUCKING),
+    ).toBe(0);
+  });
+});

--- a/src/audio/raceMix.ts
+++ b/src/audio/raceMix.ts
@@ -1,0 +1,97 @@
+import type {
+  RaceSessionAudioEvent,
+  RaceSessionImpactAudioEvent,
+} from "@/game/raceSession";
+
+export interface RaceMusicDucking {
+  readonly volumeScale: number;
+  readonly holdMs: number;
+}
+
+export const NO_RACE_MUSIC_DUCKING: RaceMusicDucking = Object.freeze({
+  volumeScale: 1,
+  holdMs: 0,
+});
+
+export function raceMusicDuckingForCountdownStep(step: number): RaceMusicDucking {
+  if (!Number.isFinite(step)) return NO_RACE_MUSIC_DUCKING;
+  return step <= 0
+    ? { volumeScale: 0.72, holdMs: 360 }
+    : { volumeScale: 0.82, holdMs: 220 };
+}
+
+export function raceMusicDuckingForAudioEvents(
+  events: ReadonlyArray<RaceSessionAudioEvent>,
+): RaceMusicDucking {
+  let ducking = NO_RACE_MUSIC_DUCKING;
+  for (const event of events) {
+    ducking = strongestDucking(ducking, raceMusicDuckingForAudioEvent(event));
+  }
+  return ducking;
+}
+
+export function applyRaceMusicDucking(
+  volumeScale: number,
+  ducking: RaceMusicDucking,
+): number {
+  return clampVolumeScale(volumeScale * ducking.volumeScale);
+}
+
+function raceMusicDuckingForAudioEvent(
+  event: RaceSessionAudioEvent,
+): RaceMusicDucking {
+  switch (event.kind) {
+    case "raceFinish":
+      return { volumeScale: 0.5, holdMs: 900 };
+    case "damageWarning":
+      return { volumeScale: 0.52, holdMs: 720 };
+    case "impact":
+      return { volumeScale: impactDuckingScale(event.hitKind), holdMs: 360 };
+    case "nitroEngage":
+      return { volumeScale: 0.66, holdMs: 480 };
+    case "lapComplete":
+      return { volumeScale: 0.7, holdMs: 520 };
+    case "pickupCollected":
+      return {
+        volumeScale: event.pickupKind === "nitro" ? 0.68 : 0.76,
+        holdMs: event.pickupKind === "nitro" ? 420 : 300,
+      };
+    case "surfaceHush":
+      return { volumeScale: 0.78, holdMs: 260 };
+    case "tireSqueal":
+      return { volumeScale: 0.82, holdMs: 220 };
+    case "brakeScrub":
+      return { volumeScale: 0.88, holdMs: 180 };
+    case "gearShift":
+      return NO_RACE_MUSIC_DUCKING;
+  }
+}
+
+function strongestDucking(
+  current: RaceMusicDucking,
+  next: RaceMusicDucking,
+): RaceMusicDucking {
+  if (next.volumeScale < current.volumeScale) return next;
+  if (next.volumeScale === current.volumeScale && next.holdMs > current.holdMs) {
+    return next;
+  }
+  return current;
+}
+
+function impactDuckingScale(hitKind: RaceSessionImpactAudioEvent["hitKind"]): number {
+  switch (hitKind) {
+    case "wallHit":
+      return 0.48;
+    case "carHit":
+    case "offRoadObject":
+      return 0.58;
+    case "rub":
+    case "offRoadPersistent":
+      return 0.84;
+  }
+}
+
+function clampVolumeScale(value: number): number {
+  if (!Number.isFinite(value) || value <= 0) return 0;
+  return Math.min(1.2, value);
+}

--- a/src/audio/sfx.test.ts
+++ b/src/audio/sfx.test.ts
@@ -272,6 +272,30 @@ describe("ProceduralSfxRuntime", () => {
     expect(context.oscillators[1]?.stop).toHaveBeenCalledWith(0.34);
   });
 
+  it("plays a distinct damage warning cue", () => {
+    const context = new FakeAudioContext();
+    const runtime = new ProceduralSfxRuntime({
+      context: () => context,
+      baseGain: 0.2,
+    });
+
+    expect(runtime.playDamageWarning({ audio: AUDIO })).toBe(true);
+
+    expect(context.oscillators[0]?.type).toBe("square");
+    expect(context.oscillators[0]?.frequency.setValueAtTime).toHaveBeenCalledWith(
+      440,
+      0,
+    );
+    expect(
+      context.oscillators[0]?.frequency.linearRampToValueAtTime,
+    ).toHaveBeenCalledWith(330, 0.28);
+    expect(context.gains[0]?.gain.linearRampToValueAtTime).toHaveBeenCalledWith(
+      1 * 0.9 * 0.2 * 0.72,
+      0.01,
+    );
+    expect(context.oscillators[0]?.stop).toHaveBeenCalledWith(0.28);
+  });
+
   it("plays surface cues with speed-scaled ramps", () => {
     const context = new FakeAudioContext();
     const runtime = new ProceduralSfxRuntime({

--- a/src/audio/sfx.ts
+++ b/src/audio/sfx.ts
@@ -72,6 +72,10 @@ export interface ResultsStingerSfxInput {
   readonly audio: AudioSettings | undefined;
 }
 
+export interface DamageWarningSfxInput {
+  readonly audio: AudioSettings | undefined;
+}
+
 export interface BrakeScrubSfxInput {
   readonly speedFactor: number;
   readonly audio: AudioSettings | undefined;
@@ -198,6 +202,17 @@ export class ProceduralSfxRuntime {
       gainScale: 0.8,
       durationSeconds: 0.34,
       endFrequency: 1320,
+    });
+  }
+
+  playDamageWarning(input: DamageWarningSfxInput): boolean {
+    return this.playTone({
+      audio: input.audio,
+      frequency: 440,
+      oscillatorType: "square",
+      gainScale: 0.72,
+      durationSeconds: 0.28,
+      endFrequency: 330,
     });
   }
 

--- a/src/game/__tests__/raceSession.test.ts
+++ b/src/game/__tests__/raceSession.test.ts
@@ -2345,6 +2345,45 @@ describe("stepRaceSession (§13 damage wiring, F-047)", () => {
     );
   });
 
+  it("emits a damage warning when the player enters the severe band", () => {
+    const config = buildConfig({ countdownSec: 0 });
+    let session = createRaceSession(config);
+    const nearSevere = createDamageState({
+      engine: 0.75,
+      tires: 0.75,
+      body: 0.74,
+    });
+    expect(nearSevere.total).toBeLessThan(0.75);
+    session = {
+      ...session,
+      player: {
+        ...session.player,
+        car: { ...session.player.car, x: 0, z: 100, speed: 40 },
+        damage: nearSevere,
+      },
+      ai: session.ai.map((entry) => ({
+        ...entry,
+        car: { ...entry.car, x: 0, z: 101, speed: 40 },
+      })),
+    };
+
+    session = stepRaceSession(session, fullThrottle(), config, DT);
+
+    expect(session.player.damage.total).toBeGreaterThanOrEqual(0.75);
+    expect(session.audioEvents).toContainEqual({
+      kind: "damageWarning",
+      carId: "player",
+      damagePercent: Math.round(session.player.damage.total * 100),
+    });
+    expect(session.audioEvents).toContainEqual(
+      expect.objectContaining({
+        kind: "impact",
+        carId: "player",
+        hitKind: "carHit",
+      }),
+    );
+  });
+
   it("does not register a collision when cars are laterally separated past CAR_WIDTH_M", () => {
     // Snap the player to one side of the road and the AI to the other
     // so the lateral gap (~4 m) sits comfortably outside the §13

--- a/src/game/raceSession.ts
+++ b/src/game/raceSession.ts
@@ -252,6 +252,12 @@ export interface RaceSessionRaceFinishAudioEvent {
   readonly carId: string;
 }
 
+export interface RaceSessionDamageWarningAudioEvent {
+  readonly kind: "damageWarning";
+  readonly carId: string;
+  readonly damagePercent: number;
+}
+
 export interface RaceSessionBrakeScrubAudioEvent {
   readonly kind: "brakeScrub";
   readonly carId: string;
@@ -290,6 +296,7 @@ export type RaceSessionAudioEvent =
   | RaceSessionGearShiftAudioEvent
   | RaceSessionLapCompleteAudioEvent
   | RaceSessionRaceFinishAudioEvent
+  | RaceSessionDamageWarningAudioEvent
   | RaceSessionBrakeScrubAudioEvent
   | RaceSessionTireSquealAudioEvent
   | RaceSessionSurfaceHushAudioEvent
@@ -661,6 +668,7 @@ const BRAKE_SCRUB_SPEED_M_PER_S = 8;
 const TIRE_SQUEAL_SPEED_M_PER_S = 18;
 const TIRE_SQUEAL_STEER_THRESHOLD = 0.65;
 const SURFACE_HUSH_SPEED_M_PER_S = 10;
+const DAMAGE_WARNING_THRESHOLD = 0.75;
 
 /**
  * Reference top speed (m/s) used to normalise the §13 `speedFactor`
@@ -1614,6 +1622,17 @@ export function stepRaceSession(
     hitsByCarId.get(PLAYER_CAR_ID) ?? [],
     playerAssistScalars,
   );
+  const playerDamageWarningEvents: RaceSessionDamageWarningAudioEvent[] =
+    state.player.damage.total < DAMAGE_WARNING_THRESHOLD &&
+    playerDamageResult.damage.total >= DAMAGE_WARNING_THRESHOLD
+      ? [
+          {
+            kind: "damageWarning",
+            carId: PLAYER_CAR_ID,
+            damagePercent: Math.round(playerDamageResult.damage.total * 100),
+          },
+        ]
+      : [];
   const aiAfterDamage: RaceSessionAICar[] = nextAi.map((entry, index) => {
     const id = aiCarId(index);
     const result = advanceDamage(
@@ -1882,6 +1901,7 @@ export function stepRaceSession(
     playerNitroEvents.length > 0 ||
     playerShiftEvents.length > 0 ||
     playerLapEvents.length > 0 ||
+    playerDamageWarningEvents.length > 0 ||
     playerSurfaceAudio.events.length > 0 ||
     playerPickupAudioEvents.length > 0;
   const nextAudioEvents: ReadonlyArray<RaceSessionAudioEvent> =
@@ -1890,6 +1910,7 @@ export function stepRaceSession(
           ...playerNitroEvents,
           ...playerShiftEvents,
           ...playerLapEvents,
+          ...playerDamageWarningEvents,
           ...playerSurfaceAudio.events,
           ...playerPickupAudioEvents,
           ...playerImpactEvents,


### PR DESCRIPTION
## Summary
- Add a race-mix ducking policy so countdown, nitro, finish, collision, pickup, tire, surface, and damage-warning cues stay readable with race music.
- Add a severe-damage warning race audio event and procedural warning cue.
- Add race route telemetry plus browser coverage for countdown and live race event ducking.

## GDD
- docs/gdd/10-driving-model-and-physics.md
- docs/gdd/13-damage-repairs-and-risk.md
- docs/gdd/18-sound-and-music-design.md
- docs/gdd/20-hud-and-ui-ux.md

## Progress Log
- docs/PROGRESS_LOG.md: 2026-05-02: Slice: Race mix and event emphasis

## Test Plan
- npx vitest run src/audio/raceMix.test.ts src/audio/sfx.test.ts src/game/__tests__/raceSession.test.ts
- npx playwright test e2e/race-audio-mix.spec.ts --project=chromium
- npm run typecheck
- npm run lint
- npm run docs:check
- npm run content-lint
- git diff --check

## Followups
- None
