### PR TITLE
feat(rivalry): named per-race rival in the HUD pressure moment (F-092 slice 1)

### DIFF
--- a/docs/FOLLOWUPS.md
+++ b/docs/FOLLOWUPS.md
@@ -192,8 +192,24 @@ authoring + the existing pickup runtime; no new code.
 ## F-092: Named rival driver per race with season-long score
 **Created:** 2026-05-07
 **Priority:** nice-to-have
-**Status:** open
-**Notes:** Surfaced by the 2026-05-07 mass-appeal audit (Tier S #2).
+**Status:** in-progress
+**Notes:** 2026-05-08 slice 1 shipped under `feat/named-rival`. New
+pure module `src/game/rival.ts` picks the AI with the highest
+`paceScalar` as the per-race rival (ties break on driver id
+ascending) and threads the grid index into the in-race car id so
+the rivalry HUD can match against `RankedCar.id`. Extended
+`deriveRaceStoryMoment` with an optional `rival: { carId,
+displayName } | null`: when the trailing pressure is the rival,
+the existing "Rival close" moment now reads the driver name
+(e.g. "D. Korsak") in the title; the gap detail is unchanged. No
+save schema change. Practice and time-trial sessions stay
+unaffected (empty AI grid -> `null` rival). Follow-up slices
+under this F-NNN: tour-pinned rival so the same name recurs
+across all 4 races; `save.rivalScores` head-to-head (wins /
+losses / podiums) persisted per driver across the tour; prep-card
+and results-screen surfaces. Original notes follow.
+
+Surfaced by the 2026-05-07 mass-appeal audit (Tier S #2).
 Every opponent today is anonymous: `RankedCar` carries a generic id and
 the rivalry HUD signal (`raceMoments.deriveRaceStoryMoment`) reports
 "Rival close" without naming who. Designate one of the 11 AI per race

--- a/docs/PROGRESS_LOG.md
+++ b/docs/PROGRESS_LOG.md
@@ -6,6 +6,72 @@ Correct them by adding a new entry that references the old one.
 
 ---
 
+## 2026-05-08: feat(rivalry): named per-race rival in the HUD pressure moment (F-092 slice 1)
+
+**GDD sections touched:** [§15](gdd/15-ai.md) (rivalry framing on the
+existing AI grid; no balance change),
+[§20](gdd/20-hud-and-pause.md) (HUD rivalry signal now names the
+trailing pressure when it is the designated rival).
+**Branch / PR:** `feat/named-rival`, PR pending.
+**Status:** Slice 1 of F-092. Tour-pinned rival selection, save-resident
+head-to-head score, and the prep-card / results-screen surfaces stay
+open under F-092 for follow-up slices.
+
+### Done
+- Added `src/game/rival.ts`. Pure `pickRival({ drivers })` returns
+  `{ driverId, displayName, carId }` for the AI with the highest
+  `paceScalar`, ties broken on `id` ascending so the choice is stable
+  without consuming any RNG. Empty grids return `null` so practice
+  and time-trial sessions branch on absence cleanly.
+- Extended `src/game/raceMoments.ts:deriveRaceStoryMoment` with an
+  optional `rival: { carId, displayName } | null`. When the trailing
+  pressure car id matches the rival, the existing `rival-pressure`
+  moment surfaces the driver name in the `title` field
+  (e.g. "D. Korsak"); the `detail` ("18 m back") is unchanged. The
+  generic "Rival close" string is preserved for non-rival pressure
+  and for sessions that do not pass a rival.
+- Refactored `nearestTrailingGap` -> `nearestTrailingCar` so the
+  helper carries the trailing car id alongside the gap. Equivalent
+  behavior on the existing call sites; required to match against the
+  rival's `carId`.
+- Wired into `src/app/race/page.tsx`. New `rivalRef` is populated
+  once at session creation from `pickRival(aiDriverRoster)` and read
+  per frame by the existing `deriveRaceStoryMoment` call. No
+  changes to the in-race tick or session shape.
+
+### Verified
+- `npm run typecheck` clean.
+- `npm run lint` clean.
+- `npm run test` 2913 / 2913 passed across 156 suites; 5 new cases
+  in `src/game/__tests__/rival.test.ts` (empty grid, max paceScalar,
+  id tie-break, grid-index threading, single-driver grid) and 2 new
+  cases in `raceMoments.test.ts` (rival named when trailing, generic
+  title kept when the trailing pressure is not the rival).
+- `npm run content-lint` clean.
+
+### Decisions and assumptions
+- No save schema change. The rival is per-race, derived from the
+  active AI roster at session creation. Cross-race head-to-head is
+  a follow-up slice once the basic plumbing is proven.
+- "Highest paceScalar" rather than tour-pinned. A tour-pinned rival
+  needs a save slot to remember the choice; deferred to slice 2 to
+  keep slice 1 a pure plumbing change.
+- HUD title carries the rival name; detail keeps the gap. This
+  preserves the existing layout / character budget rather than
+  cramming both into one string.
+
+### Coverage ledger
+- §15 AI framing gains a named rival surface; balance unchanged.
+- §20 HUD rivalry signal now optionally names the trailing pressure.
+
+### Followups created
+None. F-092 stays open for the deferred slices noted above.
+
+### GDD edits
+None this slice.
+
+---
+
 ## 2026-05-08: feat(tutorial): first-race HUD hints for brake and nitro (F-101)
 
 **GDD sections touched:** [§19](gdd/19-accessibility.md) (overlay is

--- a/src/app/race/page.tsx
+++ b/src/app/race/page.tsx
@@ -165,6 +165,7 @@ import { drawHud } from "@/render/uiRenderer";
 import { defaultSave, loadSave, saveSave } from "@/persistence/save";
 import { TutorialHintOverlay } from "@/components/tutorial/TutorialHintOverlay";
 import { deriveTutorialHint } from "@/game/tutorialHints";
+import { pickRival, type RivalRef } from "@/game/rival";
 import {
   awardCredits,
   baseRewardForTrackDifficulty,
@@ -1175,6 +1176,12 @@ function RaceCanvas({
   const lastSpeedLineMsRef = useRef<number>(0);
   const previousRaceStoryCarsRef = useRef<readonly RankedCar[] | null>(null);
   const lastRaceStoryMomentMsRef = useRef<number>(0);
+  // F-092 slice 1. Designated rival for the active race. Resolved
+  // once at session creation by `pickRival(aiDriverRoster)` and read
+  // by the per-frame `deriveRaceStoryMoment` call below so the
+  // rivalry HUD signal can name them when the trailing pressure is
+  // them. Stays `null` for practice / time-trial (empty AI grid).
+  const rivalRef = useRef<RivalRef | null>(null);
   const observedAiCuesRef = useRef<Set<AIReadabilityCue>>(new Set());
   // Per-mount guard for the natural finish wiring. The render callback
   // fires every frame, so without this latch a `phase === "finished"`
@@ -1551,6 +1558,7 @@ function RaceCanvas({
       segments: config.track.segments,
       topSpeedMps: playerStats.topSpeed,
     };
+    rivalRef.current = pickRival({ drivers: aiDriverRoster });
     resetTimeTrialRuntime();
     // Re-arm the natural-finish guard on every fresh mount. The
     // restart callback below also flips it back so a second race
@@ -2194,11 +2202,16 @@ function RaceCanvas({
           }),
         ];
         if (session.race.phase === "racing") {
+          const rival = rivalRef.current;
           const raceStoryMoment = deriveRaceStoryMoment({
             playerId: PLAYER_ID,
             previousCars: previousRaceStoryCarsRef.current,
             currentCars: cars,
             threatDistanceMeters: RIVAL_PRESSURE_DISTANCE_METERS,
+            rival:
+              rival === null
+                ? null
+                : { carId: rival.carId, displayName: rival.displayName },
           });
           const nowMs = performance.now();
           if (

--- a/src/game/__tests__/raceMoments.test.ts
+++ b/src/game/__tests__/raceMoments.test.ts
@@ -93,4 +93,36 @@ describe("deriveRaceStoryMoment", () => {
       }),
     ).toBeNull();
   });
+
+  it("names the rival when the trailing pressure is them", () => {
+    expect(
+      deriveRaceStoryMoment({
+        playerId: PLAYER,
+        previousCars: [car(PLAYER, 200), car("ai-a", 160)],
+        currentCars: [car(PLAYER, 220), car("ai-a", 199.6), car("ai-b", 40)],
+        threatDistanceMeters: 25,
+        rival: { carId: "ai-a", displayName: "D. Korsak" },
+      }),
+    ).toEqual({
+      kind: "rival-pressure",
+      title: "D. Korsak",
+      detail: "20 m back",
+    });
+  });
+
+  it("keeps the generic title when the trailing pressure is not the rival", () => {
+    expect(
+      deriveRaceStoryMoment({
+        playerId: PLAYER,
+        previousCars: [car(PLAYER, 200), car("ai-a", 160)],
+        currentCars: [car(PLAYER, 220), car("ai-a", 199.6), car("ai-b", 40)],
+        threatDistanceMeters: 25,
+        rival: { carId: "ai-b", displayName: "K. Vega" },
+      }),
+    ).toEqual({
+      kind: "rival-pressure",
+      title: "Rival close",
+      detail: "20 m back",
+    });
+  });
 });

--- a/src/game/__tests__/rival.test.ts
+++ b/src/game/__tests__/rival.test.ts
@@ -1,0 +1,82 @@
+/**
+ * Unit tests for the F-092 slice 1 rival picker. Pin the deterministic
+ * choice (highest paceScalar, ties broken by id ascending) and the
+ * empty-grid early return so callers can branch on `null` without a
+ * length check.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import type { AIDriver } from "@/data/schemas";
+import { pickRival } from "@/game/rival";
+
+function driver(
+  id: string,
+  displayName: string,
+  paceScalar: number,
+): AIDriver {
+  return {
+    id,
+    displayName,
+    archetype: "clean_line",
+    paceScalar,
+    mistakeRate: 0.1,
+    aggression: 0.5,
+    weatherSkill: { clear: 1, rain: 1, fog: 1, snow: 1 },
+    nitroUsage: { launchBias: 0.5, straightBias: 0.5, panicBias: 0.5 },
+  };
+}
+
+describe("pickRival", () => {
+  it("returns null for an empty grid", () => {
+    expect(pickRival({ drivers: [] })).toBeNull();
+  });
+
+  it("picks the driver with the highest paceScalar", () => {
+    const ref = pickRival({
+      drivers: [
+        driver("ai_a", "A. One", 0.95),
+        driver("ai_b", "B. Two", 1.05),
+        driver("ai_c", "C. Three", 1.0),
+      ],
+    });
+    expect(ref).toEqual({
+      driverId: "ai_b",
+      displayName: "B. Two",
+      carId: "ai-1",
+    });
+  });
+
+  it("breaks paceScalar ties on id ascending", () => {
+    const ref = pickRival({
+      drivers: [
+        driver("ai_zeta", "Z", 1.0),
+        driver("ai_alpha", "A", 1.0),
+        driver("ai_mike", "M", 1.0),
+      ],
+    });
+    expect(ref?.driverId).toBe("ai_alpha");
+    expect(ref?.carId).toBe("ai-1");
+  });
+
+  it("threads the grid index into the carId", () => {
+    const ref = pickRival({
+      drivers: [
+        driver("ai_a", "A", 1.0),
+        driver("ai_b", "B", 1.0),
+        driver("ai_c", "C", 1.1),
+        driver("ai_d", "D", 0.9),
+      ],
+    });
+    expect(ref?.carId).toBe("ai-2");
+  });
+
+  it("still returns a rival when the grid has a single driver", () => {
+    const ref = pickRival({ drivers: [driver("ai_solo", "Solo", 1.0)] });
+    expect(ref).toEqual({
+      driverId: "ai_solo",
+      displayName: "Solo",
+      carId: "ai-0",
+    });
+  });
+});

--- a/src/game/raceMoments.ts
+++ b/src/game/raceMoments.ts
@@ -11,30 +11,49 @@ export interface RaceStoryMoment {
   readonly detail: string;
 }
 
+export interface RivalNamingRef {
+  /** In-race car id that maps to the named rival (e.g. `"ai-3"`). */
+  readonly carId: string;
+  /** Player-facing short name (`"D. Korsak"`). */
+  readonly displayName: string;
+}
+
 export interface RaceStoryMomentInput {
   readonly playerId: string;
   readonly previousCars: readonly RankedCar[] | null;
   readonly currentCars: readonly RankedCar[];
   readonly threatDistanceMeters: number;
+  /**
+   * F-092 slice 1. Optional rival ref. When present and the trailing
+   * pressure is the rival, the rival-pressure moment surfaces their
+   * name in the detail string. Absent for non-tour or practice runs.
+   */
+  readonly rival?: RivalNamingRef | null;
 }
 
-function nearestTrailingGap(input: {
+interface TrailingCar {
+  readonly id: string;
+  readonly gap: number;
+}
+
+function nearestTrailingCar(input: {
   readonly playerId: string;
   readonly cars: readonly RankedCar[];
-}): number | null {
+}): TrailingCar | null {
   const player = input.cars.find((car) => car.id === input.playerId);
   if (player === undefined) return null;
 
-  let closestGap = Number.POSITIVE_INFINITY;
+  let closest: TrailingCar | null = null;
   for (const car of input.cars) {
     if (car.id === input.playerId) continue;
     const gap = player.totalProgress - car.totalProgress;
-    if (gap > 0.5 && gap < closestGap) {
-      closestGap = gap;
+    if (gap <= 0.5) continue;
+    if (closest === null || gap < closest.gap) {
+      closest = { id: car.id, gap };
     }
   }
 
-  return Number.isFinite(closestGap) ? closestGap : null;
+  return closest;
 }
 
 export function deriveRaceStoryMoment(
@@ -69,18 +88,21 @@ export function deriveRaceStoryMoment(
     }
   }
 
-  const trailingGap = nearestTrailingGap({
+  const trailing = nearestTrailingCar({
     playerId: input.playerId,
     cars: input.currentCars,
   });
   if (
-    trailingGap !== null &&
-    trailingGap <= Math.max(1, input.threatDistanceMeters)
+    trailing !== null &&
+    trailing.gap <= Math.max(1, input.threatDistanceMeters)
   ) {
+    const meters = Math.round(trailing.gap);
+    const rival = input.rival ?? null;
+    const isRival = rival !== null && rival.carId === trailing.id;
     return {
       kind: "rival-pressure",
-      title: "Rival close",
-      detail: `${Math.round(trailingGap)} m back`,
+      title: isRival ? rival.displayName : "Rival close",
+      detail: `${meters} m back`,
     };
   }
 

--- a/src/game/rival.ts
+++ b/src/game/rival.ts
@@ -1,0 +1,64 @@
+/**
+ * F-092 slice 1. Pure rival-driver picker.
+ *
+ * Designates one AI driver per race as the player's rival so the
+ * existing rivalry HUD signal can name them ("Korsak, 18 m back")
+ * instead of the generic "Rival close". The choice is deterministic:
+ * the driver with the highest `paceScalar` is the natural foil because
+ * they are the AI most likely to occupy the same lap-time band as a
+ * skilled player. Ties break on `id` ascending so the choice is stable
+ * across runs without consuming any RNG.
+ *
+ * Out of scope this slice (filed under F-092):
+ *   - Cross-race head-to-head score persisted on the save.
+ *   - Tour-pinned rival so the same name recurs across all 4 races.
+ *   - Prep-card and results-screen surfaces.
+ *
+ * Returns `null` for grids with no AI (practice / time-trial) so
+ * callers can branch on absence without an explicit length check.
+ */
+
+import type { AIDriver } from "@/data/schemas";
+
+export interface RivalRef {
+  /** AI driver id from `aiDriverRoster` (e.g. `"ai_bully_01"`). */
+  readonly driverId: string;
+  /** Player-facing short name (`"D. Korsak"`). */
+  readonly displayName: string;
+  /**
+   * Race-scoped car id matching the `ai-${index}` shape that the race
+   * page uses for `RankedCar.id`. Stored alongside the driver fields
+   * so HUD code can match against the in-race car id without re-deriving
+   * the index.
+   */
+  readonly carId: string;
+}
+
+export interface PickRivalInput {
+  readonly drivers: readonly AIDriver[];
+}
+
+export function pickRival(input: PickRivalInput): RivalRef | null {
+  if (input.drivers.length === 0) return null;
+  let bestIndex = 0;
+  for (let i = 1; i < input.drivers.length; i++) {
+    const candidate = input.drivers[i]!;
+    const incumbent = input.drivers[bestIndex]!;
+    if (candidate.paceScalar > incumbent.paceScalar) {
+      bestIndex = i;
+      continue;
+    }
+    if (
+      candidate.paceScalar === incumbent.paceScalar &&
+      candidate.id < incumbent.id
+    ) {
+      bestIndex = i;
+    }
+  }
+  const winner = input.drivers[bestIndex]!;
+  return {
+    driverId: winner.id,
+    displayName: winner.displayName,
+    carId: `ai-${bestIndex}`,
+  };
+}


### PR DESCRIPTION
## Summary
- Slice 1 of F-092. Designates one AI driver per race as the player's rival so the existing rivalry HUD signal can name them ("D. Korsak, 18 m back") instead of the generic "Rival close".
- New pure module \`src/game/rival.ts\` with \`pickRival({ drivers })\` returns the AI with the highest \`paceScalar\` (ties broken on id ascending) and threads the grid index into the in-race car id so HUD code can match against \`RankedCar.id\`.
- Extended \`deriveRaceStoryMoment\` with an optional rival ref. When the trailing pressure is the rival, the existing rival-pressure moment surfaces their name in the \`title\`; the gap detail is unchanged. No save schema change.
- Deferred to follow-up slices under F-092: tour-pinned rival selection, save-resident head-to-head score (wins / losses / podiums), prep-card and results-screen surfaces.

## Test plan
- [x] \`pnpm typecheck\` clean
- [x] \`pnpm lint\` clean
- [x] \`pnpm test\` 2913 / 2913 across 156 suites; 5 new \`rival.test.ts\` cases + 2 new \`raceMoments.test.ts\` cases (rival named, generic title kept when not the rival)
- [x] \`pnpm content-lint\` clean
- [x] \`pnpm docs:check\` clean
- [ ] Manual playtest: start a tour race, get pressured by an AI, confirm the named-rival pressure surfaces only when the trailing AI matches the highest-paceScalar driver.
- [ ] Practice / time-trial regression: confirm the rivalry HUD still produces the generic "Rival close" since those modes have no AI grid (rival resolves to null).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added rival AI car selection and tracking during races.
  * Rival driver names now appear in race story moments when pressuring the player.
  * Rival selection uses deterministic logic to ensure consistency.

* **Tests**
  * Added comprehensive test coverage for rival selection and story moment integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->