### PR TITLE
feat(hazards): oil-slick lateral-grip hazard (F-095 slice 1)

### DIFF
--- a/docs/FOLLOWUPS.md
+++ b/docs/FOLLOWUPS.md
@@ -155,8 +155,27 @@ back for "I want the gold-podium livery" exactly as Top Gear 2's
 ## F-095: Authored hazard variety beyond `puddle` and `gravel_band`
 **Created:** 2026-05-07
 **Priority:** nice-to-have
-**Status:** open
-**Notes:** Surfaced by the 2026-05-07 mass-appeal audit (Tier A #6).
+**Status:** in-progress
+**Notes:** 2026-05-08 oil-slick slice shipped under
+`feat/oil-slick-hazard`. Audit-correction note: the original
+"limited to puddle + gravel_band" framing was wrong on second
+look. The schema already has 7 kinds and 6 are authored (the
+audit grep missed the recurring `slick_paint`, `traffic_cone`,
+`sign_marker`, `snow_buildup`, and `tunnel`). The real gap is
+the four new kinds the audit names. Slice 1 ships the first of
+those four (`oil_slick`, lateral grip drop) end-to-end: schema
+enum, registry entry (grip 0.5 vs. puddle 0.65, no damage,
+non-breakable, narrower 8 m footprint than a puddle so it sits
+on a single lane), and three authored placements (Foundry Mile
+inside-line uphill apex, Cinder Gate left-curve climb, Grand
+Meridian late tour decreasing-radius left). Deferred under this
+F-NNN: `debris`, `slow_traffic`, `wind_gust`. Each is a clean
+follow-up slice (the pure runtime already handles per-tick grip
++ optional damage, so debris is a one-line addition; slow_traffic
+needs a per-tick lane-bias term; wind_gust needs a lateral-push
+extension to evaluateHazards). Original notes follow.
+
+Surfaced by the 2026-05-07 mass-appeal audit (Tier A #6).
 A grep across all 32 production tracks shows hazards limited to `puddle`
 + `gravel_band` (and most segments are `"hazards": []`). GDD §3 / §9
 call for richer authored tactical decisions. Add three or four new

--- a/docs/PROGRESS_LOG.md
+++ b/docs/PROGRESS_LOG.md
@@ -6,6 +6,78 @@ Correct them by adding a new entry that references the old one.
 
 ---
 
+## 2026-05-08: feat(hazards): oil-slick lateral-grip hazard (F-095 slice 1)
+
+**GDD sections touched:** [§9](gdd/09-track-design.md) (track
+authoring gains a fourth grip-drop kind), [§22](gdd/22-data-and-content-pipeline.md)
+(`HazardKindSchema` enum extension; existing data files unchanged).
+**Branch / PR:** `feat/oil-slick-hazard`, PR pending.
+**Status:** First of four hazard kinds the F-095 audit named.
+F-095 stays in-progress for `debris`, `slow_traffic`, `wind_gust`.
+
+### Done
+- Added `oil_slick` to `HazardKindSchema` in `src/data/schemas.ts`.
+- Registered the hazard in `src/data/hazards.json`. Grip 0.5 (sharper
+  than a puddle's 0.65, less punishing than gravel's 0.55 + 3 dmg),
+  defaultWidth 8 m so it occupies one lane (puddles are 14 m and
+  cover the road), no damage so the player can recover with a careful
+  steer rather than getting a body hit, non-breakable.
+- Authored the hazard on three production tracks distributed across
+  the difficulty curve: Iron Borough Foundry Mile (industrial uphill
+  inside-line apex, segment 2), Ember Steppe Cinder Gate (left-curve
+  climb, segment 3), and Crown Circuit Grand Meridian (late-tour
+  decreasing-radius left, segment 5). Each placement is on a corner
+  approach where braking already matters, so the grip drop adds
+  tactical pressure rather than feeling random.
+- Documented the audit-correction in FOLLOWUPS: the original
+  "limited to puddle + gravel_band" framing was a grep miss. 6 of
+  7 existing kinds are authored on 32 tracks; the genuine gap is
+  the four new kinds the F-095 entry names.
+
+### Verified
+- `npm run typecheck` clean.
+- `npm run lint` clean.
+- `npm run test` 2917 / 2917 passed across 157 suites; new case in
+  `src/game/__tests__/hazards.test.ts` confirms the Foundry Mile
+  authored placement yields a 0.5 grip multiplier with no hit
+  payload.
+- `npm run content-lint` clean. The `hazards-content.test` suite
+  validates the new registry entry against `HazardRegistryEntrySchema`
+  and confirms every hazard id referenced by tracks resolves.
+- `npm run docs:check` clean.
+
+### Decisions and assumptions
+- No runtime change. `evaluateHazards` already reads the optional
+  `gripMultiplier` and `damageKind` from the registry entry, so
+  adding a new kind is data-only as long as the new kind fits the
+  existing event shape (per-tick grip with optional damage).
+  `wind_gust` will need a lateral-push extension; that lives in a
+  follow-up slice.
+- Width 8 m vs. puddle 14 m. The thinner footprint means the player
+  can pick a wider line to skip the slick, so an inside-line apex
+  placement lets the player choose between a fast tight line at
+  reduced grip and a wider safe line. That asymmetry is the §9
+  authored-tactical-decision goal.
+- Three placements rather than the F-095 ask of "distribute across
+  mid-late tours". Three is enough to validate the kind in playtest;
+  a sweep across all 32 tracks belongs in a separate authoring slice
+  once `debris` / `slow_traffic` / `wind_gust` also land so we don't
+  re-pass the tracks four times.
+
+### Coverage ledger
+- §9 track-design: hazard variety expanded from 6 authored kinds
+  to 7 across the 32-track production set.
+- §22 schema: `HazardKindSchema` now lists 8 kinds. Existing
+  hazard JSONs and track files load unchanged.
+
+### Followups created
+None. F-095 stays open for the three remaining hazard kinds.
+
+### GDD edits
+None this slice.
+
+---
+
 ## 2026-05-08: feat(garage): tour-completion gate on car purchases (F-097)
 
 **GDD sections touched:** [§8](gdd/08-progression-and-rewards.md)

--- a/src/data/hazards.json
+++ b/src/data/hazards.json
@@ -82,5 +82,17 @@
     "damageKind": null,
     "damageMagnitude": null,
     "breakable": false
+  },
+  {
+    "id": "oil_slick",
+    "kind": "oil_slick",
+    "displayName": "Oil Slick",
+    "defaultWidth": 8,
+    "defaultLength": 16,
+    "laneOffset": 0,
+    "gripMultiplier": 0.5,
+    "damageKind": null,
+    "damageMagnitude": null,
+    "breakable": false
   }
 ]

--- a/src/data/schemas.ts
+++ b/src/data/schemas.ts
@@ -114,6 +114,13 @@ export const HazardKindSchema = z.enum([
   "gravel_band",
   "snow_buildup",
   "tunnel",
+  // F-095 slice 1. Oil slick. Lateral grip drop sharper than a
+  // puddle (0.5 vs. 0.65) and authored on industrial / pit-stop
+  // adjacent segments where the fiction reads. No direct damage so
+  // the player can recover with a careful steer rather than getting
+  // a drive-by hit. Future slices add `debris`, `slow_traffic`, and
+  // `wind_gust` per the F-095 ask.
+  "oil_slick",
 ]);
 export type HazardKind = z.infer<typeof HazardKindSchema>;
 

--- a/src/data/tracks/crown-circuit-grand-meridian.json
+++ b/src/data/tracks/crown-circuit-grand-meridian.json
@@ -35,7 +35,7 @@
       ]
     },
     { "len": 340, "curve": 0.14, "grade": -0.04, "roadsideLeft": "rock_boulder", "roadsideRight": "light_pole", "hazards": ["snow_buildup"] },
-    { "len": 320, "curve": -0.16, "grade": -0.02, "roadsideLeft": "guardrail", "roadsideRight": "sign_marker", "hazards": [] },
+    { "len": 320, "curve": -0.16, "grade": -0.02, "roadsideLeft": "guardrail", "roadsideRight": "sign_marker", "hazards": ["oil_slick"] },
     { "len": 360, "curve": 0.1, "grade": 0.02, "roadsideLeft": "light_pole", "roadsideRight": "guardrail", "hazards": ["traffic_cone"] },
     {
       "len": 500,

--- a/src/data/tracks/ember-steppe-cinder-gate.json
+++ b/src/data/tracks/ember-steppe-cinder-gate.json
@@ -24,7 +24,7 @@
         { "id": "cinder-gate-apex-nitro", "kind": "nitro", "laneOffset": 0.4, "value": 25 }
       ]
     },
-    { "len": 280, "curve": -0.08, "grade": 0.05, "roadsideLeft": "fence_post", "roadsideRight": "rock_boulder", "hazards": [] },
+    { "len": 280, "curve": -0.08, "grade": 0.05, "roadsideLeft": "fence_post", "roadsideRight": "rock_boulder", "hazards": ["oil_slick"] },
     {
       "len": 260,
       "curve": 0.14,

--- a/src/data/tracks/iron-borough-foundry-mile.json
+++ b/src/data/tracks/iron-borough-foundry-mile.json
@@ -23,7 +23,7 @@
         { "id": "foundry-mile-cone-nitro", "kind": "nitro", "laneOffset": 0.35, "value": 25 }
       ]
     },
-    { "len": 240, "curve": -0.08, "grade": 0.04, "roadsideLeft": "rock_boulder", "roadsideRight": "light_pole", "hazards": [] },
+    { "len": 240, "curve": -0.08, "grade": 0.04, "roadsideLeft": "rock_boulder", "roadsideRight": "light_pole", "hazards": ["oil_slick"] },
     { "len": 240, "curve": -0.12, "grade": -0.03, "roadsideLeft": "light_pole", "roadsideRight": "fence_post", "hazards": ["puddle"] },
     {
       "len": 324,

--- a/src/game/__tests__/hazards.test.ts
+++ b/src/game/__tests__/hazards.test.ts
@@ -91,4 +91,20 @@ describe("evaluateHazards", () => {
     expect(effect.events).toEqual([]);
     expect(effect.gripMultiplier).toBe(1);
   });
+
+  it("applies the F-095 oil-slick grip drop without damage", () => {
+    // Foundry Mile authored segment 2 (z range 480-720) carries the
+    // F-095 oil_slick. The 0.5 grip drop is sharper than a puddle's
+    // 0.65 so a player who clips the inside line bleeds noticeable
+    // grip without taking a body hit.
+    const track = loadTrack("iron-borough/foundry-mile");
+    const effect = evaluateHazards({
+      car: car({ z: 600 }),
+      track,
+      hazardsById: HAZARDS_BY_ID,
+    });
+    expect(effect.events[0]?.hazard.id).toBe("oil_slick");
+    expect(effect.gripMultiplier).toBeCloseTo(0.5, 6);
+    expect(effect.events[0]?.hit).toBeNull();
+  });
 });


### PR DESCRIPTION
## Summary
- First of the four new hazard kinds the F-095 audit named. Adds \`oil_slick\` to \`HazardKindSchema\`, registers it with grip 0.5 / no damage / 8 m width (one lane vs. a puddle's 14 m), and authors three placements: Iron Borough Foundry Mile, Ember Steppe Cinder Gate, Crown Circuit Grand Meridian.
- Each placement is on a corner approach where braking already matters so the grip drop adds tactical pressure rather than feeling random.
- Pure runtime unchanged. \`evaluateHazards\` already reads optional \`gripMultiplier\` from the registry entry, so adding the kind is data-only when the kind fits the per-tick grip + optional damage shape.
- Audit-correction filed in FOLLOWUPS: the "limited to puddle + gravel_band" framing was a grep miss. 6 of 7 existing kinds were already authored across 32 tracks; the real gap is the four new kinds.
- Deferred under F-095: \`debris\`, \`slow_traffic\`, \`wind_gust\` (each a discrete follow-up slice).

## Test plan
- [x] \`pnpm typecheck\` clean
- [x] \`pnpm lint\` clean
- [x] \`pnpm test\` 2917 / 2917 across 157 suites; new \`hazards.test.ts\` case asserts the Foundry Mile authored placement yields 0.5 grip with no hit
- [x] \`pnpm content-lint\` clean
- [x] \`pnpm docs:check\` clean
- [ ] Manual playtest: drive Foundry Mile / Cinder Gate / Grand Meridian, confirm the inside-line slick reads as a tactical "skip me" choice and not a random grip glitch.