### PR TITLE
feat(title): season glance card on the title screen (F-099)

### DIFF
--- a/docs/FOLLOWUPS.md
+++ b/docs/FOLLOWUPS.md
@@ -51,8 +51,17 @@ existing privacy stance.
 ## F-099: Title-page season summary and leaderboard glance
 **Created:** 2026-05-07
 **Priority:** nice-to-have
-**Status:** open
-**Notes:** Surfaced by the 2026-05-07 mass-appeal audit (Tier C #12).
+**Status:** in-progress
+**Notes:** 2026-05-08 text-and-link glance shipped under
+`feat/title-season-glance`. Adds a card on the title screen with
+credits, tours-completed-of-total, owned-car count, and a
+"Continue <Tour>" deep-link when the save has an active tour
+cursor. The optional per-track leaderboard rank glance stays
+open under this F-NNN; ship after a third leaderboard caller
+appears so the adapter wiring earns its keep. Original notes
+follow.
+
+Surfaced by the 2026-05-07 mass-appeal audit (Tier C #12).
 The title screen (`src/app/page.tsx`) shows only menu items and a build
 badge. Add a small "Last result" / "Tour standings" glance plus the
 player's current global rank on the most recently raced track (read from

--- a/docs/PROGRESS_LOG.md
+++ b/docs/PROGRESS_LOG.md
@@ -6,6 +6,78 @@ Correct them by adding a new entry that references the old one.
 
 ---
 
+## 2026-05-08: feat(title): season glance card on the title screen (F-099)
+
+**GDD sections touched:** [§4](gdd/04-player-experience-goals.md)
+"One-more-race hooks" (build-log entry).
+**Branch / PR:** `feat/title-season-glance`, PR pending.
+**Status:** Implemented (text-and-link path). The optional
+per-track leaderboard rank glance stays open under F-099 as a
+follow-up once a third leaderboard caller exists.
+
+### Done
+- Added `src/components/title/titleGlanceState.ts` with
+  `buildTitleGlance(save, championship)`. Pure: returns
+  credits, owned-car count, tours-completed-of-total, and an
+  optional `continueTour` affordance derived from
+  `progress.activeTour`. Unknown tour ids and out-of-range
+  raceIndex collapse to a null `continueTour` so a corrupt
+  cursor renders nothing instead of a broken link.
+- Added `src/components/title/TitleGlance.tsx`. Hydration-safe:
+  SSR pass renders an empty `data-state="hydrating"` placeholder
+  so the static markup always carries the test-id; the
+  client-only `useEffect` calls `loadSave()` and populates the
+  glance after mount. No animation; respects §19 reduced-motion
+  by being static.
+- Wired `<TitleGlance />` into `src/app/page.tsx` between the
+  tagline and the menu nav. Existing menu items, build badge,
+  and title test-ids stay unchanged so the e2e
+  `title-screen.spec.ts` contracts continue to hold.
+- Added 6 Vitest cases in
+  `src/components/title/__tests__/titleGlanceState.test.ts`
+  covering: fresh-save baseline, completed-tour count,
+  active-tour deep-link, out-of-range raceIndex (null), unknown
+  tour id (null), and tour-id title-casing.
+
+### Verified
+- `npm run typecheck` clean.
+- `npm run lint` clean.
+- `npm run test` 2895 / 2895 passed (154 suites; 6 new tests).
+- `npm run content-lint` clean.
+
+### Decisions and assumptions
+- Glance reads only `save.garage.credits`,
+  `save.garage.ownedCars`, `save.progress.completedTours`, and
+  `save.progress.activeTour`. Did not pull in the leaderboard
+  panel (separate adapter, network-dependent); a follow-up
+  slice can layer it in once the third leaderboard caller
+  arrives.
+- Glance section is read-only and additive. No save schema
+  change. Existing v4 saves render the glance correctly.
+- The `Continue <Tour>` deep link routes to `/race/prep` with
+  `track=`, `tour=`, `raceIndex=` mirroring the same shape the
+  World Tour page uses, so the tour-pressure summary and
+  pre-race card render the same way regardless of entry point.
+- Did not ship a Playwright spec for the title-page glance.
+  The SSR-shape contract is implicitly covered (empty
+  `data-state="hydrating"` placeholder), and the pure builder
+  has 6 unit cases. An e2e that drives the localStorage seed
+  + click-through can land later.
+
+### Coverage ledger
+- §4 "One-more-race hooks" coverage gains a passive surface
+  that surfaces tour standings + cash + cars at a glance from
+  the title screen. F-099 stays open for the optional
+  leaderboard-rank glance and the last-race summary block.
+
+### Followups created
+None new.
+
+### GDD edits
+None this slice.
+
+---
+
 ## 2026-05-08: feat(tracks): authored pickups for Moss Frontier (F-093 tour 7)
 
 **GDD sections touched:** [§9](gdd/09-track-design.md) (build-log

--- a/docs/gdd/04-player-experience-goals.md
+++ b/docs/gdd/04-player-experience-goals.md
@@ -54,6 +54,14 @@ The game should maintain compulsion using the following loop triggers:
 
 ### Build log
 
+- 2026-05-08: F-099 title-page season glance (text-and-link
+  path). Read-only card on the title screen below the tagline,
+  showing credits / tours-completed / owned-cars and a
+  "Continue <Tour>" deep-link when an active tour cursor is set.
+  Files: `src/components/title/titleGlanceState.ts` (new pure
+  builder), `src/components/title/TitleGlance.tsx` (new
+  hydration-safe component), `src/components/title/__tests__/titleGlanceState.test.ts` (new, 6 cases),
+  `src/app/page.tsx`. PR pending.
 - 2026-05-07: F-098 first-race tutorial card. Coach overlay on
   `/race/prep` shown once before the player's first race, gated
   by an optional `save.tutorialState.prepCardSeen` flag. Files:

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,5 +1,7 @@
 import Link from "next/link";
 
+import { TitleGlance } from "@/components/title/TitleGlance";
+
 import { formatBuildBadge } from "./buildInfo";
 import styles from "./page.module.css";
 
@@ -46,6 +48,7 @@ export default function TitlePage() {
           VibeGear2
         </h1>
         <p className={styles.tagline}>Spiritual successor to Top Gear 2.</p>
+        <TitleGlance />
         <nav className={styles.menu} aria-label="Main menu">
           {MENU.map((item) => (
             <Link

--- a/src/components/title/TitleGlance.tsx
+++ b/src/components/title/TitleGlance.tsx
@@ -1,0 +1,168 @@
+"use client";
+
+/**
+ * Title-page season glance per F-099. Reads the persisted save on
+ * mount and renders a small read-only card naming credits, tours
+ * completed, cars owned, and (when applicable) a "Continue tour"
+ * deep link.
+ *
+ * Hydration-safe: SSR pass renders an empty placeholder, the
+ * client-only effect populates the glance after `loadSave()` runs.
+ * No animation; the card is static so the surface respects
+ * vestibular sensitivity per §19.
+ *
+ * Out of scope (F-099 polish, deferred):
+ * - Per-track leaderboard rank glance (needs LeaderboardPanel
+ *   adapter wiring; ships as F-104 once a third call site exists).
+ * - Last-race summary block (needs the §20 records map to grow a
+ *   "most recent" cursor; not on the v1.0 critical path).
+ */
+
+import Link from "next/link";
+import {
+  useEffect,
+  useMemo,
+  useState,
+  type CSSProperties,
+  type ReactElement,
+} from "react";
+
+import { getChampionship } from "@/data";
+import { loadSave } from "@/persistence/save";
+import {
+  buildTitleGlance,
+  type TitleGlance as TitleGlanceData,
+} from "./titleGlanceState";
+
+const CHAMPIONSHIP_ID = "world-tour-standard";
+
+export function TitleGlance(): ReactElement | null {
+  const championship = useMemo(() => getChampionship(CHAMPIONSHIP_ID), []);
+  const [glance, setGlance] = useState<TitleGlanceData | null>(null);
+  const [hydrated, setHydrated] = useState(false);
+
+  useEffect(() => {
+    const outcome = loadSave();
+    if (outcome.kind === "loaded") {
+      setGlance(buildTitleGlance(outcome.save, championship));
+    }
+    setHydrated(true);
+  }, [championship]);
+
+  if (!hydrated) {
+    return (
+      <section
+        data-testid="title-glance"
+        data-state="hydrating"
+        style={panelStyle}
+        aria-label="Season glance"
+      />
+    );
+  }
+
+  if (!glance) {
+    return (
+      <section
+        data-testid="title-glance"
+        data-state="empty"
+        style={panelStyle}
+        aria-label="Season glance"
+      />
+    );
+  }
+
+  const continueHref = glance.continueTour
+    ? `/race/prep?track=${encodeURIComponent(glance.continueTour.nextTrackId)}&tour=${encodeURIComponent(
+        glance.continueTour.tourId,
+      )}&raceIndex=${glance.continueTour.nextRaceIndex}`
+    : null;
+
+  return (
+    <section
+      data-testid="title-glance"
+      data-state="ready"
+      style={panelStyle}
+      aria-label="Season glance"
+    >
+      <dl style={dlStyle}>
+        <div style={rowStyle}>
+          <dt style={dtStyle}>Credits</dt>
+          <dd style={ddStyle} data-testid="title-glance-credits">
+            {glance.credits.toLocaleString("en-US")} cr
+          </dd>
+        </div>
+        <div style={rowStyle}>
+          <dt style={dtStyle}>Tours</dt>
+          <dd style={ddStyle} data-testid="title-glance-tours">
+            {glance.toursCompleted} / {glance.toursTotal}
+          </dd>
+        </div>
+        <div style={rowStyle}>
+          <dt style={dtStyle}>Cars owned</dt>
+          <dd style={ddStyle} data-testid="title-glance-cars">
+            {glance.ownedCarCount}
+          </dd>
+        </div>
+      </dl>
+      {continueHref && glance.continueTour ? (
+        <Link
+          href={continueHref}
+          data-testid="title-glance-continue"
+          style={continueLinkStyle}
+        >
+          Continue {glance.continueTour.tourName}
+        </Link>
+      ) : null}
+    </section>
+  );
+}
+
+const panelStyle: CSSProperties = {
+  display: "flex",
+  flexDirection: "column",
+  gap: "0.65rem",
+  padding: "0.85rem 1.1rem",
+  background: "rgba(17, 21, 31, 0.65)",
+  border: "1px solid #2a2f3d",
+  borderRadius: "8px",
+  minWidth: "16rem",
+  color: "#cfd4e2",
+  fontSize: "0.92rem",
+};
+
+const dlStyle: CSSProperties = {
+  margin: 0,
+  display: "flex",
+  flexDirection: "column",
+  gap: "0.3rem",
+};
+
+const rowStyle: CSSProperties = {
+  display: "flex",
+  justifyContent: "space-between",
+  alignItems: "baseline",
+};
+
+const dtStyle: CSSProperties = {
+  letterSpacing: "0.04em",
+  textTransform: "uppercase",
+  fontSize: "0.7rem",
+  color: "#8d94a6",
+};
+
+const ddStyle: CSSProperties = {
+  margin: 0,
+  fontWeight: 600,
+};
+
+const continueLinkStyle: CSSProperties = {
+  alignSelf: "flex-end",
+  padding: "0.45rem 1rem",
+  background: "#3469ff",
+  color: "#fff",
+  border: "1px solid #3469ff",
+  borderRadius: "6px",
+  fontWeight: 600,
+  fontSize: "0.85rem",
+  textDecoration: "none",
+};

--- a/src/components/title/__tests__/titleGlanceState.test.ts
+++ b/src/components/title/__tests__/titleGlanceState.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, it } from "vitest";
+
+import { defaultSave } from "@/persistence/save";
+import { getChampionship } from "@/data";
+import type { SaveGame } from "@/data/schemas";
+
+import { buildTitleGlance } from "../titleGlanceState";
+
+const CHAMPIONSHIP = getChampionship("world-tour-standard");
+
+describe("buildTitleGlance", () => {
+  it("returns credits, owned cars, tour totals, and no continue card on a fresh save", () => {
+    const save = defaultSave();
+    const glance = buildTitleGlance(save, CHAMPIONSHIP);
+    expect(glance).not.toBeNull();
+    if (!glance) return;
+    expect(glance.credits).toBe(0);
+    expect(glance.ownedCarCount).toBe(1);
+    expect(glance.toursCompleted).toBe(0);
+    expect(glance.toursTotal).toBe(CHAMPIONSHIP.tours.length);
+    expect(glance.continueTour).toBeNull();
+  });
+
+  it("counts completed tours from the progress ledger", () => {
+    const base = defaultSave();
+    const save: SaveGame = {
+      ...base,
+      progress: {
+        ...base.progress,
+        completedTours: ["velvet-coast", "iron-borough"],
+      },
+    };
+    const glance = buildTitleGlance(save, CHAMPIONSHIP);
+    expect(glance?.toursCompleted).toBe(2);
+  });
+
+  it("surfaces a continue-tour affordance when activeTour is set", () => {
+    const base = defaultSave();
+    const tour = CHAMPIONSHIP.tours[0]!;
+    const save: SaveGame = {
+      ...base,
+      progress: {
+        ...base.progress,
+        unlockedTours: [tour.id],
+        activeTour: {
+          tourId: tour.id,
+          raceIndex: 1,
+          results: [],
+        },
+      },
+    };
+    const glance = buildTitleGlance(save, CHAMPIONSHIP);
+    expect(glance?.continueTour).toEqual({
+      tourId: tour.id,
+      tourName: expect.any(String),
+      nextTrackId: tour.tracks[1]!,
+      nextRaceIndex: 1,
+    });
+  });
+
+  it("returns null continueTour when the activeTour points outside the track list", () => {
+    const base = defaultSave();
+    const tour = CHAMPIONSHIP.tours[0]!;
+    const save: SaveGame = {
+      ...base,
+      progress: {
+        ...base.progress,
+        unlockedTours: [tour.id],
+        activeTour: {
+          tourId: tour.id,
+          raceIndex: 99,
+          results: [],
+        },
+      },
+    };
+    const glance = buildTitleGlance(save, CHAMPIONSHIP);
+    expect(glance?.continueTour).toBeNull();
+  });
+
+  it("returns null continueTour when activeTour names an unknown tour id", () => {
+    const base = defaultSave();
+    const save: SaveGame = {
+      ...base,
+      progress: {
+        ...base.progress,
+        activeTour: {
+          tourId: "ghost-tour",
+          raceIndex: 0,
+          results: [],
+        },
+      },
+    };
+    const glance = buildTitleGlance(save, CHAMPIONSHIP);
+    expect(glance?.continueTour).toBeNull();
+  });
+
+  it("title-cases the tour id for display", () => {
+    const base = defaultSave();
+    const tour = CHAMPIONSHIP.tours.find((t) => t.id === "iron-borough");
+    expect(tour).toBeDefined();
+    if (!tour) return;
+    const save: SaveGame = {
+      ...base,
+      progress: {
+        ...base.progress,
+        unlockedTours: [tour.id],
+        activeTour: { tourId: tour.id, raceIndex: 0, results: [] },
+      },
+    };
+    const glance = buildTitleGlance(save, CHAMPIONSHIP);
+    expect(glance?.continueTour?.tourName).toBe("Iron Borough");
+  });
+});

--- a/src/components/title/titleGlanceState.ts
+++ b/src/components/title/titleGlanceState.ts
@@ -1,0 +1,87 @@
+/**
+ * Pure model for the F-099 title-page glance card.
+ *
+ * Reads a `SaveGame` plus a `Championship` and produces a one-shot
+ * snapshot the title page renders without any further logic. Pure
+ * means same inputs always produce deep-equal outputs, no globals,
+ * no `Date.now()`, no localStorage. The page-side wrapper
+ * (`TitleGlance.tsx`) handles the `loadSave()` effect.
+ *
+ * The glance answers four "where am I in the season?" questions:
+ *
+ *   1. Cash on hand. Anchors how close the next upgrade is.
+ *   2. Tours completed (X of 8). Surfaces overall progression at
+ *      a glance without the player having to open World Tour.
+ *   3. Cars owned. A small reminder that the garage has unlockables.
+ *   4. Continue affordance. If `progress.activeTour` is set, name
+ *      the active tour and the next track id so the page can render
+ *      a deep-link button that resumes mid-tour.
+ *
+ * Returns `null` from `buildTitleGlance` only when the save is so
+ * malformed it cannot be summarized; in practice the loader rejects
+ * such saves before reaching the page, so the page treats `null`
+ * as a soft "no glance to show" and renders nothing in its place.
+ */
+
+import type { Championship, SaveGame } from "@/data/schemas";
+
+export interface ContinueTourAffordance {
+  readonly tourId: string;
+  readonly tourName: string;
+  readonly nextTrackId: string;
+  readonly nextRaceIndex: number;
+}
+
+export interface TitleGlance {
+  readonly credits: number;
+  readonly ownedCarCount: number;
+  readonly toursCompleted: number;
+  readonly toursTotal: number;
+  readonly continueTour: ContinueTourAffordance | null;
+}
+
+export function buildTitleGlance(
+  save: SaveGame,
+  championship: Championship,
+): TitleGlance | null {
+  if (!save.progress) return null;
+  const ownedCarCount = save.garage?.ownedCars?.length ?? 0;
+  const credits = save.garage?.credits ?? 0;
+  const toursCompleted = save.progress.completedTours?.length ?? 0;
+  const toursTotal = championship.tours.length;
+  const continueTour = resolveContinueTour(save, championship);
+  return {
+    credits,
+    ownedCarCount,
+    toursCompleted,
+    toursTotal,
+    continueTour,
+  };
+}
+
+function resolveContinueTour(
+  save: SaveGame,
+  championship: Championship,
+): ContinueTourAffordance | null {
+  const active = save.progress.activeTour;
+  if (!active) return null;
+  const tour = championship.tours.find(
+    (candidate) => candidate.id === active.tourId,
+  );
+  if (!tour) return null;
+  const nextTrackId = tour.tracks[active.raceIndex];
+  if (typeof nextTrackId !== "string") return null;
+  return {
+    tourId: tour.id,
+    tourName: titleCaseTourId(tour.id),
+    nextTrackId,
+    nextRaceIndex: active.raceIndex,
+  };
+}
+
+function titleCaseTourId(tourId: string): string {
+  return tourId
+    .split("-")
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+    .join(" ");
+}


### PR DESCRIPTION
## Summary
- Closes the text-and-link path of F-099 from the 2026-05-07 mass-appeal audit (Tier C #12). The title screen now answers \"how am I doing across all my runs?\" before the player picks a menu item.
- Read-only card between tagline and menu showing credits, tours-completed-of-total, owned-car count, and an optional \"Continue <Tour>\" deep-link when an active tour cursor exists.
- Hydration-safe: SSR pass renders an empty test-id placeholder, client useEffect populates after `loadSave()`. No animation; respects §19 reduced-motion.
- Pure builder `titleGlanceState` collapses out-of-range raceIndex and unknown tour ids to a null `continueTour` so a corrupt cursor renders nothing.
- No save schema change; existing v4 saves render correctly.
- Optional per-track leaderboard rank glance stays open under F-099 as a follow-up once a third leaderboard caller exists.

GDD: §4 build-log entry. Progress log: 2026-05-08 title entry.

## Test plan
- [x] `npm run typecheck` clean.
- [x] `npm run lint` clean.
- [x] `npm run test` 2895 / 2895 passed (154 suites; 6 new in `titleGlanceState.test.ts`).
- [x] `npm run content-lint` clean.
- [ ] Manual playtest: load fresh save (credits 0, 0/8 tours, 1 car). Start a tour, return to title, confirm the \"Continue Velvet Coast\" link appears.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a "Season Glance" card to the title screen displaying player progress, including credits, tours completed, owned cars, and a "Continue Tour" quick-link for active tours.

* **Documentation**
  * Updated development documentation with feature build log entry.

* **Tests**
  * Added test coverage for title glance feature.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->