### PR TITLE
feat(tracks): authored pickups for Ember Steppe (F-093 tour 3)

### DIFF
--- a/docs/FOLLOWUPS.md
+++ b/docs/FOLLOWUPS.md
@@ -131,13 +131,15 @@ crest is crossed at speed. Pairs with §16 (camera shake on landing).
 **Created:** 2026-05-07
 **Priority:** nice-to-have
 **Status:** in-progress
-**Notes:** 2026-05-07 split per-tour. Tour 2 (Iron Borough)
-shipped under `feat/pickups-tours-2-to-8`: 3 pickups per track
-(1 inside-line nitro on a corner apex, 1 cash on a curve or
-post-curve straight, 1 cash on the final straight) across all
-4 tracks. Tours 3-8 stay open under this F-NNN; each subsequent
-tour ships as its own PR for review tractability. Original
-notes follow.
+**Notes:** 2026-05-07 split per-tour. Tour 2 (Iron Borough) and
+Tour 3 (Ember Steppe) shipped under `feat/pickups-tours-2-to-8`
+and `feat/pickups-ember-steppe`: 3 pickups per track each (1
+inside-line nitro on a corner apex, 1 cash on a tactical beat,
+1 cash on the final straight) across all 8 tracks. Tours 4-8
+(Breakwater Isles, Glass Ridge, Neon Meridian, Moss Frontier,
+Crown Circuit) stay open under this F-NNN; each subsequent tour
+ships as its own PR for review tractability. Original notes
+follow.
 
 Surfaced by the 2026-05-07 mass-appeal audit (Tier A #4).
 A grep of all 32 production tracks shows pickups are only authored on

--- a/docs/PROGRESS_LOG.md
+++ b/docs/PROGRESS_LOG.md
@@ -74,6 +74,68 @@ None this slice.
 
 ---
 
+## 2026-05-07: feat(tracks): authored pickups for Ember Steppe (F-093 tour 3)
+
+**GDD sections touched:** [§9](gdd/09-track-design.md) (build-log
+entry).
+**Branch / PR:** `feat/pickups-ember-steppe`, PR pending.
+**Status:** Implemented (Ember Steppe only). F-093 stays open
+covering tours 4-8.
+
+### Done
+- Added 3 pickups per track to all 4 Ember Steppe tracks (Tour 3):
+  Cinder Gate, Dustbreak Causeway, Mesa Coil, Redglass Straight.
+  Same pattern the Iron Borough slice established: one inside-line
+  nitro at the dominant corner apex, one cash on a tactical beat
+  (corner exit, climb, or supporting curve), one cash on the final
+  straight.
+- Difficulty-aware placement:
+  - Cinder Gate (difficulty 5, hardest in tour): nitro on the
+    sharp +0.2 right apex (segment 2), cash on the descent
+    +0.14 right (segment 4).
+  - Mesa Coil (4): nitro on the -0.2 left apex (segment 2),
+    cash on the +0.16 climb (segment 3).
+  - Dustbreak Causeway (4): cash on the +0.12 climb (segment 2),
+    nitro on the -0.14 left apex (segment 4).
+  - Redglass Straight (3, mostly straight): nitro on the long
+    320 m climb at grade 0.03 (segment 2, centerline) since the
+    track has no strong corner apex; cash on the only meaningful
+    -0.08 bend (segment 3).
+- Pickup ids follow the same `<track-slug-suffix>-<beat>-<kind>`
+  shape Iron Borough used. Values stay at 75 cr cash and 25%
+  nitro mirroring the Velvet Coast and Iron Borough authored
+  values.
+
+### Verified
+- `npm run typecheck` clean.
+- `npm run lint` clean.
+- `npm run test` 2881 / 2881 passed (152 suites; the existing
+  `tracks-content.test.ts` validates every JSON against the
+  schema and the new pickups passed without change).
+- `npm run content-lint` clean.
+
+### Decisions and assumptions
+- Did not add or change any code. Pure data authoring against
+  the existing pickup runtime and schema.
+- Redglass Straight's nitro on a centerline straight is an
+  intentional break from the inside-apex template because the
+  track has no strong corner. Rewards the player who holds the
+  racing line on the climb instead of drifting to the rumble.
+
+### Coverage ledger
+- §9 track-design coverage gains 4 more tracks worth of authored
+  pickup data. F-093 stays open with 20 tracks remaining
+  (Breakwater Isles + Glass Ridge + Neon Meridian + Moss Frontier
+  + Crown Circuit).
+
+### Followups created
+None.
+
+### GDD edits
+None this slice.
+
+---
+
 ## 2026-05-07: feat(tracks): authored pickups for Iron Borough (F-093 tour 2)
 
 **GDD sections touched:** [§9](gdd/09-track-design.md) (build-log

--- a/src/data/tracks/ember-steppe-cinder-gate.json
+++ b/src/data/tracks/ember-steppe-cinder-gate.json
@@ -13,11 +13,41 @@
   "segments": [
     { "len": 240, "curve": 0.04, "grade": 0.02, "roadsideLeft": "rock_spire", "roadsideRight": "sign_marker", "hazards": [] },
     { "len": 240, "curve": -0.16, "grade": 0.04, "roadsideLeft": "rock_boulder", "roadsideRight": "heat_sign", "hazards": ["gravel_band"] },
-    { "len": 280, "curve": 0.2, "grade": -0.02, "roadsideLeft": "heat_sign", "roadsideRight": "rock_spire", "hazards": ["sign_marker"] },
+    {
+      "len": 280,
+      "curve": 0.2,
+      "grade": -0.02,
+      "roadsideLeft": "heat_sign",
+      "roadsideRight": "rock_spire",
+      "hazards": ["sign_marker"],
+      "pickups": [
+        { "id": "cinder-gate-apex-nitro", "kind": "nitro", "laneOffset": 0.4, "value": 25 }
+      ]
+    },
     { "len": 280, "curve": -0.08, "grade": 0.05, "roadsideLeft": "fence_post", "roadsideRight": "rock_boulder", "hazards": [] },
-    { "len": 260, "curve": 0.14, "grade": -0.05, "roadsideLeft": "rock_spire", "roadsideRight": "heat_sign", "hazards": ["traffic_cone"] },
+    {
+      "len": 260,
+      "curve": 0.14,
+      "grade": -0.05,
+      "roadsideLeft": "rock_spire",
+      "roadsideRight": "heat_sign",
+      "hazards": ["traffic_cone"],
+      "pickups": [
+        { "id": "cinder-gate-descent-cash", "kind": "cash", "laneOffset": 0.35, "value": 75 }
+      ]
+    },
     { "len": 260, "curve": -0.12, "grade": 0.01, "roadsideLeft": "rock_boulder", "roadsideRight": "sign_marker", "hazards": ["gravel_band"] },
-    { "len": 360, "curve": 0, "grade": 0, "roadsideLeft": "heat_sign", "roadsideRight": "rock_spire", "hazards": [] }
+    {
+      "len": 360,
+      "curve": 0,
+      "grade": 0,
+      "roadsideLeft": "heat_sign",
+      "roadsideRight": "rock_spire",
+      "hazards": [],
+      "pickups": [
+        { "id": "cinder-gate-finish-cash", "kind": "cash", "laneOffset": 0, "value": 75 }
+      ]
+    }
   ],
   "checkpoints": [
     { "segmentIndex": 0, "label": "start" },

--- a/src/data/tracks/ember-steppe-dustbreak-causeway.json
+++ b/src/data/tracks/ember-steppe-dustbreak-causeway.json
@@ -13,11 +13,41 @@
   "segments": [
     { "len": 260, "curve": 0, "grade": 0, "roadsideLeft": "heat_sign", "roadsideRight": "fence_post", "hazards": [] },
     { "len": 220, "curve": -0.1, "grade": -0.01, "roadsideLeft": "rock_boulder", "roadsideRight": "rock_spire", "hazards": ["gravel_band"] },
-    { "len": 280, "curve": 0.12, "grade": 0.02, "roadsideLeft": "rock_spire", "roadsideRight": "heat_sign", "hazards": [] },
+    {
+      "len": 280,
+      "curve": 0.12,
+      "grade": 0.02,
+      "roadsideLeft": "rock_spire",
+      "roadsideRight": "heat_sign",
+      "hazards": [],
+      "pickups": [
+        { "id": "dustbreak-causeway-rise-cash", "kind": "cash", "laneOffset": 0.35, "value": 75 }
+      ]
+    },
     { "len": 240, "curve": 0, "grade": 0.05, "roadsideLeft": "sign_marker", "roadsideRight": "rock_boulder", "hazards": ["traffic_cone"] },
-    { "len": 300, "curve": -0.14, "grade": -0.04, "roadsideLeft": "rock_boulder", "roadsideRight": "sign_marker", "hazards": [] },
+    {
+      "len": 300,
+      "curve": -0.14,
+      "grade": -0.04,
+      "roadsideLeft": "rock_boulder",
+      "roadsideRight": "sign_marker",
+      "hazards": [],
+      "pickups": [
+        { "id": "dustbreak-causeway-apex-nitro", "kind": "nitro", "laneOffset": -0.4, "value": 25 }
+      ]
+    },
     { "len": 260, "curve": 0.1, "grade": 0.01, "roadsideLeft": "heat_sign", "roadsideRight": "rock_spire", "hazards": ["gravel_band"] },
-    { "len": 300, "curve": 0, "grade": 0, "roadsideLeft": "fence_post", "roadsideRight": "heat_sign", "hazards": [] }
+    {
+      "len": 300,
+      "curve": 0,
+      "grade": 0,
+      "roadsideLeft": "fence_post",
+      "roadsideRight": "heat_sign",
+      "hazards": [],
+      "pickups": [
+        { "id": "dustbreak-causeway-finish-cash", "kind": "cash", "laneOffset": 0, "value": 75 }
+      ]
+    }
   ],
   "checkpoints": [
     { "segmentIndex": 0, "label": "start" },

--- a/src/data/tracks/ember-steppe-mesa-coil.json
+++ b/src/data/tracks/ember-steppe-mesa-coil.json
@@ -13,11 +13,41 @@
   "segments": [
     { "len": 220, "curve": 0.08, "grade": 0.02, "roadsideLeft": "rock_boulder", "roadsideRight": "heat_sign", "hazards": [] },
     { "len": 220, "curve": 0.18, "grade": 0.03, "roadsideLeft": "rock_spire", "roadsideRight": "rock_boulder", "hazards": ["gravel_band"] },
-    { "len": 260, "curve": -0.2, "grade": -0.01, "roadsideLeft": "heat_sign", "roadsideRight": "rock_spire", "hazards": [] },
-    { "len": 260, "curve": 0.16, "grade": 0.04, "roadsideLeft": "rock_boulder", "roadsideRight": "sign_marker", "hazards": ["sign_marker"] },
+    {
+      "len": 260,
+      "curve": -0.2,
+      "grade": -0.01,
+      "roadsideLeft": "heat_sign",
+      "roadsideRight": "rock_spire",
+      "hazards": [],
+      "pickups": [
+        { "id": "mesa-coil-apex-nitro", "kind": "nitro", "laneOffset": -0.4, "value": 25 }
+      ]
+    },
+    {
+      "len": 260,
+      "curve": 0.16,
+      "grade": 0.04,
+      "roadsideLeft": "rock_boulder",
+      "roadsideRight": "sign_marker",
+      "hazards": ["sign_marker"],
+      "pickups": [
+        { "id": "mesa-coil-climb-cash", "kind": "cash", "laneOffset": 0.35, "value": 75 }
+      ]
+    },
     { "len": 280, "curve": -0.12, "grade": -0.03, "roadsideLeft": "fence_post", "roadsideRight": "rock_boulder", "hazards": [] },
     { "len": 260, "curve": 0.06, "grade": 0.01, "roadsideLeft": "rock_spire", "roadsideRight": "heat_sign", "hazards": ["traffic_cone"] },
-    { "len": 300, "curve": 0, "grade": 0, "roadsideLeft": "sign_marker", "roadsideRight": "rock_spire", "hazards": [] }
+    {
+      "len": 300,
+      "curve": 0,
+      "grade": 0,
+      "roadsideLeft": "sign_marker",
+      "roadsideRight": "rock_spire",
+      "hazards": [],
+      "pickups": [
+        { "id": "mesa-coil-finish-cash", "kind": "cash", "laneOffset": 0, "value": 75 }
+      ]
+    }
   ],
   "checkpoints": [
     { "segmentIndex": 0, "label": "start" },

--- a/src/data/tracks/ember-steppe-redglass-straight.json
+++ b/src/data/tracks/ember-steppe-redglass-straight.json
@@ -13,10 +13,40 @@
   "segments": [
     { "len": 300, "curve": 0, "grade": 0.01, "roadsideLeft": "rock_spire", "roadsideRight": "sign_marker", "hazards": [] },
     { "len": 260, "curve": 0.04, "grade": 0, "roadsideLeft": "heat_sign", "roadsideRight": "rock_boulder", "hazards": ["gravel_band"] },
-    { "len": 320, "curve": 0, "grade": 0.03, "roadsideLeft": "rock_boulder", "roadsideRight": "heat_sign", "hazards": [] },
-    { "len": 240, "curve": -0.08, "grade": -0.02, "roadsideLeft": "sign_marker", "roadsideRight": "rock_spire", "hazards": ["traffic_cone"] },
+    {
+      "len": 320,
+      "curve": 0,
+      "grade": 0.03,
+      "roadsideLeft": "rock_boulder",
+      "roadsideRight": "heat_sign",
+      "hazards": [],
+      "pickups": [
+        { "id": "redglass-straight-climb-nitro", "kind": "nitro", "laneOffset": 0, "value": 25 }
+      ]
+    },
+    {
+      "len": 240,
+      "curve": -0.08,
+      "grade": -0.02,
+      "roadsideLeft": "sign_marker",
+      "roadsideRight": "rock_spire",
+      "hazards": ["traffic_cone"],
+      "pickups": [
+        { "id": "redglass-straight-bend-cash", "kind": "cash", "laneOffset": -0.3, "value": 75 }
+      ]
+    },
     { "len": 260, "curve": 0.08, "grade": 0, "roadsideLeft": "rock_spire", "roadsideRight": "fence_post", "hazards": [] },
-    { "len": 360, "curve": 0, "grade": 0, "roadsideLeft": "heat_sign", "roadsideRight": "sign_marker", "hazards": [] }
+    {
+      "len": 360,
+      "curve": 0,
+      "grade": 0,
+      "roadsideLeft": "heat_sign",
+      "roadsideRight": "sign_marker",
+      "hazards": [],
+      "pickups": [
+        { "id": "redglass-straight-finish-cash", "kind": "cash", "laneOffset": 0, "value": 75 }
+      ]
+    }
   ],
   "checkpoints": [
     { "segmentIndex": 0, "label": "start" },


### PR DESCRIPTION
## Summary
- Tour 3 (Ember Steppe) of the F-093 backlog: 3 pickups per track across all 4 desert / canyon tracks. Same template Iron Borough (#188) established: inside-line nitro at the dominant apex, cash on a tactical beat, cash on the final straight.
- Difficulty-aware: Cinder Gate (5) and Mesa Coil (4) place the nitro on the hardest curve. Redglass Straight (mostly straight) places the nitro on a centerline climb instead since the track has no strong corner.
- Pure JSON authoring; no code change. Tours 4-8 stay open under F-093.

GDD: §9 ([gdd/09-track-design.md](docs/gdd/09-track-design.md)). Progress log: [PROGRESS_LOG.md](docs/PROGRESS_LOG.md) 2026-05-07 Ember Steppe entry.

## Test plan
- [x] `npm run typecheck` clean.
- [x] `npm run lint` clean.
- [x] `npm run test` 2881 / 2881 passed (152 suites).
- [x] `npm run content-lint` clean.
- [ ] Manual playtest: enter a Cinder Gate race, drive the inside line through segment 2's +0.2 apex, confirm the nitro pickup is collectible at laneOffset 0.4.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added pickups to multiple Ember Steppe tracks: nitro boosts and cash rewards are now available on specific segments in Cinder Gate, Dustbreak Causeway, Mesa Coil, and Redglass Straight tracks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->