### PR TITLE
feat(garage): tour-completion gate on car purchases (F-097)

### DIFF
--- a/docs/FOLLOWUPS.md
+++ b/docs/FOLLOWUPS.md
@@ -106,8 +106,26 @@ practice for now, so the inline hints are the v1.0 surface.
 ## F-097: Car purchase loop in the garage
 **Created:** 2026-05-07
 **Priority:** nice-to-have
-**Status:** open
-**Notes:** Surfaced by the 2026-05-07 mass-appeal audit (Tier B #9).
+**Status:** in-progress
+**Notes:** 2026-05-08 tour-gating slice shipped under
+`feat/car-tour-gating`. Verified that the cars subroute, the
+purchase callback, and the `save.garage.ownedCars` schema were
+already in place pre-audit (the F-097 entry overstated the gap).
+The remaining gap was the GDD §8 podium-progression unlock: the
+buy affordance was credit-only, no tour gate. Slice adds an
+optional `requiresTour` slug to `CarSchema`, authors it on
+Bastion LM (`iron-borough`), Tempest R (`breakwater-isles`), and
+Nova Shade (`neon-meridian`), and threads a pure
+`isCarUnlocked(car, completedTours)` helper through the cars page
+so the Buy button locks with a "Win <Tour> to unlock" reason
+until the prerequisite tour is in `save.progress.completedTours`.
+No save schema migration needed (the existing `completedTours`
+list is read directly). Deferred under this F-NNN: pretty tour
+display names from championship data, livery-cosmetic unlocks
+(those belong under F-096), and an e2e for the locked-state
+disabled button. Original notes follow.
+
+Originally surfaced by the 2026-05-07 mass-appeal audit (Tier B #9).
 GDD §5 ("Car selection if entering a new championship or buying a new
 car") and §8 ("Full podium progression unlocks bonus content and
 alternate cars") promise a car-buying loop, but the garage

--- a/docs/PROGRESS_LOG.md
+++ b/docs/PROGRESS_LOG.md
@@ -6,6 +6,89 @@ Correct them by adding a new entry that references the old one.
 
 ---
 
+## 2026-05-08: feat(garage): tour-completion gate on car purchases (F-097)
+
+**GDD sections touched:** [§8](gdd/08-progression-and-rewards.md)
+"Full podium progression unlocks bonus content and alternate cars"
+(build-log entry), [§11](gdd/11-cars-and-stats.md) (car catalogue
+gains an optional `requiresTour` slug; existing data files load
+unchanged because the field is optional).
+**Branch / PR:** `feat/car-tour-gating`, PR pending.
+**Status:** Tour-gating shipped. The other half of the F-097
+ledger ask (the cars subroute itself, ownership tracking, and the
+`ownedCars` save slot) was already in place from earlier slices.
+F-097 stays in-progress for the deferred items noted in FOLLOWUPS
+(pretty tour display names, livery cosmetics under F-096, locked
+e2e).
+
+### Done
+- Added optional `requiresTour: slug` to `CarSchema` in
+  `src/data/schemas.ts`. Documented as optional so existing car
+  files (sparrow-gt, breaker-s, vanta-xr) keep loading unchanged.
+- Authored the gate on the late-tier cars: Bastion LM gates on
+  `iron-borough`, Tempest R gates on `breakwater-isles`, and
+  Nova Shade gates on `neon-meridian`. The progression curve
+  matches the GDD §8 "podium unlocks bonus content" promise:
+  cars get more capable as the player wins later tours.
+- Added `src/game/carUnlock.ts` with pure
+  `isCarUnlocked(car, completedTours)`. Cars without
+  `requiresTour` are always unlocked; gated cars unlock once the
+  required tour appears in `save.progress.completedTours`. The
+  helper does not look at credits so the UI can show the lock
+  message before the credits message in the natural reading
+  order.
+- Wired the helper into `src/app/garage/cars/page.tsx`. The
+  Buy button now renders as a disabled "Locked" affordance with a
+  "Win <Tour> to unlock" tooltip when the gate fails, and a small
+  amber lock-reason line appears under the class / repair row.
+  The buyCar callback also short-circuits with a status-bar error
+  if the lock somehow gets bypassed (defense in depth so a bad
+  click can not slip through).
+
+### Verified
+- `npm run typecheck` clean.
+- `npm run lint` clean.
+- `npm run test` 2916 / 2916 passed across 157 suites; new
+  `src/game/__tests__/carUnlock.test.ts` pins the three cases the
+  UI branches on (no requiresTour, required tour absent, required
+  tour present).
+- `npm run content-lint` clean.
+
+### Decisions and assumptions
+- No save schema migration. The lock reads
+  `save.progress.completedTours` (already a `string[]` on the
+  schema) and the new `requiresTour` is optional on `Car`, so
+  existing v4 saves and existing car JSONs both load without a
+  bump.
+- "Win" used in the lock copy maps to the GDD §8 podium rule, the
+  same condition that drives `unlockNextTour` in
+  `src/game/championship.ts`. A future slice can refine the
+  gate to "podium win" vs. "any completion" if needed.
+- Tour name in the lock copy is title-cased from the slug
+  (`iron-borough` -> `Iron Borough`) inline. Pretty names from
+  the championship JSON are deferred (those don't exist on the
+  data file today; adding them is its own slice).
+- Three cars gated, three cars unlocked from the start. The
+  starter (Sparrow GT, 0 credits) and the two early choices
+  (Breaker S, Vanta XR) stay available as-is so a brand-new save
+  still has the §11 starter picker.
+
+### Coverage ledger
+- §8 progression: car-purchase loop now has the podium gate
+  promised by the GDD; F-097 stays open only for the deferred
+  niceties (pretty names, livery overlay, e2e).
+- §11 cars: `Car.requiresTour` is the only schema addition. No
+  data migration; existing car files unchanged.
+
+### Followups created
+None. F-097 ledger updated to in-progress with the deferred
+items.
+
+### GDD edits
+None this slice.
+
+---
+
 ## 2026-05-08: feat(rivalry): named per-race rival in the HUD pressure moment (F-092 slice 1)
 
 **GDD sections touched:** [§15](gdd/15-ai.md) (rivalry framing on the

--- a/src/app/garage/cars/page.tsx
+++ b/src/app/garage/cars/page.tsx
@@ -25,6 +25,7 @@ import { useCallback, useEffect, useMemo, useState } from "react";
 
 import { CARS, getCar } from "@/data/cars";
 import type { Car, CarBaseStats, SaveGame } from "@/data/schemas";
+import { isCarUnlocked } from "@/game/carUnlock";
 import { defaultSave, loadSave, saveSave } from "@/persistence";
 
 interface PageStatus {
@@ -105,6 +106,13 @@ export default function GarageCarsPage() {
       if (ownedCars.has(carId)) return;
       const car = getCar(carId);
       if (!car) return;
+      if (!isCarUnlocked(car, save.progress.completedTours)) {
+        setStatus({
+          kind: "error",
+          message: `${car.name} unlocks after winning ${formatTourName(car.requiresTour ?? "")}.`,
+        });
+        return;
+      }
       if (save.garage.credits < car.purchasePrice) {
         setStatus({
           kind: "error",
@@ -175,6 +183,7 @@ export default function GarageCarsPage() {
             owned={ownedCars.has(car.id)}
             active={save.garage.activeCarId === car.id}
             credits={save.garage.credits}
+            unlocked={isCarUnlocked(car, save.progress.completedTours)}
             onSelect={() => selectCar(car.id)}
             onBuy={() => buyCar(car.id)}
           />
@@ -189,6 +198,7 @@ interface CarCardProps {
   owned: boolean;
   active: boolean;
   credits: number;
+  unlocked: boolean;
   onSelect: () => void;
   onBuy: () => void;
 }
@@ -198,10 +208,14 @@ function CarCard({
   owned,
   active,
   credits,
+  unlocked,
   onSelect,
   onBuy,
 }: CarCardProps): ReactElement {
   const canAfford = credits >= car.purchasePrice;
+  const lockedReason = !unlocked
+    ? `Win ${formatTourName(car.requiresTour ?? "")} to unlock`
+    : "";
   const action = owned ? (
     <button
       type="button"
@@ -211,6 +225,16 @@ function CarCard({
       style={buttonStyle(active)}
     >
       {active ? "Active" : "Set Active"}
+    </button>
+  ) : !unlocked ? (
+    <button
+      type="button"
+      disabled
+      data-testid={`buy-${car.id}`}
+      style={buttonStyle(false)}
+      title={lockedReason}
+    >
+      Locked
     </button>
   ) : (
     <button
@@ -233,6 +257,14 @@ function CarCard({
           <p style={{ margin: 0, color: "var(--muted, #aaa)", fontSize: "0.875rem" }}>
             Class: <span data-testid={`class-${car.id}`}>{car.class}</span>. Repair x{car.repairFactor.toFixed(2)}.
           </p>
+          {!unlocked ? (
+            <p
+              style={{ margin: "0.25rem 0 0", fontSize: "0.85rem", color: "#f8c060" }}
+              data-testid={`lock-reason-${car.id}`}
+            >
+              {lockedReason}.
+            </p>
+          ) : null}
         </div>
         {action}
       </header>
@@ -255,6 +287,14 @@ function CarCard({
 
 function formatStat(value: number): string {
   return Number.isInteger(value) ? value.toFixed(1) : value.toFixed(2);
+}
+
+function formatTourName(tourId: string): string {
+  if (tourId === "") return "the next tour";
+  return tourId
+    .split("-")
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+    .join(" ");
 }
 
 const pageStyle: CSSProperties = {

--- a/src/data/cars/bastion-lm.json
+++ b/src/data/cars/bastion-lm.json
@@ -3,6 +3,7 @@
   "name": "Bastion LM",
   "class": "enduro",
   "purchasePrice": 28000,
+  "requiresTour": "iron-borough",
   "repairFactor": 0.85,
   "baseStats": {
     "topSpeed": 72.0,

--- a/src/data/cars/nova-shade.json
+++ b/src/data/cars/nova-shade.json
@@ -3,6 +3,7 @@
   "name": "Nova Shade",
   "class": "power",
   "purchasePrice": 48000,
+  "requiresTour": "neon-meridian",
   "repairFactor": 1.3,
   "baseStats": {
     "topSpeed": 82.0,

--- a/src/data/cars/tempest-r.json
+++ b/src/data/cars/tempest-r.json
@@ -3,6 +3,7 @@
   "name": "Tempest R",
   "class": "balance",
   "purchasePrice": 32000,
+  "requiresTour": "breakwater-isles",
   "repairFactor": 1.15,
   "baseStats": {
     "topSpeed": 76.0,

--- a/src/data/schemas.ts
+++ b/src/data/schemas.ts
@@ -296,6 +296,14 @@ export const CarSchema = z.object({
   baseStats: CarBaseStatsSchema,
   upgradeCaps: CarUpgradeCapsSchema,
   visualProfile: CarVisualProfileSchema,
+  /**
+   * F-097 follow-up. Optional tour-completion gate. When present, the
+   * car only becomes purchasable after the player has completed the
+   * named tour (the slug must appear in
+   * `save.progress.completedTours`). Omitted on starter cars and the
+   * mid-pack catalogue so existing data files load unchanged.
+   */
+  requiresTour: slug.optional(),
 });
 export type Car = z.infer<typeof CarSchema>;
 

--- a/src/game/__tests__/carUnlock.test.ts
+++ b/src/game/__tests__/carUnlock.test.ts
@@ -1,0 +1,61 @@
+/**
+ * Unit tests for the F-097 follow-up tour-completion gate. Pin the
+ * three cases the cars-page UI branches on so a future refactor of
+ * the gate (e.g. requiring multiple tours, or adding a credits
+ * pre-check) does not silently change the contract.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import type { Car } from "@/data/schemas";
+import { isCarUnlocked } from "@/game/carUnlock";
+
+const BASE_CAR: Car = {
+  id: "stub",
+  name: "Stub",
+  class: "balance",
+  purchasePrice: 1000,
+  repairFactor: 1,
+  baseStats: {
+    topSpeed: 60,
+    accel: 16,
+    brake: 28,
+    gripDry: 1,
+    gripWet: 0.85,
+    stability: 1,
+    durability: 1,
+    nitroEfficiency: 1,
+  },
+  upgradeCaps: {
+    engine: 4,
+    gearbox: 4,
+    dryTires: 4,
+    wetTires: 4,
+    nitro: 4,
+    armor: 4,
+    cooling: 4,
+    aero: 4,
+  },
+  visualProfile: { spriteSet: "sparrow_gt", paletteSet: "early_a" },
+};
+
+describe("isCarUnlocked", () => {
+  it("returns true when the car has no requiresTour", () => {
+    expect(isCarUnlocked(BASE_CAR, [])).toBe(true);
+    expect(isCarUnlocked(BASE_CAR, ["any-tour"])).toBe(true);
+  });
+
+  it("returns false when the required tour has not been completed", () => {
+    const gated: Car = { ...BASE_CAR, requiresTour: "iron-borough" };
+    expect(isCarUnlocked(gated, [])).toBe(false);
+    expect(isCarUnlocked(gated, ["velvet-coast"])).toBe(false);
+  });
+
+  it("returns true once the required tour is in completedTours", () => {
+    const gated: Car = { ...BASE_CAR, requiresTour: "iron-borough" };
+    expect(isCarUnlocked(gated, ["iron-borough"])).toBe(true);
+    expect(
+      isCarUnlocked(gated, ["velvet-coast", "iron-borough", "ember-steppe"]),
+    ).toBe(true);
+  });
+});

--- a/src/game/carUnlock.ts
+++ b/src/game/carUnlock.ts
@@ -1,0 +1,22 @@
+/**
+ * F-097 follow-up. Pure helper for the optional tour-completion gate
+ * on car purchases. The garage car selector calls this once per car
+ * card to decide whether the Buy affordance should be locked.
+ *
+ * A car with no `requiresTour` is always unlocked (starter and
+ * mid-pack catalogue). A car with `requiresTour` is unlocked once
+ * that tour id appears in `save.progress.completedTours`. The helper
+ * does not look at credits; the existing `purchasePrice` check stays
+ * as a separate disabled-on-affordability gate so the player sees
+ * "Win <Tour> to unlock" before "Save up <N> credits".
+ */
+
+import type { Car } from "@/data/schemas";
+
+export function isCarUnlocked(
+  car: Car,
+  completedTours: readonly string[],
+): boolean {
+  if (car.requiresTour === undefined) return true;
+  return completedTours.includes(car.requiresTour);
+}


### PR DESCRIPTION
## Summary
- Implements the GDD §8 podium-progression promise on the existing cars subroute. Until this slice the buy affordance was credit-only; now the late-tier cars lock behind a tour-completion gate.
- Adds optional \`requiresTour\` slug to \`CarSchema\` and authors it on Bastion LM (\`iron-borough\`), Tempest R (\`breakwater-isles\`), and Nova Shade (\`neon-meridian\`). New pure helper \`isCarUnlocked(car, completedTours)\` reads \`save.progress.completedTours\`.
- The cars page now shows a disabled "Locked" button with "Win <Tour> to unlock" tooltip plus a small lock-reason line under the class row. The \`buyCar\` callback short-circuits with a status-bar error if a click ever slips through.
- No save schema migration. Starter and early-choice cars (Sparrow GT, Breaker S, Vanta XR) stay available from a fresh save so the §11 starter picker still works.
- Deferred: pretty tour display names from championship data, livery cosmetics (under F-096), and a Playwright spec for the locked-state disabled button.

## Test plan
- [x] \`pnpm typecheck\` clean
- [x] \`pnpm lint\` clean
- [x] \`pnpm test\` 2916 / 2916 across 157 suites; new \`carUnlock.test.ts\` pins the three branches the UI uses
- [x] \`pnpm content-lint\` clean
- [x] \`pnpm docs:check\` clean
- [ ] Manual playtest fresh save: confirm Bastion LM / Tempest R / Nova Shade show "Locked" with the tour name in the tooltip; confirm Sparrow GT / Breaker S / Vanta XR remain buyable.
- [ ] Manual playtest with \`completedTours\` containing \`iron-borough\`: confirm Bastion LM unlocks while Tempest R / Nova Shade stay locked.