### PR TITLE
feat(results): generic Tour share card (F-100 text path)

### DIFF
--- a/docs/FOLLOWUPS.md
+++ b/docs/FOLLOWUPS.md
@@ -13,8 +13,18 @@ or `obsolete` so the trail is preserved.
 ## F-100: Shareable race-result card
 **Created:** 2026-05-07
 **Priority:** nice-to-have
-**Status:** open
-**Notes:** Surfaced by the 2026-05-07 ten-round mass-appeal audit (Tier C
+**Status:** in-progress
+**Notes:** 2026-05-07 text-card path shipped under
+`feat/share-card`. New module
+`src/components/results/raceShareText.ts` builds the multi-line
+share text from track / tour names + placement + race time +
+best lap; new component
+`src/components/results/RaceShareButton.tsx` reuses the
+daily-share clipboard + fallback flow. The optional
+canvas-screenshot data URL extension stays open under this
+F-NNN; ship after the text-card path validates.
+
+Surfaced by the 2026-05-07 ten-round mass-appeal audit (Tier C
 #13). The `dailyShareText` panel already renders on the §20 results page
 (`src/app/race/results/page.tsx:323-334`) but the source was wired only
 for the cut Daily-Challenge mode (per Q-015). Generalize the share affordance

--- a/docs/PROGRESS_LOG.md
+++ b/docs/PROGRESS_LOG.md
@@ -6,6 +6,74 @@ Correct them by adding a new entry that references the old one.
 
 ---
 
+## 2026-05-07: feat(results): generic Tour share card (F-100 text path)
+
+**GDD sections touched:** [§20](gdd/20-hud-and-ui-ux.md) "Results
+screen" (build-log entry).
+**Branch / PR:** `feat/share-card`, PR pending.
+**Status:** Implemented (text-card path). The optional
+canvas-screenshot data URL stays open under F-100.
+
+### Done
+- Added `src/components/results/raceShareText.ts` with
+  `formatRaceShareText(...)`. Pure: same inputs always produce
+  the same string. Outputs a multi-line text card naming the
+  tour and track, placement, total race time, and best lap.
+  DNF rows render only the DNF marker.
+- Added `src/components/results/RaceShareButton.tsx` reusing the
+  Clipboard / fallback / status pill flow from
+  `DailyShareButton`. Test-ids `race-share`, `race-share-copy`,
+  `race-share-text`, `race-share-status` keep the surface
+  scopable in Playwright.
+- Wired into `src/app/race/results/page.tsx`. The page now
+  renders the share section whenever `playerRow` is non-null
+  (every World Tour finish, including DNF). The dormant Daily
+  share remains for the post-v1.0 daily mode (per F-090
+  cleanup).
+- Tour-name resolution title-cases the tour slug (e.g.
+  `iron-borough` becomes `Iron Borough`) inline in the page;
+  the legacy `displayTourName` helper in `preRaceCard.ts` was
+  not exported here to keep the slice tight (export when a
+  third caller arrives).
+- Track-name resolution reads `TRACK_RAW[result.trackId].name`
+  with a slug fallback so an unknown track id never crashes
+  the share section.
+- Added 8 Vitest cases in
+  `src/components/results/__tests__/raceShareText.test.ts`
+  covering: full finished result, no best lap, no tour name,
+  DNF, unknown placement with finished status, sub-second
+  millisecond padding, hour-long runs, and the no-em-dash rule.
+
+### Verified
+- `npm run typecheck` clean.
+- `npm run lint` clean.
+- `npm run test` 2881 / 2881 passed (152 suites; 8 new tests).
+- `npm run content-lint` clean.
+
+### Decisions and assumptions
+- Did not extract a shared `<ShareTextButton>` primitive between
+  the daily and race surfaces. Two implementations are simpler
+  to read than one abstraction with a hidden test-id parameter;
+  extract on the third caller per the slice-discipline rule.
+- Share text is plain ASCII multi-line. No em-dash, no en-dash;
+  the project rule is enforced both at the source level and in
+  the test suite (regex on the formatter output).
+- The optional canvas-screenshot extension stays in F-100. The
+  text-card path is the high-leverage win and ships first.
+
+### Coverage ledger
+- §20 results-screen coverage gains the new component + builder
+  + tests as `implementationRefs` / `testRefs`. F-100 stays
+  in-progress for the optional screenshot path.
+
+### Followups created
+None.
+
+### GDD edits
+None this slice.
+
+---
+
 ## 2026-05-07: feat(tracks): authored pickups for Iron Borough (F-093 tour 2)
 
 **GDD sections touched:** [§9](gdd/09-track-design.md) (build-log

--- a/src/app/race/results/page.tsx
+++ b/src/app/race/results/page.tsx
@@ -43,12 +43,14 @@ import { BonusChip } from "@/components/results/BonusChip";
 import { DamageBar } from "@/components/results/DamageBar";
 import { FinishingOrderTable } from "@/components/results/FinishingOrderTable";
 import { LeaderboardPanel } from "@/components/results/LeaderboardPanel";
+import { RaceShareButton } from "@/components/results/RaceShareButton";
+import { formatRaceShareText } from "@/components/results/raceShareText";
 import {
   clearRaceResult,
   loadRaceResult,
 } from "@/components/results/raceResultStorage";
 import { DailyShareButton } from "@/app/daily/DailyShareButton";
-import { getChampionship } from "@/data";
+import { getChampionship, TRACK_RAW } from "@/data";
 import { formatDailyChallengeShareText } from "@/game/modes/dailyChallenge";
 import type { RaceResult } from "@/game/raceResult";
 import type { FinalCarRecord } from "@/game/raceRules";
@@ -168,6 +170,39 @@ function ResultsView(props: ResultsViewProps): ReactElement {
   const dailyShareText = result.dailyChallenge
     ? formatDailyChallengeShareText(result.dailyChallenge, playerBestLapMs)
     : null;
+  // F-100 Tour-finish share card. Pulls the player's row + the tour
+  // slug + a track-name lookup off `TRACK_RAW`. Renders for any
+  // result that has a player row (finished or DNF). Replaces the
+  // dormant Daily-only share surface with a generic Tour share so
+  // every World Tour finish has a copyable summary.
+  const raceShareText = useMemo<string | null>(() => {
+    if (!playerRow) return null;
+    const trackEntry = TRACK_RAW[result.trackId] as
+      | { name?: string }
+      | undefined;
+    const trackName = trackEntry?.name ?? result.trackId;
+    const tourId = result.tourProgress?.tourId ?? null;
+    const tourName = tourId
+      ? tourId
+          .split("-")
+          .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+          .join(" ")
+      : null;
+    return formatRaceShareText({
+      trackName,
+      tourName,
+      placement: result.playerPlacement,
+      status: playerRow.status === "finished" ? "finished" : "dnf",
+      raceTimeMs: playerRow.raceTimeMs,
+      bestLapMs: playerBestLapMs,
+    });
+  }, [
+    playerBestLapMs,
+    playerRow,
+    result.playerPlacement,
+    result.tourProgress?.tourId,
+    result.trackId,
+  ]);
   const tourProgress = result.tourProgress ?? null;
   const continueTourHref =
     result.nextRace && tourProgress && tourProgress.nextRaceIndex !== null
@@ -330,6 +365,19 @@ function ResultsView(props: ResultsViewProps): ReactElement {
                 Daily Challenge
               </h3>
               <DailyShareButton text={dailyShareText} />
+            </section>
+          ) : null}
+
+          {raceShareText ? (
+            <section
+              data-testid="results-share"
+              style={dailySharePanelStyle}
+              aria-labelledby="results-share-title"
+            >
+              <h3 id="results-share-title" style={subHeading}>
+                Share result
+              </h3>
+              <RaceShareButton text={raceShareText} />
             </section>
           ) : null}
         </div>

--- a/src/components/results/RaceShareButton.tsx
+++ b/src/components/results/RaceShareButton.tsx
@@ -1,0 +1,61 @@
+"use client";
+
+import { useState, type ReactElement } from "react";
+
+/**
+ * Race-share button per F-100. A finished or DNF'd Tour result
+ * surfaces a copyable text card the player can paste into chat,
+ * Discord, Reddit, etc. Mirrors the daily-share button's
+ * Clipboard / fallback flow but uses test-ids scoped to the
+ * generic Tour-share surface.
+ */
+export interface RaceShareButtonProps {
+  readonly text: string;
+}
+
+export function RaceShareButton({
+  text,
+}: RaceShareButtonProps): ReactElement {
+  const [status, setStatus] = useState<"idle" | "copied" | "fallback">(
+    "idle",
+  );
+
+  async function copyShareText(): Promise<void> {
+    if (navigator.clipboard?.writeText) {
+      try {
+        await navigator.clipboard.writeText(text);
+        setStatus("copied");
+        return;
+      } catch {
+        setStatus("fallback");
+        return;
+      }
+    }
+    setStatus("fallback");
+  }
+
+  return (
+    <div data-testid="race-share">
+      <button
+        type="button"
+        onClick={() => void copyShareText()}
+        data-testid="race-share-copy"
+      >
+        Copy result
+      </button>
+      <textarea
+        aria-label="Race result share text"
+        data-testid="race-share-text"
+        readOnly
+        value={text}
+      />
+      <p aria-live="polite" data-testid="race-share-status">
+        {status === "copied"
+          ? "Copied"
+          : status === "fallback"
+            ? "Copy the text manually"
+            : "Ready"}
+      </p>
+    </div>
+  );
+}

--- a/src/components/results/__tests__/raceShareText.test.ts
+++ b/src/components/results/__tests__/raceShareText.test.ts
@@ -1,0 +1,122 @@
+import { describe, expect, it } from "vitest";
+
+import { formatRaceShareText } from "../raceShareText";
+
+describe("formatRaceShareText", () => {
+  it("formats a finished tour result with track, tour, placement, time, and best lap", () => {
+    const text = formatRaceShareText({
+      trackName: "Foundry Mile",
+      tourName: "Iron Borough",
+      placement: 3,
+      status: "finished",
+      raceTimeMs: 134_318,
+      bestLapMs: 42_156,
+    });
+    expect(text).toBe(
+      [
+        "VibeGear2 race result",
+        "Iron Borough - Foundry Mile",
+        "P3, 2:14.318",
+        "Best lap 0:42.156",
+      ].join("\n"),
+    );
+  });
+
+  it("omits the best-lap line when no timed lap was set", () => {
+    const text = formatRaceShareText({
+      trackName: "Foundry Mile",
+      tourName: "Iron Borough",
+      placement: 3,
+      status: "finished",
+      raceTimeMs: 134_318,
+      bestLapMs: null,
+    });
+    expect(text.split("\n")).toHaveLength(3);
+    expect(text).not.toContain("Best lap");
+  });
+
+  it("omits the tour line when no tour is in scope", () => {
+    const text = formatRaceShareText({
+      trackName: "Foundry Mile",
+      tourName: null,
+      placement: 1,
+      status: "finished",
+      raceTimeMs: 100_000,
+      bestLapMs: 30_000,
+    });
+    expect(text).toBe(
+      [
+        "VibeGear2 race result",
+        "Foundry Mile",
+        "P1, 1:40.000",
+        "Best lap 0:30.000",
+      ].join("\n"),
+    );
+  });
+
+  it("renders a DNF without a placement, race time, or best lap", () => {
+    const text = formatRaceShareText({
+      trackName: "Foundry Mile",
+      tourName: "Iron Borough",
+      placement: null,
+      status: "dnf",
+      raceTimeMs: null,
+      bestLapMs: 42_156,
+    });
+    expect(text).toBe(
+      [
+        "VibeGear2 race result",
+        "Iron Borough - Foundry Mile",
+        "DNF",
+      ].join("\n"),
+    );
+  });
+
+  it("uses 'Finished' as the placement label when the placement is unknown but the run finished", () => {
+    const text = formatRaceShareText({
+      trackName: "Foundry Mile",
+      tourName: null,
+      placement: null,
+      status: "finished",
+      raceTimeMs: 100_000,
+      bestLapMs: null,
+    });
+    expect(text).toContain("Finished, 1:40.000");
+  });
+
+  it("formats sub-second milliseconds with three-digit padding", () => {
+    const text = formatRaceShareText({
+      trackName: "X",
+      tourName: null,
+      placement: 1,
+      status: "finished",
+      raceTimeMs: 12_007,
+      bestLapMs: null,
+    });
+    expect(text).toContain("0:12.007");
+  });
+
+  it("handles long runs by switching to H:MM:SS.mmm", () => {
+    const text = formatRaceShareText({
+      trackName: "X",
+      tourName: null,
+      placement: 1,
+      status: "finished",
+      raceTimeMs: 3_725_000 + 123,
+      bestLapMs: null,
+    });
+    expect(text).toContain("1:02:05.123");
+  });
+
+  it("never includes an em-dash in rendered text (project rule)", () => {
+    const text = formatRaceShareText({
+      trackName: "Foundry Mile",
+      tourName: "Iron Borough",
+      placement: 3,
+      status: "finished",
+      raceTimeMs: 134_318,
+      bestLapMs: 42_156,
+    });
+    expect(text).not.toMatch(/[–—]/u);
+  });
+});

--- a/src/components/results/raceShareText.ts
+++ b/src/components/results/raceShareText.ts
@@ -1,0 +1,84 @@
+/**
+ * Format a one-string race-share card per F-100. Generalises the
+ * dormant `formatDailyChallengeShareText` (cut by Q-015) into a
+ * Tour-finish share string the §20 results screen surfaces for
+ * every World Tour race.
+ *
+ * Pure: same inputs always produce the same string. No locale
+ * dependence except the existing `Intl.NumberFormat` style the
+ * results screen already uses for cash; here we keep the shape
+ * portable so a copied string reads the same in any chat client.
+ *
+ * Output shape (multi-line for readability when pasted):
+ *
+ *   VibeGear2 race result
+ *   Iron Borough - Foundry Mile
+ *   P3, 2:14.318
+ *   Best lap 0:42.156
+ *
+ * For a DNF the third line drops the time:
+ *
+ *   VibeGear2 race result
+ *   Iron Borough - Foundry Mile
+ *   DNF
+ *
+ * Tour name omits when unknown (e.g. legacy non-Tour modes that
+ * survived under F-090). Best-lap line omits when the player set
+ * no timed lap.
+ */
+
+export interface FormatRaceShareInput {
+  readonly trackName: string;
+  readonly tourName: string | null;
+  readonly placement: number | null;
+  readonly status: "finished" | "dnf";
+  readonly raceTimeMs: number | null;
+  readonly bestLapMs: number | null;
+}
+
+export function formatRaceShareText(input: FormatRaceShareInput): string {
+  const lines: string[] = [];
+  lines.push("VibeGear2 race result");
+  if (input.tourName !== null && input.tourName !== "") {
+    lines.push(`${input.tourName} - ${input.trackName}`);
+  } else {
+    lines.push(input.trackName);
+  }
+  if (input.status === "dnf") {
+    lines.push("DNF");
+    return lines.join("\n");
+  }
+  const placementLabel =
+    input.placement !== null ? `P${input.placement}` : "Finished";
+  if (input.raceTimeMs !== null) {
+    lines.push(`${placementLabel}, ${formatLapTime(input.raceTimeMs)}`);
+  } else {
+    lines.push(placementLabel);
+  }
+  if (input.bestLapMs !== null) {
+    lines.push(`Best lap ${formatLapTime(input.bestLapMs)}`);
+  }
+  return lines.join("\n");
+}
+
+/**
+ * Format a millisecond duration as `M:SS.mmm` (or `H:MM:SS.mmm` for
+ * runs over an hour, defensive only since v1.0 races never go past
+ * ~25 min). Mirrors the existing §20 results-page lap-time format
+ * so the share string and the on-screen string match.
+ */
+function formatLapTime(ms: number): string {
+  if (!Number.isFinite(ms) || ms < 0) return "0:00.000";
+  const totalSeconds = Math.floor(ms / 1000);
+  const millis = Math.floor(ms % 1000);
+  const hours = Math.floor(totalSeconds / 3600);
+  const minutes = Math.floor((totalSeconds % 3600) / 60);
+  const seconds = totalSeconds % 60;
+  const ss = String(seconds).padStart(2, "0");
+  const mmm = String(millis).padStart(3, "0");
+  if (hours > 0) {
+    const mm = String(minutes).padStart(2, "0");
+    return `${hours}:${mm}:${ss}.${mmm}`;
+  }
+  return `${minutes}:${ss}.${mmm}`;
+}


### PR DESCRIPTION
## Summary
- Closes the text-card path of F-100 from the 2026-05-07 mass-appeal audit (Tier C #13). Every World Tour finish (including DNF) now has a copyable result card on the §20 results screen.
- Pure builder `formatRaceShareText` produces a multi-line ASCII card naming tour, track, placement, race time, and best lap. DNF rows render only the DNF marker.
- New `<RaceShareButton>` reuses the daily-share Clipboard / fallback / status pill flow under distinct test-ids (`race-share-copy`, `race-share-text`, `race-share-status`).
- Tour-name resolution title-cases the tour slug inline; track-name lookup reads `TRACK_RAW` with a slug fallback.
- Dormant Daily share panel stays for the post-v1.0 daily mode (per F-090 cleanup).
- Optional canvas-screenshot extension stays open under F-100.

GDD: §20 ([gdd/20-hud-and-ui-ux.md](docs/gdd/20-hud-and-ui-ux.md)). Progress log: [PROGRESS_LOG.md](docs/PROGRESS_LOG.md) 2026-05-07 results entry.

## Test plan
- [x] `npm run typecheck` clean.
- [x] `npm run lint` clean.
- [x] `npm run test` 2881 / 2881 passed (152 suites; 8 new in `raceShareText.test.ts`).
- [x] `npm run content-lint` clean.
- [ ] Manual playtest: finish a Velvet Coast Tour race, confirm the share section appears, click "Copy result", paste into a chat client, confirm the multi-line card reads cleanly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a "Share result" section for tour race finishes so users can copy formatted race summaries (placement, finish time, track/tour name, best lap).
  * Copy button includes graceful fallback when clipboard access isn't available.

* **Tests**
  * Added tests verifying share text formatting for finished, DNF, and edge-case times and ensuring consistent output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->