### PR TITLE
feat(tracks): authored pickups for Moss Frontier (F-093 tour 7)

### DIFF
--- a/docs/FOLLOWUPS.md
+++ b/docs/FOLLOWUPS.md
@@ -152,13 +152,12 @@ crest is crossed at speed. Pairs with §16 (camera shake on landing).
 **Created:** 2026-05-07
 **Priority:** nice-to-have
 **Status:** in-progress
-**Notes:** 2026-05-07 split per-tour. Tours 2-6 (Iron Borough,
-Ember Steppe, Breakwater Isles, Glass Ridge, Neon Meridian)
-shipped each in their own PR with 3 pickups per track (1
-inside-line nitro on a corner apex, 1 cash on a tactical beat,
-1 cash on the final straight) across all 20 tracks. Tours 7-8
-(Moss Frontier, Crown Circuit) stay open under this F-NNN; each
-subsequent tour ships as its own PR for review tractability.
+**Notes:** 2026-05-07 split per-tour. Tours 2-7 (Iron Borough,
+Ember Steppe, Breakwater Isles, Glass Ridge, Neon Meridian,
+Moss Frontier) shipped each in their own PR with 3 pickups per
+track (1 inside-line nitro on a corner apex, 1 cash on a
+tactical beat, 1 cash on the final straight) across all 24
+tracks. Tour 8 (Crown Circuit) stays open under this F-NNN.
 Original notes follow.
 
 Surfaced by the 2026-05-07 mass-appeal audit (Tier A #4).

--- a/docs/PROGRESS_LOG.md
+++ b/docs/PROGRESS_LOG.md
@@ -6,6 +6,53 @@ Correct them by adding a new entry that references the old one.
 
 ---
 
+## 2026-05-08: feat(tracks): authored pickups for Moss Frontier (F-093 tour 7)
+
+**GDD sections touched:** [§9](gdd/09-track-design.md) (build-log
+entry).
+**Branch / PR:** `feat/pickups-moss-frontier`, PR pending.
+**Status:** Implemented (Moss Frontier only). F-093 stays open
+covering tour 8 (Crown Circuit).
+
+### Done
+- Added 3 pickups per track to all 4 Moss Frontier tracks (Tour 7):
+  Millstream, Mistbarrow, Pine Switchback, Wetroot Drive. Same
+  template Iron Borough through Neon Meridian established.
+- All four Moss Frontier tracks are difficulty 5 long-scenic
+  (2-lap) with heavy rain or fog. The pickup placement compounds
+  the wet-grip pressure: every track puts the cash on a
+  `slick_paint` or `gravel_band` segment at an inside-line apex,
+  and the nitro on the strongest left-or-right curve in the track
+  also surrounded by a wet hazard.
+- Pickup ids and 75 cr / 25% values match the established
+  template. The 480-460-420 m closing straights (longer than any
+  previous tour) get the standard centerline finish cash.
+
+### Verified
+- `npm run typecheck` clean.
+- `npm run lint` clean.
+- `npm run test` 2889 / 2889 passed (153 suites).
+- `npm run content-lint` clean.
+
+### Decisions and assumptions
+- Did not add or change any code. Pure data authoring against
+  the existing pickup runtime and schema.
+- Per-lap pickup density on these 2-lap tracks matches the
+  3-lap standard tracks (3 pickups per lap, 6 per race).
+
+### Coverage ledger
+- §9 track-design coverage gains 4 more tracks worth of authored
+  pickup data. F-093 stays open with 4 tracks remaining (Crown
+  Circuit only).
+
+### Followups created
+None.
+
+### GDD edits
+None this slice.
+
+---
+
 ## 2026-05-08: feat(tracks): authored pickups for Neon Meridian (F-093 tour 6)
 
 **GDD sections touched:** [§9](gdd/09-track-design.md) (build-log

--- a/src/data/tracks/moss-frontier-millstream.json
+++ b/src/data/tracks/moss-frontier-millstream.json
@@ -13,11 +13,41 @@
   "segments": [
     { "len": 280, "curve": 0, "grade": 0, "roadsideLeft": "fence_post", "roadsideRight": "sign_marker", "hazards": [] },
     { "len": 260, "curve": -0.14, "grade": -0.01, "roadsideLeft": "tree_pine", "roadsideRight": "fence_post", "hazards": ["puddle"] },
-    { "len": 240, "curve": 0.16, "grade": 0.02, "roadsideLeft": "sign_marker", "roadsideRight": "tree_pine", "hazards": ["slick_paint"] },
+    {
+      "len": 240,
+      "curve": 0.16,
+      "grade": 0.02,
+      "roadsideLeft": "sign_marker",
+      "roadsideRight": "tree_pine",
+      "hazards": ["slick_paint"],
+      "pickups": [
+        { "id": "millstream-paint-cash", "kind": "cash", "laneOffset": 0.35, "value": 75 }
+      ]
+    },
     { "len": 300, "curve": -0.08, "grade": 0.03, "roadsideLeft": "fence_post", "roadsideRight": "rock_boulder", "hazards": ["puddle"] },
     { "len": 260, "curve": 0.18, "grade": -0.02, "roadsideLeft": "tree_pine", "roadsideRight": "fence_post", "hazards": [] },
-    { "len": 300, "curve": -0.2, "grade": 0.01, "roadsideLeft": "rock_boulder", "roadsideRight": "sign_marker", "hazards": ["gravel_band"] },
-    { "len": 340, "curve": 0, "grade": 0, "roadsideLeft": "fence_post", "roadsideRight": "tree_pine", "hazards": [] }
+    {
+      "len": 300,
+      "curve": -0.2,
+      "grade": 0.01,
+      "roadsideLeft": "rock_boulder",
+      "roadsideRight": "sign_marker",
+      "hazards": ["gravel_band"],
+      "pickups": [
+        { "id": "millstream-apex-nitro", "kind": "nitro", "laneOffset": -0.4, "value": 25 }
+      ]
+    },
+    {
+      "len": 340,
+      "curve": 0,
+      "grade": 0,
+      "roadsideLeft": "fence_post",
+      "roadsideRight": "tree_pine",
+      "hazards": [],
+      "pickups": [
+        { "id": "millstream-finish-cash", "kind": "cash", "laneOffset": 0, "value": 75 }
+      ]
+    }
   ],
   "checkpoints": [
     { "segmentIndex": 0, "label": "start" },

--- a/src/data/tracks/moss-frontier-mistbarrow.json
+++ b/src/data/tracks/moss-frontier-mistbarrow.json
@@ -13,11 +13,41 @@
   "segments": [
     { "len": 300, "curve": 0.02, "grade": 0.02, "roadsideLeft": "sign_marker", "roadsideRight": "tree_pine", "hazards": [] },
     { "len": 300, "curve": -0.16, "grade": 0.04, "roadsideLeft": "tree_pine", "roadsideRight": "fence_post", "hazards": ["gravel_band"] },
-    { "len": 280, "curve": 0.2, "grade": 0.03, "roadsideLeft": "rock_boulder", "roadsideRight": "tree_pine", "hazards": ["puddle"] },
+    {
+      "len": 280,
+      "curve": 0.2,
+      "grade": 0.03,
+      "roadsideLeft": "rock_boulder",
+      "roadsideRight": "tree_pine",
+      "hazards": ["puddle"],
+      "pickups": [
+        { "id": "mistbarrow-apex-nitro", "kind": "nitro", "laneOffset": 0.4, "value": 25 }
+      ]
+    },
     { "len": 300, "curve": -0.12, "grade": -0.04, "roadsideLeft": "fence_post", "roadsideRight": "rock_boulder", "hazards": ["puddle"] },
-    { "len": 320, "curve": 0.18, "grade": 0.01, "roadsideLeft": "tree_pine", "roadsideRight": "sign_marker", "hazards": ["slick_paint"] },
+    {
+      "len": 320,
+      "curve": 0.18,
+      "grade": 0.01,
+      "roadsideLeft": "tree_pine",
+      "roadsideRight": "sign_marker",
+      "hazards": ["slick_paint"],
+      "pickups": [
+        { "id": "mistbarrow-paint-cash", "kind": "cash", "laneOffset": 0.35, "value": 75 }
+      ]
+    },
     { "len": 340, "curve": -0.08, "grade": -0.02, "roadsideLeft": "fence_post", "roadsideRight": "tree_pine", "hazards": ["gravel_band"] },
-    { "len": 480, "curve": 0, "grade": 0, "roadsideLeft": "tree_pine", "roadsideRight": "fence_post", "hazards": [] }
+    {
+      "len": 480,
+      "curve": 0,
+      "grade": 0,
+      "roadsideLeft": "tree_pine",
+      "roadsideRight": "fence_post",
+      "hazards": [],
+      "pickups": [
+        { "id": "mistbarrow-finish-cash", "kind": "cash", "laneOffset": 0, "value": 75 }
+      ]
+    }
   ],
   "checkpoints": [
     { "segmentIndex": 0, "label": "start" },

--- a/src/data/tracks/moss-frontier-pine-switchback.json
+++ b/src/data/tracks/moss-frontier-pine-switchback.json
@@ -13,11 +13,41 @@
   "segments": [
     { "len": 260, "curve": 0.04, "grade": 0.01, "roadsideLeft": "tree_pine", "roadsideRight": "fence_post", "hazards": [] },
     { "len": 240, "curve": 0.2, "grade": 0.03, "roadsideLeft": "tree_pine", "roadsideRight": "sign_marker", "hazards": ["gravel_band"] },
-    { "len": 260, "curve": -0.22, "grade": 0.04, "roadsideLeft": "fence_post", "roadsideRight": "tree_pine", "hazards": ["puddle"] },
-    { "len": 280, "curve": 0.18, "grade": -0.02, "roadsideLeft": "rock_boulder", "roadsideRight": "tree_pine", "hazards": [] },
+    {
+      "len": 260,
+      "curve": -0.22,
+      "grade": 0.04,
+      "roadsideLeft": "fence_post",
+      "roadsideRight": "tree_pine",
+      "hazards": ["puddle"],
+      "pickups": [
+        { "id": "pine-switchback-apex-nitro", "kind": "nitro", "laneOffset": -0.4, "value": 25 }
+      ]
+    },
+    {
+      "len": 280,
+      "curve": 0.18,
+      "grade": -0.02,
+      "roadsideLeft": "rock_boulder",
+      "roadsideRight": "tree_pine",
+      "hazards": [],
+      "pickups": [
+        { "id": "pine-switchback-climb-cash", "kind": "cash", "laneOffset": 0.35, "value": 75 }
+      ]
+    },
     { "len": 300, "curve": -0.16, "grade": -0.03, "roadsideLeft": "tree_pine", "roadsideRight": "fence_post", "hazards": ["gravel_band"] },
     { "len": 340, "curve": 0.08, "grade": 0.02, "roadsideLeft": "sign_marker", "roadsideRight": "tree_pine", "hazards": ["puddle"] },
-    { "len": 420, "curve": 0, "grade": 0, "roadsideLeft": "fence_post", "roadsideRight": "tree_pine", "hazards": [] }
+    {
+      "len": 420,
+      "curve": 0,
+      "grade": 0,
+      "roadsideLeft": "fence_post",
+      "roadsideRight": "tree_pine",
+      "hazards": [],
+      "pickups": [
+        { "id": "pine-switchback-finish-cash", "kind": "cash", "laneOffset": 0, "value": 75 }
+      ]
+    }
   ],
   "checkpoints": [
     { "segmentIndex": 0, "label": "start" },

--- a/src/data/tracks/moss-frontier-wetroot-drive.json
+++ b/src/data/tracks/moss-frontier-wetroot-drive.json
@@ -13,11 +13,41 @@
   "segments": [
     { "len": 300, "curve": -0.04, "grade": 0.01, "roadsideLeft": "tree_pine", "roadsideRight": "tree_pine", "hazards": [] },
     { "len": 260, "curve": 0.18, "grade": 0.02, "roadsideLeft": "fence_post", "roadsideRight": "rock_boulder", "hazards": ["puddle"] },
-    { "len": 260, "curve": -0.2, "grade": 0.04, "roadsideLeft": "tree_pine", "roadsideRight": "fence_post", "hazards": ["gravel_band"] },
+    {
+      "len": 260,
+      "curve": -0.2,
+      "grade": 0.04,
+      "roadsideLeft": "tree_pine",
+      "roadsideRight": "fence_post",
+      "hazards": ["gravel_band"],
+      "pickups": [
+        { "id": "wetroot-drive-apex-nitro", "kind": "nitro", "laneOffset": -0.4, "value": 25 }
+      ]
+    },
     { "len": 320, "curve": 0.1, "grade": -0.03, "roadsideLeft": "sign_marker", "roadsideRight": "tree_pine", "hazards": ["puddle"] },
-    { "len": 280, "curve": -0.18, "grade": -0.02, "roadsideLeft": "rock_boulder", "roadsideRight": "fence_post", "hazards": ["slick_paint"] },
+    {
+      "len": 280,
+      "curve": -0.18,
+      "grade": -0.02,
+      "roadsideLeft": "rock_boulder",
+      "roadsideRight": "fence_post",
+      "hazards": ["slick_paint"],
+      "pickups": [
+        { "id": "wetroot-drive-paint-cash", "kind": "cash", "laneOffset": -0.35, "value": 75 }
+      ]
+    },
     { "len": 320, "curve": 0.16, "grade": 0.02, "roadsideLeft": "tree_pine", "roadsideRight": "sign_marker", "hazards": ["gravel_band"] },
-    { "len": 460, "curve": 0, "grade": 0, "roadsideLeft": "fence_post", "roadsideRight": "tree_pine", "hazards": [] }
+    {
+      "len": 460,
+      "curve": 0,
+      "grade": 0,
+      "roadsideLeft": "fence_post",
+      "roadsideRight": "tree_pine",
+      "hazards": [],
+      "pickups": [
+        { "id": "wetroot-drive-finish-cash", "kind": "cash", "laneOffset": 0, "value": 75 }
+      ]
+    }
   ],
   "checkpoints": [
     { "segmentIndex": 0, "label": "start" },


### PR DESCRIPTION
## Summary
- Tour 7 (Moss Frontier) of F-093: 3 pickups per track across all 4 forest-highway tracks. Same template Iron Borough through Neon Meridian established.
- All four are difficulty 5 long-scenic (2-lap) with heavy rain or fog. Pickup placement compounds wet-grip pressure: every track puts the cash on `slick_paint` or `gravel_band` and the nitro on the strongest curve also surrounded by a wet hazard.
- Pure JSON; no code change. Only Crown Circuit remains under F-093.

## Test plan
- [x] typecheck, lint, 2889/2889 tests, content-lint clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Four Moss Frontier tracks (Millstream, Mistbarrow, Pine Switchback, Wetroot Drive) received new in-track pickups—cash and nitro—added at strategic spots (apexes, paint zones, climbs and finishes) to boost collectible placement and gameplay variety.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->