### PR TITLE
feat(render): pure VfxState audio-event bridge module (dormant)

### DIFF
--- a/docs/FOLLOWUPS.md
+++ b/docs/FOLLOWUPS.md
@@ -10,6 +10,20 @@ or `obsolete` so the trail is preserved.
 
 ---
 
+## F-087: Playwright pixel-delta spec for the VfxState wiring
+**Created:** 2026-05-06
+**Priority:** nice-to-have
+**Status:** open
+**Notes:** The fire-camera slice (`feat/fire-vfx-on-impact-and-lap`)
+ships unit-test coverage for the audio-event to VfxState bridge but
+defers the in-browser pixel-delta assertion the dot named. Spec should
+drive a Velvet Coast race, induce a rub by holding hard steer at top
+speed (post lateral-fix), capture canvas screenshots pre-impact and
+post-impact, and assert a non-zero pixel delta within 200 ms. The
+existing `e2e/projection-readability.spec.ts` is a working template for
+the canvas-paint wait pattern. This is preventive coverage; the unit
+suite already pins the bridge contract end-to-end.
+
 ## F-086: Banked-corner lateral cap lift on the §10 racing-line tension slice
 **Created:** 2026-05-05
 **Priority:** nice-to-have

--- a/docs/FOLLOWUPS.md
+++ b/docs/FOLLOWUPS.md
@@ -10,6 +10,34 @@ or `obsolete` so the trail is preserved.
 
 ---
 
+## F-088: Wire `vfxBridge` into the race page (deferred from fire-camera slice)
+**Created:** 2026-05-06
+**Priority:** nice-to-have
+**Status:** open
+**Notes:** The fire-camera slice
+(`feat/fire-vfx-on-impact-and-lap`, PR pending) shipped the pure
+audio-event -> VfxState bridge module + Vitest suite but NOT the
+in-page integration. Two CI attempts at the wire-up consistently
+regressed two `e2e/race-demo.spec.ts` canvas-pixel-sampling tests on
+the `test/elevation` track —
+`projects authored elevation` (line 90: `centerRoadTopY` returned `0`,
+i.e. the road appeared at row 0 of the canvas center column) and
+`renders parallax and roadside billboard colours` (line 118: mountain
+RGB ~(37,58,85) sampling returned false). The regression reproduced
+with three retries on each run. Gating `vfx` to `undefined` when
+neither flashes nor shakes are active did NOT fix it, so the
+mechanism is not the `drawVfx` overlay path. Likely candidates:
+module-load timing shift from the new imports, rAF cadence shift from
+the per-frame `tickVfx` call, or a `performance.now()` quantum
+difference moving an AI car a sub-pixel that happens to fall on the
+sampled column. Recommended next steps: (1) bisect the page.tsx
+diff (try only the imports, then only the ref, then only the bridge
+call, then only the rAF tick) to find the smallest reproducer; (2)
+if cadence-related, lift the per-frame `tickVfx` to run only when
+state is non-empty; (3) if test is genuinely brittle on
+test/elevation, propose a pixel-count threshold instead of a
+"first non-zero row" boundary.
+
 ## F-087: Playwright pixel-delta spec for the VfxState wiring
 **Created:** 2026-05-06
 **Priority:** nice-to-have

--- a/docs/PROGRESS_LOG.md
+++ b/docs/PROGRESS_LOG.md
@@ -6,21 +6,29 @@ Correct them by adding a new entry that references the old one.
 
 ---
 
-## 2026-05-06: feat(render): wire dormant VfxState into the race renderer
+## 2026-05-06: feat(render): pure VfxState audio-event bridge module (dormant)
 
 **GDD sections touched:** [§16](gdd/16-rendering-and-visual-design.md)
 "Camera shake on impact" + "HUD flash on lap complete",
 [§19](gdd/19-accessibility.md) "Reduced motion".
 **Branch / PR:** `feat/fire-vfx-on-impact-and-lap`, PR pending.
-**Status:** Implemented.
+**Status:** Bridge module implemented and unit-tested. Wire-up deferred
+to F-088. The first attempt to wire the bridge into
+`src/app/race/page.tsx` regressed two `e2e/race-demo.spec.ts`
+canvas-pixel-sampling tests on the `test/elevation` track over two CI
+runs (`projects authored elevation` and `renders parallax and roadside
+billboard colours`), even with the `vfx` parameter gated to undefined
+when the state was empty. The unit suite below pins the bridge contract
+end-to-end so the follow-up wire-up slice can land without re-deriving
+the mapping.
 
 ### Done
-- Closed iter-8's high-impact dead-code finding. `src/render/vfx.ts`
-  shipped `fireFlash` / `fireShake` / `tickVfx` / `drawVfx` end-to-end
+- Captured iter-8's high-impact dead-code finding. `src/render/vfx.ts`
+  ships `fireFlash` / `fireShake` / `tickVfx` / `drawVfx` end-to-end
   with reduced-motion gating and `drawRoad` integration plumbed, but
-  every call site outside the module was zero. Net: every impact was
-  silent visually, every lap rollover was silent visually, and the
-  reduced-motion gate was irrelevant because the FX never ran.
+  every call site outside the module is zero. Net: every impact is
+  silent visually, every lap rollover is silent visually, and the
+  reduced-motion gate is irrelevant because the FX never run.
 - Added a pure bridge module
   `src/app/race/vfxBridge.ts` exporting `applyAudioEventToVfx` and
   `applyAudioEventsToVfx`. The bridge maps `RaceSessionAudioEvent`
@@ -32,12 +40,7 @@ Correct them by adding a new entry that references the old one.
   brakeScrub, tireSqueal, surfaceHush, pickupCollected, damageWarning)
   return state unchanged.
 - Filtered to player-only events. Rival impacts and rival lap rollovers
-  do NOT jolt the player camera, per §16.
-- Wired the bridge into `src/app/race/page.tsx`: a new `vfxRef` holds
-  the state, `applyAudioEventsToVfx` runs once per session-tick block
-  alongside the existing SFX play, `tickVfx` runs once per rAF using
-  the wall-clock delta (so flashes age in real time even when the rAF
-  drops below 60 Hz), and `drawRoad` receives `vfx: vfxRef.current`.
+  must NOT jolt the player camera, per §16.
 - Seeded shakes deterministically from `(session.tick) ^
   hitKindHash(hitKind)` so two runs at the same tick reproduce the same
   pixel offsets. The hash is a per-kind 32-bit constant.
@@ -54,8 +57,20 @@ Correct them by adding a new entry that references the old one.
 - `npm run test` 2816 / 2816 passed (148 suites; 10 new tests in the
   vfxBridge suite).
 - `npm run content-lint` clean.
-- Iter-8's finding stands verified one more time. Closes
-  `VibeGear2-implement-fire-camera-36ae8ff4`.
+
+### Deferred to F-088
+- The wire-up into `src/app/race/page.tsx` (own a `vfxRef`, call
+  `applyAudioEventsToVfx` once per session-tick block, call `tickVfx`
+  once per rAF, forward `vfx: vfxRef.current` to `drawRoad`). Two CI
+  attempts each regressed
+  `e2e/race-demo.spec.ts:90` (`centerRoadTopY` returned `0`, so the
+  road appeared at row 0 of the center column on the test/elevation
+  track) and
+  `e2e/race-demo.spec.ts:118` (mountain RGB ~(37,58,85) sampling
+  returned false). Even gating `vfx` to `undefined` when no flashes or
+  shakes are active did not eliminate the regression, so the failure
+  mode is not the `drawVfx` overlay — likely subtle module-load timing
+  or rAF cadence shift. Investigation queued under F-088.
 
 ### Decisions and assumptions
 - Off-road kinds (`offRoadObject`, `offRoadPersistent`) reuse the rub
@@ -69,30 +84,34 @@ Correct them by adding a new entry that references the old one.
 - Did NOT ship the e2e Playwright spec
   `e2e/vfx-impact-feedback.spec.ts` the dot named. The pixel-delta
   assertion the dot describes is a useful addition but the unit suite
-  pins the wiring contract end-to-end (audio event in, shake/flash
-  pushed onto VfxState, drawRoad reads VfxState). Filed as F-087 to
-  prevent silent regression in the future.
-- The wall-clock `tickVfx` cadence intentionally uses the same
-  `audioUpdateMs = performance.now()` value the SFX path already
-  computes. Reusing the existing timestamp avoids an extra
-  `performance.now()` call per frame and keeps the audio and visual
-  cues aligned to the same wall clock.
+  pins the bridge contract end-to-end (audio event in, shake/flash
+  pushed onto VfxState). Filed as F-087.
+- Shipping the bridge dormant rather than holding the slice until the
+  e2e regression is root-caused. The bridge contract is large and the
+  unit suite pins it; landing it now keeps the iter-8 finding moving
+  and lets a focused F-088 slice own the page-integration debug
+  without dragging the full bridge through the same review again.
 
 ### Coverage ledger
-- Updates the §16 visual-feel coverage with the bridge and the test
-  suite. Existing rows for `GDD-16-IMPACT-CAMERA-SHAKE` and
-  `GDD-16-LAP-FLASH` (or whichever §16 row the audit picks up) reflect
-  the wiring as new `implementationRefs` and `testRefs`.
-- Uncovered adjacent requirements: a Playwright pixel-delta spec
-  (F-087), the speed-coupled FOV / brake-dip slice
-  (`speed-coupled-3cc0838f`) which can now also pass `vfx: vfxRef.current`
-  to drawRoad without needing to introduce its own state-owner.
+- Adds bridge module + test suite under §16 visual-feel coverage.
+  Wiring (drawRoad receiving the live VfxState) is not yet shipped;
+  rows for impact-shake / lap-flash stay at "implementation in flight"
+  until F-088 lands.
 
 ### Followups created
 - F-087: e2e/vfx-impact-feedback.spec.ts. Drive a Velvet Coast race,
   induce a rub by holding hard steer at top speed (post-lateral-fix),
   capture a canvas screenshot pre-impact and post-impact, assert a
   non-zero pixel delta within 200 ms.
+- F-088: wire `src/app/race/vfxBridge.ts` into `src/app/race/page.tsx`
+  (own a `vfxRef`, run the bridge per session-tick block, run
+  `tickVfx` per rAF, forward `vfx` to `drawRoad`). Must root-cause the
+  `e2e/race-demo.spec.ts` regression on test/elevation that blocked
+  this slice's wire-up — even with the `vfx` parameter `undefined`
+  when no FX active, the canvas-pixel-sampling tests
+  `projects authored elevation` and `renders parallax and roadside
+  billboard colours` failed twice with retries. The bridge contract
+  itself is locked by the unit suite.
 
 ### GDD edits
 None.

--- a/docs/PROGRESS_LOG.md
+++ b/docs/PROGRESS_LOG.md
@@ -6,6 +6,99 @@ Correct them by adding a new entry that references the old one.
 
 ---
 
+## 2026-05-06: feat(render): wire dormant VfxState into the race renderer
+
+**GDD sections touched:** [§16](gdd/16-rendering-and-visual-design.md)
+"Camera shake on impact" + "HUD flash on lap complete",
+[§19](gdd/19-accessibility.md) "Reduced motion".
+**Branch / PR:** `feat/fire-vfx-on-impact-and-lap`, PR pending.
+**Status:** Implemented.
+
+### Done
+- Closed iter-8's high-impact dead-code finding. `src/render/vfx.ts`
+  shipped `fireFlash` / `fireShake` / `tickVfx` / `drawVfx` end-to-end
+  with reduced-motion gating and `drawRoad` integration plumbed, but
+  every call site outside the module was zero. Net: every impact was
+  silent visually, every lap rollover was silent visually, and the
+  reduced-motion gate was irrelevant because the FX never ran.
+- Added a pure bridge module
+  `src/app/race/vfxBridge.ts` exporting `applyAudioEventToVfx` and
+  `applyAudioEventsToVfx`. The bridge maps `RaceSessionAudioEvent`
+  kinds to VFX calls per the dot's spec: impact -> shake + flash with
+  per-`HitKind` style (wallHit 14 px shake / 0.45 white flash, carHit
+  9 px / 0.32 white, rub 4 px / 0.18 amber, off-road kinds reuse the
+  rub style); lapComplete -> 0.55 gold flash 360 ms; raceFinish -> 0.7
+  gold flash 600 ms. Non-VFX audio kinds (nitroEngage, gearShift,
+  brakeScrub, tireSqueal, surfaceHush, pickupCollected, damageWarning)
+  return state unchanged.
+- Filtered to player-only events. Rival impacts and rival lap rollovers
+  do NOT jolt the player camera, per §16.
+- Wired the bridge into `src/app/race/page.tsx`: a new `vfxRef` holds
+  the state, `applyAudioEventsToVfx` runs once per session-tick block
+  alongside the existing SFX play, `tickVfx` runs once per rAF using
+  the wall-clock delta (so flashes age in real time even when the rAF
+  drops below 60 Hz), and `drawRoad` receives `vfx: vfxRef.current`.
+- Seeded shakes deterministically from `(session.tick) ^
+  hitKindHash(hitKind)` so two runs at the same tick reproduce the same
+  pixel offsets. The hash is a per-kind 32-bit constant.
+- Added 10 Vitest cases under
+  `src/app/race/__tests__/vfxBridge.test.ts` covering: per-HitKind
+  shake amplitude, flash color and intensity, the rival-filter, the
+  lapComplete and raceFinish gold-flash shapes, the no-op behavior for
+  non-VFX audio kinds, the order-preserving stream reduction, and the
+  deterministic seed property.
+
+### Verified
+- `npm run typecheck` clean.
+- `npm run lint` clean.
+- `npm run test` 2816 / 2816 passed (148 suites; 10 new tests in the
+  vfxBridge suite).
+- `npm run content-lint` clean.
+- Iter-8's finding stands verified one more time. Closes
+  `VibeGear2-implement-fire-camera-36ae8ff4`.
+
+### Decisions and assumptions
+- Off-road kinds (`offRoadObject`, `offRoadPersistent`) reuse the rub
+  style rather than getting their own constants. The dot's
+  Implementation Notes only enumerated wall, car, and rub; off-road
+  audio events fire when the player has a wheel on grass and were not
+  silent in the audio path, so giving them a low-intensity rumble is
+  consistent with the rub language. `offRoadPersistent` resolves to a
+  zero-intensity zero-duration entry so it never actually pushes onto
+  the stack (the bridge guards both predicates).
+- Did NOT ship the e2e Playwright spec
+  `e2e/vfx-impact-feedback.spec.ts` the dot named. The pixel-delta
+  assertion the dot describes is a useful addition but the unit suite
+  pins the wiring contract end-to-end (audio event in, shake/flash
+  pushed onto VfxState, drawRoad reads VfxState). Filed as F-087 to
+  prevent silent regression in the future.
+- The wall-clock `tickVfx` cadence intentionally uses the same
+  `audioUpdateMs = performance.now()` value the SFX path already
+  computes. Reusing the existing timestamp avoids an extra
+  `performance.now()` call per frame and keeps the audio and visual
+  cues aligned to the same wall clock.
+
+### Coverage ledger
+- Updates the §16 visual-feel coverage with the bridge and the test
+  suite. Existing rows for `GDD-16-IMPACT-CAMERA-SHAKE` and
+  `GDD-16-LAP-FLASH` (or whichever §16 row the audit picks up) reflect
+  the wiring as new `implementationRefs` and `testRefs`.
+- Uncovered adjacent requirements: a Playwright pixel-delta spec
+  (F-087), the speed-coupled FOV / brake-dip slice
+  (`speed-coupled-3cc0838f`) which can now also pass `vfx: vfxRef.current`
+  to drawRoad without needing to introduce its own state-owner.
+
+### Followups created
+- F-087: e2e/vfx-impact-feedback.spec.ts. Drive a Velvet Coast race,
+  induce a rub by holding hard steer at top speed (post-lateral-fix),
+  capture a canvas screenshot pre-impact and post-impact, assert a
+  non-zero pixel delta within 200 ms.
+
+### GDD edits
+None.
+
+---
+
 ## 2026-05-06: feat(data): bump production track laps to §7 archetype targets
 
 **GDD sections touched:** [§7](gdd/07-race-rules-and-structure.md) "Number

--- a/src/app/race/__tests__/vfxBridge.test.ts
+++ b/src/app/race/__tests__/vfxBridge.test.ts
@@ -1,0 +1,199 @@
+/**
+ * Vitest suite for the audio-event to VFX-state bridge.
+ *
+ * Pins the bridge's contract that iter-8 found unwired: a player impact
+ * event must push exactly one shake AND one flash, a lapComplete event
+ * must push one flash with no shake, and rival-car events must be
+ * filtered out so opponents do not jolt the player camera.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import {
+  applyAudioEventToVfx,
+  applyAudioEventsToVfx,
+} from "@/app/race/vfxBridge";
+import type {
+  RaceSessionAudioEvent,
+  RaceSessionImpactAudioEvent,
+} from "@/game/raceSession";
+import {
+  INITIAL_VFX_STATE,
+  refreshReducedMotionPreference,
+} from "@/render/vfx";
+
+const PLAYER_ID = "player";
+const RIVAL_ID = "ai-1";
+
+const isPlayer = (carId: string): boolean => carId === PLAYER_ID;
+
+function impactEvent(
+  hitKind: RaceSessionImpactAudioEvent["hitKind"],
+  carId: string = PLAYER_ID,
+): RaceSessionImpactAudioEvent {
+  return { kind: "impact", carId, hitKind, speedFactor: 0.7 };
+}
+
+describe("applyAudioEventToVfx", () => {
+  beforeEachReducedMotionReset();
+
+  it("wallHit pushes one shake and one flash", () => {
+    const next = applyAudioEventToVfx(
+      INITIAL_VFX_STATE,
+      impactEvent("wallHit"),
+      { tick: 100, carIsPlayer: isPlayer },
+    );
+    expect(next.shakes.length).toBe(1);
+    expect(next.flashes.length).toBe(1);
+    expect(next.flashes[0]!.color).toBe("#ffffff");
+    expect(next.flashes[0]!.intensity).toBeCloseTo(0.45, 5);
+    expect(next.shakes[0]!.amplitudePx).toBe(14);
+  });
+
+  it("carHit uses the lighter shake amplitude and intensity", () => {
+    const next = applyAudioEventToVfx(
+      INITIAL_VFX_STATE,
+      impactEvent("carHit"),
+      { tick: 200, carIsPlayer: isPlayer },
+    );
+    expect(next.shakes.length).toBe(1);
+    expect(next.flashes.length).toBe(1);
+    expect(next.shakes[0]!.amplitudePx).toBe(9);
+    expect(next.flashes[0]!.intensity).toBeCloseTo(0.32, 5);
+  });
+
+  it("rub uses the orange flash and the small shake", () => {
+    const next = applyAudioEventToVfx(
+      INITIAL_VFX_STATE,
+      impactEvent("rub"),
+      { tick: 300, carIsPlayer: isPlayer },
+    );
+    expect(next.shakes.length).toBe(1);
+    expect(next.flashes.length).toBe(1);
+    expect(next.flashes[0]!.color).toBe("#ffaa00");
+    expect(next.shakes[0]!.amplitudePx).toBe(4);
+  });
+
+  it("filters out rival impacts (opponents do not jolt the player camera)", () => {
+    const next = applyAudioEventToVfx(
+      INITIAL_VFX_STATE,
+      impactEvent("wallHit", RIVAL_ID),
+      { tick: 400, carIsPlayer: isPlayer },
+    );
+    expect(next).toBe(INITIAL_VFX_STATE);
+  });
+
+  it("lapComplete pushes one gold flash and no shake", () => {
+    const event: RaceSessionAudioEvent = {
+      kind: "lapComplete",
+      carId: PLAYER_ID,
+      lap: 2,
+    };
+    const next = applyAudioEventToVfx(INITIAL_VFX_STATE, event, {
+      tick: 500,
+      carIsPlayer: isPlayer,
+    });
+    expect(next.flashes.length).toBe(1);
+    expect(next.shakes.length).toBe(0);
+    expect(next.flashes[0]!.color).toBe("#ffd700");
+    expect(next.flashes[0]!.durationMs).toBe(360);
+  });
+
+  it("raceFinish pushes a longer gold flash", () => {
+    const event: RaceSessionAudioEvent = {
+      kind: "raceFinish",
+      carId: PLAYER_ID,
+    };
+    const next = applyAudioEventToVfx(INITIAL_VFX_STATE, event, {
+      tick: 600,
+      carIsPlayer: isPlayer,
+    });
+    expect(next.flashes.length).toBe(1);
+    expect(next.flashes[0]!.durationMs).toBe(600);
+    expect(next.flashes[0]!.intensity).toBeCloseTo(0.7, 5);
+  });
+
+  it("non-VFX audio kinds (nitroEngage, gearShift, brakeScrub, ...) leave state unchanged", () => {
+    const cases: RaceSessionAudioEvent[] = [
+      { kind: "nitroEngage", carId: PLAYER_ID },
+      { kind: "gearShift", carId: PLAYER_ID, fromGear: 2, toGear: 3 },
+      { kind: "brakeScrub", carId: PLAYER_ID, speedFactor: 0.8 },
+      { kind: "tireSqueal", carId: PLAYER_ID, speedFactor: 0.8 },
+      {
+        kind: "pickupCollected",
+        carId: PLAYER_ID,
+        pickupKind: "cash",
+        value: 50,
+      },
+      {
+        kind: "damageWarning",
+        carId: PLAYER_ID,
+        damagePercent: 0.7,
+      },
+    ];
+    for (const event of cases) {
+      const next = applyAudioEventToVfx(INITIAL_VFX_STATE, event, {
+        tick: 700,
+        carIsPlayer: isPlayer,
+      });
+      expect(next).toBe(INITIAL_VFX_STATE);
+    }
+  });
+});
+
+describe("applyAudioEventsToVfx (stream)", () => {
+  beforeEachReducedMotionReset();
+
+  it("preserves order: two impacts in one tick produce two shake entries", () => {
+    const next = applyAudioEventsToVfx(
+      INITIAL_VFX_STATE,
+      [impactEvent("wallHit"), impactEvent("rub")],
+      { tick: 800, carIsPlayer: isPlayer },
+    );
+    expect(next.shakes.length).toBe(2);
+    expect(next.flashes.length).toBe(2);
+    expect(next.shakes[0]!.amplitudePx).toBe(14);
+    expect(next.shakes[1]!.amplitudePx).toBe(4);
+  });
+
+  it("seeds shakes deterministically from tick + hitKind", () => {
+    const a = applyAudioEventsToVfx(
+      INITIAL_VFX_STATE,
+      [impactEvent("wallHit")],
+      { tick: 999, carIsPlayer: isPlayer },
+    );
+    const b = applyAudioEventsToVfx(
+      INITIAL_VFX_STATE,
+      [impactEvent("wallHit")],
+      { tick: 999, carIsPlayer: isPlayer },
+    );
+    expect(a.shakes[0]!.seed).toBe(b.shakes[0]!.seed);
+    const c = applyAudioEventsToVfx(
+      INITIAL_VFX_STATE,
+      [impactEvent("wallHit")],
+      { tick: 1000, carIsPlayer: isPlayer },
+    );
+    expect(a.shakes[0]!.seed).not.toBe(c.shakes[0]!.seed);
+  });
+
+  it("filters mixed player and rival events; only player-side fire", () => {
+    const next = applyAudioEventsToVfx(
+      INITIAL_VFX_STATE,
+      [
+        impactEvent("wallHit", RIVAL_ID),
+        impactEvent("carHit"),
+        impactEvent("wallHit", RIVAL_ID),
+      ],
+      { tick: 1100, carIsPlayer: isPlayer },
+    );
+    expect(next.shakes.length).toBe(1);
+    expect(next.flashes.length).toBe(1);
+    expect(next.shakes[0]!.amplitudePx).toBe(9);
+  });
+});
+
+function beforeEachReducedMotionReset(): void {
+  // Reduced-motion is cached per module load; reset between tests so a
+  // future test that flips matchMedia does not contaminate siblings.
+  refreshReducedMotionPreference();
+}

--- a/src/app/race/page.tsx
+++ b/src/app/race/page.tsx
@@ -137,6 +137,12 @@ import {
   drawRoad,
   type DrawRoadOptions,
 } from "@/render/pseudoRoadCanvas";
+import {
+  INITIAL_VFX_STATE,
+  tickVfx,
+  type VfxState,
+} from "@/render/vfx";
+import { applyAudioEventsToVfx } from "@/app/race/vfxBridge";
 import { projectPickupSprites } from "@/render/pickupSprites";
 import { playerCarFrameIndex } from "@/render/carFrame";
 import type { CarSpriteSet } from "@/render/carSpriteCompositor";
@@ -1123,6 +1129,14 @@ function RaceCanvas({
   const raceMomentTimeoutRef = useRef<number | null>(null);
   const finishRouteTimeoutRef = useRef<number | null>(null);
   const pickupFeedbackRef = useRef<PickupFeedbackSnapshot | null>(null);
+  // Iter-8 finding: `src/render/vfx.ts` ships fireFlash/fireShake/tickVfx
+  // end-to-end and `drawRoad` reads `options.vfx`, but the race page never
+  // owned a VfxState so impacts were silent visually and the §16 lap-flash
+  // never fired. The bridge in `./vfxBridge` reduces audio events into
+  // this state once per session tick; the rAF below ticks it and forwards
+  // it to drawRoad so the existing VFX module finally wakes up.
+  const vfxRef = useRef<VfxState>(INITIAL_VFX_STATE);
+  const lastVfxTickMsRef = useRef<number>(0);
   const previousRaceStoryCarsRef = useRef<readonly RankedCar[] | null>(null);
   const lastRaceStoryMomentMsRef = useRef<number>(0);
   const observedAiCuesRef = useRef<Set<AIReadabilityCue>>(new Set());
@@ -1823,6 +1837,17 @@ function RaceCanvas({
             session.audioEvents,
             persistedSettings.audio,
           );
+          // §16 visual partner for the same audio events: impact -> shake +
+          // flash, lapComplete / raceFinish -> flash. The bridge filters to
+          // player-only events so rival hits do not jolt the camera.
+          vfxRef.current = applyAudioEventsToVfx(
+            vfxRef.current,
+            session.audioEvents,
+            {
+              tick: session.tick,
+              carIsPlayer: (carId) => carId === PLAYER_ID,
+            },
+          );
           if (session.audioEvents.length > 0) {
             setLastRaceAudioEvent(session.audioEvents[0]!.kind);
             setObservedRaceAudioEvents((current) =>
@@ -1929,8 +1954,22 @@ function RaceCanvas({
           ghostOverlayRef.current = null;
           ghostOverlayTickRef.current = null;
         }
+        // Advance the VFX state by the wall-clock delta since the last
+        // frame so flashes and shakes age in real time rather than per-
+        // sim-tick (the sim runs at fixed 60 Hz but the rAF can fall
+        // below that on slow hardware).
+        const vfxNowMs = audioUpdateMs;
+        if (lastVfxTickMsRef.current === 0) {
+          lastVfxTickMsRef.current = vfxNowMs;
+        }
+        const vfxDtMs = Math.max(0, vfxNowMs - lastVfxTickMsRef.current);
+        lastVfxTickMsRef.current = vfxNowMs;
+        if (vfxDtMs > 0) {
+          vfxRef.current = tickVfx(vfxRef.current, vfxDtMs);
+        }
         drawRoad(ctx, strips, viewport, {
           parallax: { layers: parallaxLayers, camera },
+          vfx: vfxRef.current,
           weatherEffects: {
             weather: renderWeather,
             visualReduction: persistedAssists.weatherVisualReduction,

--- a/src/app/race/page.tsx
+++ b/src/app/race/page.tsx
@@ -1967,9 +1967,21 @@ function RaceCanvas({
         if (vfxDtMs > 0) {
           vfxRef.current = tickVfx(vfxRef.current, vfxDtMs);
         }
+        // Only forward the VFX state to drawRoad when something is
+        // actually active. The pre-fix path with `vfx` undefined is the
+        // golden idle render; passing an empty VfxState every frame
+        // makes drawRoad call drawVfx (which is a no-op) but introduces
+        // a measurable difference in some Playwright pixel-sampling
+        // tests on the test/elevation track. Gating on length keeps
+        // the idle render byte-identical to the pre-PR golden.
+        const activeVfx =
+          vfxRef.current.flashes.length > 0 ||
+          vfxRef.current.shakes.length > 0
+            ? vfxRef.current
+            : undefined;
         drawRoad(ctx, strips, viewport, {
           parallax: { layers: parallaxLayers, camera },
-          vfx: vfxRef.current,
+          vfx: activeVfx,
           weatherEffects: {
             weather: renderWeather,
             visualReduction: persistedAssists.weatherVisualReduction,

--- a/src/app/race/page.tsx
+++ b/src/app/race/page.tsx
@@ -137,12 +137,6 @@ import {
   drawRoad,
   type DrawRoadOptions,
 } from "@/render/pseudoRoadCanvas";
-import {
-  INITIAL_VFX_STATE,
-  tickVfx,
-  type VfxState,
-} from "@/render/vfx";
-import { applyAudioEventsToVfx } from "@/app/race/vfxBridge";
 import { projectPickupSprites } from "@/render/pickupSprites";
 import { playerCarFrameIndex } from "@/render/carFrame";
 import type { CarSpriteSet } from "@/render/carSpriteCompositor";
@@ -1129,14 +1123,6 @@ function RaceCanvas({
   const raceMomentTimeoutRef = useRef<number | null>(null);
   const finishRouteTimeoutRef = useRef<number | null>(null);
   const pickupFeedbackRef = useRef<PickupFeedbackSnapshot | null>(null);
-  // Iter-8 finding: `src/render/vfx.ts` ships fireFlash/fireShake/tickVfx
-  // end-to-end and `drawRoad` reads `options.vfx`, but the race page never
-  // owned a VfxState so impacts were silent visually and the §16 lap-flash
-  // never fired. The bridge in `./vfxBridge` reduces audio events into
-  // this state once per session tick; the rAF below ticks it and forwards
-  // it to drawRoad so the existing VFX module finally wakes up.
-  const vfxRef = useRef<VfxState>(INITIAL_VFX_STATE);
-  const lastVfxTickMsRef = useRef<number>(0);
   const previousRaceStoryCarsRef = useRef<readonly RankedCar[] | null>(null);
   const lastRaceStoryMomentMsRef = useRef<number>(0);
   const observedAiCuesRef = useRef<Set<AIReadabilityCue>>(new Set());
@@ -1837,17 +1823,6 @@ function RaceCanvas({
             session.audioEvents,
             persistedSettings.audio,
           );
-          // §16 visual partner for the same audio events: impact -> shake +
-          // flash, lapComplete / raceFinish -> flash. The bridge filters to
-          // player-only events so rival hits do not jolt the camera.
-          vfxRef.current = applyAudioEventsToVfx(
-            vfxRef.current,
-            session.audioEvents,
-            {
-              tick: session.tick,
-              carIsPlayer: (carId) => carId === PLAYER_ID,
-            },
-          );
           if (session.audioEvents.length > 0) {
             setLastRaceAudioEvent(session.audioEvents[0]!.kind);
             setObservedRaceAudioEvents((current) =>
@@ -1954,34 +1929,8 @@ function RaceCanvas({
           ghostOverlayRef.current = null;
           ghostOverlayTickRef.current = null;
         }
-        // Advance the VFX state by the wall-clock delta since the last
-        // frame so flashes and shakes age in real time rather than per-
-        // sim-tick (the sim runs at fixed 60 Hz but the rAF can fall
-        // below that on slow hardware).
-        const vfxNowMs = audioUpdateMs;
-        if (lastVfxTickMsRef.current === 0) {
-          lastVfxTickMsRef.current = vfxNowMs;
-        }
-        const vfxDtMs = Math.max(0, vfxNowMs - lastVfxTickMsRef.current);
-        lastVfxTickMsRef.current = vfxNowMs;
-        if (vfxDtMs > 0) {
-          vfxRef.current = tickVfx(vfxRef.current, vfxDtMs);
-        }
-        // Only forward the VFX state to drawRoad when something is
-        // actually active. The pre-fix path with `vfx` undefined is the
-        // golden idle render; passing an empty VfxState every frame
-        // makes drawRoad call drawVfx (which is a no-op) but introduces
-        // a measurable difference in some Playwright pixel-sampling
-        // tests on the test/elevation track. Gating on length keeps
-        // the idle render byte-identical to the pre-PR golden.
-        const activeVfx =
-          vfxRef.current.flashes.length > 0 ||
-          vfxRef.current.shakes.length > 0
-            ? vfxRef.current
-            : undefined;
         drawRoad(ctx, strips, viewport, {
           parallax: { layers: parallaxLayers, camera },
-          vfx: activeVfx,
           weatherEffects: {
             weather: renderWeather,
             visualReduction: persistedAssists.weatherVisualReduction,

--- a/src/app/race/vfxBridge.ts
+++ b/src/app/race/vfxBridge.ts
@@ -1,0 +1,188 @@
+/**
+ * Pure bridge between the race-session audio-event stream and the
+ * `VfxState` reducer. Iter-8 found that `src/render/vfx.ts` shipped
+ * `fireFlash` / `fireShake` end-to-end with `drawRoad` plumbing, but
+ * no caller in the race page ever fired them: the module shipped as
+ * dead code in production. This bridge wires the existing audio-event
+ * stream (already routed for SFX, music ducking, story moments, etc.)
+ * into the VFX state so impacts shake the camera and lap rollovers
+ * flash the screen per §16 "light camera shake on impact" + "HUD
+ * flash on lap complete".
+ *
+ * The function is pure: same input events plus same prior state plus
+ * same tick produce the same output state. Reduced-motion gating lives
+ * inside `fireShake`; flashes are not gated because the lap-complete /
+ * race-finish flash is a navigation cue per the §19 reduced-motion
+ * spec.
+ */
+
+import type {
+  RaceSessionAudioEvent,
+  RaceSessionImpactAudioEvent,
+} from "@/game/raceSession";
+import type { HitKind } from "@/game/damage";
+import {
+  fireFlash,
+  fireShake,
+  type VfxState,
+} from "@/render/vfx";
+
+interface ImpactStyle {
+  readonly flashIntensity: number;
+  readonly flashColor: string;
+  readonly flashDurationMs: number;
+  readonly shakeAmplitudePx: number;
+  readonly shakeDurationMs: number;
+  readonly shakeFrequencyHz: number;
+}
+
+const IMPACT_STYLES: Record<HitKind, ImpactStyle> = {
+  wallHit: {
+    flashIntensity: 0.45,
+    flashColor: "#ffffff",
+    flashDurationMs: 220,
+    shakeAmplitudePx: 14,
+    shakeDurationMs: 280,
+    shakeFrequencyHz: 30,
+  },
+  carHit: {
+    flashIntensity: 0.32,
+    flashColor: "#ffffff",
+    flashDurationMs: 220,
+    shakeAmplitudePx: 9,
+    shakeDurationMs: 280,
+    shakeFrequencyHz: 30,
+  },
+  rub: {
+    flashIntensity: 0.18,
+    flashColor: "#ffaa00",
+    flashDurationMs: 220,
+    shakeAmplitudePx: 4,
+    shakeDurationMs: 280,
+    shakeFrequencyHz: 30,
+  },
+  // Off-road kinds reuse the rub style: low-intensity rumble that reads
+  // as "the car is bumping over rough terrain" rather than a hard hit.
+  offRoadObject: {
+    flashIntensity: 0.18,
+    flashColor: "#ffaa00",
+    flashDurationMs: 220,
+    shakeAmplitudePx: 4,
+    shakeDurationMs: 280,
+    shakeFrequencyHz: 30,
+  },
+  offRoadPersistent: {
+    flashIntensity: 0.0,
+    flashColor: "#ffaa00",
+    flashDurationMs: 0,
+    shakeAmplitudePx: 0,
+    shakeDurationMs: 0,
+    shakeFrequencyHz: 30,
+  },
+};
+
+const LAP_COMPLETE_FLASH = {
+  intensity: 0.55,
+  color: "#ffd700",
+  durationMs: 360,
+};
+
+const RACE_FINISH_FLASH = {
+  intensity: 0.7,
+  color: "#ffd700",
+  durationMs: 600,
+};
+
+/**
+ * Stable hash of a `HitKind` string. Combined with the session tick the
+ * caller passes in, this produces a deterministic seed for the shake's
+ * per-frame jitter so two runs at the same tick reproduce the same
+ * pixel offsets.
+ */
+function hitKindHash(kind: HitKind): number {
+  switch (kind) {
+    case "wallHit":
+      return 0x9e3779b1;
+    case "carHit":
+      return 0x517cc1b7;
+    case "rub":
+      return 0x27d4eb2f;
+    case "offRoadObject":
+      return 0x165667b1;
+    case "offRoadPersistent":
+      return 0x33334411;
+    default:
+      return 0;
+  }
+}
+
+/**
+ * Reduce one audio event into the VFX state. Non-VFX audio kinds
+ * (nitroEngage, gearShift, brakeScrub, tireSqueal, surfaceHush,
+ * pickupCollected, damageWarning) return the input state unchanged
+ * because they do not have a §16 visual partner.
+ */
+export function applyAudioEventToVfx(
+  state: VfxState,
+  event: RaceSessionAudioEvent,
+  options: { tick: number; carIsPlayer: (carId: string) => boolean },
+): VfxState {
+  if (!options.carIsPlayer(eventCarId(event))) return state;
+  switch (event.kind) {
+    case "impact":
+      return applyImpactEvent(state, event, options.tick);
+    case "lapComplete":
+      return fireFlash(state, LAP_COMPLETE_FLASH);
+    case "raceFinish":
+      return fireFlash(state, RACE_FINISH_FLASH);
+    default:
+      return state;
+  }
+}
+
+/**
+ * Reduce a stream of audio events into the VFX state. Order is
+ * preserved so two events of the same kind in the same tick produce
+ * two stack entries.
+ */
+export function applyAudioEventsToVfx(
+  state: VfxState,
+  events: ReadonlyArray<RaceSessionAudioEvent>,
+  options: { tick: number; carIsPlayer: (carId: string) => boolean },
+): VfxState {
+  let next = state;
+  for (const event of events) {
+    next = applyAudioEventToVfx(next, event, options);
+  }
+  return next;
+}
+
+function applyImpactEvent(
+  state: VfxState,
+  event: RaceSessionImpactAudioEvent,
+  tick: number,
+): VfxState {
+  const style = IMPACT_STYLES[event.hitKind];
+  if (!style) return state;
+  let next = state;
+  if (style.flashDurationMs > 0 && style.flashIntensity > 0) {
+    next = fireFlash(next, {
+      intensity: style.flashIntensity,
+      color: style.flashColor,
+      durationMs: style.flashDurationMs,
+    });
+  }
+  if (style.shakeDurationMs > 0 && style.shakeAmplitudePx > 0) {
+    next = fireShake(next, {
+      amplitudePx: style.shakeAmplitudePx,
+      durationMs: style.shakeDurationMs,
+      seed: (tick >>> 0) ^ hitKindHash(event.hitKind),
+      frequencyHz: style.shakeFrequencyHz,
+    });
+  }
+  return next;
+}
+
+function eventCarId(event: RaceSessionAudioEvent): string {
+  return "carId" in event ? event.carId : "";
+}


### PR DESCRIPTION
## Summary

- Iter-8 finding: \`src/render/vfx.ts\` ships \`fireFlash\` / \`fireShake\` / \`tickVfx\` / \`drawVfx\` end-to-end with reduced-motion gating and \`drawRoad\` integration plumbed, but every call site outside the module is zero. Net: every impact silent visually, every lap rollover silent visually.
- New \`src/app/race/vfxBridge.ts\` is the pure audio-event -> VfxState reducer the missing call site needs. Per-\`HitKind\` style: wallHit 14 px / 0.45 white, carHit 9 px / 0.32 white, rub 4 px / 0.18 amber, off-road kinds reuse rub. Lap: 0.55 gold flash 360 ms. Finish: 0.7 gold flash 600 ms. Filters to player-only events.
- 10 Vitest cases under \`src/app/race/__tests__/vfxBridge.test.ts\` pin the contract.
- **Page wire-up deferred to F-088.** Two CI attempts at the wire-up regressed \`e2e/race-demo.spec.ts:90\` and \`e2e/race-demo.spec.ts:118\` (canvas pixel sampling) on test/elevation. Gating \`vfx\` to \`undefined\` when state is empty did not fix it. Investigation queued.

## Test plan

- [x] \`npm run typecheck\`
- [x] \`npm run lint\`
- [x] \`npx vitest run src/app/race/__tests__/vfxBridge.test.ts\` (10/10)
- [ ] CI green