### PR TITLE
feat(tracks): authored pickups for Iron Borough (F-093 tour 2)

### DIFF
--- a/docs/FOLLOWUPS.md
+++ b/docs/FOLLOWUPS.md
@@ -120,8 +120,16 @@ crest is crossed at speed. Pairs with §16 (camera shake on landing).
 ## F-093: On-track pickups extended to tours 2-8
 **Created:** 2026-05-07
 **Priority:** nice-to-have
-**Status:** open
-**Notes:** Surfaced by the 2026-05-07 mass-appeal audit (Tier A #4).
+**Status:** in-progress
+**Notes:** 2026-05-07 split per-tour. Tour 2 (Iron Borough)
+shipped under `feat/pickups-tours-2-to-8`: 3 pickups per track
+(1 inside-line nitro on a corner apex, 1 cash on a curve or
+post-curve straight, 1 cash on the final straight) across all
+4 tracks. Tours 3-8 stay open under this F-NNN; each subsequent
+tour ships as its own PR for review tractability. Original
+notes follow.
+
+Surfaced by the 2026-05-07 mass-appeal audit (Tier A #4).
 A grep of all 32 production tracks shows pickups are only authored on
 4 of 4 Velvet Coast tracks (1-2 segments each). Tours 2-8 have zero
 on-track tactical decisions beyond steering. The existing

--- a/docs/PROGRESS_LOG.md
+++ b/docs/PROGRESS_LOG.md
@@ -6,6 +6,78 @@ Correct them by adding a new entry that references the old one.
 
 ---
 
+## 2026-05-07: feat(tracks): authored pickups for Iron Borough (F-093 tour 2)
+
+**GDD sections touched:** [§9](gdd/09-track-design.md) (build-log
+entry).
+**Branch / PR:** `feat/pickups-tours-2-to-8`, PR pending.
+**Status:** Implemented (Iron Borough only). F-093 stays open
+covering tours 3-8.
+
+### Done
+- Added 3 pickups per track to all 4 Iron Borough tracks (Tour 2):
+  Foundry Mile, Freightline Ring, Outer Exchange, Rivet Tunnel.
+  Pattern per track:
+  1. One inside-line nitro pickup at a corner apex (laneOffset
+     toward the curve direction, magnitude 0.35-0.4) so the
+     player must hold the racing line to collect.
+  2. One cash pickup on a corner-exit straight or descent
+     (centerline or inside line) rewarding clean exits.
+  3. One cash pickup on the final straight (centerline) so a
+     close finish has a small additional decision: hit the line
+     or save lateral grip for a late pass.
+- Pickup ids follow the existing
+  `<track-slug-suffix>-<beat>-<kind>` shape (per the Velvet Coast
+  template). `cash` value 75 cr, `nitro` value 25%, mirroring the
+  Velvet Coast authored values.
+- Per F-093, tours 3-8 (Ember Steppe, Breakwater Isles, Glass
+  Ridge, Neon Meridian, Moss Frontier, Crown Circuit) stay open.
+  Each subsequent tour ships as its own PR for review
+  tractability.
+
+### Verified
+- `npm run typecheck` clean.
+- `npm run lint` clean.
+- `npm run test` 2873 / 2873 passed (151 suites; the existing
+  `tracks-content.test.ts` validates every JSON against the
+  schema and the new pickups passed without change).
+- `npm run content-lint` clean.
+
+### Decisions and assumptions
+- Did not add or change any code. Pure data authoring against
+  the existing pickup runtime (`src/game/pickups.ts`) and schema
+  (`PickupSchema` in `src/data/schemas.ts`).
+- Pickup placement biases toward "tactical decision the player
+  must commit to before the apex" rather than free centerline
+  collectibles. The §3 + §15 reference material treats authored
+  pickups as the racing-line layer, not as a reward for driving
+  straight.
+- Tunnel-track Rivet Tunnel: the cash pickup sits on the tunnel
+  exit corner, so the player who held the racing line through
+  reduced visibility gets paid for it.
+- Foundry Mile is the only Iron Borough track with two corner
+  beats placed in pickups (the inside-curve nitro on segment 1
+  plus the post-corner cash on segment 4) because its difficulty
+  rating is 3 (the highest in the tour) and the §3 narrative
+  authors more decisions for the harder tracks.
+
+### Coverage ledger
+- §9 track-design coverage gains 4 tracks worth of authored
+  pickup data. F-093 stays open with 24 tracks remaining
+  (Ember Steppe + Breakwater Isles + Glass Ridge + Neon Meridian
+  + Moss Frontier + Crown Circuit).
+
+### Followups created
+None.
+
+### GDD edits
+None this slice. Tour-by-tour pickup data does not change the
+GDD spec text; the §9 build-log entry was last touched on
+2026-05-06 for the archetype classification slice and stays as
+the canonical pickup-placement note.
+
+---
+
 ## 2026-05-07: feat(ai): per-archetype nitro firing (F-091)
 
 **GDD sections touched:** [§15](gdd/15-cpu-opponents-and-ai.md) "AI design

--- a/src/data/tracks/iron-borough-foundry-mile.json
+++ b/src/data/tracks/iron-borough-foundry-mile.json
@@ -12,11 +12,41 @@
   "archetype": "short-sprint",
   "segments": [
     { "len": 240, "curve": 0, "grade": 0.01, "roadsideLeft": "sign_marker", "roadsideRight": "light_pole", "hazards": [] },
-    { "len": 240, "curve": 0.14, "grade": 0, "roadsideLeft": "fence_post", "roadsideRight": "rock_boulder", "hazards": ["traffic_cone"] },
+    {
+      "len": 240,
+      "curve": 0.14,
+      "grade": 0,
+      "roadsideLeft": "fence_post",
+      "roadsideRight": "rock_boulder",
+      "hazards": ["traffic_cone"],
+      "pickups": [
+        { "id": "foundry-mile-cone-nitro", "kind": "nitro", "laneOffset": 0.35, "value": 25 }
+      ]
+    },
     { "len": 240, "curve": -0.08, "grade": 0.04, "roadsideLeft": "rock_boulder", "roadsideRight": "light_pole", "hazards": [] },
     { "len": 240, "curve": -0.12, "grade": -0.03, "roadsideLeft": "light_pole", "roadsideRight": "fence_post", "hazards": ["puddle"] },
-    { "len": 324, "curve": 0.06, "grade": 0, "roadsideLeft": "sign_marker", "roadsideRight": "rock_boulder", "hazards": [] },
-    { "len": 360, "curve": 0, "grade": 0, "roadsideLeft": "fence_post", "roadsideRight": "sign_marker", "hazards": [] }
+    {
+      "len": 324,
+      "curve": 0.06,
+      "grade": 0,
+      "roadsideLeft": "sign_marker",
+      "roadsideRight": "rock_boulder",
+      "hazards": [],
+      "pickups": [
+        { "id": "foundry-mile-mid-cash", "kind": "cash", "laneOffset": 0, "value": 75 }
+      ]
+    },
+    {
+      "len": 360,
+      "curve": 0,
+      "grade": 0,
+      "roadsideLeft": "fence_post",
+      "roadsideRight": "sign_marker",
+      "hazards": [],
+      "pickups": [
+        { "id": "foundry-mile-finish-cash", "kind": "cash", "laneOffset": 0, "value": 75 }
+      ]
+    }
   ],
   "checkpoints": [
     { "segmentIndex": 0, "label": "start" },

--- a/src/data/tracks/iron-borough-freightline-ring.json
+++ b/src/data/tracks/iron-borough-freightline-ring.json
@@ -12,11 +12,41 @@
   "archetype": "short-sprint",
   "segments": [
     { "len": 240, "curve": 0, "grade": 0, "roadsideLeft": "light_pole", "roadsideRight": "sign_marker", "hazards": [] },
-    { "len": 240, "curve": 0.1, "grade": 0, "roadsideLeft": "fence_post", "roadsideRight": "light_pole", "hazards": ["traffic_cone"] },
+    {
+      "len": 240,
+      "curve": 0.1,
+      "grade": 0,
+      "roadsideLeft": "fence_post",
+      "roadsideRight": "light_pole",
+      "hazards": ["traffic_cone"],
+      "pickups": [
+        { "id": "freightline-ring-yard-nitro", "kind": "nitro", "laneOffset": -0.4, "value": 25 }
+      ]
+    },
     { "len": 240, "curve": 0, "grade": 0.03, "roadsideLeft": "rock_boulder", "roadsideRight": "fence_post", "hazards": [] },
-    { "len": 240, "curve": -0.12, "grade": -0.02, "roadsideLeft": "sign_marker", "roadsideRight": "rock_boulder", "hazards": [] },
+    {
+      "len": 240,
+      "curve": -0.12,
+      "grade": -0.02,
+      "roadsideLeft": "sign_marker",
+      "roadsideRight": "rock_boulder",
+      "hazards": [],
+      "pickups": [
+        { "id": "freightline-ring-descent-cash", "kind": "cash", "laneOffset": -0.35, "value": 75 }
+      ]
+    },
     { "len": 288, "curve": 0.06, "grade": 0, "roadsideLeft": "light_pole", "roadsideRight": "fence_post", "hazards": [] },
-    { "len": 360, "curve": 0, "grade": 0, "roadsideLeft": "fence_post", "roadsideRight": "light_pole", "hazards": [] }
+    {
+      "len": 360,
+      "curve": 0,
+      "grade": 0,
+      "roadsideLeft": "fence_post",
+      "roadsideRight": "light_pole",
+      "hazards": [],
+      "pickups": [
+        { "id": "freightline-ring-finish-cash", "kind": "cash", "laneOffset": 0, "value": 75 }
+      ]
+    }
   ],
   "checkpoints": [
     { "segmentIndex": 0, "label": "start" },

--- a/src/data/tracks/iron-borough-outer-exchange.json
+++ b/src/data/tracks/iron-borough-outer-exchange.json
@@ -12,11 +12,41 @@
   "archetype": "short-sprint",
   "segments": [
     { "len": 240, "curve": 0, "grade": 0, "roadsideLeft": "light_pole", "roadsideRight": "sign_marker", "hazards": [] },
-    { "len": 240, "curve": -0.12, "grade": 0.03, "roadsideLeft": "fence_post", "roadsideRight": "rock_boulder", "hazards": [] },
-    { "len": 240, "curve": 0.12, "grade": -0.02, "roadsideLeft": "sign_marker", "roadsideRight": "light_pole", "hazards": ["traffic_cone"] },
+    {
+      "len": 240,
+      "curve": -0.12,
+      "grade": 0.03,
+      "roadsideLeft": "fence_post",
+      "roadsideRight": "rock_boulder",
+      "hazards": [],
+      "pickups": [
+        { "id": "outer-exchange-climb-nitro", "kind": "nitro", "laneOffset": -0.4, "value": 25 }
+      ]
+    },
+    {
+      "len": 240,
+      "curve": 0.12,
+      "grade": -0.02,
+      "roadsideLeft": "sign_marker",
+      "roadsideRight": "light_pole",
+      "hazards": ["traffic_cone"],
+      "pickups": [
+        { "id": "outer-exchange-overpass-cash", "kind": "cash", "laneOffset": 0.35, "value": 75 }
+      ]
+    },
     { "len": 288, "curve": 0.08, "grade": 0, "roadsideLeft": "rock_boulder", "roadsideRight": "fence_post", "hazards": [] },
     { "len": 300, "curve": -0.06, "grade": 0.03, "roadsideLeft": "light_pole", "roadsideRight": "sign_marker", "hazards": ["puddle"] },
-    { "len": 360, "curve": 0, "grade": -0.01, "roadsideLeft": "fence_post", "roadsideRight": "light_pole", "hazards": [] }
+    {
+      "len": 360,
+      "curve": 0,
+      "grade": -0.01,
+      "roadsideLeft": "fence_post",
+      "roadsideRight": "light_pole",
+      "hazards": [],
+      "pickups": [
+        { "id": "outer-exchange-finish-cash", "kind": "cash", "laneOffset": 0, "value": 75 }
+      ]
+    }
   ],
   "checkpoints": [
     { "segmentIndex": 0, "label": "start" },

--- a/src/data/tracks/iron-borough-rivet-tunnel.json
+++ b/src/data/tracks/iron-borough-rivet-tunnel.json
@@ -12,11 +12,41 @@
   "archetype": "short-sprint",
   "segments": [
     { "len": 240, "curve": 0, "grade": 0, "roadsideLeft": "light_pole", "roadsideRight": "light_pole", "hazards": [] },
-    { "len": 240, "curve": -0.1, "grade": 0.02, "roadsideLeft": "fence_post", "roadsideRight": "rock_boulder", "hazards": [] },
+    {
+      "len": 240,
+      "curve": -0.1,
+      "grade": 0.02,
+      "roadsideLeft": "fence_post",
+      "roadsideRight": "rock_boulder",
+      "hazards": [],
+      "pickups": [
+        { "id": "rivet-tunnel-approach-nitro", "kind": "nitro", "laneOffset": -0.35, "value": 25 }
+      ]
+    },
     { "len": 240, "curve": 0, "grade": -0.02, "roadsideLeft": "rock_boulder", "roadsideRight": "rock_boulder", "hazards": ["tunnel"], "inTunnel": true, "tunnelMaterial": "iron-borough/riveted-steel" },
-    { "len": 240, "curve": 0.12, "grade": 0, "roadsideLeft": "sign_marker", "roadsideRight": "fence_post", "hazards": [] },
+    {
+      "len": 240,
+      "curve": 0.12,
+      "grade": 0,
+      "roadsideLeft": "sign_marker",
+      "roadsideRight": "fence_post",
+      "hazards": [],
+      "pickups": [
+        { "id": "rivet-tunnel-exit-cash", "kind": "cash", "laneOffset": 0.35, "value": 75 }
+      ]
+    },
     { "len": 300, "curve": -0.04, "grade": 0.02, "roadsideLeft": "light_pole", "roadsideRight": "sign_marker", "hazards": ["traffic_cone"] },
-    { "len": 360, "curve": 0, "grade": 0, "roadsideLeft": "fence_post", "roadsideRight": "light_pole", "hazards": [] }
+    {
+      "len": 360,
+      "curve": 0,
+      "grade": 0,
+      "roadsideLeft": "fence_post",
+      "roadsideRight": "light_pole",
+      "hazards": [],
+      "pickups": [
+        { "id": "rivet-tunnel-finish-cash", "kind": "cash", "laneOffset": 0, "value": 75 }
+      ]
+    }
   ],
   "checkpoints": [
     { "segmentIndex": 0, "label": "start" },


### PR DESCRIPTION
## Summary
- Closes Tier A #4 of the 2026-05-07 mass-appeal audit for tour 2 (Iron Borough). Pre-fix, only Velvet Coast (tour 1) had on-track pickups; tours 2-8 were 0-pickup. Now Iron Borough has 3 pickups per track.
- Pattern: inside-line nitro at a corner apex, cash on a corner-exit straight, cash on the final straight. Matches the Velvet Coast template (75 cr cash, 25% nitro).
- Pure data authoring; no code change. The existing `pickups.ts` runtime and `PickupSchema` consume the new entries unchanged.
- F-093 stays open. Tours 3-8 (Ember Steppe, Breakwater Isles, Glass Ridge, Neon Meridian, Moss Frontier, Crown Circuit) ship as subsequent per-tour PRs.

GDD: §9 ([gdd/09-track-design.md](docs/gdd/09-track-design.md)). Progress log: [PROGRESS_LOG.md](docs/PROGRESS_LOG.md) 2026-05-07 tracks entry.

## Test plan
- [x] `npm run typecheck` clean.
- [x] `npm run lint` clean.
- [x] `npm run test` 2873 / 2873 passed (151 suites). The existing `tracks-content.test.ts` validates every track JSON against the schema and the new pickups parse without changes.
- [x] `npm run content-lint` clean.
- [ ] Manual playtest: enter a Foundry Mile race, drive the inside line through segment 1's right turn, confirm the nitro pickup is collectible at laneOffset 0.35.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added pickup items (nitro boosts and cash rewards) to track segments across multiple Iron Borough racing courses including Foundry Mile, Freightline Ring, Outer Exchange, and Rivet Tunnel, providing new strategic opportunities and enhanced gameplay variety.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->