### PR TITLE
feat(tracks): authored pickups for Breakwater Isles (F-093 tour 4)

### DIFF
--- a/docs/FOLLOWUPS.md
+++ b/docs/FOLLOWUPS.md
@@ -131,15 +131,13 @@ crest is crossed at speed. Pairs with §16 (camera shake on landing).
 **Created:** 2026-05-07
 **Priority:** nice-to-have
 **Status:** in-progress
-**Notes:** 2026-05-07 split per-tour. Tour 2 (Iron Borough) and
-Tour 3 (Ember Steppe) shipped under `feat/pickups-tours-2-to-8`
-and `feat/pickups-ember-steppe`: 3 pickups per track each (1
-inside-line nitro on a corner apex, 1 cash on a tactical beat,
-1 cash on the final straight) across all 8 tracks. Tours 4-8
-(Breakwater Isles, Glass Ridge, Neon Meridian, Moss Frontier,
-Crown Circuit) stay open under this F-NNN; each subsequent tour
-ships as its own PR for review tractability. Original notes
-follow.
+**Notes:** 2026-05-07 split per-tour. Tours 2-4 (Iron Borough,
+Ember Steppe, Breakwater Isles) shipped: 3 pickups per track
+each (1 inside-line nitro on a corner apex, 1 cash on a tactical
+beat, 1 cash on the final straight) across all 12 tracks. Tours
+5-8 (Glass Ridge, Neon Meridian, Moss Frontier, Crown Circuit)
+stay open under this F-NNN; each subsequent tour ships as its
+own PR for review tractability. Original notes follow.
 
 Surfaced by the 2026-05-07 mass-appeal audit (Tier A #4).
 A grep of all 32 production tracks shows pickups are only authored on

--- a/docs/PROGRESS_LOG.md
+++ b/docs/PROGRESS_LOG.md
@@ -74,6 +74,61 @@ None this slice.
 
 ---
 
+## 2026-05-07: feat(tracks): authored pickups for Breakwater Isles (F-093 tour 4)
+
+**GDD sections touched:** [§9](gdd/09-track-design.md) (build-log
+entry).
+**Branch / PR:** `feat/pickups-breakwater-isles`, PR pending.
+**Status:** Implemented (Breakwater Isles only). F-093 stays open
+covering tours 5-8.
+
+### Done
+- Added 3 pickups per track to all 4 Breakwater Isles tracks (Tour 4):
+  Gull Point, Sealight Shelf, Storm Span, Tidewire.
+  Same template Iron Borough (#188) and Ember Steppe (#190)
+  established: one inside-line nitro at the dominant corner apex,
+  one cash on a tactical beat, one cash on the final straight.
+- Wet-weather authoring: every Breakwater Isles track ships with
+  rain or heavy rain in its `weatherOptions`. The cash on the
+  middle apex sits on a `slick_paint` hazard segment for three of
+  four tracks (Gull Point, Storm Span, Tidewire) so the player
+  rewards holding the racing line through reduced grip. Sealight
+  Shelf (the difficulty-5 track) skips the slick-paint placement
+  because the apex sits on a clean climb instead.
+- The nitro placement consistently rewards the inside-line on the
+  strongest left turn in each track (curves -0.16 to -0.22), so a
+  player who threads the apex through standing puddles gets paid.
+- Pickup ids and 75 cr / 25% values match the established template.
+
+### Verified
+- `npm run typecheck` clean.
+- `npm run lint` clean.
+- `npm run test` 2881 / 2881 passed (152 suites; the existing
+  `tracks-content.test.ts` validates every JSON against the
+  schema).
+- `npm run content-lint` clean.
+
+### Decisions and assumptions
+- Did not add or change any code. Pure data authoring against
+  the existing pickup runtime and schema.
+- The `slick_paint` hazard interaction with pickups is reused
+  here exactly as Iron Borough's `traffic_cone` placements:
+  pickups sit on the inside line so a clean apex collects them
+  even with reduced surface grip.
+
+### Coverage ledger
+- §9 track-design coverage gains 4 more tracks worth of authored
+  pickup data. F-093 stays open with 16 tracks remaining (Glass
+  Ridge + Neon Meridian + Moss Frontier + Crown Circuit).
+
+### Followups created
+None.
+
+### GDD edits
+None this slice.
+
+---
+
 ## 2026-05-07: feat(tracks): authored pickups for Ember Steppe (F-093 tour 3)
 
 **GDD sections touched:** [§9](gdd/09-track-design.md) (build-log

--- a/src/data/tracks/breakwater-isles-gull-point.json
+++ b/src/data/tracks/breakwater-isles-gull-point.json
@@ -14,10 +14,40 @@
     { "len": 260, "curve": 0, "grade": 0.01, "roadsideLeft": "marina_signs", "roadsideRight": "light_pole", "hazards": [] },
     { "len": 240, "curve": 0.14, "grade": 0.03, "roadsideLeft": "guardrail", "roadsideRight": "water_wall", "hazards": ["puddle"] },
     { "len": 260, "curve": -0.1, "grade": -0.02, "roadsideLeft": "water_wall", "roadsideRight": "guardrail", "hazards": [] },
-    { "len": 280, "curve": 0.18, "grade": 0.04, "roadsideLeft": "light_pole", "roadsideRight": "marina_signs", "hazards": ["slick_paint"] },
-    { "len": 260, "curve": -0.2, "grade": -0.03, "roadsideLeft": "guardrail", "roadsideRight": "water_wall", "hazards": ["puddle"] },
+    {
+      "len": 280,
+      "curve": 0.18,
+      "grade": 0.04,
+      "roadsideLeft": "light_pole",
+      "roadsideRight": "marina_signs",
+      "hazards": ["slick_paint"],
+      "pickups": [
+        { "id": "gull-point-paint-cash", "kind": "cash", "laneOffset": 0.35, "value": 75 }
+      ]
+    },
+    {
+      "len": 260,
+      "curve": -0.2,
+      "grade": -0.03,
+      "roadsideLeft": "guardrail",
+      "roadsideRight": "water_wall",
+      "hazards": ["puddle"],
+      "pickups": [
+        { "id": "gull-point-apex-nitro", "kind": "nitro", "laneOffset": -0.4, "value": 25 }
+      ]
+    },
     { "len": 300, "curve": 0.08, "grade": 0.01, "roadsideLeft": "marina_signs", "roadsideRight": "light_pole", "hazards": [] },
-    { "len": 380, "curve": 0, "grade": 0, "roadsideLeft": "water_wall", "roadsideRight": "guardrail", "hazards": [] }
+    {
+      "len": 380,
+      "curve": 0,
+      "grade": 0,
+      "roadsideLeft": "water_wall",
+      "roadsideRight": "guardrail",
+      "hazards": [],
+      "pickups": [
+        { "id": "gull-point-finish-cash", "kind": "cash", "laneOffset": 0, "value": 75 }
+      ]
+    }
   ],
   "checkpoints": [
     { "segmentIndex": 0, "label": "start" },

--- a/src/data/tracks/breakwater-isles-sealight-shelf.json
+++ b/src/data/tracks/breakwater-isles-sealight-shelf.json
@@ -14,10 +14,40 @@
     { "len": 280, "curve": 0.04, "grade": 0.02, "roadsideLeft": "light_pole", "roadsideRight": "marina_signs", "hazards": [] },
     { "len": 260, "curve": -0.16, "grade": 0.05, "roadsideLeft": "guardrail", "roadsideRight": "water_wall", "hazards": ["puddle"] },
     { "len": 300, "curve": 0.12, "grade": -0.04, "roadsideLeft": "water_wall", "roadsideRight": "guardrail", "hazards": ["slick_paint"] },
-    { "len": 280, "curve": 0.2, "grade": 0.03, "roadsideLeft": "marina_signs", "roadsideRight": "light_pole", "hazards": [] },
-    { "len": 280, "curve": -0.22, "grade": -0.05, "roadsideLeft": "guardrail", "roadsideRight": "water_wall", "hazards": ["puddle"] },
+    {
+      "len": 280,
+      "curve": 0.2,
+      "grade": 0.03,
+      "roadsideLeft": "marina_signs",
+      "roadsideRight": "light_pole",
+      "hazards": [],
+      "pickups": [
+        { "id": "sealight-shelf-rise-cash", "kind": "cash", "laneOffset": 0.35, "value": 75 }
+      ]
+    },
+    {
+      "len": 280,
+      "curve": -0.22,
+      "grade": -0.05,
+      "roadsideLeft": "guardrail",
+      "roadsideRight": "water_wall",
+      "hazards": ["puddle"],
+      "pickups": [
+        { "id": "sealight-shelf-apex-nitro", "kind": "nitro", "laneOffset": -0.4, "value": 25 }
+      ]
+    },
     { "len": 320, "curve": 0.1, "grade": 0.01, "roadsideLeft": "light_pole", "roadsideRight": "guardrail", "hazards": ["traffic_cone"] },
-    { "len": 400, "curve": 0, "grade": 0, "roadsideLeft": "water_wall", "roadsideRight": "marina_signs", "hazards": [] }
+    {
+      "len": 400,
+      "curve": 0,
+      "grade": 0,
+      "roadsideLeft": "water_wall",
+      "roadsideRight": "marina_signs",
+      "hazards": [],
+      "pickups": [
+        { "id": "sealight-shelf-finish-cash", "kind": "cash", "laneOffset": 0, "value": 75 }
+      ]
+    }
   ],
   "checkpoints": [
     { "segmentIndex": 0, "label": "start" },

--- a/src/data/tracks/breakwater-isles-storm-span.json
+++ b/src/data/tracks/breakwater-isles-storm-span.json
@@ -14,10 +14,40 @@
     { "len": 260, "curve": 0, "grade": 0, "roadsideLeft": "light_pole", "roadsideRight": "light_pole", "hazards": [] },
     { "len": 260, "curve": -0.12, "grade": 0.02, "roadsideLeft": "guardrail", "roadsideRight": "water_wall", "hazards": ["puddle"] },
     { "len": 280, "curve": 0, "grade": 0.04, "roadsideLeft": "water_wall", "roadsideRight": "guardrail", "hazards": [] },
-    { "len": 260, "curve": 0.16, "grade": -0.03, "roadsideLeft": "marina_signs", "roadsideRight": "light_pole", "hazards": ["slick_paint"] },
-    { "len": 280, "curve": -0.18, "grade": 0.03, "roadsideLeft": "guardrail", "roadsideRight": "water_wall", "hazards": ["puddle"] },
+    {
+      "len": 260,
+      "curve": 0.16,
+      "grade": -0.03,
+      "roadsideLeft": "marina_signs",
+      "roadsideRight": "light_pole",
+      "hazards": ["slick_paint"],
+      "pickups": [
+        { "id": "storm-span-paint-cash", "kind": "cash", "laneOffset": 0.35, "value": 75 }
+      ]
+    },
+    {
+      "len": 280,
+      "curve": -0.18,
+      "grade": 0.03,
+      "roadsideLeft": "guardrail",
+      "roadsideRight": "water_wall",
+      "hazards": ["puddle"],
+      "pickups": [
+        { "id": "storm-span-apex-nitro", "kind": "nitro", "laneOffset": -0.4, "value": 25 }
+      ]
+    },
     { "len": 320, "curve": 0.08, "grade": -0.02, "roadsideLeft": "light_pole", "roadsideRight": "marina_signs", "hazards": ["traffic_cone"] },
-    { "len": 380, "curve": 0, "grade": 0, "roadsideLeft": "water_wall", "roadsideRight": "guardrail", "hazards": [] }
+    {
+      "len": 380,
+      "curve": 0,
+      "grade": 0,
+      "roadsideLeft": "water_wall",
+      "roadsideRight": "guardrail",
+      "hazards": [],
+      "pickups": [
+        { "id": "storm-span-finish-cash", "kind": "cash", "laneOffset": 0, "value": 75 }
+      ]
+    }
   ],
   "checkpoints": [
     { "segmentIndex": 0, "label": "start" },

--- a/src/data/tracks/breakwater-isles-tidewire.json
+++ b/src/data/tracks/breakwater-isles-tidewire.json
@@ -14,10 +14,40 @@
     { "len": 280, "curve": 0, "grade": 0, "roadsideLeft": "marina_signs", "roadsideRight": "light_pole", "hazards": [] },
     { "len": 220, "curve": 0.1, "grade": 0.01, "roadsideLeft": "guardrail", "roadsideRight": "water_wall", "hazards": ["puddle"] },
     { "len": 240, "curve": -0.08, "grade": 0.03, "roadsideLeft": "water_wall", "roadsideRight": "guardrail", "hazards": [] },
-    { "len": 240, "curve": 0.14, "grade": -0.02, "roadsideLeft": "light_pole", "roadsideRight": "marina_signs", "hazards": ["slick_paint"] },
-    { "len": 260, "curve": -0.16, "grade": 0.02, "roadsideLeft": "guardrail", "roadsideRight": "water_wall", "hazards": ["puddle"] },
+    {
+      "len": 240,
+      "curve": 0.14,
+      "grade": -0.02,
+      "roadsideLeft": "light_pole",
+      "roadsideRight": "marina_signs",
+      "hazards": ["slick_paint"],
+      "pickups": [
+        { "id": "tidewire-paint-cash", "kind": "cash", "laneOffset": 0.3, "value": 75 }
+      ]
+    },
+    {
+      "len": 260,
+      "curve": -0.16,
+      "grade": 0.02,
+      "roadsideLeft": "guardrail",
+      "roadsideRight": "water_wall",
+      "hazards": ["puddle"],
+      "pickups": [
+        { "id": "tidewire-apex-nitro", "kind": "nitro", "laneOffset": -0.4, "value": 25 }
+      ]
+    },
     { "len": 300, "curve": 0.04, "grade": -0.01, "roadsideLeft": "marina_signs", "roadsideRight": "light_pole", "hazards": [] },
-    { "len": 340, "curve": 0, "grade": 0, "roadsideLeft": "water_wall", "roadsideRight": "guardrail", "hazards": [] }
+    {
+      "len": 340,
+      "curve": 0,
+      "grade": 0,
+      "roadsideLeft": "water_wall",
+      "roadsideRight": "guardrail",
+      "hazards": [],
+      "pickups": [
+        { "id": "tidewire-finish-cash", "kind": "cash", "laneOffset": 0, "value": 75 }
+      ]
+    }
   ],
   "checkpoints": [
     { "segmentIndex": 0, "label": "start" },


### PR DESCRIPTION
## Summary
- Tour 4 (Breakwater Isles) of the F-093 backlog: 3 pickups per track across all 4 sea-bridge / causeway tracks. Same template Iron Borough (#188) and Ember Steppe (#190) established.
- Wet-weather adaptation: every Breakwater Isles track ships rain or heavy_rain. Three of four tracks place the mid-apex cash on a slick_paint hazard so the player gets paid for holding the line through reduced grip. The nitro sits on the strongest left turn and rewards threading puddle hazards.
- Pure JSON authoring; no code change. Tours 5-8 (Glass Ridge, Neon Meridian, Moss Frontier, Crown Circuit) stay open under F-093.

GDD: §9 ([gdd/09-track-design.md](docs/gdd/09-track-design.md)). Progress log: [PROGRESS_LOG.md](docs/PROGRESS_LOG.md) 2026-05-07 Breakwater Isles entry.

## Test plan
- [x] `npm run typecheck` clean.
- [x] `npm run lint` clean.
- [x] `npm run test` 2881 / 2881 passed (152 suites).
- [x] `npm run content-lint` clean.
- [ ] Manual playtest: enter a Sealight Shelf race in heavy rain, drive the inside line through segment 4's -0.22 apex, confirm the nitro pickup is collectible at laneOffset -0.4 with reduced grip.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added cash and nitro pickup items to four race tracks with strategic placement across multiple segments.
  * Enhanced track layouts with varying pickup values and lane offsets throughout different sections.
  * Pickup distribution now includes both monetary rewards and performance boosts to diversify player progression and challenge.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->