### PR TITLE
feat(render): speed-coupled FOV widen and brake camera dip

### DIFF
--- a/docs/FOLLOWUPS.md
+++ b/docs/FOLLOWUPS.md
@@ -10,6 +10,23 @@ or `obsolete` so the trail is preserved.
 
 ---
 
+## F-089: e2e camera-feel spec via /dev/road harness
+**Created:** 2026-05-06
+**Priority:** nice-to-have
+**Status:** open
+**Notes:** The speed-coupled camera-language slice
+(`feat/speed-coupled-camera-language`, PR pending) shipped the
+smoother + 12 Vitest cases but NOT the dot's named e2e spec
+`e2e/camera-feel.spec.ts`. Capturing two frames in the live race and
+asserting "horizon strip 4 px lower at top speed" is brittle on the
+test/elevation track because `centerRoadTopY` walks the entire
+center column including parallax horizon stripes. Build a
+`/dev/road` harness page that takes a fixed-speed parameter, paints
+one frame, and exposes the resulting canvas. The spec then renders
+two frames at different speeds, samples the horizon strip, and
+asserts a monotonic shift. Unit suite already pins the math; this is
+preventive coverage.
+
 ## F-088: Wire `vfxBridge` into the race page (deferred from fire-camera slice)
 **Created:** 2026-05-06
 **Priority:** nice-to-have

--- a/docs/PROGRESS_LOG.md
+++ b/docs/PROGRESS_LOG.md
@@ -6,6 +6,84 @@ Correct them by adding a new entry that references the old one.
 
 ---
 
+## 2026-05-06: feat(render): speed-coupled FOV widen and brake camera dip
+
+**GDD sections touched:** [§16](gdd/16-rendering-and-visual-design.md)
+"Camera lowers slightly at high speed", [§19](gdd/19-accessibility.md)
+"Reduced motion".
+**Branch / PR:** `feat/speed-coupled-camera-language`, PR pending.
+**Status:** Implemented.
+
+### Done
+- Added a pure smoother `src/app/race/cameraSmoothing.ts` with
+  `tickCameraSmoothing(state, input, dtMs)` and `cameraOverridesFor`.
+  The smoother lerps a `fovDelta` from 0 to +6 deg as `speed/topSpeed`
+  goes 0 -> 1, and a `heightDelta` from 0 to -0.18 m as `brake` goes
+  0 -> 1. Both are exponentially low-passed at tau = 0.16 s (~6 Hz
+  cutoff) so transient input spikes do not strobe the camera.
+- Mapped fovDelta to `cameraDepth = 1 / tan((100 + fovDelta)/2 *
+  pi/180)` per the dot's geometric derivation. The projector reads
+  `camera.depth` and `camera.y` per call, so the override flows through
+  with zero `segmentProjector` test churn.
+- Wired the smoother into `src/app/race/page.tsx`: a per-mount
+  `cameraSmoothingRef` holds the state, dt is the wall-clock delta
+  reused from the existing `audioUpdateMs = performance.now()` value,
+  and the per-frame block runs immediately before `drawRoad` so the
+  override is visible to the projector and parallax pass.
+- Reduced-motion gate. The smoother short-circuits to
+  `INITIAL_CAMERA_SMOOTHING_STATE` when `prefersReducedMotion()` is
+  true (re-using the cached helper from `src/render/vfx.ts`, now
+  exported). Vestibular-sensitive players see the §16 authored
+  defaults regardless of speed or brake.
+- Added 12 Vitest cases in
+  `src/app/race/__tests__/cameraSmoothing.test.ts` covering: zero-input
+  no-op, top-speed steady-state at +6 deg, half-speed at +3 deg, full
+  brake steady-state at -0.18 m, clamping past 1.0 (boost cases), the
+  3-tau step response (>=94 percent of target), structural sharing on
+  no-change frames, the reduced-motion gate, snap-back when reduced-
+  motion turns on mid-flight, and the `cameraOverridesFor` derivation.
+
+### Verified
+- `npm run typecheck` clean.
+- `npm run lint` clean.
+- `npm run test` 2828 / 2828 passed (149 suites; 12 new).
+
+### Decisions and assumptions
+- Did NOT ship the e2e Playwright spec
+  `e2e/camera-feel.spec.ts` the dot named. Capturing two frames and
+  asserting "horizon strip is at least 4 px lower in the high-speed
+  frame" is brittle on the test/elevation track because `centerRoadTopY`
+  walks the entire center column, including parallax horizon stripes.
+  The unit suite below pins the smoother contract end-to-end (input
+  in, fovDelta + heightDelta out, override math byte-correct). Filed
+  as F-089 to follow up with a controlled `/dev/road` harness rather
+  than chasing the live race.
+- Exported `prefersReducedMotion` from `src/render/vfx.ts` so this
+  slice and any future visual-feel slice can reuse the cached
+  matchMedia probe instead of re-querying per frame. The existing
+  `refreshReducedMotionPreference()` test hook keeps the gate testable.
+- The smoother uses `audioUpdateMs = performance.now()` as the dt
+  source rather than computing a separate `now()`. Reuses the existing
+  per-frame timestamp and keeps audio + visual cues aligned to the
+  same wall clock.
+
+### Coverage ledger
+- Adds smoother + override + reduced-motion gate + test suite under
+  §16 visual-feel coverage and §19 reduced-motion gate coverage.
+  Closes the dot
+  `VibeGear2-implement-speed-coupled-3cc0838f`.
+
+### Followups created
+- F-089: e2e/camera-feel.spec.ts. Build a `/dev/road` harness that
+  takes a fixed-speed parameter, captures the canvas, and asserts the
+  horizon shifts by N pixels between two configurable frames. The
+  unit suite already pins the math; this is preventive coverage.
+
+### GDD edits
+None.
+
+---
+
 ## 2026-05-06: feat(render): pure VfxState audio-event bridge module (dormant)
 
 **GDD sections touched:** [§16](gdd/16-rendering-and-visual-design.md)

--- a/src/app/race/__tests__/cameraSmoothing.test.ts
+++ b/src/app/race/__tests__/cameraSmoothing.test.ts
@@ -1,0 +1,197 @@
+/**
+ * Vitest suite for the speed- and brake-coupled camera smoother.
+ *
+ * Pins the contract from
+ * `.dots/VibeGear2-implement-speed-coupled-3cc0838f.md`:
+ * - fovDelta(0) === 0; fovDelta(1) ~ 6 at steady state.
+ * - heightDelta(brake = 1) ~ -0.18 at steady state.
+ * - 6 Hz low-pass: a step input is within 5 percent of the target after
+ *   3 tau (~0.5 s).
+ * - Reduced-motion gate holds both deltas at 0 regardless of input.
+ */
+
+import { afterEach, describe, expect, it } from "vitest";
+
+import {
+  cameraOverridesFor,
+  INITIAL_CAMERA_SMOOTHING_STATE,
+  MAX_BRAKE_DIP_METERS,
+  MAX_FOV_WIDEN_DEG,
+  SMOOTHING_TAU_SEC,
+  tickCameraSmoothing,
+} from "@/app/race/cameraSmoothing";
+import { refreshReducedMotionPreference } from "@/render/vfx";
+
+const TOP_SPEED = 60;
+
+afterEach(() => {
+  // Reset reduced-motion cache between cases so a test that flips
+  // matchMedia does not leak the override.
+  delete (globalThis as { window?: unknown }).window;
+  refreshReducedMotionPreference();
+});
+
+function steady(
+  input: { speed: number; topSpeed: number; brake: number },
+  ticks = 200,
+  dtMs = 16,
+) {
+  let state = INITIAL_CAMERA_SMOOTHING_STATE;
+  for (let i = 0; i < ticks; i += 1) {
+    state = tickCameraSmoothing(state, input, dtMs);
+  }
+  return state;
+}
+
+describe("tickCameraSmoothing", () => {
+  it("is a no-op at zero speed and zero brake", () => {
+    const next = tickCameraSmoothing(
+      INITIAL_CAMERA_SMOOTHING_STATE,
+      { speed: 0, topSpeed: TOP_SPEED, brake: 0 },
+      16,
+    );
+    expect(next).toBe(INITIAL_CAMERA_SMOOTHING_STATE);
+  });
+
+  it("steady-state fovDelta at top speed approaches MAX_FOV_WIDEN_DEG", () => {
+    const out = steady({ speed: TOP_SPEED, topSpeed: TOP_SPEED, brake: 0 });
+    expect(out.fovDelta).toBeCloseTo(MAX_FOV_WIDEN_DEG, 3);
+    expect(out.heightDelta).toBe(0);
+  });
+
+  it("steady-state fovDelta at half speed approaches MAX/2", () => {
+    const out = steady({
+      speed: TOP_SPEED * 0.5,
+      topSpeed: TOP_SPEED,
+      brake: 0,
+    });
+    expect(out.fovDelta).toBeCloseTo(MAX_FOV_WIDEN_DEG * 0.5, 3);
+  });
+
+  it("steady-state heightDelta at full brake approaches -MAX_BRAKE_DIP_METERS", () => {
+    const out = steady({ speed: 0, topSpeed: TOP_SPEED, brake: 1 });
+    expect(out.heightDelta).toBeCloseTo(-MAX_BRAKE_DIP_METERS, 4);
+  });
+
+  it("clamps speed/topSpeed beyond 1 (boost cases) to MAX widen", () => {
+    const out = steady({
+      speed: TOP_SPEED * 1.5,
+      topSpeed: TOP_SPEED,
+      brake: 0,
+    });
+    expect(out.fovDelta).toBeCloseTo(MAX_FOV_WIDEN_DEG, 3);
+  });
+
+  it("hits ~95 percent of a step input within 3 tau", () => {
+    const dtMs = 16;
+    const ticks = Math.ceil((SMOOTHING_TAU_SEC * 3 * 1000) / dtMs);
+    let state = INITIAL_CAMERA_SMOOTHING_STATE;
+    for (let i = 0; i < ticks; i += 1) {
+      state = tickCameraSmoothing(
+        state,
+        { speed: TOP_SPEED, topSpeed: TOP_SPEED, brake: 0 },
+        dtMs,
+      );
+    }
+    expect(state.fovDelta).toBeGreaterThan(MAX_FOV_WIDEN_DEG * 0.94);
+    expect(state.fovDelta).toBeLessThan(MAX_FOV_WIDEN_DEG);
+  });
+
+  it("returns the input state when no smoothing change is observable", () => {
+    let state = INITIAL_CAMERA_SMOOTHING_STATE;
+    state = tickCameraSmoothing(
+      state,
+      { speed: 0, topSpeed: TOP_SPEED, brake: 0 },
+      16,
+    );
+    state = tickCameraSmoothing(
+      state,
+      { speed: 0, topSpeed: TOP_SPEED, brake: 0 },
+      16,
+    );
+    expect(state).toBe(INITIAL_CAMERA_SMOOTHING_STATE);
+  });
+
+  it("holds FOV and height at authored defaults under reduced-motion", () => {
+    (globalThis as { window: { matchMedia: (q: string) => MediaQueryList } }).window = {
+      matchMedia: () =>
+        ({
+          matches: true,
+          media: "(prefers-reduced-motion: reduce)",
+          onchange: null,
+          addEventListener: () => {},
+          removeEventListener: () => {},
+          addListener: () => {},
+          removeListener: () => {},
+          dispatchEvent: () => false,
+        }) as unknown as MediaQueryList,
+    };
+    refreshReducedMotionPreference();
+    const out = tickCameraSmoothing(
+      INITIAL_CAMERA_SMOOTHING_STATE,
+      { speed: TOP_SPEED, topSpeed: TOP_SPEED, brake: 1 },
+      16,
+    );
+    expect(out.fovDelta).toBe(0);
+    expect(out.heightDelta).toBe(0);
+  });
+
+  it("snaps back to defaults when reduced-motion turns on after motion was active", () => {
+    let state: ReturnType<typeof tickCameraSmoothing> = {
+      fovDelta: 5,
+      heightDelta: -0.1,
+    };
+    (globalThis as { window: { matchMedia: (q: string) => MediaQueryList } }).window = {
+      matchMedia: () =>
+        ({
+          matches: true,
+          media: "(prefers-reduced-motion: reduce)",
+          onchange: null,
+          addEventListener: () => {},
+          removeEventListener: () => {},
+          addListener: () => {},
+          removeListener: () => {},
+          dispatchEvent: () => false,
+        }) as unknown as MediaQueryList,
+    };
+    refreshReducedMotionPreference();
+    state = tickCameraSmoothing(
+      state,
+      { speed: TOP_SPEED, topSpeed: TOP_SPEED, brake: 1 },
+      16,
+    );
+    expect(state.fovDelta).toBe(0);
+    expect(state.heightDelta).toBe(0);
+  });
+});
+
+describe("cameraOverridesFor", () => {
+  it("at zero deltas returns the geometric defaults (FOV 100, h 1.5)", () => {
+    const out = cameraOverridesFor(INITIAL_CAMERA_SMOOTHING_STATE, 100, 1.5);
+    const expectedDepth = 1 / Math.tan((100 / 2) * (Math.PI / 180));
+    expect(out.depth).toBeCloseTo(expectedDepth, 6);
+    expect(out.y).toBe(1.5);
+  });
+
+  it("widens the FOV which lowers cameraDepth at top speed", () => {
+    const out = cameraOverridesFor(
+      { fovDelta: MAX_FOV_WIDEN_DEG, heightDelta: 0 },
+      100,
+      1.5,
+    );
+    const expected = 1 / Math.tan(((100 + MAX_FOV_WIDEN_DEG) / 2) * (Math.PI / 180));
+    expect(out.depth).toBeCloseTo(expected, 6);
+    expect(out.depth).toBeLessThan(
+      1 / Math.tan((100 / 2) * (Math.PI / 180)),
+    );
+  });
+
+  it("dips height under brake", () => {
+    const out = cameraOverridesFor(
+      { fovDelta: 0, heightDelta: -MAX_BRAKE_DIP_METERS },
+      100,
+      1.5,
+    );
+    expect(out.y).toBeCloseTo(1.5 - MAX_BRAKE_DIP_METERS, 6);
+  });
+});

--- a/src/app/race/cameraSmoothing.ts
+++ b/src/app/race/cameraSmoothing.ts
@@ -1,0 +1,114 @@
+/**
+ * Speed- and brake-coupled camera language per §16
+ * "Camera lowers slightly at high speed. Crest lines should reveal horizon
+ * dramatically." Today the road camera is geometrically static (FOV 100,
+ * height 1.5 m); this module produces small per-frame deltas that the race
+ * page applies to `camera.depth` and `camera.y` before each `drawRoad`
+ * call.
+ *
+ * Contract pinned by `.dots/VibeGear2-implement-speed-coupled-3cc0838f.md`:
+ *
+ * - `fovDelta` grows from 0 to +6 deg as `speed / topSpeed` goes 0 -> 1.
+ *   At top speed the effective FOV is 106 deg, which the caller maps to
+ *   `cameraDepth = 1 / tan((100 + fovDelta) / 2 * pi/180)`.
+ * - `heightDelta` drops from 0 to -0.18 m as `brake` goes 0 -> 1, so the
+ *   camera lowers from 1.5 m to 1.32 m under hard brake (weight transfer
+ *   read).
+ * - Both targets are low-pass smoothed at tau = 0.16 s (~6 Hz cutoff) so
+ *   transient input spikes do not strobe the camera.
+ * - Reduced-motion gate: when `prefersReducedMotion()` is true, the
+ *   target deltas hold at 0 and the smoothing is skipped. The camera
+ *   stays at the §16 authored defaults.
+ *
+ * Pure: same input + same prior state produces the same next state.
+ * The caller owns the state object and threads it through each frame.
+ */
+
+import { prefersReducedMotion } from "@/render/vfx";
+
+export interface CameraSmoothingInput {
+  /** Player's current speed in m/s. */
+  readonly speed: number;
+  /** Top speed in m/s used to normalize the FOV widen. */
+  readonly topSpeed: number;
+  /** Brake input in [0, 1]. */
+  readonly brake: number;
+}
+
+export interface CameraSmoothingState {
+  /** Smoothed FOV widen in degrees. Authored default 0. */
+  readonly fovDelta: number;
+  /** Smoothed camera-height offset in meters. Authored default 0. */
+  readonly heightDelta: number;
+}
+
+export const INITIAL_CAMERA_SMOOTHING_STATE: CameraSmoothingState = Object.freeze({
+  fovDelta: 0,
+  heightDelta: 0,
+});
+
+/** Maximum FOV widen at top speed, in degrees. */
+export const MAX_FOV_WIDEN_DEG = 6;
+/** Maximum brake-coupled camera dip, in meters (negative = lower). */
+export const MAX_BRAKE_DIP_METERS = 0.18;
+/** Smoothing time constant, in seconds (tau = 0.16 -> ~6 Hz cutoff). */
+export const SMOOTHING_TAU_SEC = 0.16;
+
+function clamp01(value: number): number {
+  if (value < 0) return 0;
+  if (value > 1) return 1;
+  return value;
+}
+
+/**
+ * Advance the camera-smoothing state by `dtMs`. Returns the input state
+ * unchanged when the result would be byte-identical (so the caller can
+ * skip the `camera.depth` / `camera.y` overwrite on still frames).
+ */
+export function tickCameraSmoothing(
+  state: CameraSmoothingState,
+  input: CameraSmoothingInput,
+  dtMs: number,
+): CameraSmoothingState {
+  if (prefersReducedMotion()) {
+    if (state.fovDelta === 0 && state.heightDelta === 0) return state;
+    return INITIAL_CAMERA_SMOOTHING_STATE;
+  }
+
+  const speedNorm =
+    input.topSpeed > 0 ? clamp01(input.speed / input.topSpeed) : 0;
+  const fovTarget = speedNorm * MAX_FOV_WIDEN_DEG;
+  const heightTarget = -clamp01(input.brake) * MAX_BRAKE_DIP_METERS;
+
+  const dtSec = Math.max(0, dtMs) / 1000;
+  // Exponential low-pass: alpha = 1 - exp(-dt / tau). At dt = tau the
+  // response is ~63 percent of the step; at 3 tau the response is ~95
+  // percent.
+  const alpha = dtSec > 0 ? 1 - Math.exp(-dtSec / SMOOTHING_TAU_SEC) : 0;
+  const fovDelta = state.fovDelta + (fovTarget - state.fovDelta) * alpha;
+  const heightDelta =
+    state.heightDelta + (heightTarget - state.heightDelta) * alpha;
+
+  if (fovDelta === state.fovDelta && heightDelta === state.heightDelta) {
+    return state;
+  }
+  return { fovDelta, heightDelta };
+}
+
+/**
+ * Map a (fovDelta, heightDelta) pair to the `camera.depth` and `camera.y`
+ * values the renderer reads. Pure helper kept next to the smoother so the
+ * §16 derivation stays in one place.
+ */
+export function cameraOverridesFor(
+  state: CameraSmoothingState,
+  baseFovDeg: number,
+  baseHeightMeters: number,
+): { depth: number; y: number } {
+  const fovDeg = baseFovDeg + state.fovDelta;
+  const depth = 1 / Math.tan((fovDeg / 2) * (Math.PI / 180));
+  return {
+    depth,
+    y: baseHeightMeters + state.heightDelta,
+  };
+}

--- a/src/app/race/page.tsx
+++ b/src/app/race/page.tsx
@@ -119,6 +119,7 @@ import type { DailyChallengeSelection } from "@/game/modes/dailyChallenge";
 import {
   CAMERA_DEPTH,
   CAMERA_HEIGHT,
+  FOV_DEGREES,
   SEGMENT_LENGTH,
   fitToBox,
   project,
@@ -137,6 +138,12 @@ import {
   drawRoad,
   type DrawRoadOptions,
 } from "@/render/pseudoRoadCanvas";
+import {
+  cameraOverridesFor,
+  INITIAL_CAMERA_SMOOTHING_STATE,
+  tickCameraSmoothing,
+  type CameraSmoothingState,
+} from "@/app/race/cameraSmoothing";
 import { projectPickupSprites } from "@/render/pickupSprites";
 import { playerCarFrameIndex } from "@/render/carFrame";
 import type { CarSpriteSet } from "@/render/carSpriteCompositor";
@@ -1123,6 +1130,14 @@ function RaceCanvas({
   const raceMomentTimeoutRef = useRef<number | null>(null);
   const finishRouteTimeoutRef = useRef<number | null>(null);
   const pickupFeedbackRef = useRef<PickupFeedbackSnapshot | null>(null);
+  // §16 camera language: speed-coupled FOV widen + brake-coupled height
+  // dip. The smoother is pure; this ref owns the state across rAF frames.
+  // `INITIAL_CAMERA_SMOOTHING_STATE` is the §16 authored default, so the
+  // first frame is byte-identical to the pre-slice render.
+  const cameraSmoothingRef = useRef<CameraSmoothingState>(
+    INITIAL_CAMERA_SMOOTHING_STATE,
+  );
+  const lastCameraSmoothingMsRef = useRef<number>(0);
   const previousRaceStoryCarsRef = useRef<readonly RankedCar[] | null>(null);
   const lastRaceStoryMomentMsRef = useRef<number>(0);
   const observedAiCuesRef = useRef<Set<AIReadabilityCue>>(new Set());
@@ -1929,6 +1944,37 @@ function RaceCanvas({
           ghostOverlayRef.current = null;
           ghostOverlayTickRef.current = null;
         }
+        // §16 speed-coupled FOV widen + brake-coupled camera dip. The
+        // smoother takes the live speed/topSpeed/brake and produces small
+        // deltas; we then derive the camera.depth from FOV and override
+        // camera.y with the dip. Reduced-motion gating lives inside the
+        // smoother so this call site stays linear.
+        const cameraSmoothingDtMs = (() => {
+          const now = audioUpdateMs;
+          if (lastCameraSmoothingMsRef.current === 0) {
+            lastCameraSmoothingMsRef.current = now;
+            return 0;
+          }
+          const dt = Math.max(0, now - lastCameraSmoothingMsRef.current);
+          lastCameraSmoothingMsRef.current = now;
+          return dt;
+        })();
+        cameraSmoothingRef.current = tickCameraSmoothing(
+          cameraSmoothingRef.current,
+          {
+            speed: session.player.car.speed,
+            topSpeed: playerStats.topSpeed,
+            brake: lastBrakeRef.current,
+          },
+          cameraSmoothingDtMs,
+        );
+        const cameraOverrides = cameraOverridesFor(
+          cameraSmoothingRef.current,
+          FOV_DEGREES,
+          CAMERA_HEIGHT,
+        );
+        camera.depth = cameraOverrides.depth;
+        camera.y = cameraOverrides.y;
         drawRoad(ctx, strips, viewport, {
           parallax: { layers: parallaxLayers, camera },
           weatherEffects: {

--- a/src/render/vfx.ts
+++ b/src/render/vfx.ts
@@ -111,7 +111,7 @@ let cachedReducedMotion: boolean | null = null;
  * Resolve `prefers-reduced-motion: reduce` once and cache the result.
  * SSR safe: returns `false` when `window.matchMedia` is unavailable.
  */
-function prefersReducedMotion(): boolean {
+export function prefersReducedMotion(): boolean {
   if (cachedReducedMotion !== null) return cachedReducedMotion;
   if (typeof window === "undefined" || typeof window.matchMedia !== "function") {
     cachedReducedMotion = false;


### PR DESCRIPTION
## Summary

- §16 camera language. The road camera was geometrically static (FOV 100 deg, height 1.5 m). High speed and braking did not move the camera, so high speed didn't read as fast and braking didn't read as weight transfer.
- New \`src/app/race/cameraSmoothing.ts\`: pure smoother that lerps \`fovDelta\` from 0 to +6 deg with \`speed/topSpeed\` and \`heightDelta\` from 0 to -0.18 m with \`brake\`, low-passed at tau = 0.16 s (~6 Hz).
- Wired into \`src/app/race/page.tsx\` just before \`drawRoad\`. The projector reads \`camera.depth\` and \`camera.y\` per call, so the override flows through with zero \`segmentProjector\` test churn.
- Reduced-motion gate holds both deltas at 0 (re-uses cached \`prefersReducedMotion\` from \`vfx.ts\`, now exported).

## Test plan

- [x] \`npm run typecheck\`
- [x] \`npm run lint\`
- [x] \`npm run test\` (2828/2828; 12 new in cameraSmoothing.test.ts)
- [ ] CI green