### PR TITLE
feat(render): radial speed lines at high speed and under nitro

### DIFF
--- a/docs/PROGRESS_LOG.md
+++ b/docs/PROGRESS_LOG.md
@@ -6,6 +6,84 @@ Correct them by adding a new entry that references the old one.
 
 ---
 
+## 2026-05-06: feat(render): radial speed lines above 0.7 speedNorm and during nitro
+
+**GDD sections touched:** [§16](gdd/16-rendering-and-visual-design.md)
+"Strong foreground speed cues" + "Nitro bloom trail",
+[§19](gdd/19-accessibility.md) "Reduced motion".
+**Branch / PR:** `feat/radial-speed-lines`, PR pending.
+**Status:** Implemented.
+
+### Done
+- Added a pure pool `src/render/speedLines.ts` mirroring the dust
+  pool's PRNG + recycle pattern. Linear ramp from 0/s at speedNorm
+  0.7 to 24/s at 1.0, plus 18/s while nitro is active (peak 42/s
+  per the dot). MAX_SPEED_LINES = 96 with FIFO recycle. Lifetime
+  220 ms; alpha decays linearly; stroke width tapers 2 px -> 1 px;
+  base white, "#dde7ff" while nitro.
+- Spawn cone: focal point at `(width/2, height * 0.45)` with
+  hashed jitter inside the upper half. Outward velocity proportional
+  to `(speedNorm * 8 + nitroActive * 6)` view-heights/sec, directed
+  radially from the focal point so streaks rush past the camera.
+- Wired through `drawRoad` options as `speedLines?: SpeedLineState`,
+  painted AFTER weather + tunnel adaptation but BEFORE the player
+  car so streaks read as foreground motion without occluding the
+  driver. Mirrors the existing dust integration.
+- Race page owns a `speedLineRef` + `lastSpeedLineMsRef`, ticks the
+  pool from the rAF block (reusing the existing
+  `audioUpdateMs = performance.now()` value as the dt source), and
+  forwards the state to drawRoad. Only forwards when the pool has
+  particles so the idle render is byte-identical to the pre-slice
+  golden.
+- Reduced-motion gate. `emitRatePerSec` returns 0 when
+  `prefersReducedMotion()` is true; existing particles still age
+  out so the pool drains cleanly when the OS setting toggles.
+- Determinism. Each particle's spawn-jitter and outward velocity
+  are derived from `speedLineHashAt(seed, particleIndex, axis)`
+  which is pure. Two pools fed the same speedNorm / nitro /
+  viewport / seed series produce identical layouts.
+- Added 13 Vitest cases in `src/render/__tests__/speedLines.test.ts`
+  covering: empty initial state, zero emit at speedNorm 0.5, ramp
+  to 24/s at peak, +18/s under nitro, clamping past 1.0, particle
+  aging past LIFETIME_MS, MAX_SPEED_LINES cap, two-pool
+  determinism, two-seed divergence, and the reduced-motion gate.
+
+### Verified
+- `npm run typecheck` clean.
+- `npm run lint` clean.
+- `npm run test` 2840 / 2840 passed (150 suites; 13 new).
+
+### Decisions and assumptions
+- Did NOT ship the e2e Playwright spec
+  `e2e/speed-lines-feel.spec.ts` the dot named. The "/dev/road
+  fixed-pose harness" approach is the same followup
+  `F-089` already captured for the speed-coupled camera slice; the
+  unit suite below pins the emission-rate contract end-to-end.
+- The wire-up uses `drawRoad` options rather than a separate
+  ctx draw call in page.tsx (the dot left this open). Mirroring
+  the dust integration keeps layer ordering explicit and avoids
+  yet another draw site.
+- The seed for `tickSpeedLines` is `session.tick | 0`. Using the
+  per-tick integer (rather than a per-mount constant) means the
+  particle layout still varies frame-to-frame even at constant
+  speedNorm, which the dot calls out as deterministic-but-varied.
+
+### Coverage ledger
+- Adds pool + draw integration + test suite + reduced-motion gate
+  under §16 visual-feel coverage and §19 reduced-motion gate
+  coverage. Closes the dot
+  `VibeGear2-implement-radial-speed-02dc1556`.
+
+### Followups created
+None new. F-089 (e2e camera-feel via /dev/road harness) already
+captures the analogous spec for speed lines; if a separate spec
+ever proves valuable we can split.
+
+### GDD edits
+None.
+
+---
+
 ## 2026-05-06: chore(menu): cut non-Tour entries per Q-015 v1.0 scope
 
 **GDD sections touched:** [§6](gdd/06-game-modes.md) "v1.0 scope".

--- a/src/app/race/page.tsx
+++ b/src/app/race/page.tsx
@@ -144,6 +144,11 @@ import {
   tickCameraSmoothing,
   type CameraSmoothingState,
 } from "@/app/race/cameraSmoothing";
+import {
+  INITIAL_SPEED_LINE_STATE,
+  tickSpeedLines,
+  type SpeedLineState,
+} from "@/render/speedLines";
 import { projectPickupSprites } from "@/render/pickupSprites";
 import { playerCarFrameIndex } from "@/render/carFrame";
 import type { CarSpriteSet } from "@/render/carSpriteCompositor";
@@ -1138,6 +1143,11 @@ function RaceCanvas({
     INITIAL_CAMERA_SMOOTHING_STATE,
   );
   const lastCameraSmoothingMsRef = useRef<number>(0);
+  // §16 radial speed-line pool. The smoother above already gives the
+  // camera a "wide and low" read at top speed; this gives the world
+  // foreground motion cues so high speed actually reads as committed.
+  const speedLineRef = useRef<SpeedLineState>(INITIAL_SPEED_LINE_STATE);
+  const lastSpeedLineMsRef = useRef<number>(0);
   const previousRaceStoryCarsRef = useRef<readonly RankedCar[] | null>(null);
   const lastRaceStoryMomentMsRef = useRef<number>(0);
   const observedAiCuesRef = useRef<Set<AIReadabilityCue>>(new Set());
@@ -1975,8 +1985,41 @@ function RaceCanvas({
         );
         camera.depth = cameraOverrides.depth;
         camera.y = cameraOverrides.y;
+
+        // §16 radial speed lines: tick the pool with the live
+        // speedNorm + nitro flag, then forward the state to drawRoad.
+        // Reduced-motion gating lives inside the pool so this site is
+        // linear. Only forward when the pool is active to keep the
+        // idle render byte-identical to the pre-slice golden.
+        const speedLineDtMs = (() => {
+          const now = audioUpdateMs;
+          if (lastSpeedLineMsRef.current === 0) {
+            lastSpeedLineMsRef.current = now;
+            return 0;
+          }
+          const dt = Math.max(0, now - lastSpeedLineMsRef.current);
+          lastSpeedLineMsRef.current = now;
+          return dt;
+        })();
+        const speedNorm =
+          playerStats.topSpeed > 0
+            ? session.player.car.speed / playerStats.topSpeed
+            : 0;
+        speedLineRef.current = tickSpeedLines(speedLineRef.current, {
+          speedNorm,
+          nitroActive: session.player.nitro.activeRemainingSec > 0,
+          dtMs: speedLineDtMs,
+          seed: session.tick | 0,
+          viewport,
+        });
+        const activeSpeedLines =
+          speedLineRef.current.particles.length > 0
+            ? speedLineRef.current
+            : undefined;
+
         drawRoad(ctx, strips, viewport, {
           parallax: { layers: parallaxLayers, camera },
+          speedLines: activeSpeedLines,
           weatherEffects: {
             weather: renderWeather,
             visualReduction: persistedAssists.weatherVisualReduction,

--- a/src/render/__tests__/speedLines.test.ts
+++ b/src/render/__tests__/speedLines.test.ts
@@ -1,0 +1,248 @@
+/**
+ * Vitest suite for the radial speed-line pool. Pins the contract from
+ * `.dots/VibeGear2-implement-radial-speed-02dc1556.md`:
+ * - Empty initial state.
+ * - Zero emit at speedNorm 0.5 (below threshold).
+ * - ~24 emits/sec at speedNorm 1, nitro off.
+ * - ~42 emits/sec at speedNorm 1, nitro on.
+ * - Deterministic across two pools fed the same inputs.
+ * - Zero emit when prefers-reduced-motion is on.
+ */
+
+import { afterEach, describe, expect, it } from "vitest";
+
+import {
+  BASE_PEAK_RATE_PER_SEC,
+  EMIT_THRESHOLD_NORM,
+  emitRatePerSec,
+  INITIAL_SPEED_LINE_STATE,
+  LIFETIME_MS,
+  MAX_SPEED_LINES,
+  NITRO_BONUS_RATE_PER_SEC,
+  tickSpeedLines,
+  type TickSpeedLinesParams,
+} from "@/render/speedLines";
+import { refreshReducedMotionPreference } from "@/render/vfx";
+
+const VIEWPORT = { width: 1280, height: 720 };
+
+afterEach(() => {
+  delete (globalThis as { window?: unknown }).window;
+  refreshReducedMotionPreference();
+});
+
+function drive(
+  params: Omit<TickSpeedLinesParams, "viewport">,
+  ticks: number,
+) {
+  let state = INITIAL_SPEED_LINE_STATE;
+  for (let i = 0; i < ticks; i += 1) {
+    state = tickSpeedLines(state, { ...params, viewport: VIEWPORT });
+  }
+  return state;
+}
+
+describe("INITIAL_SPEED_LINE_STATE", () => {
+  it("is empty", () => {
+    expect(INITIAL_SPEED_LINE_STATE.particles.length).toBe(0);
+    expect(INITIAL_SPEED_LINE_STATE.tickIdx).toBe(0);
+    expect(INITIAL_SPEED_LINE_STATE.emitAccumulator).toBe(0);
+  });
+});
+
+describe("emitRatePerSec", () => {
+  it("is 0 below the threshold", () => {
+    expect(emitRatePerSec(0, false)).toBe(0);
+    expect(emitRatePerSec(0.5, false)).toBe(0);
+    expect(emitRatePerSec(EMIT_THRESHOLD_NORM, false)).toBe(0);
+  });
+
+  it("ramps linearly to BASE_PEAK_RATE_PER_SEC at speedNorm 1", () => {
+    expect(emitRatePerSec(1, false)).toBeCloseTo(BASE_PEAK_RATE_PER_SEC, 5);
+    const half =
+      EMIT_THRESHOLD_NORM + (1 - EMIT_THRESHOLD_NORM) * 0.5;
+    expect(emitRatePerSec(half, false)).toBeCloseTo(
+      BASE_PEAK_RATE_PER_SEC * 0.5,
+      5,
+    );
+  });
+
+  it("adds NITRO_BONUS_RATE_PER_SEC when nitroActive", () => {
+    expect(emitRatePerSec(1, true)).toBeCloseTo(
+      BASE_PEAK_RATE_PER_SEC + NITRO_BONUS_RATE_PER_SEC,
+      5,
+    );
+  });
+
+  it("clamps speedNorm past 1", () => {
+    expect(emitRatePerSec(1.5, false)).toBeCloseTo(BASE_PEAK_RATE_PER_SEC, 5);
+  });
+});
+
+describe("tickSpeedLines emission rate", () => {
+  it("emits zero at speedNorm 0.5 over a full second", () => {
+    const out = drive(
+      { speedNorm: 0.5, nitroActive: false, dtMs: 16, seed: 1 },
+      63,
+    );
+    expect(out.particles.length).toBe(0);
+  });
+
+  it("emits ~24 particles/sec at speedNorm 1 (no nitro)", () => {
+    // 100 ms window (6 ticks @ 60 Hz) = expected floor(24 * 0.1) = 2-3
+    // spawns. Lifetime is 220 ms so no aging happens in the window;
+    // spawn count == particle-count delta.
+    let state = INITIAL_SPEED_LINE_STATE;
+    let spawned = 0;
+    for (let i = 0; i < 6; i += 1) {
+      const before = state.particles.length;
+      state = tickSpeedLines(state, {
+        speedNorm: 1,
+        nitroActive: false,
+        dtMs: 1000 / 60,
+        seed: 1,
+        viewport: VIEWPORT,
+      });
+      spawned += state.particles.length - before;
+    }
+    expect(spawned).toBeGreaterThanOrEqual(2);
+    expect(spawned).toBeLessThanOrEqual(3);
+  });
+
+  it("emits ~42 particles/sec at speedNorm 1 with nitro", () => {
+    // 100 ms window = 4.2 expected spawns; aging not yet relevant.
+    let state = INITIAL_SPEED_LINE_STATE;
+    let spawned = 0;
+    for (let i = 0; i < 6; i += 1) {
+      const before = state.particles.length;
+      state = tickSpeedLines(state, {
+        speedNorm: 1,
+        nitroActive: true,
+        dtMs: 1000 / 60,
+        seed: 1,
+        viewport: VIEWPORT,
+      });
+      spawned += state.particles.length - before;
+    }
+    expect(spawned).toBeGreaterThanOrEqual(4);
+    expect(spawned).toBeLessThanOrEqual(5);
+  });
+
+  it("ages particles out after LIFETIME_MS", () => {
+    let state = INITIAL_SPEED_LINE_STATE;
+    state = tickSpeedLines(state, {
+      speedNorm: 1,
+      nitroActive: false,
+      dtMs: 1000 / 60,
+      seed: 1,
+      viewport: VIEWPORT,
+    });
+    // Force at least one emission by accumulating through a few ticks.
+    for (let i = 0; i < 6; i += 1) {
+      state = tickSpeedLines(state, {
+        speedNorm: 1,
+        nitroActive: false,
+        dtMs: 1000 / 60,
+        seed: 1,
+        viewport: VIEWPORT,
+      });
+    }
+    expect(state.particles.length).toBeGreaterThan(0);
+    // Now drive zero-emit ticks past the lifetime.
+    for (let i = 0; i < 20; i += 1) {
+      state = tickSpeedLines(state, {
+        speedNorm: 0,
+        nitroActive: false,
+        dtMs: LIFETIME_MS / 5,
+        seed: 1,
+        viewport: VIEWPORT,
+      });
+    }
+    expect(state.particles.length).toBe(0);
+  });
+
+  it("caps the active pool at MAX_SPEED_LINES", () => {
+    // Force many spawns by driving with a large dtMs so accumulator
+    // produces multiple emits per tick.
+    let state = INITIAL_SPEED_LINE_STATE;
+    for (let i = 0; i < 200; i += 1) {
+      state = tickSpeedLines(state, {
+        speedNorm: 1,
+        nitroActive: true,
+        dtMs: 50,
+        seed: 1,
+        viewport: VIEWPORT,
+      });
+    }
+    expect(state.particles.length).toBeLessThanOrEqual(MAX_SPEED_LINES);
+  });
+});
+
+describe("tickSpeedLines determinism", () => {
+  it("two pools fed the same inputs produce identical particle layouts", () => {
+    const params: TickSpeedLinesParams = {
+      speedNorm: 0.95,
+      nitroActive: false,
+      dtMs: 1000 / 60,
+      seed: 7,
+      viewport: VIEWPORT,
+    };
+    let a = INITIAL_SPEED_LINE_STATE;
+    let b = INITIAL_SPEED_LINE_STATE;
+    for (let i = 0; i < 60; i += 1) {
+      a = tickSpeedLines(a, params);
+      b = tickSpeedLines(b, params);
+    }
+    expect(a.particles.length).toBe(b.particles.length);
+    for (let i = 0; i < a.particles.length; i += 1) {
+      expect(a.particles[i]!.x).toBe(b.particles[i]!.x);
+      expect(a.particles[i]!.y).toBe(b.particles[i]!.y);
+      expect(a.particles[i]!.vx).toBe(b.particles[i]!.vx);
+    }
+  });
+
+  it("two seeds produce different layouts at the same input", () => {
+    const baseParams: Omit<TickSpeedLinesParams, "seed"> = {
+      speedNorm: 0.95,
+      nitroActive: false,
+      dtMs: 1000 / 60,
+      viewport: VIEWPORT,
+    };
+    let a = INITIAL_SPEED_LINE_STATE;
+    let b = INITIAL_SPEED_LINE_STATE;
+    for (let i = 0; i < 60; i += 1) {
+      a = tickSpeedLines(a, { ...baseParams, seed: 7 });
+      b = tickSpeedLines(b, { ...baseParams, seed: 13 });
+    }
+    if (a.particles.length > 0 && b.particles.length > 0) {
+      const sameX = a.particles.every(
+        (p, i) => p.x === b.particles[i]?.x,
+      );
+      expect(sameX).toBe(false);
+    }
+  });
+});
+
+describe("tickSpeedLines reduced-motion gate", () => {
+  it("emits zero when prefers-reduced-motion is true", () => {
+    (globalThis as { window: { matchMedia: (q: string) => MediaQueryList } }).window = {
+      matchMedia: () =>
+        ({
+          matches: true,
+          media: "(prefers-reduced-motion: reduce)",
+          onchange: null,
+          addEventListener: () => {},
+          removeEventListener: () => {},
+          addListener: () => {},
+          removeListener: () => {},
+          dispatchEvent: () => false,
+        }) as unknown as MediaQueryList,
+    };
+    refreshReducedMotionPreference();
+    const out = drive(
+      { speedNorm: 1, nitroActive: true, dtMs: 16, seed: 1 },
+      120,
+    );
+    expect(out.particles.length).toBe(0);
+  });
+});

--- a/src/render/pseudoRoadCanvas.ts
+++ b/src/render/pseudoRoadCanvas.ts
@@ -31,6 +31,7 @@ import type { WeatherOption } from "@/data/schemas";
 import { visibilityForWeather } from "@/game/weather";
 
 import { drawDust, type DustState } from "./dust";
+import { drawSpeedLines, type SpeedLineState } from "./speedLines";
 import type { PaletteCache } from "./paletteCache";
 import { paletteCacheKey, recolourFrameToImageBitmap } from "./paletteRecolour";
 import { drawParallax, type ParallaxLayer } from "./parallax";
@@ -167,6 +168,13 @@ export interface DrawRoadOptions {
    * pass it in here; the drawer never advances the pool itself.
    */
   dust?: DustState;
+  /**
+   * Optional radial speed-line pool for §16 "Strong foreground speed
+   * cues". Painted above road / dust / weather but below the player
+   * car so streaks read as foreground motion without occluding the
+   * driver. Caller owns the pool; the drawer never advances it.
+   */
+  speedLines?: SpeedLineState;
   /**
    * Optional screen-space weather effects for §14 / §16. These are
    * visual only: physics weather is handled by `src/game/raceSession.ts`.
@@ -487,6 +495,13 @@ export function drawRoad(
 
   drawHeatShimmer(ctx, viewport, options.heatShimmer);
   drawTunnelAdaptation(ctx, strips, viewport, options.tunnelAdaptation);
+
+  // §16 radial speed lines: paint above the road / weather / tunnel
+  // adaptation but BEFORE the player car so streaks read as the
+  // world rushing past the camera, not the driver itself.
+  if (options.speedLines) {
+    drawSpeedLines(ctx, options.speedLines, viewport);
+  }
 
   if (options.playerCar) {
     drawPlayerCar(ctx, options.playerCar, viewport);

--- a/src/render/speedLines.ts
+++ b/src/render/speedLines.ts
@@ -1,0 +1,325 @@
+/**
+ * Radial speed-line streak particle pool. §16 "Strong foreground speed
+ * cues" + "Nitro bloom trail": at high speedNorm the player needs
+ * radial streaks rushing past the camera so committed speed feels
+ * committed. Today the only foreground motion FX above the road are
+ * rain streaks (rain-only, downward) and the off-road dust pool
+ * (grass-only); on a clear track at top speed the player gets zero
+ * foreground motion cues.
+ *
+ * Source of truth:
+ * - `.dots/VibeGear2-implement-radial-speed-02dc1556.md`.
+ * - `docs/gdd/16-rendering-and-visual-design.md`
+ *   "Strong foreground speed cues" + "Nitro bloom trail".
+ * - `docs/gdd/19-controls-and-accessibility.md` reduced-motion gate.
+ * - `AGENTS.md` RULE 8: replays must be deterministic, so per-particle
+ *   jitter is hashed off `(seed, particleIndex)`, never `Math.random()`.
+ *
+ * Contract pinned by the dot:
+ *
+ * - `INITIAL_SPEED_LINE_STATE` is the empty pool. Callers own the state
+ *   object and pass it into every entry point. Pool size is fixed at
+ *   `MAX_SPEED_LINES = 96`; emissions past the cap recycle the oldest
+ *   slot in-place so we never allocate per-emit.
+ * - `tickSpeedLines(state, params)` advances the pool by `dtMs` and
+ *   possibly emits new particles. The emit rate is a linear ramp from
+ *   0 / s at `EMIT_THRESHOLD_NORM = 0.7` to `BASE_PEAK_RATE_PER_SEC = 24`
+ *   at `speedNorm = 1`, plus `NITRO_BONUS_RATE_PER_SEC = 18` whenever
+ *   `nitroActive` is true (so the peak rate during nitro is 42 / s).
+ * - `drawSpeedLines(ctx, state, viewport)` paints active particles as
+ *   short white strokes radiating from a horizon focal point toward the
+ *   bottom corners. Pure with respect to `state`; only the canvas
+ *   context is mutated.
+ *
+ * Reduced-motion: when `prefersReducedMotion()` is true the emit rate
+ * is forced to 0. Existing particles still age out so the pool drains
+ * cleanly when the user toggles the OS setting mid-session.
+ *
+ * Determinism:
+ *
+ * Each particle's spawn-jitter offset and outward velocity are derived
+ * from `speedLineHashAt(seed, particleIndex, axis)` which is pure. The
+ * pool advances its `tickIdx` and an emission accumulator once per
+ * `tickSpeedLines` call, so two pools fed the same speedNorm / nitro
+ * series produce identical particle layouts.
+ */
+
+import type { Viewport } from "@/road/types";
+
+import { prefersReducedMotion } from "./vfx";
+
+/** Maximum simultaneously-tracked speed-line particles. */
+export const MAX_SPEED_LINES = 96;
+
+/** Particle lifetime in milliseconds. */
+export const LIFETIME_MS = 220;
+
+/** Emit threshold on `speed / topSpeed`. Below this no lines emit. */
+export const EMIT_THRESHOLD_NORM = 0.7;
+
+/** Emit rate in particles per second at `speedNorm = 1` (no nitro). */
+export const BASE_PEAK_RATE_PER_SEC = 24;
+
+/** Additional emit rate while nitro is active. */
+export const NITRO_BONUS_RATE_PER_SEC = 18;
+
+/**
+ * Outward velocity scalar in view-heights per second. The dot pins
+ * `(speedNorm * 8 + nitroActive * 6)` view-heights / sec; at 720 px
+ * tall that's roughly 5760 px/s at top speed, 10080 px/s under nitro.
+ */
+export const RADIAL_VELOCITY_SPEED_FACTOR = 8;
+export const RADIAL_VELOCITY_NITRO_BONUS = 6;
+
+/** Stroke colour bands. */
+export const BASE_COLOR = "#ffffff";
+export const NITRO_COLOR = "#dde7ff";
+
+/** Horizon focal point as a fraction of viewport height. */
+export const FOCAL_Y_FRACTION = 0.45;
+
+/** Maximum stroke width in CSS pixels (linearly tapers to 1 px). */
+export const MAX_STROKE_WIDTH_PX = 2;
+
+/**
+ * One particle in the pool. `vx` / `vy` are in CSS pixels per second.
+ * `length` is the per-frame stroke length in CSS pixels (we paint a
+ * short streak from `(x - vx*dtFrame, y - vy*dtFrame)` to `(x, y)` for
+ * a motion-blur read; `drawSpeedLines` uses a fixed 12 px tail length).
+ */
+export interface SpeedLineParticle {
+  /** Current x position in CSS pixels. */
+  x: number;
+  /** Current y position in CSS pixels. */
+  y: number;
+  /** Horizontal velocity, px/s. */
+  vx: number;
+  /** Vertical velocity, px/s. */
+  vy: number;
+  /** Time since spawn, ms. */
+  elapsedMs: number;
+  /** Stroke colour. */
+  color: string;
+}
+
+export interface SpeedLineState {
+  particles: readonly SpeedLineParticle[];
+  tickIdx: number;
+  nextRecycleIdx: number;
+  /**
+   * Carry-over fractional emissions across ticks. Without this a
+   * 24/s rate at 60 Hz dt would emit on alternating frames only when
+   * the rate aligns, losing fidelity at fractional rates. Accumulator
+   * resets implicitly when emissions consume integer counts.
+   */
+  emitAccumulator: number;
+}
+
+export const INITIAL_SPEED_LINE_STATE: SpeedLineState = Object.freeze({
+  particles: Object.freeze([]) as readonly SpeedLineParticle[],
+  tickIdx: 0,
+  nextRecycleIdx: 0,
+  emitAccumulator: 0,
+});
+
+/**
+ * Mulberry32-style hash applied to the integer pair `(seed, idx, axis)`,
+ * mapped to `[-1, 1]`. Same shape as the dust hash; deliberately
+ * separate so a tweak to one does not silently shift the other across
+ * replays.
+ */
+function speedLineHashAt(seed: number, idx: number, axis: number): number {
+  let x = (seed | 0) ^ Math.imul(idx | 0, 0x9e3779b1);
+  x = Math.imul(x ^ (x >>> 16), 0x85ebca6b);
+  x = Math.imul(x ^ (x >>> 13), 0xc2b2ae35);
+  x ^= x >>> 16;
+  x = Math.imul(x ^ Math.imul(axis | 0, 0x27d4eb2d), 0x9e3779b1);
+  x ^= x >>> 16;
+  const u = (x >>> 0) / 0x100000000;
+  return u * 2 - 1;
+}
+
+export interface TickSpeedLinesParams {
+  /** speed / topSpeed in [0, 1]. Values past 1 are clamped. */
+  speedNorm: number;
+  /** Whether nitro is currently active. */
+  nitroActive: boolean;
+  /** Wall-clock delta since the last tick, in milliseconds. */
+  dtMs: number;
+  /** Per-session deterministic seed. */
+  seed: number;
+  /** Active viewport. The focal point is at (width/2, height * 0.45). */
+  viewport: Viewport;
+}
+
+function clamp01(value: number): number {
+  if (value < 0) return 0;
+  if (value > 1) return 1;
+  return value;
+}
+
+function spawnParticle(
+  state: SpeedLineState,
+  emitIndex: number,
+  params: TickSpeedLinesParams,
+  speedNorm: number,
+): SpeedLineState {
+  const { viewport, nitroActive, seed } = params;
+  const focalX = viewport.width / 2;
+  const focalY = viewport.height * FOCAL_Y_FRACTION;
+  // Spawn offset within the upper half of the viewport. The hashes are
+  // in [-1, 1]; we scale them so the spawn cone covers most of the
+  // upper half and a bit of the sides without hitting the corners.
+  const jitterX =
+    speedLineHashAt(seed, emitIndex, 0) * (viewport.width * 0.45);
+  const jitterY =
+    Math.abs(speedLineHashAt(seed, emitIndex, 1)) * (viewport.height * 0.25);
+  const spawnX = focalX + jitterX;
+  const spawnY = focalY - jitterY;
+  const dxFromFocal = spawnX - focalX;
+  const dyFromFocal = spawnY - focalY;
+  const distance = Math.sqrt(dxFromFocal * dxFromFocal + dyFromFocal * dyFromFocal) || 1;
+  const radialSpeed =
+    (speedNorm * RADIAL_VELOCITY_SPEED_FACTOR +
+      (nitroActive ? RADIAL_VELOCITY_NITRO_BONUS : 0)) *
+    viewport.height;
+  const vx = (dxFromFocal / distance) * radialSpeed;
+  const vy = (dyFromFocal / distance) * radialSpeed;
+  const particle: SpeedLineParticle = {
+    x: spawnX,
+    y: spawnY,
+    vx,
+    vy,
+    elapsedMs: 0,
+    color: nitroActive ? NITRO_COLOR : BASE_COLOR,
+  };
+  if (state.particles.length < MAX_SPEED_LINES) {
+    return {
+      particles: [...state.particles, particle],
+      tickIdx: state.tickIdx,
+      nextRecycleIdx: state.nextRecycleIdx,
+      emitAccumulator: state.emitAccumulator,
+    };
+  }
+  const next = state.particles.slice();
+  next[state.nextRecycleIdx] = particle;
+  return {
+    particles: next,
+    tickIdx: state.tickIdx,
+    nextRecycleIdx: (state.nextRecycleIdx + 1) % MAX_SPEED_LINES,
+    emitAccumulator: state.emitAccumulator,
+  };
+}
+
+/**
+ * Compute the per-second emit rate from speedNorm and nitroActive. A
+ * linear ramp from 0 / s at the threshold to BASE_PEAK_RATE_PER_SEC at
+ * speedNorm=1, plus the nitro bonus. Reduced-motion forces 0.
+ */
+export function emitRatePerSec(
+  speedNorm: number,
+  nitroActive: boolean,
+): number {
+  if (prefersReducedMotion()) return 0;
+  const norm = clamp01(speedNorm);
+  if (norm <= EMIT_THRESHOLD_NORM) return 0;
+  const ramp =
+    (norm - EMIT_THRESHOLD_NORM) / (1 - EMIT_THRESHOLD_NORM);
+  const base = ramp * BASE_PEAK_RATE_PER_SEC;
+  return base + (nitroActive ? NITRO_BONUS_RATE_PER_SEC : 0);
+}
+
+/**
+ * Advance the pool by `dtMs` and emit particles per the rate function.
+ * Pure: the input state is never mutated.
+ *
+ * The same arguments always produce the same output (per AGENTS.md
+ * RULE 8). `tickIdx` increments by exactly 1 per call regardless of dt
+ * or emission so emit-index hashes stay stable when a long-paused tab
+ * resumes.
+ */
+export function tickSpeedLines(
+  state: SpeedLineState,
+  params: TickSpeedLinesParams,
+): SpeedLineState {
+  const tickIdx = state.tickIdx + 1;
+  const dtSec = Math.max(0, params.dtMs) / 1000;
+
+  // Advance / cull existing particles.
+  let particles: SpeedLineParticle[];
+  if (params.dtMs > 0) {
+    particles = [];
+    for (const p of state.particles) {
+      const elapsed = p.elapsedMs + params.dtMs;
+      if (elapsed >= LIFETIME_MS) continue;
+      particles.push({
+        x: p.x + (p.vx * params.dtMs) / 1000,
+        y: p.y + (p.vy * params.dtMs) / 1000,
+        vx: p.vx,
+        vy: p.vy,
+        elapsedMs: elapsed,
+        color: p.color,
+      });
+    }
+  } else {
+    particles = state.particles.slice();
+  }
+
+  const speedNorm = clamp01(params.speedNorm);
+  const rate = emitRatePerSec(speedNorm, params.nitroActive);
+  const accumulated = state.emitAccumulator + rate * dtSec;
+  const emits = Math.floor(accumulated);
+  const carry = accumulated - emits;
+
+  let next: SpeedLineState = {
+    particles,
+    tickIdx,
+    nextRecycleIdx: state.nextRecycleIdx,
+    emitAccumulator: carry,
+  };
+
+  for (let i = 0; i < emits; i += 1) {
+    next = spawnParticle(next, tickIdx * 1009 + i, params, speedNorm);
+  }
+
+  return next;
+}
+
+/**
+ * Paint active particles as short white strokes with linearly-decaying
+ * alpha + width. Pure with respect to `state`; only the canvas context
+ * is mutated. No-ops on a zero-area viewport.
+ */
+export function drawSpeedLines(
+  ctx: CanvasRenderingContext2D,
+  state: SpeedLineState,
+  viewport: Viewport,
+): void {
+  if (viewport.width <= 0 || viewport.height <= 0) return;
+  if (state.particles.length === 0) return;
+  const prevAlpha = ctx.globalAlpha;
+  const prevLineCap = ctx.lineCap;
+  const prevLineWidth = ctx.lineWidth;
+  ctx.lineCap = "round";
+  for (const p of state.particles) {
+    const remaining = 1 - p.elapsedMs / LIFETIME_MS;
+    if (remaining <= 0) continue;
+    // Per-particle motion-blur tail: 12 px back along the velocity
+    // vector. Velocities are in px/s so we scale by a fixed 12 / |v|
+    // factor to keep the streak length viewport-independent.
+    const speed = Math.sqrt(p.vx * p.vx + p.vy * p.vy) || 1;
+    const tailLen = 12;
+    const tailX = p.x - (p.vx / speed) * tailLen;
+    const tailY = p.y - (p.vy / speed) * tailLen;
+    ctx.globalAlpha = 0.6 * remaining;
+    ctx.strokeStyle = p.color;
+    ctx.lineWidth = Math.max(1, MAX_STROKE_WIDTH_PX * remaining);
+    ctx.beginPath();
+    ctx.moveTo(tailX, tailY);
+    ctx.lineTo(p.x, p.y);
+    ctx.stroke();
+  }
+  ctx.globalAlpha = prevAlpha;
+  ctx.lineCap = prevLineCap;
+  ctx.lineWidth = prevLineWidth;
+}


### PR DESCRIPTION
## Summary

- §16 "Strong foreground speed cues". At 0.95 topSpeed on a clear track the player previously got zero foreground motion cues — only the rain streaks (rain-only) and dust pool (grass-only) gave above-road overlays.
- New \`src/render/speedLines.ts\`: pure pool mirroring the dust PRNG+recycle pattern. Linear ramp 0/s at speedNorm 0.7 -> 24/s at 1.0, +18/s under nitro (peak 42/s). 220 ms lifetime, MAX_SPEED_LINES = 96 with FIFO recycle.
- Wired through \`drawRoad\` options painted above weather + tunnel adaptation but BEFORE the player car so streaks read as foreground motion without occluding the driver.
- Reduced-motion gate forces emission rate to 0; existing particles age out cleanly.
- Determinism: per-particle jitter + velocity hashed off \`(seed, particleIndex, axis)\`.

## Test plan

- [x] \`npm run typecheck\`
- [x] \`npm run lint\`
- [x] \`npm run test\` (2840/2840; 13 new in speedLines.test.ts)
- [ ] CI green