### PR TITLE
chore(review): switch from Copilot to CodeRabbit

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,74 @@
+# CodeRabbit configuration. Schema: https://docs.coderabbit.ai/reference/yaml-template
+#
+# Adopted 2026-05-06 after the Copilot monthly review quota was exhausted.
+# Project context for the reviewer is split between:
+# - AGENTS.md (RULE 1..N: deterministic replays, ledger discipline, slice rules).
+# - docs/WORKING_AGREEMENT.md (PR / merge / review process).
+# - docs/IMPLEMENTATION_PLAN.md (slice template + acceptance gates).
+# - docs/gdd/*.md (per-section game-design specs the slices reference).
+language: en
+early_access: false
+
+reviews:
+  profile: chill
+  request_changes_workflow: false
+  high_level_summary: true
+  poem: false
+  review_status: true
+  collapse_walkthrough: false
+  auto_review:
+    enabled: true
+    drafts: false
+    base_branches:
+      - main
+  path_filters:
+    # Lockfiles and generated assets — no signal in review.
+    - "!package-lock.json"
+    - "!pnpm-lock.yaml"
+    - "!**/node_modules/**"
+    - "!.next/**"
+    - "!coverage/**"
+    - "!playwright-report/**"
+    - "!test-results/**"
+    - "!public/assets/**"
+    # Append-only ledgers. CodeRabbit should not nitpick prose in
+    # historical entries; the discipline is encoded in
+    # .claude/rules/ledger-append-only.md.
+    - "!docs/PROGRESS_LOG.md"
+    - "!docs/FOLLOWUPS.md"
+    - "!docs/OPEN_QUESTIONS.md"
+    # Archived pre-spiral docs are frozen.
+    - "!docs/archive/**"
+  path_instructions:
+    - path: "src/game/**/*.ts"
+      instructions: |
+        Game logic must stay deterministic for replay (AGENTS.md RULE 8).
+        Flag any new use of Math.random, Date.now, or performance.now in
+        files under src/game. Per-tick state mutations should be derived
+        from a seeded PRNG or the session tick.
+    - path: "src/render/**/*.ts"
+      instructions: |
+        Pure render modules own state objects passed in by the caller.
+        Flag any new module-level mutable state. Reduced-motion gates
+        should re-use prefersReducedMotion() from src/render/vfx.ts
+        rather than re-querying matchMedia per frame.
+    - path: "src/road/**/*.ts"
+      instructions: |
+        Constants in src/road/constants.ts are golden values for the
+        segment projector. Any change here must be paired with a
+        regenerated golden tolerance in segmentProjector tests.
+    - path: "docs/gdd/**/*.md"
+      instructions: |
+        GDD section files follow the build-log discipline
+        (.claude/rules/gdd-build-log.md). Status line + append-only
+        Build log entries with file paths and PR numbers. Flag PRs that
+        modify spec text without an accompanying Build log entry.
+    - path: "e2e/**/*.spec.ts"
+      instructions: |
+        Playwright canvas-pixel-sampling tests on the test/elevation
+        track have been brittle (see F-088). Prefer threshold-based
+        assertions over exact-row assertions when sampling canvas
+        pixels.
+
+chat:
+  auto_reply: true

--- a/docs/WORKING_AGREEMENT.md
+++ b/docs/WORKING_AGREEMENT.md
@@ -55,10 +55,12 @@ build*; this agreement wins for *how to operate*.
 - Do not open a PR until CI would plausibly pass locally (type-check, lint,
   tests).
 - Before merging, inspect unresolved PR review comments, including inline
-  and threaded review comments plus automated Copilot feedback. Address
-  actionable comments with a follow-up commit. Respond to each actionable
-  thread with what changed or why no code change is appropriate, then
-  re-check for new comments before merge.
+  and threaded review comments plus automated CodeRabbit feedback (this
+  project switched from Copilot review to CodeRabbit on 2026-05-06 after
+  the Copilot monthly review quota was exhausted). Address actionable
+  comments with a follow-up commit. Respond to each actionable thread
+  with what changed or why no code change is appropriate, then re-check
+  for new comments before merge.
 - Wait for CI to go green before merging. If CI fails, fix the cause; do not
   retry the same red push hoping for a flake.
 - Squash-merge into `main` unless the slice deliberately benefits from


### PR DESCRIPTION
## Summary

- Copilot monthly review quota was exhausted on 2026-05-06; CodeRabbit takes over PR review from this point.
- \`docs/WORKING_AGREEMENT.md\` updated: \"automated Copilot feedback\" -> \"automated CodeRabbit feedback\" with the date the switch happened.
- New \`.coderabbit.yaml\` gives the bot project-specific path filters and path instructions so it doesn't nitpick the append-only ledgers and respects the AGENTS.md / .claude/rules/ discipline (deterministic game logic, pure render modules, golden road constants, GDD build-log).

## Notes

- Historical \`docs/PROGRESS_LOG.md\` entries that mention the Copilot reviewer are unchanged per the ledger-append-only rule. Those entries document past review interactions and should stay as the audit trail.
- This PR will be CodeRabbit's first review — useful smoke-test of the new config.

## Test plan

- [x] \`npm run content-lint\`
- [ ] CodeRabbit posts a review on this PR (validates the bot is wired up)
- [ ] CI green

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated repository automation configuration to enable code review guidelines with path-based filtering and specialized review rules.
  * Updated team documentation to reflect current code review processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->