### PR TITLE
feat(tracks): authored pickups for Crown Circuit (F-093 tour 8, closes F-093)

### DIFF
--- a/docs/FOLLOWUPS.md
+++ b/docs/FOLLOWUPS.md
@@ -160,14 +160,16 @@ crest is crossed at speed. Pairs with §16 (camera shake on landing).
 ## F-093: On-track pickups extended to tours 2-8
 **Created:** 2026-05-07
 **Priority:** nice-to-have
-**Status:** in-progress
-**Notes:** 2026-05-07 split per-tour. Tours 2-7 (Iron Borough,
-Ember Steppe, Breakwater Isles, Glass Ridge, Neon Meridian,
-Moss Frontier) shipped each in their own PR with 3 pickups per
-track (1 inside-line nitro on a corner apex, 1 cash on a
-tactical beat, 1 cash on the final straight) across all 24
-tracks. Tour 8 (Crown Circuit) stays open under this F-NNN.
-Original notes follow.
+**Status:** done
+**Resolved:** 2026-05-08
+**Notes:** All 7 remaining tours shipped in 7 PRs (tours 2-8):
+Iron Borough, Ember Steppe, Breakwater Isles, Glass Ridge, Neon
+Meridian, Moss Frontier, Crown Circuit. 3 pickups per track (1
+inside-line nitro on a corner apex, 1 cash on a tactical beat,
+1 cash on the final straight) across all 28 tracks. The full
+32-track production set (including Velvet Coast tour 1) now
+ships with on-track tactical decisions across the whole World
+Tour. Original notes follow.
 
 Surfaced by the 2026-05-07 mass-appeal audit (Tier A #4).
 A grep of all 32 production tracks shows pickups are only authored on

--- a/docs/PROGRESS_LOG.md
+++ b/docs/PROGRESS_LOG.md
@@ -78,6 +78,59 @@ None this slice.
 
 ---
 
+## 2026-05-08: feat(tracks): authored pickups for Crown Circuit (F-093 tour 8, closes F-093)
+
+**GDD sections touched:** [§9](gdd/09-track-design.md) (build-log
+entry).
+**Branch / PR:** `feat/pickups-crown-circuit`, PR pending.
+**Status:** Implemented. F-093 closes with this slice.
+
+### Done
+- Added 3 pickups per track to all 4 Crown Circuit endurance
+  tracks (Tour 8): Embassy Loop, Final Horizon, Grand Meridian,
+  Victory Causeway. Same template Iron Borough through Moss
+  Frontier established.
+- All four tracks use the `endurance` archetype (2 laps,
+  difficulty 5). Final Horizon ships every supported weather
+  option (clear, rain, snow, fog) and gets the only mid-track
+  cash on a `snow_buildup` apex; the other three pair the cash
+  with `slick_paint`, `snow_buildup`, or a clean apex per
+  per-track weather profile.
+- The closing straights are the longest in the game (440-500 m,
+  including the 500 m straights on Final Horizon and Grand
+  Meridian); each gets the standard centerline finish cash so
+  the endgame still pays off the racing line.
+- Pickup ids and 75 cr / 25% values match the established
+  template.
+
+### Verified
+- `npm run typecheck` clean.
+- `npm run lint` clean.
+- `npm run test` 2889 / 2889 passed (153 suites).
+- `npm run content-lint` clean.
+
+### Decisions and assumptions
+- Pure data authoring; no code change.
+- F-093 is now fully shipped: every one of the 28 tracks across
+  tours 2-8 has the 3-pickup template authored. Tour 1 (Velvet
+  Coast) had its own pickup pass under
+  `VibeGear2-feat-tracks-first-10ebfec0` previously. The full
+  32-track production set now ships with on-track tactical
+  decisions across the whole World Tour.
+
+### Coverage ledger
+- §9 track-design coverage gains the final 4 tracks worth of
+  authored pickup data. F-093 marked done in the same PR's
+  FOLLOWUPS edit.
+
+### Followups created
+None.
+
+### GDD edits
+None this slice.
+
+---
+
 ## 2026-05-08: feat(tracks): authored pickups for Moss Frontier (F-093 tour 7)
 
 **GDD sections touched:** [§9](gdd/09-track-design.md) (build-log

--- a/src/data/tracks/crown-circuit-embassy-loop.json
+++ b/src/data/tracks/crown-circuit-embassy-loop.json
@@ -12,12 +12,42 @@
   "archetype": "endurance",
   "segments": [
     { "len": 320, "curve": 0.04, "grade": 0, "roadsideLeft": "light_pole", "roadsideRight": "sign_marker", "hazards": [] },
-    { "len": 280, "curve": 0.18, "grade": 0.02, "roadsideLeft": "guardrail", "roadsideRight": "light_pole", "hazards": ["slick_paint"] },
+    {
+      "len": 280,
+      "curve": 0.18,
+      "grade": 0.02,
+      "roadsideLeft": "guardrail",
+      "roadsideRight": "light_pole",
+      "hazards": ["slick_paint"],
+      "pickups": [
+        { "id": "embassy-loop-paint-cash", "kind": "cash", "laneOffset": 0.35, "value": 75 }
+      ]
+    },
     { "len": 280, "curve": -0.16, "grade": 0.01, "roadsideLeft": "sign_marker", "roadsideRight": "guardrail", "hazards": [] },
     { "len": 320, "curve": 0.14, "grade": -0.02, "roadsideLeft": "light_pole", "roadsideRight": "sign_marker", "hazards": ["traffic_cone"] },
-    { "len": 300, "curve": -0.18, "grade": 0.03, "roadsideLeft": "guardrail", "roadsideRight": "light_pole", "hazards": [] },
+    {
+      "len": 300,
+      "curve": -0.18,
+      "grade": 0.03,
+      "roadsideLeft": "guardrail",
+      "roadsideRight": "light_pole",
+      "hazards": [],
+      "pickups": [
+        { "id": "embassy-loop-apex-nitro", "kind": "nitro", "laneOffset": -0.4, "value": 25 }
+      ]
+    },
     { "len": 340, "curve": 0.08, "grade": -0.01, "roadsideLeft": "sign_marker", "roadsideRight": "guardrail", "hazards": ["puddle"] },
-    { "len": 400, "curve": 0, "grade": 0, "roadsideLeft": "light_pole", "roadsideRight": "sign_marker", "hazards": [] }
+    {
+      "len": 400,
+      "curve": 0,
+      "grade": 0,
+      "roadsideLeft": "light_pole",
+      "roadsideRight": "sign_marker",
+      "hazards": [],
+      "pickups": [
+        { "id": "embassy-loop-finish-cash", "kind": "cash", "laneOffset": 0, "value": 75 }
+      ]
+    }
   ],
   "checkpoints": [
     { "segmentIndex": 0, "label": "start" },

--- a/src/data/tracks/crown-circuit-final-horizon.json
+++ b/src/data/tracks/crown-circuit-final-horizon.json
@@ -13,11 +13,41 @@
   "segments": [
     { "len": 360, "curve": 0, "grade": 0.03, "roadsideLeft": "light_pole", "roadsideRight": "sign_marker", "hazards": [] },
     { "len": 320, "curve": -0.16, "grade": 0.05, "roadsideLeft": "guardrail", "roadsideRight": "rock_boulder", "hazards": ["slick_paint"] },
-    { "len": 340, "curve": 0.2, "grade": -0.02, "roadsideLeft": "sign_marker", "roadsideRight": "guardrail", "hazards": ["puddle"] },
-    { "len": 360, "curve": -0.18, "grade": 0.04, "roadsideLeft": "light_pole", "roadsideRight": "sign_marker", "hazards": ["snow_buildup"] },
+    {
+      "len": 340,
+      "curve": 0.2,
+      "grade": -0.02,
+      "roadsideLeft": "sign_marker",
+      "roadsideRight": "guardrail",
+      "hazards": ["puddle"],
+      "pickups": [
+        { "id": "final-horizon-apex-nitro", "kind": "nitro", "laneOffset": 0.4, "value": 25 }
+      ]
+    },
+    {
+      "len": 360,
+      "curve": -0.18,
+      "grade": 0.04,
+      "roadsideLeft": "light_pole",
+      "roadsideRight": "sign_marker",
+      "hazards": ["snow_buildup"],
+      "pickups": [
+        { "id": "final-horizon-snow-cash", "kind": "cash", "laneOffset": -0.35, "value": 75 }
+      ]
+    },
     { "len": 340, "curve": 0.12, "grade": -0.05, "roadsideLeft": "guardrail", "roadsideRight": "light_pole", "hazards": [] },
     { "len": 380, "curve": -0.08, "grade": 0.02, "roadsideLeft": "rock_boulder", "roadsideRight": "guardrail", "hazards": ["traffic_cone"] },
-    { "len": 500, "curve": 0, "grade": 0, "roadsideLeft": "sign_marker", "roadsideRight": "light_pole", "hazards": [] }
+    {
+      "len": 500,
+      "curve": 0,
+      "grade": 0,
+      "roadsideLeft": "sign_marker",
+      "roadsideRight": "light_pole",
+      "hazards": [],
+      "pickups": [
+        { "id": "final-horizon-finish-cash", "kind": "cash", "laneOffset": 0, "value": 75 }
+      ]
+    }
   ],
   "checkpoints": [
     { "segmentIndex": 0, "label": "start" },

--- a/src/data/tracks/crown-circuit-grand-meridian.json
+++ b/src/data/tracks/crown-circuit-grand-meridian.json
@@ -12,12 +12,42 @@
   "archetype": "endurance",
   "segments": [
     { "len": 340, "curve": 0.02, "grade": 0.02, "roadsideLeft": "light_pole", "roadsideRight": "sign_marker", "hazards": [] },
-    { "len": 320, "curve": 0.18, "grade": 0.05, "roadsideLeft": "guardrail", "roadsideRight": "rock_boulder", "hazards": ["snow_buildup"] },
-    { "len": 300, "curve": -0.2, "grade": 0.03, "roadsideLeft": "sign_marker", "roadsideRight": "guardrail", "hazards": [] },
+    {
+      "len": 320,
+      "curve": 0.18,
+      "grade": 0.05,
+      "roadsideLeft": "guardrail",
+      "roadsideRight": "rock_boulder",
+      "hazards": ["snow_buildup"],
+      "pickups": [
+        { "id": "grand-meridian-climb-cash", "kind": "cash", "laneOffset": 0.35, "value": 75 }
+      ]
+    },
+    {
+      "len": 300,
+      "curve": -0.2,
+      "grade": 0.03,
+      "roadsideLeft": "sign_marker",
+      "roadsideRight": "guardrail",
+      "hazards": [],
+      "pickups": [
+        { "id": "grand-meridian-apex-nitro", "kind": "nitro", "laneOffset": -0.4, "value": 25 }
+      ]
+    },
     { "len": 340, "curve": 0.14, "grade": -0.04, "roadsideLeft": "rock_boulder", "roadsideRight": "light_pole", "hazards": ["snow_buildup"] },
     { "len": 320, "curve": -0.16, "grade": -0.02, "roadsideLeft": "guardrail", "roadsideRight": "sign_marker", "hazards": [] },
     { "len": 360, "curve": 0.1, "grade": 0.02, "roadsideLeft": "light_pole", "roadsideRight": "guardrail", "hazards": ["traffic_cone"] },
-    { "len": 500, "curve": 0, "grade": 0, "roadsideLeft": "sign_marker", "roadsideRight": "light_pole", "hazards": [] }
+    {
+      "len": 500,
+      "curve": 0,
+      "grade": 0,
+      "roadsideLeft": "sign_marker",
+      "roadsideRight": "light_pole",
+      "hazards": [],
+      "pickups": [
+        { "id": "grand-meridian-finish-cash", "kind": "cash", "laneOffset": 0, "value": 75 }
+      ]
+    }
   ],
   "checkpoints": [
     { "segmentIndex": 0, "label": "start" },

--- a/src/data/tracks/crown-circuit-victory-causeway.json
+++ b/src/data/tracks/crown-circuit-victory-causeway.json
@@ -13,11 +13,41 @@
   "segments": [
     { "len": 320, "curve": 0, "grade": 0.01, "roadsideLeft": "guardrail", "roadsideRight": "guardrail", "hazards": [] },
     { "len": 300, "curve": -0.12, "grade": 0.03, "roadsideLeft": "light_pole", "roadsideRight": "sign_marker", "hazards": ["puddle"] },
-    { "len": 300, "curve": 0.16, "grade": 0.02, "roadsideLeft": "guardrail", "roadsideRight": "light_pole", "hazards": [] },
-    { "len": 340, "curve": -0.18, "grade": -0.03, "roadsideLeft": "sign_marker", "roadsideRight": "guardrail", "hazards": ["slick_paint"] },
+    {
+      "len": 300,
+      "curve": 0.16,
+      "grade": 0.02,
+      "roadsideLeft": "guardrail",
+      "roadsideRight": "light_pole",
+      "hazards": [],
+      "pickups": [
+        { "id": "victory-causeway-crest-cash", "kind": "cash", "laneOffset": 0.35, "value": 75 }
+      ]
+    },
+    {
+      "len": 340,
+      "curve": -0.18,
+      "grade": -0.03,
+      "roadsideLeft": "sign_marker",
+      "roadsideRight": "guardrail",
+      "hazards": ["slick_paint"],
+      "pickups": [
+        { "id": "victory-causeway-apex-nitro", "kind": "nitro", "laneOffset": -0.4, "value": 25 }
+      ]
+    },
     { "len": 320, "curve": 0.14, "grade": 0.04, "roadsideLeft": "light_pole", "roadsideRight": "sign_marker", "hazards": [] },
     { "len": 340, "curve": -0.08, "grade": -0.02, "roadsideLeft": "guardrail", "roadsideRight": "light_pole", "hazards": ["puddle"] },
-    { "len": 440, "curve": 0, "grade": 0, "roadsideLeft": "sign_marker", "roadsideRight": "guardrail", "hazards": [] }
+    {
+      "len": 440,
+      "curve": 0,
+      "grade": 0,
+      "roadsideLeft": "sign_marker",
+      "roadsideRight": "guardrail",
+      "hazards": [],
+      "pickups": [
+        { "id": "victory-causeway-finish-cash", "kind": "cash", "laneOffset": 0, "value": 75 }
+      ]
+    }
   ],
   "checkpoints": [
     { "segmentIndex": 0, "label": "start" },


### PR DESCRIPTION
## Summary
- Final tour of F-093: 3 pickups per track across all 4 Crown Circuit endurance tracks. Same template Iron Borough through Moss Frontier established.
- All four are difficulty 5 endurance (2-lap). Final Horizon ships every supported weather option and gets the only mid-track cash on a `snow_buildup` apex.
- Closing 440-500 m straights (longest in the game) get the standard centerline finish cash.
- **F-093 closes with this slice.** Full 32-track production set now has on-track tactical decisions across the whole World Tour.

## Test plan
- [x] typecheck, lint, 2889/2889 tests, content-lint clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added cash and nitro pickups across four Crown Circuit tracks (Embassy Loop, Final Horizon, Grand Meridian, Victory Causeway), placed at crests, apexes, climbs and finishes.
  * Increases on-track reward opportunities and strategic boost collection during races, enhancing player choices and race dynamics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->