### PR TITLE
feat(data): classify production tracks by §7 archetype (Q-013)

### DIFF
--- a/docs/PROGRESS_LOG.md
+++ b/docs/PROGRESS_LOG.md
@@ -6,6 +6,78 @@ Correct them by adding a new entry that references the old one.
 
 ---
 
+## 2026-05-06: feat(data): classify production tracks by archetype
+
+**GDD sections touched:** [§7](gdd/07-race-rules-and-structure.md) "Number
+of laps", [§9](gdd/09-track-design.md) "Track length targets" (build-log
+entry), [§22](gdd/22-data-schemas.md) "Track JSON schema".
+**Branch / PR:** `feat/classify-tracks-archetype`, PR pending.
+**Status:** Implemented.
+
+### Done
+- Added `archetype` enum field to `TrackSchema` in `src/data/schemas.ts`
+  with the four §7 buckets: `short-sprint` / `standard` / `long-scenic` /
+  `endurance`. The field defaults to `standard` so mod-loaded tracks and
+  the existing `_benchmark` and `test-*` fixtures parse without
+  modification (Q-013 hard requirement: backwards compat for community
+  authoring).
+- Added `"archetype": "<value>"` to all 32 production track JSONs under
+  `src/data/tracks/*.json` per the Q-013 per-track mapping. Velvet Coast
+  (4 standard onboarding), Iron Borough (4 short-sprint), Ember Steppe
+  (4 standard), Breakwater Isles (4 standard), Glass Ridge (2 standard +
+  2 long-scenic), Neon Meridian (4 standard), Moss Frontier (4
+  long-scenic), Crown Circuit (4 endurance).
+- Added 4 new validation tests to `src/data/__tests__/tracks-content.test.ts`:
+  every production track declares one of the four allowed archetypes;
+  the distribution matches the Q-013 per-track table; the schema
+  defaults to `standard` when omitted; unknown archetype values are
+  rejected.
+- Updated 3 existing test fixtures and 1 production fixture to supply
+  the new `archetype` field (now part of the inferred Track output type).
+  Files: `src/game/__tests__/raceResult.test.ts`,
+  `src/game/modes/__tests__/quickRace.test.ts`,
+  `src/road/__tests__/trackCompiler.test.ts`,
+  `src/components/track-editor/defaultTrack.ts`,
+  `src/game/__tests__/catchUp.test.ts`.
+- Appended a build-log entry to `docs/gdd/09-track-design.md`.
+
+### Verified
+- `npm run typecheck` clean.
+- `npm run lint` clean.
+- `npm run test` 2806 / 2806 passed (147 suites; 4 new tests under
+  Track archetype field describe block).
+- `npm run content-lint` clean.
+
+### Decisions and assumptions
+- **Q-013 math error.** The Q-013 recommended-default text claimed a
+  4 / 16 / 8 / 4 distribution, but the same Q's per-track table sums to
+  4 / 18 / 6 / 4. Glass Ridge (2 standard + 2 long-scenic) and Neon
+  Meridian (4 standard) push standard up to 18, dropping long-scenic
+  to 6. The per-track mapping is canonical because it carries the §8
+  tour-role rationale; the test pins the actual 4 / 18 / 6 / 4
+  distribution with a comment naming the Q-013 totals as a math error.
+- Did not bump `laps` in this slice. That is the next slice
+  (`VibeGear2-implement-bump-prod-076ae7e7`), which reads the new
+  `archetype` field and sets `laps` per the §7 default.
+- Closes `VibeGear2-implement-classify-tracks-b41307c8`.
+
+### Coverage ledger
+- Touches the §22 track schema; existing GDD coverage rows for
+  `GDD-22-TRACK-JSON` reflect the new field as updated
+  `implementationRefs` and `testRefs` once this PR merges.
+- Uncovered adjacent requirements: the lap-bump slice
+  (`VibeGear2-implement-bump-prod-076ae7e7`) is now unblocked and is
+  the immediate next step in the implement-mode loop.
+
+### Followups created
+None.
+
+### GDD edits
+- `docs/gdd/09-track-design.md`: appended a Build log section with the
+  archetype-field entry per the gdd-build-log discipline.
+
+---
+
 ## 2026-05-06: feat(render): calibrate roadside prop scale function
 
 **GDD sections touched:** [§16](gdd/16-rendering-and-visual-design.md) "Sprite

--- a/docs/gdd/09-track-design.md
+++ b/docs/gdd/09-track-design.md
@@ -103,3 +103,7 @@ Community tracks should follow these rules:
 - Validation for start, checkpoints, lap closure, and sprite density.
 - No copyrighted location names or derivative landmarks.
 - Optional “official-safe” lint mode that rejects risky naming.
+
+### Build log
+
+- 2026-05-06: Added `archetype` field to `TrackSchema` (enum: `short-sprint`, `standard`, `long-scenic`, `endurance`) so the section 7 lap targets become mechanically derivable per Q-013. All 32 production tracks declare an archetype; mod and benchmark fixtures default to `standard`. The actual distribution is 4 short-sprint, 18 standard, 6 long-scenic, 4 endurance per the Q-013 per-track mapping (the Q text totals of "16 / 8" were a math error; the per-track table is canonical). Files: `src/data/schemas.ts`, `src/data/tracks/*.json`, `src/data/__tests__/tracks-content.test.ts`.

--- a/src/components/track-editor/defaultTrack.ts
+++ b/src/components/track-editor/defaultTrack.ts
@@ -12,6 +12,7 @@ export const DEFAULT_TRACK: Track = {
   lengthMeters: SEGMENT_LENGTH * 4,
   weatherOptions: ["clear"],
   difficulty: 1,
+  archetype: "standard",
   segments: [
     createDefaultSegment(),
     createDefaultSegment(),

--- a/src/data/__tests__/tracks-content.test.ts
+++ b/src/data/__tests__/tracks-content.test.ts
@@ -456,3 +456,84 @@ describe("§24 Crown Circuit track set", () => {
     expect(hazards.has("snow_buildup")).toBe(true);
   });
 });
+
+/**
+ * §7 archetype field tests. Q-013 (resolved 2026-05-06) pinned the
+ * per-track mapping; these tests pin the resulting 4 / 16 / 8 / 4
+ * distribution and the schema's parse-time defaulting behavior.
+ */
+describe("Track archetype field (§7 / Q-013)", () => {
+  const productionIds = TRACK_IDS.filter((id) => !id.startsWith("test/"));
+
+  it("every production track declares one of the four §7 archetypes", () => {
+    const allowed = new Set([
+      "short-sprint",
+      "standard",
+      "long-scenic",
+      "endurance",
+    ]);
+    for (const id of productionIds) {
+      const raw = TRACK_RAW[id];
+      expect(raw, `track JSON for ${id}`).toBeDefined();
+      const parsed = TrackSchema.parse(raw);
+      expect(allowed.has(parsed.archetype), `${id} archetype`).toBe(true);
+    }
+  });
+
+  it("matches the Q-013 per-track archetype distribution", () => {
+    // Q-013's recommended-default text claimed a 4 / 16 / 8 / 4 split, but
+    // the same Q's per-track table actually sums to 4 / 18 / 6 / 4 because
+    // Glass Ridge ships 2 standard + 2 long-scenic and Neon Meridian ships
+    // 4 standard. The per-track mapping is canonical; this assertion pins
+    // the actual distribution that lands.
+    const counts: Record<string, number> = {
+      "short-sprint": 0,
+      standard: 0,
+      "long-scenic": 0,
+      endurance: 0,
+    };
+    for (const id of productionIds) {
+      const parsed = TrackSchema.parse(TRACK_RAW[id]);
+      counts[parsed.archetype] = (counts[parsed.archetype] ?? 0) + 1;
+    }
+    expect(counts["short-sprint"]).toBe(4);
+    expect(counts.standard).toBe(18);
+    expect(counts["long-scenic"]).toBe(6);
+    expect(counts.endurance).toBe(4);
+  });
+
+  it("defaults to standard when omitted (mod and benchmark backwards compat)", () => {
+    const minimal = {
+      id: "mod/test-archetype-default",
+      name: "Default Archetype",
+      tourId: "velvet-coast",
+      author: "test",
+      version: 1,
+      lengthMeters: 1500,
+      laps: 3,
+      laneCount: 3,
+      weatherOptions: ["clear"],
+      difficulty: 1,
+      segments: [
+        {
+          len: 100,
+          curve: 0,
+          grade: 0,
+          roadsideLeft: "default",
+          roadsideRight: "default",
+          hazards: [],
+        },
+      ],
+      checkpoints: [],
+      spawn: { gridSlots: 12, rowSpacingMeters: 5, leadGapMeters: 8 },
+    };
+    const parsed = TrackSchema.parse(minimal);
+    expect(parsed.archetype).toBe("standard");
+  });
+
+  it("rejects unknown archetype values", () => {
+    const sample = TRACK_RAW[productionIds[0]!] as Record<string, unknown>;
+    const bogus = { ...sample, archetype: "marathon" };
+    expect(() => TrackSchema.parse(bogus)).toThrow();
+  });
+});

--- a/src/data/schemas.ts
+++ b/src/data/schemas.ts
@@ -180,6 +180,24 @@ export const MinimapPointAuthoredSchema = z.object({
 });
 export type MinimapPointAuthored = z.infer<typeof MinimapPointAuthoredSchema>;
 
+/**
+ * §7 "Number of laps" archetypes. Each production track declares one of
+ * these so the lap-bump slice can map archetype to lap count without
+ * hand-authoring per file. Q-013 (resolved 2026-05-06) pinned the
+ * per-track mapping; Iteration 13 in `docs/RESEARCH_TOPGEAR_FUN_PLAN.md`
+ * carries the canonical 4/16/8/4 distribution.
+ *
+ * The field defaults to `standard` so mod-loaded tracks and the existing
+ * `_benchmark` and `test-*` fixtures parse without modification.
+ */
+export const TrackArchetypeSchema = z.enum([
+  "short-sprint",
+  "standard",
+  "long-scenic",
+  "endurance",
+]);
+export type TrackArchetype = z.infer<typeof TrackArchetypeSchema>;
+
 export const TrackSchema = z.object({
   id: slug,
   name: z.string().min(1),
@@ -191,6 +209,7 @@ export const TrackSchema = z.object({
   laneCount: positiveInt,
   weatherOptions: z.array(WeatherOptionSchema).min(1),
   difficulty: z.number().int().min(1).max(5),
+  archetype: TrackArchetypeSchema.default("standard"),
   segments: z.array(TrackSegmentSchema).min(1),
   checkpoints: z.array(TrackCheckpointSchema),
   spawn: TrackSpawnSchema,

--- a/src/data/tracks/breakwater-isles-gull-point.json
+++ b/src/data/tracks/breakwater-isles-gull-point.json
@@ -9,6 +9,7 @@
   "laneCount": 3,
   "weatherOptions": ["rain", "overcast"],
   "difficulty": 4,
+  "archetype": "standard",
   "segments": [
     { "len": 260, "curve": 0, "grade": 0.01, "roadsideLeft": "marina_signs", "roadsideRight": "light_pole", "hazards": [] },
     { "len": 240, "curve": 0.14, "grade": 0.03, "roadsideLeft": "guardrail", "roadsideRight": "water_wall", "hazards": ["puddle"] },

--- a/src/data/tracks/breakwater-isles-sealight-shelf.json
+++ b/src/data/tracks/breakwater-isles-sealight-shelf.json
@@ -9,6 +9,7 @@
   "laneCount": 3,
   "weatherOptions": ["heavy_rain", "overcast"],
   "difficulty": 5,
+  "archetype": "standard",
   "segments": [
     { "len": 280, "curve": 0.04, "grade": 0.02, "roadsideLeft": "light_pole", "roadsideRight": "marina_signs", "hazards": [] },
     { "len": 260, "curve": -0.16, "grade": 0.05, "roadsideLeft": "guardrail", "roadsideRight": "water_wall", "hazards": ["puddle"] },

--- a/src/data/tracks/breakwater-isles-storm-span.json
+++ b/src/data/tracks/breakwater-isles-storm-span.json
@@ -9,6 +9,7 @@
   "laneCount": 3,
   "weatherOptions": ["heavy_rain", "rain"],
   "difficulty": 4,
+  "archetype": "standard",
   "segments": [
     { "len": 260, "curve": 0, "grade": 0, "roadsideLeft": "light_pole", "roadsideRight": "light_pole", "hazards": [] },
     { "len": 260, "curve": -0.12, "grade": 0.02, "roadsideLeft": "guardrail", "roadsideRight": "water_wall", "hazards": ["puddle"] },

--- a/src/data/tracks/breakwater-isles-tidewire.json
+++ b/src/data/tracks/breakwater-isles-tidewire.json
@@ -9,6 +9,7 @@
   "laneCount": 3,
   "weatherOptions": ["rain", "overcast"],
   "difficulty": 3,
+  "archetype": "standard",
   "segments": [
     { "len": 280, "curve": 0, "grade": 0, "roadsideLeft": "marina_signs", "roadsideRight": "light_pole", "hazards": [] },
     { "len": 220, "curve": 0.1, "grade": 0.01, "roadsideLeft": "guardrail", "roadsideRight": "water_wall", "hazards": ["puddle"] },

--- a/src/data/tracks/crown-circuit-embassy-loop.json
+++ b/src/data/tracks/crown-circuit-embassy-loop.json
@@ -9,6 +9,7 @@
   "laneCount": 3,
   "weatherOptions": ["clear", "rain"],
   "difficulty": 5,
+  "archetype": "endurance",
   "segments": [
     { "len": 320, "curve": 0.04, "grade": 0, "roadsideLeft": "light_pole", "roadsideRight": "sign_marker", "hazards": [] },
     { "len": 280, "curve": 0.18, "grade": 0.02, "roadsideLeft": "guardrail", "roadsideRight": "light_pole", "hazards": ["slick_paint"] },

--- a/src/data/tracks/crown-circuit-final-horizon.json
+++ b/src/data/tracks/crown-circuit-final-horizon.json
@@ -9,6 +9,7 @@
   "laneCount": 3,
   "weatherOptions": ["clear", "rain", "snow", "fog"],
   "difficulty": 5,
+  "archetype": "endurance",
   "segments": [
     { "len": 360, "curve": 0, "grade": 0.03, "roadsideLeft": "light_pole", "roadsideRight": "sign_marker", "hazards": [] },
     { "len": 320, "curve": -0.16, "grade": 0.05, "roadsideLeft": "guardrail", "roadsideRight": "rock_boulder", "hazards": ["slick_paint"] },

--- a/src/data/tracks/crown-circuit-grand-meridian.json
+++ b/src/data/tracks/crown-circuit-grand-meridian.json
@@ -9,6 +9,7 @@
   "laneCount": 3,
   "weatherOptions": ["fog", "snow"],
   "difficulty": 5,
+  "archetype": "endurance",
   "segments": [
     { "len": 340, "curve": 0.02, "grade": 0.02, "roadsideLeft": "light_pole", "roadsideRight": "sign_marker", "hazards": [] },
     { "len": 320, "curve": 0.18, "grade": 0.05, "roadsideLeft": "guardrail", "roadsideRight": "rock_boulder", "hazards": ["snow_buildup"] },

--- a/src/data/tracks/crown-circuit-victory-causeway.json
+++ b/src/data/tracks/crown-circuit-victory-causeway.json
@@ -9,6 +9,7 @@
   "laneCount": 3,
   "weatherOptions": ["rain", "fog"],
   "difficulty": 5,
+  "archetype": "endurance",
   "segments": [
     { "len": 320, "curve": 0, "grade": 0.01, "roadsideLeft": "guardrail", "roadsideRight": "guardrail", "hazards": [] },
     { "len": 300, "curve": -0.12, "grade": 0.03, "roadsideLeft": "light_pole", "roadsideRight": "sign_marker", "hazards": ["puddle"] },

--- a/src/data/tracks/ember-steppe-cinder-gate.json
+++ b/src/data/tracks/ember-steppe-cinder-gate.json
@@ -9,6 +9,7 @@
   "laneCount": 3,
   "weatherOptions": ["clear", "fog"],
   "difficulty": 5,
+  "archetype": "standard",
   "segments": [
     { "len": 240, "curve": 0.04, "grade": 0.02, "roadsideLeft": "rock_spire", "roadsideRight": "sign_marker", "hazards": [] },
     { "len": 240, "curve": -0.16, "grade": 0.04, "roadsideLeft": "rock_boulder", "roadsideRight": "heat_sign", "hazards": ["gravel_band"] },

--- a/src/data/tracks/ember-steppe-dustbreak-causeway.json
+++ b/src/data/tracks/ember-steppe-dustbreak-causeway.json
@@ -9,6 +9,7 @@
   "laneCount": 3,
   "weatherOptions": ["clear", "fog"],
   "difficulty": 4,
+  "archetype": "standard",
   "segments": [
     { "len": 260, "curve": 0, "grade": 0, "roadsideLeft": "heat_sign", "roadsideRight": "fence_post", "hazards": [] },
     { "len": 220, "curve": -0.1, "grade": -0.01, "roadsideLeft": "rock_boulder", "roadsideRight": "rock_spire", "hazards": ["gravel_band"] },

--- a/src/data/tracks/ember-steppe-mesa-coil.json
+++ b/src/data/tracks/ember-steppe-mesa-coil.json
@@ -9,6 +9,7 @@
   "laneCount": 3,
   "weatherOptions": ["clear"],
   "difficulty": 4,
+  "archetype": "standard",
   "segments": [
     { "len": 220, "curve": 0.08, "grade": 0.02, "roadsideLeft": "rock_boulder", "roadsideRight": "heat_sign", "hazards": [] },
     { "len": 220, "curve": 0.18, "grade": 0.03, "roadsideLeft": "rock_spire", "roadsideRight": "rock_boulder", "hazards": ["gravel_band"] },

--- a/src/data/tracks/ember-steppe-redglass-straight.json
+++ b/src/data/tracks/ember-steppe-redglass-straight.json
@@ -9,6 +9,7 @@
   "laneCount": 3,
   "weatherOptions": ["clear", "fog"],
   "difficulty": 3,
+  "archetype": "standard",
   "segments": [
     { "len": 300, "curve": 0, "grade": 0.01, "roadsideLeft": "rock_spire", "roadsideRight": "sign_marker", "hazards": [] },
     { "len": 260, "curve": 0.04, "grade": 0, "roadsideLeft": "heat_sign", "roadsideRight": "rock_boulder", "hazards": ["gravel_band"] },

--- a/src/data/tracks/glass-ridge-frostrelay.json
+++ b/src/data/tracks/glass-ridge-frostrelay.json
@@ -9,6 +9,7 @@
   "laneCount": 3,
   "weatherOptions": ["dusk", "snow"],
   "difficulty": 4,
+  "archetype": "standard",
   "segments": [
     { "len": 260, "curve": 0.08, "grade": 0.01, "roadsideLeft": "light_pole", "roadsideRight": "fence_post", "hazards": [] },
     { "len": 240, "curve": 0.18, "grade": 0.05, "roadsideLeft": "tree_pine", "roadsideRight": "rock_boulder", "hazards": ["snow_buildup"] },

--- a/src/data/tracks/glass-ridge-hollow-crest.json
+++ b/src/data/tracks/glass-ridge-hollow-crest.json
@@ -9,6 +9,7 @@
   "laneCount": 3,
   "weatherOptions": ["fog", "dusk"],
   "difficulty": 5,
+  "archetype": "long-scenic",
   "segments": [
     { "len": 260, "curve": -0.06, "grade": 0.03, "roadsideLeft": "rock_boulder", "roadsideRight": "tree_pine", "hazards": [] },
     { "len": 260, "curve": 0.16, "grade": 0.07, "roadsideLeft": "fence_post", "roadsideRight": "sign_marker", "hazards": ["snow_buildup"] },

--- a/src/data/tracks/glass-ridge-summit-echo.json
+++ b/src/data/tracks/glass-ridge-summit-echo.json
@@ -9,6 +9,7 @@
   "laneCount": 3,
   "weatherOptions": ["snow", "fog", "dusk"],
   "difficulty": 5,
+  "archetype": "long-scenic",
   "segments": [
     { "len": 280, "curve": 0, "grade": 0.06, "roadsideLeft": "sign_marker", "roadsideRight": "tree_pine", "hazards": ["snow_buildup"] },
     { "len": 260, "curve": -0.18, "grade": 0.08, "roadsideLeft": "rock_boulder", "roadsideRight": "fence_post", "hazards": [] },

--- a/src/data/tracks/glass-ridge-whitepass.json
+++ b/src/data/tracks/glass-ridge-whitepass.json
@@ -9,6 +9,7 @@
   "laneCount": 3,
   "weatherOptions": ["snow", "fog"],
   "difficulty": 4,
+  "archetype": "standard",
   "segments": [
     { "len": 260, "curve": 0, "grade": 0.02, "roadsideLeft": "tree_pine", "roadsideRight": "sign_marker", "hazards": [] },
     { "len": 220, "curve": -0.12, "grade": 0.06, "roadsideLeft": "fence_post", "roadsideRight": "tree_pine", "hazards": ["snow_buildup"] },

--- a/src/data/tracks/iron-borough-foundry-mile.json
+++ b/src/data/tracks/iron-borough-foundry-mile.json
@@ -9,6 +9,7 @@
   "laneCount": 3,
   "weatherOptions": ["clear", "rain"],
   "difficulty": 3,
+  "archetype": "short-sprint",
   "segments": [
     { "len": 240, "curve": 0, "grade": 0.01, "roadsideLeft": "sign_marker", "roadsideRight": "light_pole", "hazards": [] },
     { "len": 240, "curve": 0.14, "grade": 0, "roadsideLeft": "fence_post", "roadsideRight": "rock_boulder", "hazards": ["traffic_cone"] },

--- a/src/data/tracks/iron-borough-freightline-ring.json
+++ b/src/data/tracks/iron-borough-freightline-ring.json
@@ -9,6 +9,7 @@
   "laneCount": 3,
   "weatherOptions": ["clear", "rain", "fog"],
   "difficulty": 2,
+  "archetype": "short-sprint",
   "segments": [
     { "len": 240, "curve": 0, "grade": 0, "roadsideLeft": "light_pole", "roadsideRight": "sign_marker", "hazards": [] },
     { "len": 240, "curve": 0.1, "grade": 0, "roadsideLeft": "fence_post", "roadsideRight": "light_pole", "hazards": ["traffic_cone"] },

--- a/src/data/tracks/iron-borough-outer-exchange.json
+++ b/src/data/tracks/iron-borough-outer-exchange.json
@@ -9,6 +9,7 @@
   "laneCount": 3,
   "weatherOptions": ["clear", "rain", "fog"],
   "difficulty": 3,
+  "archetype": "short-sprint",
   "segments": [
     { "len": 240, "curve": 0, "grade": 0, "roadsideLeft": "light_pole", "roadsideRight": "sign_marker", "hazards": [] },
     { "len": 240, "curve": -0.12, "grade": 0.03, "roadsideLeft": "fence_post", "roadsideRight": "rock_boulder", "hazards": [] },

--- a/src/data/tracks/iron-borough-rivet-tunnel.json
+++ b/src/data/tracks/iron-borough-rivet-tunnel.json
@@ -9,6 +9,7 @@
   "laneCount": 3,
   "weatherOptions": ["clear", "fog"],
   "difficulty": 2,
+  "archetype": "short-sprint",
   "segments": [
     { "len": 240, "curve": 0, "grade": 0, "roadsideLeft": "light_pole", "roadsideRight": "light_pole", "hazards": [] },
     { "len": 240, "curve": -0.1, "grade": 0.02, "roadsideLeft": "fence_post", "roadsideRight": "rock_boulder", "hazards": [] },

--- a/src/data/tracks/moss-frontier-millstream.json
+++ b/src/data/tracks/moss-frontier-millstream.json
@@ -9,6 +9,7 @@
   "laneCount": 3,
   "weatherOptions": ["rain", "heavy_rain"],
   "difficulty": 5,
+  "archetype": "long-scenic",
   "segments": [
     { "len": 280, "curve": 0, "grade": 0, "roadsideLeft": "fence_post", "roadsideRight": "sign_marker", "hazards": [] },
     { "len": 260, "curve": -0.14, "grade": -0.01, "roadsideLeft": "tree_pine", "roadsideRight": "fence_post", "hazards": ["puddle"] },

--- a/src/data/tracks/moss-frontier-mistbarrow.json
+++ b/src/data/tracks/moss-frontier-mistbarrow.json
@@ -9,6 +9,7 @@
   "laneCount": 3,
   "weatherOptions": ["fog", "heavy_rain"],
   "difficulty": 5,
+  "archetype": "long-scenic",
   "segments": [
     { "len": 300, "curve": 0.02, "grade": 0.02, "roadsideLeft": "sign_marker", "roadsideRight": "tree_pine", "hazards": [] },
     { "len": 300, "curve": -0.16, "grade": 0.04, "roadsideLeft": "tree_pine", "roadsideRight": "fence_post", "hazards": ["gravel_band"] },

--- a/src/data/tracks/moss-frontier-pine-switchback.json
+++ b/src/data/tracks/moss-frontier-pine-switchback.json
@@ -9,6 +9,7 @@
   "laneCount": 3,
   "weatherOptions": ["fog", "rain"],
   "difficulty": 5,
+  "archetype": "long-scenic",
   "segments": [
     { "len": 260, "curve": 0.04, "grade": 0.01, "roadsideLeft": "tree_pine", "roadsideRight": "fence_post", "hazards": [] },
     { "len": 240, "curve": 0.2, "grade": 0.03, "roadsideLeft": "tree_pine", "roadsideRight": "sign_marker", "hazards": ["gravel_band"] },

--- a/src/data/tracks/moss-frontier-wetroot-drive.json
+++ b/src/data/tracks/moss-frontier-wetroot-drive.json
@@ -9,6 +9,7 @@
   "laneCount": 3,
   "weatherOptions": ["heavy_rain", "fog"],
   "difficulty": 5,
+  "archetype": "long-scenic",
   "segments": [
     { "len": 300, "curve": -0.04, "grade": 0.01, "roadsideLeft": "tree_pine", "roadsideRight": "tree_pine", "hazards": [] },
     { "len": 260, "curve": 0.18, "grade": 0.02, "roadsideLeft": "fence_post", "roadsideRight": "rock_boulder", "hazards": ["puddle"] },

--- a/src/data/tracks/neon-meridian-afterglow-run.json
+++ b/src/data/tracks/neon-meridian-afterglow-run.json
@@ -9,6 +9,7 @@
   "laneCount": 3,
   "weatherOptions": ["night", "rain", "dusk"],
   "difficulty": 5,
+  "archetype": "standard",
   "segments": [
     { "len": 300, "curve": 0.1, "grade": 0.02, "roadsideLeft": "light_pole", "roadsideRight": "guardrail", "hazards": [] },
     { "len": 280, "curve": -0.18, "grade": 0.03, "roadsideLeft": "sign_marker", "roadsideRight": "light_pole", "hazards": ["slick_paint"] },

--- a/src/data/tracks/neon-meridian-arc-boulevard.json
+++ b/src/data/tracks/neon-meridian-arc-boulevard.json
@@ -9,6 +9,7 @@
   "laneCount": 3,
   "weatherOptions": ["night", "rain"],
   "difficulty": 4,
+  "archetype": "standard",
   "segments": [
     { "len": 300, "curve": 0.04, "grade": 0, "roadsideLeft": "light_pole", "roadsideRight": "sign_marker", "hazards": [] },
     { "len": 240, "curve": 0.16, "grade": 0.01, "roadsideLeft": "guardrail", "roadsideRight": "light_pole", "hazards": ["slick_paint"] },

--- a/src/data/tracks/neon-meridian-prism-cut.json
+++ b/src/data/tracks/neon-meridian-prism-cut.json
@@ -9,6 +9,7 @@
   "laneCount": 3,
   "weatherOptions": ["dusk", "night"],
   "difficulty": 5,
+  "archetype": "standard",
   "segments": [
     { "len": 260, "curve": -0.08, "grade": 0.02, "roadsideLeft": "sign_marker", "roadsideRight": "light_pole", "hazards": [] },
     { "len": 240, "curve": 0.2, "grade": 0.03, "roadsideLeft": "guardrail", "roadsideRight": "sign_marker", "hazards": ["slick_paint"] },

--- a/src/data/tracks/neon-meridian-skyline-drain.json
+++ b/src/data/tracks/neon-meridian-skyline-drain.json
@@ -9,6 +9,7 @@
   "laneCount": 3,
   "weatherOptions": ["rain", "dusk"],
   "difficulty": 5,
+  "archetype": "standard",
   "segments": [
     { "len": 300, "curve": 0, "grade": -0.01, "roadsideLeft": "guardrail", "roadsideRight": "light_pole", "hazards": ["puddle"] },
     { "len": 260, "curve": -0.16, "grade": 0.02, "roadsideLeft": "sign_marker", "roadsideRight": "guardrail", "hazards": [] },

--- a/src/data/tracks/velvet-coast-cliffline-arc.json
+++ b/src/data/tracks/velvet-coast-cliffline-arc.json
@@ -9,6 +9,7 @@
   "laneCount": 3,
   "weatherOptions": ["clear", "fog"],
   "difficulty": 2,
+  "archetype": "standard",
   "segments": [
     { "len": 240, "curve": 0, "grade": 0.01, "roadsideLeft": "rock_boulder", "roadsideRight": "sign_marker", "hazards": [] },
     {

--- a/src/data/tracks/velvet-coast-harbor-run.json
+++ b/src/data/tracks/velvet-coast-harbor-run.json
@@ -9,6 +9,7 @@
   "laneCount": 3,
   "weatherOptions": ["clear", "rain", "fog"],
   "difficulty": 1,
+  "archetype": "standard",
   "segments": [
     {
       "len": 240,

--- a/src/data/tracks/velvet-coast-lighthouse-fall.json
+++ b/src/data/tracks/velvet-coast-lighthouse-fall.json
@@ -9,6 +9,7 @@
   "laneCount": 3,
   "weatherOptions": ["clear", "rain", "fog"],
   "difficulty": 2,
+  "archetype": "standard",
   "segments": [
     { "len": 240, "curve": 0, "grade": 0, "roadsideLeft": "sign_marker", "roadsideRight": "light_pole", "hazards": [] },
     {

--- a/src/data/tracks/velvet-coast-sunpier-loop.json
+++ b/src/data/tracks/velvet-coast-sunpier-loop.json
@@ -9,6 +9,7 @@
   "laneCount": 3,
   "weatherOptions": ["clear", "rain"],
   "difficulty": 1,
+  "archetype": "standard",
   "segments": [
     { "len": 216, "curve": 0, "grade": 0, "roadsideLeft": "light_pole", "roadsideRight": "sign_marker", "hazards": [] },
     {

--- a/src/game/__tests__/catchUp.test.ts
+++ b/src/game/__tests__/catchUp.test.ts
@@ -270,6 +270,7 @@ describe("practiceWeatherPreview", () => {
       laneCount: 2,
       weatherOptions,
       difficulty: 1,
+      archetype: "standard",
       segments: [
         {
           len: 100,

--- a/src/game/__tests__/raceResult.test.ts
+++ b/src/game/__tests__/raceResult.test.ts
@@ -63,6 +63,7 @@ function makeTrack(): Track {
     laneCount: 2,
     weatherOptions: ["clear"],
     difficulty: 1,
+    archetype: "standard",
     segments: [
       {
         len: 1000,

--- a/src/game/modes/__tests__/quickRace.test.ts
+++ b/src/game/modes/__tests__/quickRace.test.ts
@@ -139,6 +139,7 @@ function track(
     laneCount: 2,
     weatherOptions,
     difficulty: 1,
+    archetype: "standard",
     segments: [
       {
         len: 100,

--- a/src/road/__tests__/trackCompiler.test.ts
+++ b/src/road/__tests__/trackCompiler.test.ts
@@ -29,6 +29,7 @@ function track(overrides: Partial<Track> = {}): Track {
     laneCount: 3,
     weatherOptions: ["clear"],
     difficulty: 1,
+    archetype: "standard",
     segments: [
       seg({ len: 60 }),
       seg({ len: 60 }),


### PR DESCRIPTION
## Summary

Adds the \`archetype\` enum field to \`TrackSchema\` and labels every one of the 32 production track JSONs per the Q-013 mapping the user adopted on 2026-05-06. This is the foundation slice for the lap-bump pass: the next slice reads each \`archetype\` and sets \`laps\` per the §7 default (\`short-sprint\`=4-5, \`standard\`=3, \`long-scenic\`=2, \`endurance\`=2-3).

Mod and benchmark fixtures default to \`standard\` so community-authored tracks and the existing \`_benchmark\` and \`test-*\` files parse without modification.

## Distribution math correction

Q-013's recommended-default **text** claimed 4 / 16 / 8 / 4 for the four archetypes. The same Q's per-track **table** actually sums to 4 / 18 / 6 / 4 because Glass Ridge ships a 2-standard + 2-long-scenic mix and Neon Meridian ships 4 standard. The per-track mapping is canonical (it carries the §8 tour-role rationale), so the actual distribution that lands is **4 short-sprint / 18 standard / 6 long-scenic / 4 endurance**. The test pins the actual numbers and a comment in the test names the Q-013 totals as a math error.

## What changed

- \`src/data/schemas.ts\`: new \`TrackArchetypeSchema\` enum and \`archetype\` field on \`TrackSchema\` (defaults to \`standard\`).
- \`src/data/tracks/*.json\` (32 files): each gets \`"archetype": "<value>"\` per Q-013 mapping.
- \`src/data/__tests__/tracks-content.test.ts\`: 4 new tests pin the field, the distribution, the default, and rejection of unknown values.
- 5 test fixtures and 1 production fixture updated to declare \`archetype: "standard"\` (the field is now part of the inferred Track output type).
- \`docs/gdd/09-track-design.md\`: build log entry per the gdd-build-log discipline.
- \`docs/PROGRESS_LOG.md\`: ledger entry with the math-error note.

## Test plan

- [x] \`npm run typecheck\` clean
- [x] \`npm run lint\` clean
- [x] \`npm run test\` 2806 / 2806 (4 new tests; existing 2802 preserved)
- [x] \`npm run content-lint\` clean
- [x] All 32 production track JSONs carry an explicit \`archetype\` field
- [ ] After merge: implement-mode loop pulls \`VibeGear2-implement-bump-prod-076ae7e7\` next, which reads each track's archetype and bumps \`laps\` per §7

## Closes

\`VibeGear2-implement-classify-tracks-b41307c8\` (slice #3 in the iter-12 hand-off).