### PR TITLE
feat(tracks): authored pickups for Glass Ridge (F-093 tour 5)

### DIFF
--- a/docs/FOLLOWUPS.md
+++ b/docs/FOLLOWUPS.md
@@ -131,13 +131,14 @@ crest is crossed at speed. Pairs with §16 (camera shake on landing).
 **Created:** 2026-05-07
 **Priority:** nice-to-have
 **Status:** in-progress
-**Notes:** 2026-05-07 split per-tour. Tours 2-4 (Iron Borough,
-Ember Steppe, Breakwater Isles) shipped: 3 pickups per track
-each (1 inside-line nitro on a corner apex, 1 cash on a tactical
-beat, 1 cash on the final straight) across all 12 tracks. Tours
-5-8 (Glass Ridge, Neon Meridian, Moss Frontier, Crown Circuit)
-stay open under this F-NNN; each subsequent tour ships as its
-own PR for review tractability. Original notes follow.
+**Notes:** 2026-05-07 split per-tour. Tours 2-5 (Iron Borough,
+Ember Steppe, Breakwater Isles, Glass Ridge) shipped each in
+their own PR with 3 pickups per track (1 inside-line nitro on a
+corner apex, 1 cash on a tactical beat, 1 cash on the final
+straight) across all 16 tracks. Tours 6-8 (Neon Meridian, Moss
+Frontier, Crown Circuit) stay open under this F-NNN; each
+subsequent tour ships as its own PR for review tractability.
+Original notes follow.
 
 Surfaced by the 2026-05-07 mass-appeal audit (Tier A #4).
 A grep of all 32 production tracks shows pickups are only authored on

--- a/docs/PROGRESS_LOG.md
+++ b/docs/PROGRESS_LOG.md
@@ -74,6 +74,65 @@ None this slice.
 
 ---
 
+## 2026-05-07: feat(tracks): authored pickups for Glass Ridge (F-093 tour 5)
+
+**GDD sections touched:** [§9](gdd/09-track-design.md) (build-log
+entry).
+**Branch / PR:** `feat/pickups-glass-ridge`, PR pending.
+**Status:** Implemented (Glass Ridge only). F-093 stays open
+covering tours 6-8.
+
+### Done
+- Added 3 pickups per track to all 4 Glass Ridge alpine tracks
+  (Tour 5): Frostrelay, Hollow Crest, Summit Echo, Whitepass.
+  Same template Iron Borough through Breakwater Isles
+  established.
+- Two of four tracks (Hollow Crest, Summit Echo) use the
+  `long-scenic` archetype with 2 laps. The pickup count per
+  track is unchanged because the template is per-lap-relevant
+  rather than per-meter; a 2-lap player still gets 6 pickups
+  per race (3 per lap), the same density as a 3-lap standard
+  track.
+- Hollow Crest: nitro on the +0.2 corner inside the second
+  tunnel (segment 3, blue-safety-lighting). Rewards "blast
+  through the tunnel and grab the boost on the exit corner"
+  play. Cash on the snow-buildup climb (segment 1) for the
+  inside-line reward.
+- Summit Echo: nitro on the sharpest +0.22 right turn (the
+  hardest corner in the tour). Cash on the descent inside left
+  for high-commitment downhill play.
+- Snow weather authoring: every Glass Ridge track has snow or
+  fog in its weatherOptions. Three of four tracks place a cash
+  on a `snow_buildup` segment so reduced grip pays for a
+  committed apex.
+
+### Verified
+- `npm run typecheck` clean.
+- `npm run lint` clean.
+- `npm run test` 2881 / 2881 passed (152 suites).
+- `npm run content-lint` clean.
+
+### Decisions and assumptions
+- The tunnel-pickup placement on Hollow Crest is consistent
+  with the Velvet Coast Cliffline Arc and Iron Borough Rivet
+  Tunnel patterns: a cash-or-nitro pickup inside a tunnel
+  segment is fully supported by the existing pickup runtime
+  and renderer overlay. The visibility reduction is a minor
+  difficulty boost, not a different rule.
+
+### Coverage ledger
+- §9 track-design coverage gains 4 more tracks worth of authored
+  pickup data. F-093 stays open with 12 tracks remaining (Neon
+  Meridian + Moss Frontier + Crown Circuit).
+
+### Followups created
+None.
+
+### GDD edits
+None this slice.
+
+---
+
 ## 2026-05-07: feat(tracks): authored pickups for Breakwater Isles (F-093 tour 4)
 
 **GDD sections touched:** [§9](gdd/09-track-design.md) (build-log

--- a/src/data/tracks/glass-ridge-frostrelay.json
+++ b/src/data/tracks/glass-ridge-frostrelay.json
@@ -12,12 +12,42 @@
   "archetype": "standard",
   "segments": [
     { "len": 260, "curve": 0.08, "grade": 0.01, "roadsideLeft": "light_pole", "roadsideRight": "fence_post", "hazards": [] },
-    { "len": 240, "curve": 0.18, "grade": 0.05, "roadsideLeft": "tree_pine", "roadsideRight": "rock_boulder", "hazards": ["snow_buildup"] },
-    { "len": 260, "curve": -0.2, "grade": 0.02, "roadsideLeft": "sign_marker", "roadsideRight": "tree_pine", "hazards": [] },
+    {
+      "len": 240,
+      "curve": 0.18,
+      "grade": 0.05,
+      "roadsideLeft": "tree_pine",
+      "roadsideRight": "rock_boulder",
+      "hazards": ["snow_buildup"],
+      "pickups": [
+        { "id": "frostrelay-climb-cash", "kind": "cash", "laneOffset": 0.35, "value": 75 }
+      ]
+    },
+    {
+      "len": 260,
+      "curve": -0.2,
+      "grade": 0.02,
+      "roadsideLeft": "sign_marker",
+      "roadsideRight": "tree_pine",
+      "hazards": [],
+      "pickups": [
+        { "id": "frostrelay-apex-nitro", "kind": "nitro", "laneOffset": -0.4, "value": 25 }
+      ]
+    },
     { "len": 280, "curve": 0.06, "grade": -0.04, "roadsideLeft": "rock_boulder", "roadsideRight": "light_pole", "hazards": ["traffic_cone"] },
     { "len": 240, "curve": -0.14, "grade": 0.06, "roadsideLeft": "fence_post", "roadsideRight": "sign_marker", "hazards": ["snow_buildup"] },
     { "len": 320, "curve": 0.12, "grade": -0.03, "roadsideLeft": "tree_pine", "roadsideRight": "fence_post", "hazards": [] },
-    { "len": 380, "curve": 0, "grade": 0, "roadsideLeft": "light_pole", "roadsideRight": "tree_pine", "hazards": [] }
+    {
+      "len": 380,
+      "curve": 0,
+      "grade": 0,
+      "roadsideLeft": "light_pole",
+      "roadsideRight": "tree_pine",
+      "hazards": [],
+      "pickups": [
+        { "id": "frostrelay-finish-cash", "kind": "cash", "laneOffset": 0, "value": 75 }
+      ]
+    }
   ],
   "checkpoints": [
     { "segmentIndex": 0, "label": "start" },

--- a/src/data/tracks/glass-ridge-hollow-crest.json
+++ b/src/data/tracks/glass-ridge-hollow-crest.json
@@ -12,12 +12,44 @@
   "archetype": "long-scenic",
   "segments": [
     { "len": 260, "curve": -0.06, "grade": 0.03, "roadsideLeft": "rock_boulder", "roadsideRight": "tree_pine", "hazards": [] },
-    { "len": 260, "curve": 0.16, "grade": 0.07, "roadsideLeft": "fence_post", "roadsideRight": "sign_marker", "hazards": ["snow_buildup"] },
+    {
+      "len": 260,
+      "curve": 0.16,
+      "grade": 0.07,
+      "roadsideLeft": "fence_post",
+      "roadsideRight": "sign_marker",
+      "hazards": ["snow_buildup"],
+      "pickups": [
+        { "id": "hollow-crest-climb-cash", "kind": "cash", "laneOffset": 0.35, "value": 75 }
+      ]
+    },
     { "len": 300, "curve": -0.1, "grade": 0.04, "roadsideLeft": "light_pole", "roadsideRight": "rock_boulder", "hazards": ["tunnel"], "inTunnel": true, "tunnelMaterial": "cold-concrete" },
-    { "len": 280, "curve": 0.2, "grade": -0.05, "roadsideLeft": "rock_boulder", "roadsideRight": "light_pole", "hazards": ["tunnel"], "inTunnel": true, "tunnelMaterial": "blue-safety-lighting" },
+    {
+      "len": 280,
+      "curve": 0.2,
+      "grade": -0.05,
+      "roadsideLeft": "rock_boulder",
+      "roadsideRight": "light_pole",
+      "hazards": ["tunnel"],
+      "inTunnel": true,
+      "tunnelMaterial": "blue-safety-lighting",
+      "pickups": [
+        { "id": "hollow-crest-tunnel-nitro", "kind": "nitro", "laneOffset": 0.4, "value": 25 }
+      ]
+    },
     { "len": 260, "curve": -0.18, "grade": -0.03, "roadsideLeft": "tree_pine", "roadsideRight": "fence_post", "hazards": [] },
     { "len": 300, "curve": 0.12, "grade": 0.02, "roadsideLeft": "sign_marker", "roadsideRight": "tree_pine", "hazards": ["snow_buildup"] },
-    { "len": 380, "curve": 0, "grade": 0, "roadsideLeft": "fence_post", "roadsideRight": "rock_boulder", "hazards": [] }
+    {
+      "len": 380,
+      "curve": 0,
+      "grade": 0,
+      "roadsideLeft": "fence_post",
+      "roadsideRight": "rock_boulder",
+      "hazards": [],
+      "pickups": [
+        { "id": "hollow-crest-finish-cash", "kind": "cash", "laneOffset": 0, "value": 75 }
+      ]
+    }
   ],
   "checkpoints": [
     { "segmentIndex": 0, "label": "start" },

--- a/src/data/tracks/glass-ridge-summit-echo.json
+++ b/src/data/tracks/glass-ridge-summit-echo.json
@@ -13,11 +13,41 @@
   "segments": [
     { "len": 280, "curve": 0, "grade": 0.06, "roadsideLeft": "sign_marker", "roadsideRight": "tree_pine", "hazards": ["snow_buildup"] },
     { "len": 260, "curve": -0.18, "grade": 0.08, "roadsideLeft": "rock_boulder", "roadsideRight": "fence_post", "hazards": [] },
-    { "len": 280, "curve": 0.22, "grade": -0.02, "roadsideLeft": "tree_pine", "roadsideRight": "light_pole", "hazards": ["snow_buildup"] },
-    { "len": 300, "curve": -0.16, "grade": -0.07, "roadsideLeft": "fence_post", "roadsideRight": "rock_boulder", "hazards": [] },
+    {
+      "len": 280,
+      "curve": 0.22,
+      "grade": -0.02,
+      "roadsideLeft": "tree_pine",
+      "roadsideRight": "light_pole",
+      "hazards": ["snow_buildup"],
+      "pickups": [
+        { "id": "summit-echo-apex-nitro", "kind": "nitro", "laneOffset": 0.4, "value": 25 }
+      ]
+    },
+    {
+      "len": 300,
+      "curve": -0.16,
+      "grade": -0.07,
+      "roadsideLeft": "fence_post",
+      "roadsideRight": "rock_boulder",
+      "hazards": [],
+      "pickups": [
+        { "id": "summit-echo-descent-cash", "kind": "cash", "laneOffset": -0.35, "value": 75 }
+      ]
+    },
     { "len": 260, "curve": 0.12, "grade": 0.04, "roadsideLeft": "light_pole", "roadsideRight": "sign_marker", "hazards": ["traffic_cone"] },
     { "len": 340, "curve": -0.08, "grade": -0.04, "roadsideLeft": "tree_pine", "roadsideRight": "fence_post", "hazards": [] },
-    { "len": 380, "curve": 0, "grade": 0, "roadsideLeft": "rock_boulder", "roadsideRight": "tree_pine", "hazards": [] }
+    {
+      "len": 380,
+      "curve": 0,
+      "grade": 0,
+      "roadsideLeft": "rock_boulder",
+      "roadsideRight": "tree_pine",
+      "hazards": [],
+      "pickups": [
+        { "id": "summit-echo-finish-cash", "kind": "cash", "laneOffset": 0, "value": 75 }
+      ]
+    }
   ],
   "checkpoints": [
     { "segmentIndex": 0, "label": "start" },

--- a/src/data/tracks/glass-ridge-whitepass.json
+++ b/src/data/tracks/glass-ridge-whitepass.json
@@ -12,12 +12,42 @@
   "archetype": "standard",
   "segments": [
     { "len": 260, "curve": 0, "grade": 0.02, "roadsideLeft": "tree_pine", "roadsideRight": "sign_marker", "hazards": [] },
-    { "len": 220, "curve": -0.12, "grade": 0.06, "roadsideLeft": "fence_post", "roadsideRight": "tree_pine", "hazards": ["snow_buildup"] },
+    {
+      "len": 220,
+      "curve": -0.12,
+      "grade": 0.06,
+      "roadsideLeft": "fence_post",
+      "roadsideRight": "tree_pine",
+      "hazards": ["snow_buildup"],
+      "pickups": [
+        { "id": "whitepass-climb-cash", "kind": "cash", "laneOffset": -0.35, "value": 75 }
+      ]
+    },
     { "len": 240, "curve": 0.14, "grade": 0.08, "roadsideLeft": "rock_boulder", "roadsideRight": "fence_post", "hazards": [] },
     { "len": 260, "curve": -0.08, "grade": -0.03, "roadsideLeft": "sign_marker", "roadsideRight": "rock_boulder", "hazards": ["snow_buildup"] },
-    { "len": 260, "curve": 0.18, "grade": 0.04, "roadsideLeft": "tree_pine", "roadsideRight": "light_pole", "hazards": [] },
+    {
+      "len": 260,
+      "curve": 0.18,
+      "grade": 0.04,
+      "roadsideLeft": "tree_pine",
+      "roadsideRight": "light_pole",
+      "hazards": [],
+      "pickups": [
+        { "id": "whitepass-apex-nitro", "kind": "nitro", "laneOffset": 0.4, "value": 25 }
+      ]
+    },
     { "len": 300, "curve": -0.1, "grade": -0.05, "roadsideLeft": "fence_post", "roadsideRight": "tree_pine", "hazards": [] },
-    { "len": 380, "curve": 0, "grade": 0, "roadsideLeft": "rock_boulder", "roadsideRight": "sign_marker", "hazards": [] }
+    {
+      "len": 380,
+      "curve": 0,
+      "grade": 0,
+      "roadsideLeft": "rock_boulder",
+      "roadsideRight": "sign_marker",
+      "hazards": [],
+      "pickups": [
+        { "id": "whitepass-finish-cash", "kind": "cash", "laneOffset": 0, "value": 75 }
+      ]
+    }
   ],
   "checkpoints": [
     { "segmentIndex": 0, "label": "start" },


### PR DESCRIPTION
## Summary
- Tour 5 (Glass Ridge) of the F-093 backlog: 3 pickups per track across all 4 alpine tracks. Same template Iron Borough through Breakwater Isles established.
- Snow weather: every Glass Ridge track ships snow or fog. Three of four tracks place the cash on a `snow_buildup` segment so reduced grip pays for a committed apex.
- Hollow Crest places its nitro inside the second tunnel (blue-safety-lighting) on the +0.2 right corner. Summit Echo's nitro sits on the sharpest +0.22 right turn, the hardest corner in the tour.
- Two tracks (Hollow Crest, Summit Echo) are long-scenic 2-lap; 3 pickups per lap matches the per-race density of 3-lap tracks.
- Pure JSON authoring; no code change. Tours 6-8 still open under F-093.

GDD: §9. Progress log: 2026-05-07 Glass Ridge entry.

## Test plan
- [x] `npm run typecheck` clean.
- [x] `npm run lint` clean.
- [x] `npm run test` 2881 / 2881 passed.
- [x] `npm run content-lint` clean.
- [ ] Manual playtest: enter a Hollow Crest race in fog, drive the racing line through the second tunnel (segment 3), confirm the nitro pickup is collectible at laneOffset 0.4.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added cash and nitro pickups to multiple segments across Glass Ridge tracks:
    * Frostrelay — inserted cash, nitro and finish cash pickups on several segments.
    * Hollow Crest — added climb cash, tunnel nitro and finish cash pickups.
    * Summit Echo — added apex nitro, descent cash and finish cash pickups.
    * White Pass — added climb cash, apex nitro and finish cash pickups; retained existing hazards.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->