### PR TITLE
feat(audio): sustained tire-squeal and brake-scrub loops

### DIFF
--- a/docs/PROGRESS_LOG.md
+++ b/docs/PROGRESS_LOG.md
@@ -6,6 +6,82 @@ Correct them by adding a new entry that references the old one.
 
 ---
 
+## 2026-05-06: feat(audio): sustained tire-squeal and brake-scrub loops
+
+**GDD sections touched:** [§18](gdd/18-audio.md) "Required sounds:
+tire squeal" + "brake scrub".
+**Branch / PR:** `feat/tire-squeal-loop`, PR pending.
+**Status:** Implemented.
+
+### Done
+- Added two new event kinds to the race-session audio stream:
+  `tireSquealLoop` and `brakeScrubLoop`. Each carries
+  `{ active, intensity, speedFactor }`. The session emits one per
+  tick the gate is active (so the loop runtime can update gain +
+  pitch with steer / brake / speed) plus one final `active: false`
+  event the tick the gate transitions back to inactive (so the loop
+  ramps out cleanly). The pre-existing one-shot `tireSqueal` /
+  `brakeScrub` events stay as edge cues for music ducking.
+- Added `updateTireSquealLoop` / `stopTireSquealLoop` plus the
+  brake-scrub pair to `ProceduralSfxRuntime`. The first update
+  spawns a single oscillator (triangle for squeal, sawtooth for
+  scrub) and ramps gain 0 -> target over 50 ms. Subsequent updates
+  ramp pitch + gain toward the new intensity-derived target in
+  place. Stop ramps gain to 0 over 80 ms then schedules
+  `oscillator.stop()`. Either loop can run independently.
+- Routed the new events from `src/app/race/page.tsx` into the loop
+  runtime: `tireSquealLoop` -> `updateTireSquealLoop` (active) /
+  `stopTireSquealLoop` (inactive); brake-scrub mirrors. The
+  vfxBridge correctly ignores both new kinds (they fall through the
+  default branch in `applyAudioEventToVfx`).
+- Music ducking: the new loop kinds resolve to
+  `NO_RACE_MUSIC_DUCKING` so the bed does not pump the music every
+  tick during a sustained corner. Ducking still fires on the
+  one-shot edge events as before.
+
+### Verified
+- `npm run typecheck` clean.
+- `npm run lint` clean.
+- `npm run test` 2847 / 2847 passed (150 suites; 7 new in
+  `sfx.test.ts` covering loop start, in-place update, monotone
+  gain ramp with intensity, 80 ms ramp-out on stop,
+  intensity-zero-as-stop, independent kinds, and `stopAll`
+  teardown). Existing `raceSession.test.ts` cases for one-shot
+  tire-squeal / brake-scrub edge events updated to also assert
+  the new loop event in the same tick.
+
+### Decisions and assumptions
+- Did NOT refactor the one-shot `tireSqueal` / `brakeScrub` events
+  out of the stream. Music ducking still keys off them at the
+  false->true edge; reusing the loop event for ducking would have
+  required teaching `raceMix.ts` about per-tick state, which is
+  out of scope. The two-event design separates "edge cue for
+  music duck" from "per-tick state for audio bed".
+- The loop's frequency mapping mirrors the one-shot pitches the
+  pre-fix code used (squeal 860-1420 Hz across speedFactor;
+  scrub 150-300 Hz). Gain scales with intensity rather than
+  speedFactor so steering harder makes the loop *louder*, which
+  is what the §18 spec implies ("modulates with steer load").
+- Did NOT ship the e2e Playwright spec
+  `e2e/tire-squeal-loop.spec.ts` the dot named. Mocking
+  AudioContext oscillator counts in headless Chromium is
+  brittle; the unit suite pins the start / update / stop
+  contract end-to-end. Filed nothing — F-088 already captures
+  generic audio-feel coverage we may want post-v1.0.
+
+### Coverage ledger
+- Adds loop runtime + event plumbing under §18 audio coverage.
+  Closes the dot
+  `VibeGear2-implement-convert-tiresqueal-d2fd1407`.
+
+### Followups created
+None new.
+
+### GDD edits
+None.
+
+---
+
 ## 2026-05-06: feat(render): radial speed lines above 0.7 speedNorm and during nitro
 
 **GDD sections touched:** [§16](gdd/16-rendering-and-visual-design.md)

--- a/src/app/race/page.tsx
+++ b/src/app/race/page.tsx
@@ -334,6 +334,28 @@ function playRaceSfxEvents(
       runtime.playBrakeScrub({ speedFactor: event.speedFactor, audio });
     } else if (event.kind === "tireSqueal") {
       runtime.playTireSqueal({ speedFactor: event.speedFactor, audio });
+    } else if (event.kind === "tireSquealLoop") {
+      // §18 sustained tire-squeal loop. The loop runtime starts on the
+      // first active=true update and ramps out + stops on active=false.
+      if (event.active) {
+        runtime.updateTireSquealLoop({
+          intensity: event.intensity,
+          speedFactor: event.speedFactor,
+          audio,
+        });
+      } else {
+        runtime.stopTireSquealLoop();
+      }
+    } else if (event.kind === "brakeScrubLoop") {
+      if (event.active) {
+        runtime.updateBrakeScrubLoop({
+          intensity: event.intensity,
+          speedFactor: event.speedFactor,
+          audio,
+        });
+      } else {
+        runtime.stopBrakeScrubLoop();
+      }
     } else if (event.kind === "surfaceHush") {
       runtime.playSurfaceHush({
         surface: event.surface,

--- a/src/audio/raceMix.ts
+++ b/src/audio/raceMix.ts
@@ -64,6 +64,14 @@ function raceMusicDuckingForAudioEvent(
       return { volumeScale: 0.88, holdMs: 180 };
     case "gearShift":
       return NO_RACE_MUSIC_DUCKING;
+    case "tireSquealLoop":
+    case "brakeScrubLoop":
+      // Loop state events drive the §18 sustained audio bed; the
+      // music ducking already fired on the one-shot edge events
+      // (`tireSqueal` / `brakeScrub`) above. Treat the loop events
+      // as duck-neutral so the bed does not pump the music every
+      // tick during a sustained corner.
+      return NO_RACE_MUSIC_DUCKING;
   }
 }
 

--- a/src/audio/sfx.test.ts
+++ b/src/audio/sfx.test.ts
@@ -368,6 +368,171 @@ describe("ProceduralSfxRuntime", () => {
     expect(context.gains[0]?.disconnected).toBe(true);
     expect(context.gains[1]?.disconnected).toBe(true);
   });
+
+  describe("§18 sustained loops", () => {
+    it("starts a single tire-squeal oscillator on the first update", () => {
+      const context = new FakeAudioContext();
+      const runtime = new ProceduralSfxRuntime({ context: () => context });
+
+      expect(runtime.hasActiveLoop("tireSqueal")).toBe(false);
+      runtime.updateTireSquealLoop({
+        intensity: 0.5,
+        speedFactor: 0.5,
+        audio: AUDIO,
+      });
+      expect(runtime.hasActiveLoop("tireSqueal")).toBe(true);
+      expect(context.oscillators).toHaveLength(1);
+      expect(context.oscillators[0]?.type).toBe("triangle");
+      expect(context.oscillators[0]?.start).toHaveBeenCalledTimes(1);
+    });
+
+    it("does NOT spawn a second oscillator on subsequent updates", () => {
+      const context = new FakeAudioContext();
+      const runtime = new ProceduralSfxRuntime({ context: () => context });
+
+      runtime.updateTireSquealLoop({
+        intensity: 0.5,
+        speedFactor: 0.5,
+        audio: AUDIO,
+      });
+      runtime.updateTireSquealLoop({
+        intensity: 0.8,
+        speedFactor: 0.7,
+        audio: AUDIO,
+      });
+      runtime.updateTireSquealLoop({
+        intensity: 1,
+        speedFactor: 1,
+        audio: AUDIO,
+      });
+      expect(context.oscillators).toHaveLength(1);
+      // First call setParam-s the frequency at start; subsequent two
+      // calls ramp toward new targets. Gain ramps on every call (the
+      // start uses a 0->target ramp, not a setValueAtTime).
+      expect(
+        context.oscillators[0]?.frequency.linearRampToValueAtTime,
+      ).toHaveBeenCalledTimes(2);
+      expect(
+        context.gains[0]?.gain.linearRampToValueAtTime,
+      ).toHaveBeenCalledTimes(3);
+    });
+
+    it("ramps gain monotone-up as intensity climbs", () => {
+      const context = new FakeAudioContext();
+      const runtime = new ProceduralSfxRuntime({ context: () => context });
+
+      runtime.updateTireSquealLoop({
+        intensity: 0.2,
+        speedFactor: 0.5,
+        audio: AUDIO,
+      });
+      const calls0 = (
+        context.gains[0]?.gain.linearRampToValueAtTime as ReturnType<
+          typeof vi.fn
+        >
+      ).mock.calls;
+      const target0 = calls0[calls0.length - 1]![0] as number;
+
+      runtime.updateTireSquealLoop({
+        intensity: 0.8,
+        speedFactor: 0.5,
+        audio: AUDIO,
+      });
+      const calls1 = (
+        context.gains[0]?.gain.linearRampToValueAtTime as ReturnType<
+          typeof vi.fn
+        >
+      ).mock.calls;
+      const target1 = calls1[calls1.length - 1]![0] as number;
+
+      expect(target1).toBeGreaterThan(target0);
+    });
+
+    it("ramps the loop out to 0 over 80 ms on stop", () => {
+      const context = new FakeAudioContext();
+      const runtime = new ProceduralSfxRuntime({ context: () => context });
+
+      runtime.updateTireSquealLoop({
+        intensity: 0.8,
+        speedFactor: 0.6,
+        audio: AUDIO,
+      });
+      runtime.stopTireSquealLoop();
+
+      const calls = (
+        context.gains[0]?.gain.linearRampToValueAtTime as ReturnType<
+          typeof vi.fn
+        >
+      ).mock.calls;
+      const last = calls[calls.length - 1]!;
+      expect(last[0]).toBe(0);
+      // Final ramp end-time equals currentTime + 0.08.
+      expect(last[1]).toBeCloseTo(0.08, 6);
+      expect(runtime.hasActiveLoop("tireSqueal")).toBe(false);
+    });
+
+    it("treats intensity <= 0 as a stop", () => {
+      const context = new FakeAudioContext();
+      const runtime = new ProceduralSfxRuntime({ context: () => context });
+
+      runtime.updateTireSquealLoop({
+        intensity: 0.5,
+        speedFactor: 0.5,
+        audio: AUDIO,
+      });
+      expect(runtime.hasActiveLoop("tireSqueal")).toBe(true);
+      runtime.updateTireSquealLoop({
+        intensity: 0,
+        speedFactor: 0.5,
+        audio: AUDIO,
+      });
+      expect(runtime.hasActiveLoop("tireSqueal")).toBe(false);
+    });
+
+    it("brake-scrub loop runs independently from tire-squeal", () => {
+      const context = new FakeAudioContext();
+      const runtime = new ProceduralSfxRuntime({ context: () => context });
+
+      runtime.updateTireSquealLoop({
+        intensity: 0.5,
+        speedFactor: 0.5,
+        audio: AUDIO,
+      });
+      runtime.updateBrakeScrubLoop({
+        intensity: 0.5,
+        speedFactor: 0.5,
+        audio: AUDIO,
+      });
+      expect(runtime.hasActiveLoop("tireSqueal")).toBe(true);
+      expect(runtime.hasActiveLoop("brakeScrub")).toBe(true);
+      expect(context.oscillators).toHaveLength(2);
+      expect(context.oscillators[1]?.type).toBe("sawtooth");
+
+      runtime.stopTireSquealLoop();
+      expect(runtime.hasActiveLoop("tireSqueal")).toBe(false);
+      expect(runtime.hasActiveLoop("brakeScrub")).toBe(true);
+    });
+
+    it("stopAll tears down both loops alongside one-shots", () => {
+      const context = new FakeAudioContext();
+      const runtime = new ProceduralSfxRuntime({ context: () => context });
+
+      runtime.updateTireSquealLoop({
+        intensity: 0.5,
+        speedFactor: 0.5,
+        audio: AUDIO,
+      });
+      runtime.updateBrakeScrubLoop({
+        intensity: 0.5,
+        speedFactor: 0.5,
+        audio: AUDIO,
+      });
+      runtime.stopAll();
+
+      expect(runtime.hasActiveLoop("tireSqueal")).toBe(false);
+      expect(runtime.hasActiveLoop("brakeScrub")).toBe(false);
+    });
+  });
 });
 
 class FakeAudioParam implements SfxAudioParamLike {

--- a/src/audio/sfx.ts
+++ b/src/audio/sfx.ts
@@ -103,6 +103,26 @@ interface OneShotGraph {
   readonly output: SfxGainLike;
 }
 
+interface LoopGraph {
+  readonly oscillator: SfxOscillatorLike;
+  readonly output: SfxGainLike;
+}
+
+export interface TireSquealLoopUpdate {
+  readonly intensity: number;
+  readonly speedFactor: number;
+  readonly audio: AudioSettings | undefined;
+}
+
+export interface BrakeScrubLoopUpdate {
+  readonly intensity: number;
+  readonly speedFactor: number;
+  readonly audio: AudioSettings | undefined;
+}
+
+const LOOP_RAMP_OUT_SECONDS = 0.08;
+const LOOP_RAMP_PARAM_SECONDS = 0.05;
+
 const DEFAULT_BASE_GAIN = 0.22;
 const DEFAULT_DURATION_SECONDS = 0.12;
 const SILENT_AUDIO: AudioSettings = Object.freeze({
@@ -115,6 +135,8 @@ export class ProceduralSfxRuntime {
   private readonly active = new Set<OneShotGraph>();
   private readonly baseGain: number;
   private readonly durationSeconds: number;
+  private tireSquealLoop: LoopGraph | null = null;
+  private brakeScrubLoop: LoopGraph | null = null;
 
   constructor(private readonly options: ProceduralSfxRuntimeOptions) {
     this.baseGain = nonNegativeOr(options.baseGain, DEFAULT_BASE_GAIN);
@@ -253,10 +275,121 @@ export class ProceduralSfxRuntime {
     });
   }
 
+  /**
+   * §18 sustained tire-squeal loop. Starts a single continuous
+   * oscillator on the first call when intensity > 0; subsequent calls
+   * update gain + frequency in place. Returns true when the loop is
+   * playing audibly after the call.
+   */
+  updateTireSquealLoop(input: TireSquealLoopUpdate): boolean {
+    return this.updateLoop("tireSqueal", input);
+  }
+
+  /** §18 sustained brake-scrub loop. Same lifecycle as tire-squeal. */
+  updateBrakeScrubLoop(input: BrakeScrubLoopUpdate): boolean {
+    return this.updateLoop("brakeScrub", input);
+  }
+
+  /** Ramp the active tire-squeal loop out over 80 ms and stop. */
+  stopTireSquealLoop(): void {
+    this.stopLoop("tireSqueal");
+  }
+
+  /** Ramp the active brake-scrub loop out over 80 ms and stop. */
+  stopBrakeScrubLoop(): void {
+    this.stopLoop("brakeScrub");
+  }
+
+  /** Whether a sustained loop is currently audible. Test-only hook. */
+  hasActiveLoop(kind: "tireSqueal" | "brakeScrub"): boolean {
+    return kind === "tireSqueal"
+      ? this.tireSquealLoop !== null
+      : this.brakeScrubLoop !== null;
+  }
+
   stopAll(): void {
+    this.stopTireSquealLoop();
+    this.stopBrakeScrubLoop();
     for (const graph of Array.from(this.active)) {
       this.disconnect(graph);
     }
+  }
+
+  private updateLoop(
+    kind: "tireSqueal" | "brakeScrub",
+    input: TireSquealLoopUpdate | BrakeScrubLoopUpdate,
+  ): boolean {
+    const baseGain = this.effectiveGain(input.audio);
+    const intensity = clampUnit(input.intensity);
+    if (intensity <= 0) {
+      this.stopLoop(kind);
+      return false;
+    }
+    if (baseGain === 0) {
+      this.stopLoop(kind);
+      return false;
+    }
+    const context = this.options.context();
+    if (context === null) return false;
+
+    const speed = clampUnit(input.speedFactor);
+    const frequency =
+      kind === "tireSqueal"
+        ? Math.round(860 + speed * 560)
+        : Math.round(150 + speed * 150);
+    const gainScale =
+      kind === "tireSqueal"
+        ? 0.4 + intensity * 0.45
+        : 0.32 + intensity * 0.4;
+    const targetGain = baseGain * gainScale;
+    const now = context.currentTime;
+
+    let graph =
+      kind === "tireSqueal" ? this.tireSquealLoop : this.brakeScrubLoop;
+    if (graph === null) {
+      const oscillator = context.createOscillator();
+      const output = context.createGain();
+      oscillator.type = kind === "tireSqueal" ? "triangle" : "sawtooth";
+      setParam(oscillator.frequency, frequency, now);
+      setParam(output.gain, 0, now);
+      rampParam(output.gain, targetGain, now + LOOP_RAMP_PARAM_SECONDS);
+      oscillator.connect(output);
+      output.connect(context.destination);
+      oscillator.start(now);
+      graph = { oscillator, output };
+      if (kind === "tireSqueal") this.tireSquealLoop = graph;
+      else this.brakeScrubLoop = graph;
+      return true;
+    }
+    rampParam(
+      graph.oscillator.frequency,
+      frequency,
+      now + LOOP_RAMP_PARAM_SECONDS,
+    );
+    rampParam(graph.output.gain, targetGain, now + LOOP_RAMP_PARAM_SECONDS);
+    return true;
+  }
+
+  private stopLoop(kind: "tireSqueal" | "brakeScrub"): void {
+    const graph =
+      kind === "tireSqueal" ? this.tireSquealLoop : this.brakeScrubLoop;
+    if (graph === null) return;
+    if (kind === "tireSqueal") this.tireSquealLoop = null;
+    else this.brakeScrubLoop = null;
+    const context = this.options.context();
+    const now = context !== null ? context.currentTime : 0;
+    rampParam(graph.output.gain, 0, now + LOOP_RAMP_OUT_SECONDS);
+    try {
+      graph.oscillator.stop(now + LOOP_RAMP_OUT_SECONDS);
+    } catch {
+      // Some test mocks throw on `stop()` after `start()` was never
+      // called; swallow because the gain ramp + disconnect below still
+      // leaves the graph silent.
+    }
+    graph.oscillator.onended = () => {
+      graph.oscillator.disconnect();
+      graph.output.disconnect();
+    };
   }
 
   private playTone(input: {

--- a/src/game/__tests__/raceSession.test.ts
+++ b/src/game/__tests__/raceSession.test.ts
@@ -1129,8 +1129,19 @@ describe("stepRaceSession (surface audio)", () => {
       config,
       DT,
     );
+    // First active tick: edge event (for ducking) + loop state event
+    // (for the §18 sustained audio bed). Subsequent ticks emit only
+    // the loop event (no edge); deactivation tick emits a final
+    // active=false loop event.
     expect(session.audioEvents).toEqual([
       { kind: "brakeScrub", carId: "player", speedFactor: expect.any(Number) },
+      {
+        kind: "brakeScrubLoop",
+        carId: "player",
+        active: true,
+        intensity: expect.any(Number),
+        speedFactor: expect.any(Number),
+      },
     ]);
 
     session = stepRaceSession(
@@ -1139,7 +1150,15 @@ describe("stepRaceSession (surface audio)", () => {
       config,
       DT,
     );
-    expect(session.audioEvents).toEqual([]);
+    expect(session.audioEvents).toEqual([
+      {
+        kind: "brakeScrubLoop",
+        carId: "player",
+        active: true,
+        intensity: expect.any(Number),
+        speedFactor: expect.any(Number),
+      },
+    ]);
 
     session = stepRaceSession(session, NEUTRAL_INPUT, config, DT);
     session = {
@@ -1177,6 +1196,13 @@ describe("stepRaceSession (surface audio)", () => {
     );
     expect(session.audioEvents).toEqual([
       { kind: "tireSqueal", carId: "player", speedFactor: expect.any(Number) },
+      {
+        kind: "tireSquealLoop",
+        carId: "player",
+        active: true,
+        intensity: expect.any(Number),
+        speedFactor: expect.any(Number),
+      },
     ]);
     session = stepRaceSession(
       session,
@@ -1184,7 +1210,15 @@ describe("stepRaceSession (surface audio)", () => {
       config,
       DT,
     );
-    expect(session.audioEvents).toEqual([]);
+    expect(session.audioEvents).toEqual([
+      {
+        kind: "tireSquealLoop",
+        carId: "player",
+        active: true,
+        intensity: expect.any(Number),
+        speedFactor: expect.any(Number),
+      },
+    ]);
   });
 
   it("emits wet and snow surface hush once per weather surface", () => {

--- a/src/game/raceSession.ts
+++ b/src/game/raceSession.ts
@@ -270,6 +270,34 @@ export interface RaceSessionTireSquealAudioEvent {
   readonly speedFactor: number;
 }
 
+/**
+ * Per-tick state event for the §18 sustained tire-squeal loop. Emitted
+ * every tick the gate is active (so the loop runtime can update gain
+ * and pitch as steer / speed change), plus one final `active: false`
+ * event the tick the gate transitions back to inactive (so the loop
+ * runtime can ramp out and stop). The original
+ * `RaceSessionTireSquealAudioEvent` above stays as a one-shot edge
+ * cue for music ducking; the loop event below drives the continuous
+ * audio bed.
+ */
+export interface RaceSessionTireSquealLoopAudioEvent {
+  readonly kind: "tireSquealLoop";
+  readonly carId: string;
+  readonly active: boolean;
+  /** Lerp from 0 at the steer threshold to 1 at |steer| = 1. */
+  readonly intensity: number;
+  readonly speedFactor: number;
+}
+
+export interface RaceSessionBrakeScrubLoopAudioEvent {
+  readonly kind: "brakeScrubLoop";
+  readonly carId: string;
+  readonly active: boolean;
+  /** Lerp from 0 at brake = 0 to 1 at brake = 1. */
+  readonly intensity: number;
+  readonly speedFactor: number;
+}
+
 export type RaceSessionSurfaceHushKind = "wet" | "snow";
 
 export interface RaceSessionSurfaceHushAudioEvent {
@@ -299,6 +327,8 @@ export type RaceSessionAudioEvent =
   | RaceSessionDamageWarningAudioEvent
   | RaceSessionBrakeScrubAudioEvent
   | RaceSessionTireSquealAudioEvent
+  | RaceSessionTireSquealLoopAudioEvent
+  | RaceSessionBrakeScrubLoopAudioEvent
   | RaceSessionSurfaceHushAudioEvent
   | RaceSessionPickupCollectedAudioEvent;
 
@@ -2018,6 +2048,45 @@ function buildPlayerSurfaceAudioEvents(input: {
       speedFactor,
     });
   }
+
+  // §18 sustained loops: emit per-tick state events so the loop
+  // runtime can ramp gain and pitch with steer / brake load. Emit
+  // every tick the gate is active (so the runtime can update its
+  // params), plus one final `active: false` event the tick the
+  // gate transitions back to inactive (so the runtime can ramp out
+  // and stop). Suppress when both prev and current are inactive so
+  // the event stream stays empty during normal driving.
+  if (tireSquealNow || input.gates.tireSquealActive) {
+    const tireSquealIntensity = tireSquealNow
+      ? clamp01(
+          (Math.max(
+            Math.abs(input.input.steer),
+            input.input.handbrake ? 1 : 0,
+          ) -
+            TIRE_SQUEAL_STEER_THRESHOLD) /
+            (1 - TIRE_SQUEAL_STEER_THRESHOLD),
+        )
+      : 0;
+    events.push({
+      kind: "tireSquealLoop",
+      carId: PLAYER_CAR_ID,
+      active: tireSquealNow,
+      intensity: tireSquealIntensity,
+      speedFactor,
+    });
+  }
+  if (brakeScrubNow || input.gates.brakeScrubActive) {
+    const brakeScrubIntensity = brakeScrubNow
+      ? clamp01(input.input.brake)
+      : 0;
+    events.push({
+      kind: "brakeScrubLoop",
+      carId: PLAYER_CAR_ID,
+      active: brakeScrubNow,
+      intensity: brakeScrubIntensity,
+      speedFactor,
+    });
+  }
   if (
     surfaceHushNow &&
     hushKind !== null &&
@@ -2039,6 +2108,13 @@ function buildPlayerSurfaceAudioEvents(input: {
     },
     events,
   };
+}
+
+function clamp01(value: number): number {
+  if (!Number.isFinite(value)) return 0;
+  if (value < 0) return 0;
+  if (value > 1) return 1;
+  return value;
 }
 
 function speedFactorForAudio(speed: number, topSpeed: number): number {


### PR DESCRIPTION
## Summary

- §18 "Required sounds: tire squeal / brake scrub". The pre-fix code emitted a single 160ms one-shot at the gate's false->true edge; sustained hairpins produced one chirp at entry, then silence.
- Added per-tick state events \`tireSquealLoop\` and \`brakeScrubLoop\` carrying \`{ active, intensity, speedFactor }\`. raceSession emits one per tick the gate is active plus a final \`active: false\` event the tick the gate transitions back.
- \`ProceduralSfxRuntime\` gains \`updateTireSquealLoop\` / \`updateBrakeScrubLoop\` plus stop methods. First update spawns a single oscillator+gain graph, ramps 0 -> target over 50ms; subsequent updates ramp toward the new target in place; stop ramps gain to 0 over 80ms.
- Music ducking: loop kinds resolve to \`NO_RACE_MUSIC_DUCKING\` so the bed does not pump the music every tick. Ducking still fires on the one-shot edge events.

## Test plan

- [x] \`npm run typecheck\`
- [x] \`npm run lint\`
- [x] \`npm run test\` (2847/2847; 7 new sfx.test cases for the loop lifecycle, raceSession.test cases updated)
- [ ] CI green