### PR TITLE
chore(menu): cut non-Tour entries per Q-015 v1.0 scope

### DIFF
--- a/docs/FOLLOWUPS.md
+++ b/docs/FOLLOWUPS.md
@@ -10,6 +10,39 @@ or `obsolete` so the trail is preserved.
 
 ---
 
+## F-090: Delete dormant non-Tour routes, modules, and tests
+**Created:** 2026-05-06
+**Priority:** nice-to-have
+**Status:** open
+**Notes:** Q-015 scope cut deferred the deeper code deletion. The
+v1.0 title-screen menu no longer exposes Time Trial / Quick Race /
+Practice / Daily Challenge, but the underlying surfaces remain in the
+tree because deleting them in one PR would have exceeded the dot's
+~1500 LOC cap (`.dots/VibeGear2-implement-cut-non-fdcb3b2d.md`):
+`src/app/quick-race/`, `src/app/time-trial/`, `src/app/daily/`,
+`src/game/timeTrial.ts`, `src/game/modes/dailyChallenge.ts`,
+`src/game/modes/quickRace.ts`, `src/game/modes/timeTrialTargets.ts`,
+plus their `__tests__/`. The race page still wires `mode === "timeTrial"`
+ghost recording, `mode === "quickRace"` records-only handling, and
+practice-mode toggles in `src/app/race/page.tsx:579-1503` — those
+branches need to be removed when the mode plumbing is cut. Affected
+e2e specs that reference cut routes: `e2e/time-trial.spec.ts`,
+`e2e/daily-challenge.spec.ts`, `e2e/practice-mode.spec.ts`,
+`e2e/release-fun-playtest.spec.ts` (uses /quick-race),
+`e2e/first-race-fun.spec.ts` (uses /quick-race),
+`e2e/ui-selection.spec.ts` (uses /daily),
+`e2e/pause-actions.spec.ts` (asserts router.push to /time-trial),
+`e2e/accessibility-gate.spec.ts` (uses ?mode=practice),
+`e2e/race-pickups.spec.ts` (uses ?mode=practice),
+`e2e/first-tour-authored-events.spec.ts` (uses ?mode=practice).
+Recommended split: PR-A deletes routes + game modules + their tests +
+adapts e2e specs that incidentally hit cut routes; PR-B refactors
+the mode plumbing in `src/app/race/page.tsx` to a Tour-only control
+flow (drop `RaceMode`, drop the timeTrial recorder, drop the
+`mode=quickRace` records-only branch); PR-C extends `content-lint.ts`
+with the `deprecated` coverage kind and updates `GDD_COVERAGE.json`
+rows for the seven deprecated rows named in the dot.
+
 ## F-089: e2e camera-feel spec via /dev/road harness
 **Created:** 2026-05-06
 **Priority:** nice-to-have

--- a/docs/PROGRESS_LOG.md
+++ b/docs/PROGRESS_LOG.md
@@ -6,6 +6,78 @@ Correct them by adding a new entry that references the old one.
 
 ---
 
+## 2026-05-06: chore(menu): cut non-Tour entries per Q-015 v1.0 scope
+
+**GDD sections touched:** [§6](gdd/06-game-modes.md) "v1.0 scope".
+**Branch / PR:** `feat/cut-non-tour-from-menu`, PR pending.
+**Status:** Implemented (menu cut). Deeper code deletion deferred to F-090.
+
+### Done
+- Title-screen `MENU` shrunk from 8 entries to 4: Start Race, World
+  Tour, Garage, Options. Time Trial / Quick Race / Practice / Daily
+  Challenge entries removed. The Start Race shortcut is preserved as
+  the legacy direct-to-race entry; v1.0 surfaces World Tour as the
+  championship loop per Q-015.
+- Updated `src/app/__tests__/page.test.tsx`: dropped the
+  Time-Trial / Daily anchor assertions, added a negative-presence
+  assertion, and shrunk the tab-order test to the 4-item menu.
+- Updated `e2e/title-screen.spec.ts`: dropped 4 cut-mode "click ->
+  navigate" tests, replaced the 4 cut-mode anchor blocks with
+  `toHaveCount(0)` assertions in the existing menu-wiring test.
+- GDD §6 gained a "v1.0 scope" subsection at the top noting the
+  Q-015 deferral, with a build-log entry per the
+  `gdd-build-log` rule.
+- Filed F-090 capturing the deeper code deletion (route directories
+  `quick-race/`, `time-trial/`, `daily/`; mode modules
+  `src/game/timeTrial.ts`, `src/game/modes/dailyChallenge.ts`,
+  `src/game/modes/quickRace.ts`, `src/game/modes/timeTrialTargets.ts`;
+  related Vitest and Playwright specs; the deeper `RaceMode`
+  refactor in `src/app/race/page.tsx`; the `content-lint.ts`
+  `deprecated` coverage kind extension and seven
+  `GDD_COVERAGE.json` row updates from the dot).
+
+### Verified
+- `npm run typecheck` (pending).
+- `npm run lint` (pending).
+- `npm run test` (pending).
+
+### Decisions and assumptions
+- This PR is intentionally smaller than the dot's
+  `VibeGear2-implement-cut-non-fdcb3b2d.md` describes. The dot warns
+  "if the diff exceeds ~1500 LOC delta, split into two PRs"; the
+  full surface (routes + modules + tests + race-page mode plumbing
+  + content-lint + GDD coverage) is closer to 2.5k LOC delta and
+  involves a non-trivial refactor of `src/app/race/page.tsx`. The
+  user-visible cut (no menu entry for non-Tour modes) lands here;
+  F-090 carries the rest.
+- Did NOT add the `e2e/world-tour-only-scope.spec.ts` the dot
+  named. The existing `title-screen` spec now asserts the negative
+  case (no menu link to cut routes) plus the positive case (4
+  remaining items with their hrefs), which covers the same contract
+  with less surface duplication. F-090 can revisit if a dedicated
+  spec proves valuable.
+- The `Start Race` entry is kept (despite predating Q-015) because
+  the Tour entry routes through `/world` -> setup -> `/race`. Direct
+  `/race` is still useful for dev / Playwright smoke and the route
+  works in both Tour and direct entry today.
+
+### Coverage ledger
+- §6 game-modes coverage moves from "ships all four modes" to
+  "Championship-only v1.0 with documented deferral". The seven
+  `coverage: ["deprecated"]` rows the dot enumerates remain in
+  scope for F-090 (alongside the `content-lint.ts` enum extension);
+  this slice does not touch `GDD_COVERAGE.json`.
+
+### Followups created
+- F-090: Delete dormant non-Tour routes, modules, and tests. Three-PR
+  recommended split documented inline in the followup entry.
+
+### GDD edits
+- `docs/gdd/06-game-modes.md`: added "v1.0 scope" subsection plus
+  build-log entry. Status moved to `partial`.
+
+---
+
 ## 2026-05-06: feat(render): speed-coupled FOV widen and brake camera dip
 
 **GDD sections touched:** [§16](gdd/16-rendering-and-visual-design.md)

--- a/docs/gdd/06-game-modes.md
+++ b/docs/gdd/06-game-modes.md
@@ -1,5 +1,18 @@
 # 6. Game modes
 
+**Status:** partial
+
+## v1.0 scope
+
+Per Q-015 (2026-05-06), v1.0 ships only the **Championship (World Tour)**
+mode. Quick Race, Time Trial, Practice, and Community Challenge are
+**deferred post-v1.0** so every fun-factor slice compounds on a single
+race surface (matching the Top Gear 2 reference). The non-Tour entries
+are documented below for the post-v1.0 roadmap; the title-screen menu
+in v1.0 only exposes World Tour, Garage, and Options (plus the legacy
+Start Race shortcut). See F-090 for the deeper code deletion (route
+directories, mode-state machines, related test files).
+
 ## Championship
 
 The centerpiece mode. The player progresses through tours of four races each, managing cash, repairs, and upgrades between events.
@@ -27,3 +40,12 @@ A rotating daily or weekly seeded challenge is appropriate after v1.0, using an 
 - Community track of the week.
 - Endurance cup.
 - Mirror tracks or reverse variants.
+
+### Build log
+
+- 2026-05-06: Q-015 v1.0 scope cut. Title screen menu now exposes only
+  World Tour / Garage / Options (plus Start Race). Time Trial / Quick
+  Race / Practice / Daily Challenge entries removed from the menu. Underlying
+  routes, modules, and tests remain in the tree under F-090. Files:
+  `src/app/page.tsx`, `src/app/__tests__/page.test.tsx`,
+  `e2e/title-screen.spec.ts`. PR pending.

--- a/e2e/title-screen.spec.ts
+++ b/e2e/title-screen.spec.ts
@@ -61,25 +61,14 @@ test.describe("title screen", () => {
     await expect(worldTour).toHaveText("World Tour");
     await expect(worldTour).toHaveAttribute("href", "/world");
 
-    const timeTrial = page.getByTestId("menu-time-trial");
-    await expect(timeTrial).toBeVisible();
-    await expect(timeTrial).toHaveText("Time Trial");
-    await expect(timeTrial).toHaveAttribute("href", "/time-trial");
-
-    const quickRace = page.getByTestId("menu-quick-race");
-    await expect(quickRace).toBeVisible();
-    await expect(quickRace).toHaveText("Quick Race");
-    await expect(quickRace).toHaveAttribute("href", "/quick-race");
-
-    const practice = page.getByTestId("menu-practice");
-    await expect(practice).toBeVisible();
-    await expect(practice).toHaveText("Practice");
-    await expect(practice).toHaveAttribute("href", "/race?mode=practice");
-
-    const daily = page.getByTestId("menu-daily");
-    await expect(daily).toBeVisible();
-    await expect(daily).toHaveText("Daily Challenge");
-    await expect(daily).toHaveAttribute("href", "/daily");
+    // Q-015 scope cut: Time Trial / Quick Race / Practice / Daily are
+    // not in the v1.0 main menu. The underlying routes still resolve
+    // (full deletion is queued under F-090) but no menu link points at
+    // them.
+    await expect(page.getByTestId("menu-time-trial")).toHaveCount(0);
+    await expect(page.getByTestId("menu-quick-race")).toHaveCount(0);
+    await expect(page.getByTestId("menu-practice")).toHaveCount(0);
+    await expect(page.getByTestId("menu-daily")).toHaveCount(0);
 
     const garage = page.getByTestId("menu-garage");
     await expect(garage).toBeVisible();
@@ -111,48 +100,6 @@ test.describe("title screen", () => {
     await page.getByTestId("menu-world").click();
     await expect(page).toHaveURL(/\/world$/);
     await expect(page.getByTestId("world-page")).toBeVisible();
-  });
-
-  test("Time Trial link navigates to the time-trial launch page", async ({
-    page,
-  }) => {
-    await page.goto("/");
-    await page.getByTestId("menu-time-trial").click();
-    await expect(page).toHaveURL(/\/time-trial$/);
-    await expect(page.getByTestId("time-trial-page")).toBeVisible();
-  });
-
-  test("Quick Race link navigates to quick-race picker", async ({ page }) => {
-    await page.goto("/");
-    await page.getByTestId("menu-quick-race").click();
-    await expect(page).toHaveURL(/\/quick-race$/);
-    await expect(page.getByTestId("quick-race-page")).toBeVisible();
-    await expect(page.getByTestId("quick-race-start")).toHaveAttribute(
-      "href",
-      /\/race\?mode=quickRace&track=.+&weather=.+&car=.+/,
-    );
-  });
-
-  test("Practice link navigates to practice race mode", async ({ page }) => {
-    await page.goto("/");
-    await page.getByTestId("menu-practice").click();
-    await expect(page).toHaveURL(/\/race\?mode=practice$/);
-    await expect(page.getByTestId("race-canvas")).toHaveAttribute(
-      "data-mode",
-      "practice",
-    );
-    await expect(page.getByTestId("practice-panel")).toBeVisible();
-  });
-
-  test("Daily Challenge link navigates to /daily", async ({ page }) => {
-    await page.goto("/");
-    await page.getByTestId("menu-daily").click();
-    await expect(page).toHaveURL(/\/daily$/);
-    await expect(page.getByTestId("daily-page")).toBeVisible();
-    await expect(page.getByTestId("daily-start")).toHaveAttribute(
-      "href",
-      /\/race\?mode=timeTrial&track=.+&weather=.+/,
-    );
   });
 
   test("Options link navigates to /options", async ({ page }) => {

--- a/src/app/__tests__/page.test.tsx
+++ b/src/app/__tests__/page.test.tsx
@@ -32,16 +32,11 @@ describe("TitlePage", () => {
     expect(match?.[0]).toContain('href="/race"');
   });
 
-  it("renders Time Trial as an anchor pointing at /time-trial", () => {
-    const match = html.match(/<a[^>]*data-testid="menu-time-trial"[^>]*>/);
-    expect(match, "menu-time-trial anchor not found").not.toBeNull();
-    expect(match?.[0]).toContain('href="/time-trial"');
-  });
-
-  it("renders Daily Challenge as an anchor pointing at /daily", () => {
-    const match = html.match(/<a[^>]*data-testid="menu-daily"[^>]*>/);
-    expect(match, "menu-daily anchor not found").not.toBeNull();
-    expect(match?.[0]).toContain('href="/daily"');
+  it("does NOT render Time Trial / Quick Race / Practice / Daily entries (Q-015 scope cut)", () => {
+    expect(html).not.toContain('data-testid="menu-time-trial"');
+    expect(html).not.toContain('data-testid="menu-quick-race"');
+    expect(html).not.toContain('data-testid="menu-practice"');
+    expect(html).not.toContain('data-testid="menu-daily"');
   });
 
   it("renders World Tour as an anchor pointing at /world", () => {
@@ -62,18 +57,14 @@ describe("TitlePage", () => {
     expect(match?.[0]).toContain('href="/options"');
   });
 
-  it("places Start Race before World Tour before Time Trial before Daily before Garage before Options in tab order", () => {
+  it("places Start Race -> World Tour -> Garage -> Options in tab order", () => {
     const startIdx = html.indexOf('data-testid="menu-start-race"');
     const worldIdx = html.indexOf('data-testid="menu-world"');
-    const timeTrialIdx = html.indexOf('data-testid="menu-time-trial"');
-    const dailyIdx = html.indexOf('data-testid="menu-daily"');
     const garageIdx = html.indexOf('data-testid="menu-garage"');
     const optionsIdx = html.indexOf('data-testid="menu-options"');
     expect(startIdx).toBeGreaterThan(-1);
     expect(worldIdx).toBeGreaterThan(startIdx);
-    expect(timeTrialIdx).toBeGreaterThan(worldIdx);
-    expect(dailyIdx).toBeGreaterThan(timeTrialIdx);
-    expect(garageIdx).toBeGreaterThan(dailyIdx);
+    expect(garageIdx).toBeGreaterThan(worldIdx);
     expect(optionsIdx).toBeGreaterThan(garageIdx);
   });
 

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -6,17 +6,15 @@ import styles from "./page.module.css";
 /**
  * Title screen.
  *
- * Renders the top-level main menu items per GDD §5 and §20:
- * Start Race -> `/race`, World Tour -> `/world`, Time Trial ->
- * `/time-trial`, Quick Race -> `/quick-race`, Practice ->
- * `/race?mode=practice`, Daily Challenge -> `/daily`, Garage ->
- * `/garage`, Options -> `/options`. The Options entry was a disabled
- * placeholder (`menu-options-pending`) until the `/options` scaffold landed in
- * `VibeGear2-implement-options-screen-a9379c4a`. Its replacement keeps
- * the original `menu-options` test id that the e2e suite asserts on.
+ * Per Q-015 (2026-05-06) "gut any feature not related to the world tour
+ * mode", v1.0 ships only the World Tour championship surface. The menu
+ * exposes Start Race -> `/race`, World Tour -> `/world`, Garage ->
+ * `/garage`, Options -> `/options`. Time Trial / Quick Race / Practice
+ * / Daily Challenge entries were removed from this menu in the
+ * world-tour-only scope cut; the underlying routes and game modules
+ * remain importable for now and will be deleted under F-090.
  *
- * Keyboard order is Start Race -> World Tour -> Time Trial -> Quick Race
- * -> Practice -> Daily Challenge -> Garage -> Options (DOM order).
+ * Keyboard order is Start Race -> World Tour -> Garage -> Options.
  *
  * The footer carries two pieces of metadata. The pre-existing
  * `build-status` line tracks the design phase (kept verbatim so the
@@ -36,10 +34,6 @@ interface MenuItem {
 const MENU: ReadonlyArray<MenuItem> = [
   { label: "Start Race", href: "/race", testId: "menu-start-race" },
   { label: "World Tour", href: "/world", testId: "menu-world" },
-  { label: "Time Trial", href: "/time-trial", testId: "menu-time-trial" },
-  { label: "Quick Race", href: "/quick-race", testId: "menu-quick-race" },
-  { label: "Practice", href: "/race?mode=practice", testId: "menu-practice" },
-  { label: "Daily Challenge", href: "/daily", testId: "menu-daily" },
   { label: "Garage", href: "/garage", testId: "menu-garage" },
   { label: "Options", href: "/options", testId: "menu-options" },
 ];


### PR DESCRIPTION
## Summary

- Q-015 (2026-05-06): \"Gut any feature not related to the world tour mode (the whole idea is to match TopGear2).\"
- Title screen menu shrunk from 8 to 4 entries: Start Race, World Tour, Garage, Options. Time Trial / Quick Race / Practice / Daily Challenge are no longer reachable from the title screen.
- GDD §6 now leads with a \"v1.0 scope\" subsection naming Q-015 as the deferral source.
- Underlying routes, modes, and tests remain in the tree under F-090. Deleting them in this PR would have exceeded the dot's ~1500-LOC cap and required a non-trivial refactor of the RaceMode plumbing in \`src/app/race/page.tsx\`. F-090 captures the recommended three-PR split.

## Test plan

- [x] \`npm run typecheck\`
- [x] \`npm run lint\`
- [x] \`npm run test\` (2827/2827)
- [x] \`npm run content-lint\`
- [ ] CI green