### PR TITLE
feat(tracks): authored pickups for Neon Meridian (F-093 tour 6)

### DIFF
--- a/docs/FOLLOWUPS.md
+++ b/docs/FOLLOWUPS.md
@@ -152,12 +152,12 @@ crest is crossed at speed. Pairs with §16 (camera shake on landing).
 **Created:** 2026-05-07
 **Priority:** nice-to-have
 **Status:** in-progress
-**Notes:** 2026-05-07 split per-tour. Tours 2-5 (Iron Borough,
-Ember Steppe, Breakwater Isles, Glass Ridge) shipped each in
-their own PR with 3 pickups per track (1 inside-line nitro on a
-corner apex, 1 cash on a tactical beat, 1 cash on the final
-straight) across all 16 tracks. Tours 6-8 (Neon Meridian, Moss
-Frontier, Crown Circuit) stay open under this F-NNN; each
+**Notes:** 2026-05-07 split per-tour. Tours 2-6 (Iron Borough,
+Ember Steppe, Breakwater Isles, Glass Ridge, Neon Meridian)
+shipped each in their own PR with 3 pickups per track (1
+inside-line nitro on a corner apex, 1 cash on a tactical beat,
+1 cash on the final straight) across all 20 tracks. Tours 7-8
+(Moss Frontier, Crown Circuit) stay open under this F-NNN; each
 subsequent tour ships as its own PR for review tractability.
 Original notes follow.
 

--- a/docs/PROGRESS_LOG.md
+++ b/docs/PROGRESS_LOG.md
@@ -6,6 +6,58 @@ Correct them by adding a new entry that references the old one.
 
 ---
 
+## 2026-05-08: feat(tracks): authored pickups for Neon Meridian (F-093 tour 6)
+
+**GDD sections touched:** [§9](gdd/09-track-design.md) (build-log
+entry).
+**Branch / PR:** `feat/pickups-neon-meridian`, PR pending.
+**Status:** Implemented (Neon Meridian only). F-093 stays open
+covering tours 7-8 (Moss Frontier, Crown Circuit).
+
+### Done
+- Added 3 pickups per track to all 4 Neon Meridian tracks (Tour 6):
+  Afterglow Run, Arc Boulevard, Prism Cut, Skyline Drain. Same
+  template Iron Borough through Glass Ridge established.
+- Tunnel-aware authoring. Two of four tracks (Afterglow Run,
+  Prism Cut) place a cash pickup inside a neon-strip or
+  violet-service-lighting tunnel segment so a player who holds
+  the racing line through reduced visibility gets paid. Mirrors
+  the Hollow Crest pattern from Glass Ridge tour 5.
+- Wet/night weather authoring. Every Neon Meridian track has
+  rain or dusk or night in its weatherOptions; three of four
+  combine `slick_paint` with the apex pickup so reduced grip
+  scales the difficulty of the inside-line collection.
+- Skyline Drain places its nitro on a `slick_paint` puddle apex
+  (segment 2, +0.18 right) so the difficulty-5 final track
+  rewards the most committed grip play in the tour.
+- Pickup ids and 75 cr / 25% values match the established
+  template.
+
+### Verified
+- `npm run typecheck` clean.
+- `npm run lint` clean.
+- `npm run test` 2889 / 2889 passed (153 suites; the existing
+  `tracks-content.test.ts` validates every JSON against the
+  schema).
+- `npm run content-lint` clean.
+
+### Decisions and assumptions
+- Did not add or change any code. Pure data authoring against
+  the existing pickup runtime and schema.
+
+### Coverage ledger
+- §9 track-design coverage gains 4 more tracks worth of authored
+  pickup data. F-093 stays open with 8 tracks remaining (Moss
+  Frontier + Crown Circuit).
+
+### Followups created
+None.
+
+### GDD edits
+None this slice.
+
+---
+
 ## 2026-05-07: feat(onboarding): first-race tutorial prep card (F-098 slice A)
 
 **GDD sections touched:** [§4](gdd/04-player-experience-goals.md)

--- a/src/data/tracks/neon-meridian-afterglow-run.json
+++ b/src/data/tracks/neon-meridian-afterglow-run.json
@@ -13,11 +13,43 @@
   "segments": [
     { "len": 300, "curve": 0.1, "grade": 0.02, "roadsideLeft": "light_pole", "roadsideRight": "guardrail", "hazards": [] },
     { "len": 280, "curve": -0.18, "grade": 0.03, "roadsideLeft": "sign_marker", "roadsideRight": "light_pole", "hazards": ["slick_paint"] },
-    { "len": 300, "curve": 0.22, "grade": -0.02, "roadsideLeft": "guardrail", "roadsideRight": "sign_marker", "hazards": ["puddle"] },
+    {
+      "len": 300,
+      "curve": 0.22,
+      "grade": -0.02,
+      "roadsideLeft": "guardrail",
+      "roadsideRight": "sign_marker",
+      "hazards": ["puddle"],
+      "pickups": [
+        { "id": "afterglow-run-apex-nitro", "kind": "nitro", "laneOffset": 0.4, "value": 25 }
+      ]
+    },
     { "len": 300, "curve": -0.12, "grade": 0.04, "roadsideLeft": "light_pole", "roadsideRight": "guardrail", "hazards": ["tunnel"], "inTunnel": true, "tunnelMaterial": "black-ceramic" },
-    { "len": 280, "curve": 0.16, "grade": -0.04, "roadsideLeft": "sign_marker", "roadsideRight": "light_pole", "hazards": ["tunnel"], "inTunnel": true, "tunnelMaterial": "neon-strip" },
+    {
+      "len": 280,
+      "curve": 0.16,
+      "grade": -0.04,
+      "roadsideLeft": "sign_marker",
+      "roadsideRight": "light_pole",
+      "hazards": ["tunnel"],
+      "inTunnel": true,
+      "tunnelMaterial": "neon-strip",
+      "pickups": [
+        { "id": "afterglow-run-tunnel-cash", "kind": "cash", "laneOffset": 0.35, "value": 75 }
+      ]
+    },
     { "len": 320, "curve": -0.08, "grade": -0.02, "roadsideLeft": "guardrail", "roadsideRight": "sign_marker", "hazards": ["traffic_cone"] },
-    { "len": 360, "curve": 0, "grade": 0, "roadsideLeft": "light_pole", "roadsideRight": "guardrail", "hazards": [] }
+    {
+      "len": 360,
+      "curve": 0,
+      "grade": 0,
+      "roadsideLeft": "light_pole",
+      "roadsideRight": "guardrail",
+      "hazards": [],
+      "pickups": [
+        { "id": "afterglow-run-finish-cash", "kind": "cash", "laneOffset": 0, "value": 75 }
+      ]
+    }
   ],
   "checkpoints": [
     { "segmentIndex": 0, "label": "start" },

--- a/src/data/tracks/neon-meridian-arc-boulevard.json
+++ b/src/data/tracks/neon-meridian-arc-boulevard.json
@@ -12,12 +12,42 @@
   "archetype": "standard",
   "segments": [
     { "len": 300, "curve": 0.04, "grade": 0, "roadsideLeft": "light_pole", "roadsideRight": "sign_marker", "hazards": [] },
-    { "len": 240, "curve": 0.16, "grade": 0.01, "roadsideLeft": "guardrail", "roadsideRight": "light_pole", "hazards": ["slick_paint"] },
-    { "len": 260, "curve": -0.18, "grade": 0.02, "roadsideLeft": "sign_marker", "roadsideRight": "guardrail", "hazards": [] },
+    {
+      "len": 240,
+      "curve": 0.16,
+      "grade": 0.01,
+      "roadsideLeft": "guardrail",
+      "roadsideRight": "light_pole",
+      "hazards": ["slick_paint"],
+      "pickups": [
+        { "id": "arc-boulevard-paint-cash", "kind": "cash", "laneOffset": 0.35, "value": 75 }
+      ]
+    },
+    {
+      "len": 260,
+      "curve": -0.18,
+      "grade": 0.02,
+      "roadsideLeft": "sign_marker",
+      "roadsideRight": "guardrail",
+      "hazards": [],
+      "pickups": [
+        { "id": "arc-boulevard-apex-nitro", "kind": "nitro", "laneOffset": -0.4, "value": 25 }
+      ]
+    },
     { "len": 260, "curve": 0.12, "grade": -0.01, "roadsideLeft": "light_pole", "roadsideRight": "sign_marker", "hazards": ["puddle"] },
     { "len": 260, "curve": -0.1, "grade": 0.03, "roadsideLeft": "guardrail", "roadsideRight": "light_pole", "hazards": [] },
     { "len": 300, "curve": 0.08, "grade": -0.02, "roadsideLeft": "sign_marker", "roadsideRight": "guardrail", "hazards": ["traffic_cone"] },
-    { "len": 340, "curve": 0, "grade": 0, "roadsideLeft": "light_pole", "roadsideRight": "sign_marker", "hazards": [] }
+    {
+      "len": 340,
+      "curve": 0,
+      "grade": 0,
+      "roadsideLeft": "light_pole",
+      "roadsideRight": "sign_marker",
+      "hazards": [],
+      "pickups": [
+        { "id": "arc-boulevard-finish-cash", "kind": "cash", "laneOffset": 0, "value": 75 }
+      ]
+    }
   ],
   "checkpoints": [
     { "segmentIndex": 0, "label": "start" },

--- a/src/data/tracks/neon-meridian-prism-cut.json
+++ b/src/data/tracks/neon-meridian-prism-cut.json
@@ -13,11 +13,43 @@
   "segments": [
     { "len": 260, "curve": -0.08, "grade": 0.02, "roadsideLeft": "sign_marker", "roadsideRight": "light_pole", "hazards": [] },
     { "len": 240, "curve": 0.2, "grade": 0.03, "roadsideLeft": "guardrail", "roadsideRight": "sign_marker", "hazards": ["slick_paint"] },
-    { "len": 280, "curve": -0.22, "grade": -0.02, "roadsideLeft": "light_pole", "roadsideRight": "guardrail", "hazards": [] },
+    {
+      "len": 280,
+      "curve": -0.22,
+      "grade": -0.02,
+      "roadsideLeft": "light_pole",
+      "roadsideRight": "guardrail",
+      "hazards": [],
+      "pickups": [
+        { "id": "prism-cut-apex-nitro", "kind": "nitro", "laneOffset": -0.4, "value": 25 }
+      ]
+    },
     { "len": 300, "curve": 0.1, "grade": 0.01, "roadsideLeft": "sign_marker", "roadsideRight": "light_pole", "hazards": ["tunnel"], "inTunnel": true, "tunnelMaterial": "neon-strip" },
-    { "len": 280, "curve": -0.14, "grade": -0.03, "roadsideLeft": "guardrail", "roadsideRight": "sign_marker", "hazards": ["tunnel"], "inTunnel": true, "tunnelMaterial": "violet-service-lighting" },
+    {
+      "len": 280,
+      "curve": -0.14,
+      "grade": -0.03,
+      "roadsideLeft": "guardrail",
+      "roadsideRight": "sign_marker",
+      "hazards": ["tunnel"],
+      "inTunnel": true,
+      "tunnelMaterial": "violet-service-lighting",
+      "pickups": [
+        { "id": "prism-cut-tunnel-cash", "kind": "cash", "laneOffset": -0.35, "value": 75 }
+      ]
+    },
     { "len": 300, "curve": 0.16, "grade": 0.02, "roadsideLeft": "light_pole", "roadsideRight": "guardrail", "hazards": ["traffic_cone"] },
-    { "len": 360, "curve": 0, "grade": 0, "roadsideLeft": "sign_marker", "roadsideRight": "light_pole", "hazards": [] }
+    {
+      "len": 360,
+      "curve": 0,
+      "grade": 0,
+      "roadsideLeft": "sign_marker",
+      "roadsideRight": "light_pole",
+      "hazards": [],
+      "pickups": [
+        { "id": "prism-cut-finish-cash", "kind": "cash", "laneOffset": 0, "value": 75 }
+      ]
+    }
   ],
   "checkpoints": [
     { "segmentIndex": 0, "label": "start" },

--- a/src/data/tracks/neon-meridian-skyline-drain.json
+++ b/src/data/tracks/neon-meridian-skyline-drain.json
@@ -13,11 +13,41 @@
   "segments": [
     { "len": 300, "curve": 0, "grade": -0.01, "roadsideLeft": "guardrail", "roadsideRight": "light_pole", "hazards": ["puddle"] },
     { "len": 260, "curve": -0.16, "grade": 0.02, "roadsideLeft": "sign_marker", "roadsideRight": "guardrail", "hazards": [] },
-    { "len": 280, "curve": 0.18, "grade": 0.04, "roadsideLeft": "light_pole", "roadsideRight": "sign_marker", "hazards": ["slick_paint"] },
+    {
+      "len": 280,
+      "curve": 0.18,
+      "grade": 0.04,
+      "roadsideLeft": "light_pole",
+      "roadsideRight": "sign_marker",
+      "hazards": ["slick_paint"],
+      "pickups": [
+        { "id": "skyline-drain-apex-nitro", "kind": "nitro", "laneOffset": 0.4, "value": 25 }
+      ]
+    },
     { "len": 300, "curve": -0.08, "grade": -0.03, "roadsideLeft": "guardrail", "roadsideRight": "light_pole", "hazards": ["puddle"] },
     { "len": 260, "curve": 0.12, "grade": 0.02, "roadsideLeft": "sign_marker", "roadsideRight": "guardrail", "hazards": [] },
-    { "len": 320, "curve": -0.14, "grade": -0.02, "roadsideLeft": "light_pole", "roadsideRight": "sign_marker", "hazards": ["traffic_cone"] },
-    { "len": 360, "curve": 0, "grade": 0, "roadsideLeft": "guardrail", "roadsideRight": "light_pole", "hazards": [] }
+    {
+      "len": 320,
+      "curve": -0.14,
+      "grade": -0.02,
+      "roadsideLeft": "light_pole",
+      "roadsideRight": "sign_marker",
+      "hazards": ["traffic_cone"],
+      "pickups": [
+        { "id": "skyline-drain-late-cash", "kind": "cash", "laneOffset": -0.35, "value": 75 }
+      ]
+    },
+    {
+      "len": 360,
+      "curve": 0,
+      "grade": 0,
+      "roadsideLeft": "guardrail",
+      "roadsideRight": "light_pole",
+      "hazards": [],
+      "pickups": [
+        { "id": "skyline-drain-finish-cash", "kind": "cash", "laneOffset": 0, "value": 75 }
+      ]
+    }
   ],
   "checkpoints": [
     { "segmentIndex": 0, "label": "start" },


### PR DESCRIPTION
## Summary
- Tour 6 (Neon Meridian) of the F-093 backlog: 3 pickups per track across all 4 metropolitan tracks. Same template Iron Borough through Glass Ridge established.
- Tunnel-aware: Afterglow Run and Prism Cut place a cash pickup inside a tunnel (neon-strip and violet-service-lighting respectively) so holding the racing line through reduced visibility pays off.
- Wet/night weather: every track has rain, dusk, or night. Skyline Drain places its nitro on a `slick_paint` puddle apex for the most committed grip play in the tour.
- Pure JSON authoring; no code change. Tours 7-8 (Moss Frontier, Crown Circuit) stay open under F-093.

GDD: §9. Progress log: 2026-05-08 Neon Meridian entry.

## Test plan
- [x] `npm run typecheck` clean.
- [x] `npm run lint` clean.
- [x] `npm run test` 2889 / 2889 passed.
- [x] `npm run content-lint` clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added pickup items (nitro boosts and cash rewards) to multiple segments across four racing tracks, providing enhanced opportunities for in-race progression and rewards

<!-- end of auto-generated comment: release notes by coderabbit.ai -->