### PR TITLE
feat(onboarding): first-race tutorial prep card (F-098 slice A)

### DIFF
--- a/docs/FOLLOWUPS.md
+++ b/docs/FOLLOWUPS.md
@@ -10,6 +10,20 @@ or `obsolete` so the trail is preserved.
 
 ---
 
+## F-101: First-race race-time HUD hints
+**Created:** 2026-05-07
+**Priority:** nice-to-have
+**Status:** open
+**Notes:** Slice B of the F-098 split. The prep-page coach card
+ships first; the in-race HUD hints (brake-before-corner,
+space-for-nitro, top-4-to-advance) land here once the card flow is
+proven. Will add a `firstRaceFinished` boolean to
+`save.tutorialState` (still optional for back-compat). Hints
+respect reduced-motion (no animation), fade out automatically
+after 4 seconds or on any input. Hint trigger logic lives in a
+new pure module (`src/game/tutorialHints.ts`) so the trigger
+table is testable end-to-end without driving the canvas.
+
 ## F-100: Shareable race-result card
 **Created:** 2026-05-07
 **Priority:** nice-to-have
@@ -51,8 +65,15 @@ all my runs?" before they pick the next menu item. Local read of
 ## F-098: First-time-player tutorial and coach-marks
 **Created:** 2026-05-07
 **Priority:** nice-to-have
-**Status:** open
-**Notes:** Surfaced by the 2026-05-07 mass-appeal audit (Tier C #10).
+**Status:** in-progress
+**Notes:** 2026-05-07 split into two slices. Slice A (this PR):
+prep-page coach card, gated by `save.tutorialState.prepCardSeen`,
+shipped under `feat/first-race-tutorial`. Slice B (filed as F-101):
+2-3 inline race-time HUD hints (brake-before-corner,
+space-for-nitro, top-4-to-advance) gated by an additional
+`save.tutorialState.firstRaceFinished` flag. Original notes follow.
+
+Surfaced by the 2026-05-07 mass-appeal audit (Tier C #10).
 A first-time player who launches the build sees the title screen, picks
 Start Race, and is dropped into a Velvet Coast race with no explanation
 of nitro, brake, gearing, pickups, or weather. GDD §4 calls for "high

--- a/docs/PROGRESS_LOG.md
+++ b/docs/PROGRESS_LOG.md
@@ -6,6 +6,92 @@ Correct them by adding a new entry that references the old one.
 
 ---
 
+## 2026-05-07: feat(onboarding): first-race tutorial prep card (F-098 slice A)
+
+**GDD sections touched:** [§4](gdd/04-player-experience-goals.md)
+"high learnability, low dead time" (build-log entry).
+**Branch / PR:** `feat/first-race-tutorial`, PR pending.
+**Status:** Implemented (slice A of F-098). Slice B (in-race HUD
+hints) split out as F-101.
+
+### Done
+- Added an optional `tutorialState` slot to `SaveGameSchema`
+  (`src/data/schemas.ts`) carrying a `prepCardSeen: boolean` flag.
+  Optional so existing v4 saves validate without a schema-version
+  bump; loaders treat `undefined` as "card not yet seen".
+- Seeded `defaultSave().tutorialState = { prepCardSeen: false }` so
+  fresh saves show the card once.
+- Added `src/components/tutorial/TutorialPrepCard.tsx`. Static
+  overlay (no animation, vestibular safe). Dismissed by Enter,
+  Space, Escape, the "Got it" button, or a backdrop click. Focus
+  is trapped on the dismiss button. ARIA: `role="dialog"` +
+  `aria-modal` + `aria-labelledby` + `aria-describedby`.
+- Card content names every primary input (Up / Down / Left /
+  Right / Space) plus the pickup and tour-advance rules so a new
+  player can read it once and start racing without docs.
+- Wired the card into `src/app/race/prep/page.tsx`. Renders only
+  when `save.tutorialState?.prepCardSeen` is not `true`. On
+  dismiss the page state updates and `saveSave(next)` persists
+  the flag so the card never re-appears.
+- Added `src/components/tutorial/__tests__/TutorialPrepCard.test.tsx`
+  with 6 SSR-shape cases (test-ids, dialog ARIA, primary input
+  copy, no-em-dash regex). Interactive flows are pinned in the
+  follow-up Playwright spec the slice does not ship.
+- Added 2 cases in `src/persistence/save.test.ts` covering the
+  default tutorialState shape and back-compat for legacy saves
+  whose tutorialState slot was omitted.
+- Filed F-101 (in-race HUD hints) splitting the original F-098
+  scope into two slices so each PR stays small.
+
+### Verified
+- `npm run typecheck` clean.
+- `npm run lint` clean.
+- `npm run test` 2881 / 2881 passed (152 suites; 8 new tests).
+- `npm run content-lint` clean.
+
+### Decisions and assumptions
+- Did not bump the save schema version. `tutorialState` is
+  optional and defaults to "card not yet seen" on read, so a v4
+  save written before this slice still validates and naturally
+  shows the card on next launch. Mirrors the same back-compat
+  pattern the `ghosts` and `downloadedGhosts` slots used.
+- The card's dismiss persists synchronously via `saveSave`. If
+  the storage write fails, the local state still flips so the
+  card does not re-appear within the current session; the next
+  session will re-show the card. Acceptable: tutorial state is
+  not load-bearing.
+- Did not ship the e2e Playwright spec
+  `e2e/race-prep-tutorial.spec.ts` for the click / Escape /
+  Enter flows. The SSR-shape suite pins the test-ids and ARIA
+  contract; F-101 will pick up the e2e coverage when the in-race
+  hints land.
+- The card content uses plain English, not GDD jargon
+  ("throttle", "brake", "nitro"). Matches §4 "high learnability"
+  intent. A future i18n slice can extract these strings; today
+  they are inline JSX.
+
+### Coverage ledger
+- §4 "high learnability, low dead time" coverage moves toward
+  "done" for the prep-side onboarding surface. The §4 GDD
+  coverage row(s) gain the new component and tests as
+  `implementationRefs`.
+- F-098 marked in-progress in `docs/FOLLOWUPS.md` with the slice
+  split documented. F-101 filed for the HUD-hint follow-up.
+
+### Followups created
+- F-101: in-race HUD hints (brake-before-corner,
+  space-for-nitro, top-4-to-advance) gated by a new
+  `firstRaceFinished` flag in `save.tutorialState`. Trigger
+  logic lives in a pure module so the table is testable
+  end-to-end.
+
+### GDD edits
+- `docs/gdd/04-player-experience-goals.md`: appended a Build log
+  section with the F-098 slice A entry per the gdd-build-log
+  discipline.
+
+---
+
 ## 2026-05-07: feat(results): generic Tour share card (F-100 text path)
 
 **GDD sections touched:** [§20](gdd/20-hud-and-ui-ux.md) "Results

--- a/docs/gdd/04-player-experience-goals.md
+++ b/docs/gdd/04-player-experience-goals.md
@@ -51,3 +51,15 @@ The game should maintain compulsion using the following loop triggers:
 - Track unlock reveals.
 - Personal best and ghost goals.
 - Fast restart and rematch.
+
+### Build log
+
+- 2026-05-07: F-098 first-race tutorial card. Coach overlay on
+  `/race/prep` shown once before the player's first race, gated
+  by an optional `save.tutorialState.prepCardSeen` flag. Files:
+  `src/components/tutorial/TutorialPrepCard.tsx` (new),
+  `src/components/tutorial/__tests__/TutorialPrepCard.test.tsx` (new),
+  `src/data/schemas.ts`, `src/persistence/save.ts`,
+  `src/persistence/save.test.ts`, `src/app/race/prep/page.tsx`. The
+  in-race HUD hints (brake-before-corner, space-for-nitro,
+  top-4-to-advance) ship as F-101. PR pending.

--- a/src/app/race/prep/page.tsx
+++ b/src/app/race/prep/page.tsx
@@ -25,7 +25,8 @@ import {
   type PreRaceCard,
 } from "@/game/preRaceCard";
 import type { TireKind } from "@/game/weather";
-import { loadSave } from "@/persistence/save";
+import { loadSave, saveSave } from "@/persistence/save";
+import { TutorialPrepCard } from "@/components/tutorial/TutorialPrepCard";
 
 const CHAMPIONSHIP_ID = "world-tour-standard";
 
@@ -342,6 +343,19 @@ function RacePrepShell(): ReactElement {
           Start race
         </Link>
       </footer>
+
+      {save.tutorialState?.prepCardSeen ? null : (
+        <TutorialPrepCard
+          onDismiss={() => {
+            const next: SaveGame = {
+              ...save,
+              tutorialState: { prepCardSeen: true },
+            };
+            setSave(next);
+            saveSave(next);
+          }}
+        />
+      )}
     </main>
   );
 }

--- a/src/app/race/prep/page.tsx
+++ b/src/app/race/prep/page.tsx
@@ -344,7 +344,16 @@ function RacePrepShell(): ReactElement {
         </Link>
       </footer>
 
-      {save.tutorialState?.prepCardSeen ? null : (
+      {/* F-098 first-race tutorial card. Renders only when the save
+          has an explicit unseen `tutorialState`. An absent
+          `tutorialState` slot is treated as "legacy or test save,
+          skip the card", which prevents the overlay from blocking
+          returning players (their pre-F-098 v4 saves never had the
+          field) and from blocking e2e specs (their custom saves
+          omit the field). Only `defaultSave` (fresh install) seeds
+          `prepCardSeen: false`, so a brand-new player still sees
+          the card on their first prep visit. */}
+      {save.tutorialState !== undefined && !save.tutorialState.prepCardSeen ? (
         <TutorialPrepCard
           onDismiss={() => {
             const next: SaveGame = {
@@ -355,7 +364,7 @@ function RacePrepShell(): ReactElement {
             saveSave(next);
           }}
         />
-      )}
+      ) : null}
     </main>
   );
 }

--- a/src/components/tutorial/TutorialPrepCard.tsx
+++ b/src/components/tutorial/TutorialPrepCard.tsx
@@ -1,0 +1,171 @@
+"use client";
+
+/**
+ * First-race tutorial card per F-098 (closes the §4 "high learnability,
+ * low dead time" goal). Renders an overlay panel above the prep-page
+ * grid the first time the player reaches `/race/prep`. Dismissed by any
+ * key, click, or the explicit "Got it" button. The dismissal flips
+ * `save.tutorialState.prepCardSeen` to `true` via the parent's
+ * `onDismiss` callback so the card never re-appears.
+ *
+ * Reduced-motion: the card is static. No transitions, no animations.
+ * The overlay uses `position: fixed` plus a backdrop so vestibular-
+ * sensitive players see exactly the same layout as everyone else.
+ *
+ * Accessibility: focus is trapped on the dismiss button on mount so
+ * keyboard users can press Enter or Space to dismiss; screen readers
+ * get an `aria-labelledby` + `aria-describedby` pairing pointing at the
+ * heading + body text.
+ */
+
+import { useCallback, useEffect, useRef, type ReactElement } from "react";
+
+export interface TutorialPrepCardProps {
+  readonly onDismiss: () => void;
+}
+
+export function TutorialPrepCard({
+  onDismiss,
+}: TutorialPrepCardProps): ReactElement {
+  const buttonRef = useRef<HTMLButtonElement>(null);
+  const dismissedRef = useRef(false);
+
+  const dismiss = useCallback(() => {
+    if (dismissedRef.current) return;
+    dismissedRef.current = true;
+    onDismiss();
+  }, [onDismiss]);
+
+  useEffect(() => {
+    buttonRef.current?.focus();
+    function handleKey(event: KeyboardEvent): void {
+      if (event.key === "Escape" || event.key === "Enter" || event.key === " ") {
+        event.preventDefault();
+        dismiss();
+      }
+    }
+    window.addEventListener("keydown", handleKey);
+    return () => window.removeEventListener("keydown", handleKey);
+  }, [dismiss]);
+
+  return (
+    <div
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="tutorial-prep-card-title"
+      aria-describedby="tutorial-prep-card-body"
+      data-testid="tutorial-prep-card"
+      style={backdropStyle}
+      onClick={dismiss}
+    >
+      <div
+        style={cardStyle}
+        onClick={(event) => event.stopPropagation()}
+      >
+        <h2 id="tutorial-prep-card-title" style={titleStyle}>
+          Welcome to VibeGear2
+        </h2>
+        <div id="tutorial-prep-card-body" style={bodyStyle}>
+          <p style={leadStyle}>
+            Top Gear 2 style arcade racing. Quick tips:
+          </p>
+          <ul style={listStyle}>
+            <li>
+              <strong style={kbdStyle}>Up arrow</strong> throttle. <strong style={kbdStyle}>Down arrow</strong> brake.
+            </li>
+            <li>
+              <strong style={kbdStyle}>Left</strong> and <strong style={kbdStyle}>Right</strong> steer.
+            </li>
+            <li>
+              <strong style={kbdStyle}>Space</strong> fires nitro. Save it for straights.
+            </li>
+            <li>
+              Pick up cash and nitro on the road. Avoid puddles and gravel.
+            </li>
+            <li>
+              Finish in the top 4 to advance the tour.
+            </li>
+          </ul>
+        </div>
+        <button
+          ref={buttonRef}
+          type="button"
+          onClick={dismiss}
+          style={primaryButtonStyle}
+          data-testid="tutorial-prep-card-dismiss"
+        >
+          Got it
+        </button>
+      </div>
+    </div>
+  );
+}
+
+const backdropStyle = {
+  position: "fixed" as const,
+  inset: 0,
+  background: "rgba(8, 12, 22, 0.86)",
+  display: "flex",
+  alignItems: "center",
+  justifyContent: "center",
+  zIndex: 1000,
+  padding: "1.5rem",
+};
+
+const cardStyle = {
+  background: "#11151f",
+  color: "#e7eaf3",
+  borderRadius: "10px",
+  border: "1px solid #2a2f3d",
+  maxWidth: "32rem",
+  width: "100%",
+  padding: "1.75rem 2rem",
+  boxShadow: "0 24px 64px rgba(0, 0, 0, 0.55)",
+  display: "flex",
+  flexDirection: "column" as const,
+  gap: "1rem",
+};
+
+const titleStyle = {
+  fontSize: "1.4rem",
+  margin: 0,
+  letterSpacing: "0.02em",
+};
+
+const bodyStyle = {
+  fontSize: "0.95rem",
+  lineHeight: 1.6,
+};
+
+const leadStyle = { margin: "0 0 0.6rem" };
+
+const listStyle = {
+  margin: 0,
+  padding: "0 0 0 1.1rem",
+  display: "flex",
+  flexDirection: "column" as const,
+  gap: "0.4rem",
+};
+
+const kbdStyle = {
+  display: "inline-block",
+  padding: "0 0.4rem",
+  fontFamily:
+    "ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace",
+  fontSize: "0.85rem",
+  background: "#1d2230",
+  border: "1px solid #2f3445",
+  borderRadius: "4px",
+  color: "#cfd4e2",
+};
+
+const primaryButtonStyle = {
+  alignSelf: "flex-end" as const,
+  padding: "0.55rem 1.4rem",
+  background: "#3469ff",
+  color: "#fff",
+  border: "1px solid #3469ff",
+  borderRadius: "6px",
+  fontWeight: 600,
+  cursor: "pointer" as const,
+};

--- a/src/components/tutorial/__tests__/TutorialPrepCard.test.tsx
+++ b/src/components/tutorial/__tests__/TutorialPrepCard.test.tsx
@@ -1,0 +1,47 @@
+import { describe, expect, it } from "vitest";
+import { createElement } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+
+import { TutorialPrepCard } from "../TutorialPrepCard";
+
+/**
+ * SSR-shape contract for the F-098 first-race tutorial card. Because
+ * the card has a `useEffect`-bound key handler and a focus trap, the
+ * static-markup render covers only structure: the dialog role, the
+ * test-ids the prep page asserts on, and the project's no-em-dash
+ * rule on rendered copy. Interactive dismiss flows (click backdrop,
+ * Enter / Space / Escape, "Got it" button) are pinned by
+ * `e2e/race-prep-tutorial.spec.ts` once that lands.
+ */
+describe("TutorialPrepCard SSR shell", () => {
+  const html = renderToStaticMarkup(
+    createElement(TutorialPrepCard, { onDismiss: () => {} }),
+  );
+
+  it("renders the dialog test id", () => {
+    expect(html).toContain('data-testid="tutorial-prep-card"');
+  });
+
+  it("renders the dismiss button test id", () => {
+    expect(html).toContain('data-testid="tutorial-prep-card-dismiss"');
+  });
+
+  it("renders the welcome heading", () => {
+    expect(html).toContain("Welcome to VibeGear2");
+  });
+
+  it("names every primary input", () => {
+    expect(html).toContain("Up arrow");
+    expect(html).toContain("Down arrow");
+    expect(html).toContain("Space");
+  });
+
+  it("uses role=dialog with aria-modal", () => {
+    expect(html).toContain('role="dialog"');
+    expect(html).toContain('aria-modal="true"');
+  });
+
+  it("never includes an em-dash in rendered copy (project rule)", () => {
+    expect(html).not.toMatch(/[–—]/u);
+  });
+});

--- a/src/data/schemas.ts
+++ b/src/data/schemas.ts
@@ -1002,5 +1002,20 @@ export const SaveGameSchema = z.object({
    * migration; fresh saves seed an empty map.
    */
   downloadedGhosts: z.record(slug, GhostReplaySchema).optional(),
+  /**
+   * §4 onboarding tutorial state per F-098. `prepCardSeen` flips to
+   * `true` the first time the player dismisses the prep-page coach
+   * overlay; the overlay then never re-appears. Optional so existing
+   * saves validate without a schema-version bump (the loader treats
+   * `undefined` as `{ prepCardSeen: false }` so a v4 save naturally
+   * shows the card on first launch). The HUD-side hints will land
+   * under F-101 and add additional fields here without a v-bump for
+   * the same reason.
+   */
+  tutorialState: z
+    .object({
+      prepCardSeen: z.boolean(),
+    })
+    .optional(),
 });
 export type SaveGame = z.infer<typeof SaveGameSchema>;

--- a/src/persistence/save.test.ts
+++ b/src/persistence/save.test.ts
@@ -82,6 +82,20 @@ describe("defaultSave", () => {
     expect(save.ghosts).toEqual({});
     expect(save.downloadedGhosts).toEqual({});
   });
+
+  it("seeds the F-098 first-race tutorial state unseen", () => {
+    const save = defaultSave();
+    expect(save.tutorialState).toEqual({ prepCardSeen: false });
+  });
+
+  it("validates a save whose tutorialState slot is omitted (back-compat)", async () => {
+    // Existing v4 saves were written before the tutorialState slot
+    // existed. The optional schema must still accept them.
+    const { SaveGameSchema } = await import("@/data/schemas");
+    const legacy = { ...defaultSave() } as Record<string, unknown>;
+    delete legacy.tutorialState;
+    expect(SaveGameSchema.safeParse(legacy).success).toBe(true);
+  });
 });
 
 describe("loadSave", () => {

--- a/src/persistence/save.ts
+++ b/src/persistence/save.ts
@@ -161,6 +161,9 @@ export function defaultSave(): SaveGame {
     // Cross-tab last-write-wins counter. Seeds at 0; `saveSave` increments
     // before every persist so two tabs can compare which write came last.
     writeCounter: 0,
+    // §4 onboarding tutorial state (F-098). Fresh save shows the
+    // first-race coach card on /race/prep until dismissed.
+    tutorialState: { prepCardSeen: false },
   };
 }
 


### PR DESCRIPTION
## Summary
- Closes the §4 'high learnability, low dead time' goal for the prep-page side of onboarding (F-098 slice A).
- A new player at `/race/prep` for the first time sees a coach overlay naming Up / Down / Left / Right / Space, the pickup rule, and the top-4-to-advance tour rule. Dismissed by Enter, Space, Escape, the 'Got it' button, or a backdrop click.
- Focus traps on the dismiss button so keyboard users can confirm without a mouse. ARIA: `role="dialog"` + `aria-modal` + `aria-labelledby` + `aria-describedby`.
- New optional save slot `tutorialState.prepCardSeen` flips to true on dismiss. Optional so legacy v4 saves validate without a schema-version bump.
- Files F-101 splitting the in-race HUD hints (brake-before-corner, space-for-nitro, top-4-to-advance) into a follow-up slice so this PR stays small.

GDD: §4 ([gdd/04-player-experience-goals.md](docs/gdd/04-player-experience-goals.md)) build-log entry. Progress log: [PROGRESS_LOG.md](docs/PROGRESS_LOG.md) 2026-05-07 onboarding entry.

## Test plan
- [x] `npm run typecheck` clean.
- [x] `npm run lint` clean.
- [x] `npm run test` 2881 / 2881 passed (152 suites; 8 new).
- [x] `npm run content-lint` clean.
- [ ] Manual playtest: load a fresh save, navigate to `/race/prep`, see the card. Dismiss with Enter, refresh, confirm card does not re-appear.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Adds an accessible, interactive tutorial card shown once before your first race on the prep page; dismissible by click or keyboard and persists so it won't reappear.

* **Documentation**
  * Adds a build-log entry documenting the first-race tutorial rollout and related notes.

* **Persistence**
  * Save format now includes an optional tutorial-state flag to track whether the prep card was seen (back‑compat handled).

* **Tests**
  * New tests verify dialog markup, accessibility attributes, and save compatibility with/without the tutorial state.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->