### PR TITLE
feat(tutorial): first-race HUD hints for brake and nitro (F-101)

### DIFF
--- a/docs/FOLLOWUPS.md
+++ b/docs/FOLLOWUPS.md
@@ -13,16 +13,24 @@ or `obsolete` so the trail is preserved.
 ## F-101: First-race race-time HUD hints
 **Created:** 2026-05-07
 **Priority:** nice-to-have
-**Status:** open
-**Notes:** Slice B of the F-098 split. The prep-page coach card
-ships first; the in-race HUD hints (brake-before-corner,
-space-for-nitro, top-4-to-advance) land here once the card flow is
-proven. Will add a `firstRaceFinished` boolean to
-`save.tutorialState` (still optional for back-compat). Hints
-respect reduced-motion (no animation), fade out automatically
-after 4 seconds or on any input. Hint trigger logic lives in a
-new pure module (`src/game/tutorialHints.ts`) so the trigger
-table is testable end-to-end without driving the canvas.
+**Status:** in-progress
+**Notes:** Slice B of the F-098 split. 2026-05-08 first-cut shipped
+under `feat/first-race-hud-hints`. Pure trigger module
+`src/game/tutorialHints.ts` resolves at most one hint per frame from
+the upcoming-curvature lookahead, the player's speed band, and the
+nitro state; the HUD overlay
+`src/components/tutorial/TutorialHintOverlay.tsx` renders that text
+near the bottom-center of the canvas. Gate is the absence of any
+recorded race result (`Object.keys(save.records).length === 0`), so
+no save-schema migration was needed for slice B - the F-098
+tutorialState slot is still the only schema extension. The static
+overlay (no fade, no transition) already satisfies §19
+reduced-motion. Top-4 advancement hint deferred: the §6 / §7 rule is
+already surfaced on the prep card under F-098 and a HUD-side cue
+would duplicate it. Re-evaluate after a manual playtest. Auto-fade
+after 4 s deferred for the same reason - the current cycle clears
+the hint as soon as the player satisfies the predicate (slows for
+the corner, fires nitro).
 
 ## F-100: Shareable race-result card
 **Created:** 2026-05-07

--- a/docs/PROGRESS_LOG.md
+++ b/docs/PROGRESS_LOG.md
@@ -6,6 +6,81 @@ Correct them by adding a new entry that references the old one.
 
 ---
 
+## 2026-05-08: feat(tutorial): first-race HUD hints for brake and nitro (F-101)
+
+**GDD sections touched:** [§19](gdd/19-accessibility.md) (overlay is
+static, no animation; satisfies reduced-motion),
+[§20](gdd/20-hud-and-pause.md) (new HUD overlay near the canvas
+bottom-center).
+**Branch / PR:** `feat/first-race-hud-hints`, PR pending.
+**Status:** Slice B of F-098 onboarding pair. Card was slice A; this
+ships the in-race hints. Top-4 advancement hint and 4 s auto-fade
+deferred (see F-101 notes).
+
+### Done
+- Added `src/game/tutorialHints.ts`. Pure
+  `deriveTutorialHint(input)` returns at most one of two hints per
+  frame: brake-before-corner (upcoming curve magnitude over the
+  authored threshold and player above the speed floor) and tap-nitro
+  (long straight, mid-band speed, charges available, no active
+  burn). Brake takes precedence when both fire.
+- Added `src/components/tutorial/TutorialHintOverlay.tsx`. Static,
+  fixed-position banner near the bottom-center of the canvas. No
+  fade, no transition, `pointer-events: none` so it never steals
+  input.
+- Wired into `src/app/race/page.tsx`. Gate set on mount from
+  `Object.keys(save.records).length === 0` so returning players
+  silence every hint. A 250 ms `setInterval` poller resolves the
+  hint and feeds it to the overlay; the slow cadence avoids forcing
+  React re-renders at 60 Hz, and the gate short-circuits the poller
+  for returning players. New `tutorialHintContextRef` mirrors the
+  compiled segments and player top-speed so the poller does not
+  re-derive them per tick.
+
+### Verified
+- `npm run typecheck` clean.
+- `npm run lint` clean.
+- `npm run test` 2900 / 2900 passed across 154 suites; new
+  `src/game/__tests__/tutorialHints.test.ts` pins 11 cases over the
+  predicate table (gate disabled, brake fires, brake withholds when
+  slow, brake withholds below curve threshold, nitro fires on
+  straight, nitro withholds without charges, nitro withholds while
+  burning, nitro withholds below the speed floor, nitro withholds on
+  curving authored geometry, brake precedence, zero-top-speed guard).
+- `npm run content-lint` clean.
+
+### Decisions and assumptions
+- No save-schema migration. The F-098 `tutorialState` slot already
+  exists for back-compat; this slice piggybacks on the simpler
+  `save.records` count gate so legacy and test saves silence the
+  hints automatically.
+- Curvature scaling matches the
+  `src/road/segmentProjector.ts:upcomingCurvature` contract.
+  Compiled segments store `curve / CURVATURE_SCALE`, so the poller
+  re-multiplies by `CURVATURE_SCALE` (100) to compare to the authored
+  band. An earlier draft used `25` and would have shifted the
+  straight-detection threshold by a factor of four.
+- Top-4 advancement hint deferred. The §6 / §7 rule is already on
+  the F-098 prep card; a HUD echo would duplicate it without adding
+  information.
+- 4 s auto-fade deferred. The current cycle clears the hint as soon
+  as the player satisfies the predicate (slows into the corner,
+  fires nitro), which is the natural endpoint. Re-evaluate after a
+  manual playtest.
+
+### Coverage ledger
+- §19 reduced-motion: overlay is static; nothing new to track.
+- §20 HUD: new overlay component, no GDD row (the existing HUD
+  budget already covers banner-style elements).
+
+### Followups created
+None.
+
+### GDD edits
+None this slice.
+
+---
+
 ## 2026-05-08: feat(title): season glance card on the title screen (F-099)
 
 **GDD sections touched:** [§4](gdd/04-player-experience-goals.md)

--- a/src/app/race/page.tsx
+++ b/src/app/race/page.tsx
@@ -119,6 +119,7 @@ import type { DailyChallengeSelection } from "@/game/modes/dailyChallenge";
 import {
   CAMERA_DEPTH,
   CAMERA_HEIGHT,
+  CURVATURE_SCALE,
   FOV_DEGREES,
   SEGMENT_LENGTH,
   fitToBox,
@@ -162,6 +163,8 @@ import type { ParallaxLayer } from "@/render/parallax";
 import { drawSplitsWidget } from "@/render/hudSplits";
 import { drawHud } from "@/render/uiRenderer";
 import { defaultSave, loadSave, saveSave } from "@/persistence/save";
+import { TutorialHintOverlay } from "@/components/tutorial/TutorialHintOverlay";
+import { deriveTutorialHint } from "@/game/tutorialHints";
 import {
   awardCredits,
   baseRewardForTrackDifficulty,
@@ -1230,6 +1233,24 @@ function RaceCanvas({
   const [raceMoment, setRaceMoment] = useState<RaceMoment | null>(null);
   const [lastRaceStoryMoment, setLastRaceStoryMoment] =
     useState<RaceStoryMoment | null>(null);
+  const [tutorialHintText, setTutorialHintText] = useState<string | null>(
+    null,
+  );
+  // F-101 first-race HUD hint gate. Computed once on mount from
+  // `Object.keys(save.records).length === 0` so a returning player
+  // who already has any race result silences every hint. The ref
+  // never changes during a single race (`save.records` updates
+  // happen on race finish, after this page unmounts).
+  const tutorialHintsEnabledRef = useRef(false);
+  // F-101 captures the compiled track and player top-speed once the
+  // session is built so the slow (250 ms) hint poller can evaluate
+  // its predicates without re-deriving them per tick. `RaceSessionState`
+  // intentionally does not retain `config`, so we mirror just the two
+  // fields the trigger module needs.
+  const tutorialHintContextRef = useRef<{
+    readonly segments: readonly CompiledSegment[];
+    readonly topSpeedMps: number;
+  } | null>(null);
 
   const clearRaceMomentTimeout = useCallback(() => {
     if (raceMomentTimeoutRef.current === null) return;
@@ -1262,6 +1283,14 @@ function RaceCanvas({
     const persisted = loadSave();
     const sessionSave =
       persisted.kind === "loaded" ? persisted.save : defaultSave();
+    // F-101 first-race HUD hint gate. The hints fire only when the
+    // player has zero recorded race results, i.e., this is the
+    // first race ever on the active save. Returning players (any
+    // race result on file) silence every hint. The gate is set
+    // here once per mount; the per-frame poller below reads the
+    // ref without re-loading the save.
+    tutorialHintsEnabledRef.current =
+      Object.keys(sessionSave.records ?? {}).length === 0;
     const sessionCar = resolveSessionCar(sessionSave, selectedCarId);
     const spriteSet = carSpriteSetForVisualProfile(sessionCar.spriteSet);
     carSpriteSetRef.current = spriteSet;
@@ -1284,6 +1313,50 @@ function RaceCanvas({
       active = false;
     };
   }, [selectedCarId]);
+
+  // F-101 first-race HUD hint poller. Sampling cadence is slow (250 ms)
+  // because hints flip across multi-second windows (corners, straights)
+  // and a per-frame derive would force a React re-render at 60 Hz. The
+  // poller short-circuits when the gate is off, so returning players
+  // pay only a single setInterval / clearInterval cost per race mount.
+  useEffect(() => {
+    if (!tutorialHintsEnabledRef.current) return undefined;
+    const intervalId = window.setInterval(() => {
+      const session = sessionRef.current;
+      const ctx = tutorialHintContextRef.current;
+      if (!session || !ctx || session.race.phase !== "racing") {
+        setTutorialHintText((prev) => (prev === null ? prev : null));
+        return;
+      }
+      const segments = ctx.segments;
+      const upcoming = upcomingCurvature(segments, session.player.car.z);
+      const segIndex = Math.max(
+        0,
+        Math.min(
+          segments.length - 1,
+          Math.floor(session.player.car.z / SEGMENT_LENGTH),
+        ),
+      );
+      const authoredCurve =
+        Math.abs(segments[segIndex]?.curve ?? 0) * CURVATURE_SCALE;
+      const hint = deriveTutorialHint({
+        enabled: true,
+        upcomingCurveMagnitude: Math.abs(upcoming),
+        playerSpeedMps: session.player.car.speed,
+        topSpeedMps: ctx.topSpeedMps,
+        authoredCurveMagnitude: authoredCurve,
+        nitroCharges: session.player.nitro.charges,
+        nitroActive: session.player.nitro.activeRemainingSec > 0,
+      });
+      setTutorialHintText((prev) => {
+        const nextText = hint?.text ?? null;
+        return prev === nextText ? prev : nextText;
+      });
+    }, 250);
+    return () => {
+      window.clearInterval(intervalId);
+    };
+  }, []);
 
   const pause = usePauseToggle({ loop: () => handleRef.current });
   const { openMenu: openPauseMenu } = pause;
@@ -1474,6 +1547,10 @@ function RaceCanvas({
     setPickupFeedback(null);
     setAiReadability(null);
     sessionRef.current = createRaceSession(config);
+    tutorialHintContextRef.current = {
+      segments: config.track.segments,
+      topSpeedMps: playerStats.topSpeed,
+    };
     resetTimeTrialRuntime();
     // Re-arm the natural-finish guard on every fresh mount. The
     // restart callback below also flips it back so a second race
@@ -2463,6 +2540,7 @@ function RaceCanvas({
         style={canvasStyle}
       />
       <TouchControls layout={touchLayout} />
+      <TutorialHintOverlay text={tutorialHintText} />
       {raceMoment !== null ? (
         <div
           data-testid="race-moment"

--- a/src/components/tutorial/TutorialHintOverlay.tsx
+++ b/src/components/tutorial/TutorialHintOverlay.tsx
@@ -1,0 +1,54 @@
+"use client";
+
+/**
+ * F-101 first-race HUD hint overlay. Renders a single hint banner
+ * during a first-time player's first race. The race page passes the
+ * pre-resolved hint text (or null) every render frame. The overlay
+ * itself has no internal trigger logic; that lives in
+ * `src/game/tutorialHints.ts` and is a pure function so tests pin
+ * the entire predicate table without mounting React.
+ *
+ * Reduced motion: the banner is static. No fade, no transition.
+ * Position fixed near the bottom-center of the canvas so it does
+ * not occlude the speed gauge or the road horizon.
+ */
+
+import type { CSSProperties, ReactElement } from "react";
+
+export interface TutorialHintOverlayProps {
+  readonly text: string | null;
+}
+
+export function TutorialHintOverlay({
+  text,
+}: TutorialHintOverlayProps): ReactElement | null {
+  if (!text) return null;
+  return (
+    <div
+      role="status"
+      aria-live="polite"
+      data-testid="tutorial-hint-overlay"
+      style={overlayStyle}
+    >
+      {text}
+    </div>
+  );
+}
+
+const overlayStyle: CSSProperties = {
+  position: "absolute",
+  left: "50%",
+  bottom: "11%",
+  transform: "translateX(-50%)",
+  padding: "0.55rem 1.1rem",
+  background: "rgba(8, 12, 22, 0.78)",
+  color: "#e7eaf3",
+  border: "1px solid #2a2f3d",
+  borderRadius: "999px",
+  fontSize: "0.92rem",
+  letterSpacing: "0.01em",
+  fontWeight: 500,
+  pointerEvents: "none",
+  whiteSpace: "nowrap",
+  zIndex: 10,
+};

--- a/src/game/__tests__/tutorialHints.test.ts
+++ b/src/game/__tests__/tutorialHints.test.ts
@@ -1,0 +1,114 @@
+/**
+ * Unit tests for the F-101 first-race HUD hint trigger module.
+ *
+ * Pure-function semantics: each case pins one row of the predicate
+ * table that `deriveTutorialHint` evaluates. The race page passes the
+ * resolved `text` into `TutorialHintOverlay`, so these cases double
+ * as the contract for what the player sees.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import {
+  BRAKE_HINT_CURVE_THRESHOLD,
+  BRAKE_HINT_MIN_SPEED_MPS,
+  NITRO_HINT_MIN_SPEED_FRACTION,
+  NITRO_HINT_STRAIGHT_THRESHOLD,
+  deriveTutorialHint,
+  type TutorialHintInput,
+} from "@/game/tutorialHints";
+
+const STRAIGHT_INPUT: TutorialHintInput = Object.freeze({
+  enabled: true,
+  upcomingCurveMagnitude: 0,
+  playerSpeedMps: 40,
+  topSpeedMps: 80,
+  authoredCurveMagnitude: 0,
+  nitroCharges: 2,
+  nitroActive: false,
+});
+
+const CORNER_INPUT: TutorialHintInput = Object.freeze({
+  enabled: true,
+  upcomingCurveMagnitude: BRAKE_HINT_CURVE_THRESHOLD + 0.05,
+  playerSpeedMps: BRAKE_HINT_MIN_SPEED_MPS + 5,
+  topSpeedMps: 80,
+  authoredCurveMagnitude: 0.4,
+  nitroCharges: 2,
+  nitroActive: false,
+});
+
+describe("deriveTutorialHint", () => {
+  it("returns null when the gate is disabled", () => {
+    expect(deriveTutorialHint({ ...CORNER_INPUT, enabled: false })).toBeNull();
+    expect(deriveTutorialHint({ ...STRAIGHT_INPUT, enabled: false })).toBeNull();
+  });
+
+  it("fires the brake hint for a fast corner approach", () => {
+    const hint = deriveTutorialHint(CORNER_INPUT);
+    expect(hint?.id).toBe("brake-before-corner");
+  });
+
+  it("does not fire the brake hint when the player is already slow", () => {
+    const hint = deriveTutorialHint({
+      ...CORNER_INPUT,
+      playerSpeedMps: BRAKE_HINT_MIN_SPEED_MPS - 1,
+    });
+    expect(hint).toBeNull();
+  });
+
+  it("does not fire the brake hint when the curve is below threshold", () => {
+    const hint = deriveTutorialHint({
+      ...CORNER_INPUT,
+      upcomingCurveMagnitude: BRAKE_HINT_CURVE_THRESHOLD - 0.01,
+    });
+    expect(hint?.id).not.toBe("brake-before-corner");
+  });
+
+  it("fires the nitro hint on a long straight at mid-band speed", () => {
+    const hint = deriveTutorialHint(STRAIGHT_INPUT);
+    expect(hint?.id).toBe("tap-nitro");
+  });
+
+  it("withholds the nitro hint when the player has no charges", () => {
+    const hint = deriveTutorialHint({ ...STRAIGHT_INPUT, nitroCharges: 0 });
+    expect(hint).toBeNull();
+  });
+
+  it("withholds the nitro hint while a burn is already active", () => {
+    const hint = deriveTutorialHint({ ...STRAIGHT_INPUT, nitroActive: true });
+    expect(hint).toBeNull();
+  });
+
+  it("withholds the nitro hint below the mid-band speed floor", () => {
+    const hint = deriveTutorialHint({
+      ...STRAIGHT_INPUT,
+      playerSpeedMps:
+        STRAIGHT_INPUT.topSpeedMps * NITRO_HINT_MIN_SPEED_FRACTION - 1,
+    });
+    expect(hint).toBeNull();
+  });
+
+  it("withholds the nitro hint when the road is not straight enough", () => {
+    const hint = deriveTutorialHint({
+      ...STRAIGHT_INPUT,
+      authoredCurveMagnitude: NITRO_HINT_STRAIGHT_THRESHOLD + 0.01,
+    });
+    expect(hint).toBeNull();
+  });
+
+  it("prefers the brake hint when both predicates would otherwise fire", () => {
+    const hint = deriveTutorialHint({
+      ...CORNER_INPUT,
+      authoredCurveMagnitude: 0,
+      nitroCharges: 2,
+      nitroActive: false,
+    });
+    expect(hint?.id).toBe("brake-before-corner");
+  });
+
+  it("returns null when topSpeedMps is zero so the nitro fraction is undefined", () => {
+    const hint = deriveTutorialHint({ ...STRAIGHT_INPUT, topSpeedMps: 0 });
+    expect(hint).toBeNull();
+  });
+});

--- a/src/game/tutorialHints.ts
+++ b/src/game/tutorialHints.ts
@@ -1,0 +1,104 @@
+/**
+ * F-101 first-race HUD hint trigger module. Closes slice B of the
+ * F-098 onboarding pair (slice A was the prep card).
+ *
+ * Pure: same inputs always produce the same output. No globals, no
+ * `Date.now()`, no React. The race page evaluates this once per
+ * render frame and feeds the result into a small overlay component.
+ *
+ * Gating semantics:
+ *
+ *   - The page passes `enabled: false` when the player already has
+ *     a recorded race result (`Object.keys(save.records).length > 0`).
+ *     That collapses every hint to `null` for returning players.
+ *   - When `enabled: true`, two hints fire mutually-exclusively
+ *     based on per-frame race-state predicates:
+ *
+ *       1. **Brake before corners.** Triggered when an upcoming
+ *          curve magnitude exceeds `BRAKE_HINT_CURVE_THRESHOLD`
+ *          inside `BRAKE_HINT_LOOKAHEAD_METERS` and the player is
+ *          travelling faster than `BRAKE_HINT_MIN_SPEED_MPS`. Hint
+ *          stops once the player reduces speed below
+ *          `BRAKE_HINT_RESET_SPEED_MPS` so a single hint cycles
+ *          per corner approach instead of latching.
+ *
+ *       2. **Tap nitro.** Triggered on a long straight (curve below
+ *          `NITRO_HINT_STRAIGHT_THRESHOLD`) at mid-band speed
+ *          (`>= NITRO_HINT_MIN_SPEED_FRACTION * topSpeed`) when
+ *          the player still has unspent charges and is not currently
+ *          burning. Same one-shot cycle: clears once nitro fires.
+ *
+ *   - Brake hint takes precedence when both predicates fire; the
+ *     race page renders only one hint at a time so a player who
+ *     reads the corner hint resolves it before the nitro hint
+ *     pings.
+ *
+ * Out of scope (deferred):
+ *   - Top-4 finish hint. The §6 / §7 advancement rule is already
+ *     surfaced on the prep card under F-098; the HUD-side cue
+ *     would duplicate it. Re-evaluate after a manual playtest.
+ *   - Per-tour pacing. Hints fire only on the player's first race
+ *     ever (gated by `save.records`). A returning player who
+ *     deletes their save and starts fresh sees them again.
+ */
+
+export const BRAKE_HINT_CURVE_THRESHOLD = 0.15;
+export const BRAKE_HINT_LOOKAHEAD_METERS = 80;
+export const BRAKE_HINT_MIN_SPEED_MPS = 30;
+export const BRAKE_HINT_RESET_SPEED_MPS = 22;
+
+export const NITRO_HINT_STRAIGHT_THRESHOLD = 0.06;
+export const NITRO_HINT_MIN_SPEED_FRACTION = 0.5;
+
+export type TutorialHintId = "brake-before-corner" | "tap-nitro";
+
+export interface TutorialHint {
+  readonly id: TutorialHintId;
+  readonly text: string;
+}
+
+const BRAKE_HINT: TutorialHint = Object.freeze({
+  id: "brake-before-corner",
+  text: "Brake before corners. Hold Down to slow into the apex.",
+});
+
+const NITRO_HINT: TutorialHint = Object.freeze({
+  id: "tap-nitro",
+  text: "Tap Space for a nitro burst. Save it for straights.",
+});
+
+export interface TutorialHintInput {
+  readonly enabled: boolean;
+  readonly upcomingCurveMagnitude: number;
+  readonly playerSpeedMps: number;
+  readonly topSpeedMps: number;
+  readonly authoredCurveMagnitude: number;
+  readonly nitroCharges: number;
+  readonly nitroActive: boolean;
+}
+
+/**
+ * Resolve the active hint for this frame. Returns `null` when no
+ * hint should render; the caller treats `null` as "hide overlay".
+ */
+export function deriveTutorialHint(
+  input: TutorialHintInput,
+): TutorialHint | null {
+  if (!input.enabled) return null;
+  if (
+    input.upcomingCurveMagnitude > BRAKE_HINT_CURVE_THRESHOLD &&
+    input.playerSpeedMps > BRAKE_HINT_MIN_SPEED_MPS
+  ) {
+    return BRAKE_HINT;
+  }
+  if (
+    input.authoredCurveMagnitude < NITRO_HINT_STRAIGHT_THRESHOLD &&
+    input.topSpeedMps > 0 &&
+    input.playerSpeedMps >= NITRO_HINT_MIN_SPEED_FRACTION * input.topSpeedMps &&
+    input.nitroCharges > 0 &&
+    !input.nitroActive
+  ) {
+    return NITRO_HINT;
+  }
+  return null;
+}


### PR DESCRIPTION
## Summary
- Slice B of the F-098 onboarding pair. Adds a static HUD overlay that surfaces one hint at a time during a player's first race: brake-before-corner on a fast corner approach, tap-nitro on a long straight at mid-band speed with charges available. Brake takes precedence when both fire.
- New pure module `src/game/tutorialHints.ts` owns the predicate table so the trigger surface is unit-testable without driving the canvas. New `src/components/tutorial/TutorialHintOverlay.tsx` is the static (no fade, no transition) banner near the canvas bottom-center; that already satisfies the §19 reduced-motion contract.
- Gate is the absence of any recorded race result on the active save (`Object.keys(save.records).length === 0`), so returning players silence every hint and the slice ships without a save-schema migration.

## Test plan
- [x] `pnpm typecheck` clean
- [x] `pnpm lint` clean
- [x] `pnpm test` 2900 / 2900 across 154 suites; new `tutorialHints.test.ts` pins 11 cases over the predicate table
- [x] `pnpm content-lint` clean
- [x] `pnpm docs:check` clean
- [ ] Manual playtest: start a fresh save, take the first race, confirm the brake hint appears on the first hard corner approach and clears after the player slows; confirm the nitro hint appears on a long straight at mid-band speed with charges and clears once nitro fires.
- [ ] Returning-player regression: with any record on file, confirm no hint ever appears.