### PR TITLE
chore(spiral): close F-078 with production smoke evidence

### DIFF
--- a/docs/FOLLOWUPS.md
+++ b/docs/FOLLOWUPS.md
@@ -46,11 +46,17 @@ screenshot, and context block. A second submission at
 `Randroids-Dojo/VibeGear2#172` exercised the captured-errors path and
 rendered both the deferred throw and the unhandled rejection. After
 PR #169 squash-merged to `main`, the production deploy was smoke-tested
-with a direct curl to `https://vibe-gear2.vercel.app/api/feedback`
-which created `Randroids-Dojo/VibeGear2#173`, confirming the production
-env var is live; the same-origin abuse gate was verified by sending a
-mismatched `Origin` and an absent `Origin`, both returning the
-documented 403 `forbidden-origin` envelope. PAT will be rotated
+with a direct `curl -X POST https://vibe-gear2.vercel.app/api/feedback`,
+sending `Content-Type: application/json`,
+`Origin: https://vibe-gear2.vercel.app`, and
+`Referer: https://vibe-gear2.vercel.app/race` so the request passed the
+same-origin gate. The route returned 201 and created
+`Randroids-Dojo/VibeGear2#173`, confirming the production env var is
+live. The same-origin abuse gate was then verified with two negative
+POSTs from the same shell: one with `Origin: https://attacker.example`
+(mismatched host) and one with the `Origin` and `Referer` headers
+omitted entirely. Both negatives returned the documented 403
+`forbidden-origin` envelope. PAT will be rotated
 post-merge; rotation does not require code changes.
 
 ## F-077: Playwright coverage for the Feedback FAB

--- a/docs/FOLLOWUPS.md
+++ b/docs/FOLLOWUPS.md
@@ -44,8 +44,14 @@ the PR Preview, and confirmed an end-to-end submission landed at
 `Randroids-Dojo/VibeGear2#170` with the `feedback` label, inline
 screenshot, and context block. A second submission at
 `Randroids-Dojo/VibeGear2#172` exercised the captured-errors path and
-rendered both the deferred throw and the unhandled rejection. PAT will
-be rotated post-merge; rotation does not require code changes.
+rendered both the deferred throw and the unhandled rejection. After
+PR #169 squash-merged to `main`, the production deploy was smoke-tested
+with a direct curl to `https://vibe-gear2.vercel.app/api/feedback`
+which created `Randroids-Dojo/VibeGear2#173`, confirming the production
+env var is live; the same-origin abuse gate was verified by sending a
+mismatched `Origin` and an absent `Origin`, both returning the
+documented 403 `forbidden-origin` envelope. PAT will be rotated
+post-merge; rotation does not require code changes.
 
 ## F-077: Playwright coverage for the Feedback FAB
 **Created:** 2026-05-05


### PR DESCRIPTION
## Summary

Adds the production verification record to F-078 (`Provision \`GITHUB_PAT\` for the Feedback FAB on Vercel`).

After PR #169 squash-merged to \`main\`:
- Production deploy at \`https://vibe-gear2.vercel.app\` came up Ready.
- A CLI POST to \`/api/feedback\` (with valid \`Origin\` + \`Referer\`) created issue \`Randroids-Dojo/VibeGear2#173\`.
- Two abuse-gate negatives (mismatched \`Origin\`, absent \`Origin\`) both returned the documented 403 \`forbidden-origin\` envelope.

Documentation only, no code changes.

## Test plan

- [x] \`npm run content-lint\` (no progress-log entries to lint, only F-078 update)