### PR TITLE
feat(cosmetics): tour-podium livery ledger and title-screen badges (F-096 slice 1)

### DIFF
--- a/docs/FOLLOWUPS.md
+++ b/docs/FOLLOWUPS.md
@@ -139,8 +139,23 @@ migration for `ownedCars`.
 ## F-096: Cosmetic and livery unlocks on tour podium
 **Created:** 2026-05-07
 **Priority:** nice-to-have
-**Status:** open
-**Notes:** Surfaced by the 2026-05-07 mass-appeal audit (Tier B #7).
+**Status:** in-progress
+**Notes:** 2026-05-08 ledger slice shipped under
+`feat/cosmetic-ledger`. Adds an optional
+`save.unlockedCosmetics: string[]` slot, mints a per-tour
+`livery-${tourId}` cosmetic on first completion via
+`unlockNextTour`, and renders a row of text badges below the
+title-screen TitleGlance (one per unlocked cosmetic). Pure
+helpers (`cosmeticIdForTour`, `appendUnlockedCosmetic`,
+`buildCosmeticBadges`) live in `src/game/cosmetics.ts` so the
+mint and the read-side render are testable without React. No
+schema-version bump (the slot is optional). Follow-up slices
+under this F-NNN: replace the text badges with sprite icons,
+wire the unlocked livery into the player car sprite as a
+`paletteRecolour` overlay, and add the per-tour soundtrack remix
+to the music-runtime rotation. Original notes follow.
+
+Surfaced by the 2026-05-07 mass-appeal audit (Tier B #7).
 GDD §8 promises "challenge medals unlock cosmetics, soundtrack remixes,
 and extra championships". Today tour completion unlocks only the next
 tour cursor (`src/game/championship.ts:unlockNextTour`). Add a

--- a/docs/PROGRESS_LOG.md
+++ b/docs/PROGRESS_LOG.md
@@ -6,6 +6,88 @@ Correct them by adding a new entry that references the old one.
 
 ---
 
+## 2026-05-08: feat(cosmetics): tour-podium livery ledger and title-screen badges (F-096 slice 1)
+
+**GDD sections touched:** [§8](gdd/08-progression-and-rewards.md)
+"challenge medals unlock cosmetics" (build-log entry),
+[§22](gdd/22-data-and-content-pipeline.md)
+(`SaveGameSchema.unlockedCosmetics` extension; existing v4 saves
+load unchanged because the slot is optional).
+**Branch / PR:** `feat/cosmetic-ledger`, PR pending.
+**Status:** Slice 1 of F-096. Sprite-based badge icons, livery
+`paletteRecolour` overlay on the player sprite, and the
+soundtrack-remix rotation stay open under F-096 for follow-up
+slices.
+
+### Done
+- Added `src/game/cosmetics.ts` with three pure helpers:
+  `cosmeticIdForTour(tourId)` mints `livery-${tourId}`,
+  `appendUnlockedCosmetic(list, id)` returns a fresh array with
+  the id absent or unchanged contents otherwise (always a copy
+  so the result fits zod's `string[]` shape), and
+  `buildCosmeticBadges(list)` filters non-livery ids and
+  title-cases the tour slug into a player-facing label.
+- Extended `SaveGameSchema` with optional
+  `unlockedCosmetics: z.array(slug)` so existing v4 saves load
+  unchanged. The schema-version field stays at 4.
+- Wired `unlockNextTour` in `src/game/championship.ts` to mint
+  the per-tour livery on first completion. Re-completion no-ops
+  via the existing early-return guard (the test that pins
+  reference equality on a re-run still holds).
+- Added `src/components/title/CosmeticBadgeRow.tsx`. Hydration-
+  safe: SSR pass renders an empty placeholder so the static
+  markup carries the test-id, the client-only effect loads the
+  save and populates a row of text badges below
+  `<TitleGlance />`. No animation; row is static so the surface
+  respects vestibular sensitivity per §19.
+
+### Verified
+- `npm run typecheck` clean.
+- `npm run lint` clean.
+- `npm run test` 2926 / 2926 passed across 158 suites; 9 new
+  cases in `src/game/__tests__/cosmetics.test.ts` cover all
+  three helpers (id format, append idempotence, badge filter +
+  title-casing, malformed-id skip), plus 2 new
+  `championship.test.ts` cases (cosmetic minted on first
+  completion, no duplicate on re-run).
+- `npm run content-lint` clean.
+- `npm run docs:check` clean.
+
+### Decisions and assumptions
+- Cosmetic ids derived as `livery-${tourId}` rather than a
+  hand-authored mapping table. A future migration that renames
+  a tour can rename the cosmetic by editing the slug, not by
+  re-mapping a separate file.
+- Text badges instead of sprite icons in slice 1. The art for
+  per-tour badges is its own deliverable; shipping the ledger
+  first lets a player see the unlocked count on the title
+  screen without waiting for the icon set. The text is
+  accessible by default (no alt-text dance) and the layout
+  reuses the same pill style as the F-101 hint overlay.
+- One livery per tour, awarded on completion. The GDD §8 ask
+  also names "challenge medals" and "soundtrack remixes"; those
+  belong in follow-up slices because each adds a separate save
+  slot and runtime surface (medal -> per-race-result challenge
+  state, remix -> music-runtime rotation).
+
+### Coverage ledger
+- §8 progression: tour completion now mints a player-visible
+  cosmetic in addition to the next-tour unlock. F-096 stays
+  open for the deferred icon / livery / remix wiring.
+- §22 schema: `SaveGame.unlockedCosmetics` joins the optional
+  fields (`ghosts`, `downloadedGhosts`, `tutorialState`); no
+  migration required because the loader treats `undefined` as
+  "no cosmetics yet".
+
+### Followups created
+None. F-096 ledger updated to in-progress with the deferred
+items.
+
+### GDD edits
+None this slice.
+
+---
+
 ## 2026-05-08: feat(hazards): oil-slick lateral-grip hazard (F-095 slice 1)
 
 **GDD sections touched:** [§9](gdd/09-track-design.md) (track

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,5 +1,6 @@
 import Link from "next/link";
 
+import { CosmeticBadgeRow } from "@/components/title/CosmeticBadgeRow";
 import { TitleGlance } from "@/components/title/TitleGlance";
 
 import { formatBuildBadge } from "./buildInfo";
@@ -49,6 +50,7 @@ export default function TitlePage() {
         </h1>
         <p className={styles.tagline}>Spiritual successor to Top Gear 2.</p>
         <TitleGlance />
+        <CosmeticBadgeRow />
         <nav className={styles.menu} aria-label="Main menu">
           {MENU.map((item) => (
             <Link

--- a/src/components/title/CosmeticBadgeRow.tsx
+++ b/src/components/title/CosmeticBadgeRow.tsx
@@ -1,0 +1,103 @@
+"use client";
+
+/**
+ * F-096 slice 1 title-screen surface. Renders one text badge per
+ * unlocked cosmetic on the title page so a player who finishes a
+ * tour gets a visible "you earned this" cue between sessions.
+ *
+ * Hydration-safe: SSR pass renders an empty placeholder so the
+ * static markup always carries the test-id; the client-only effect
+ * loads the save and populates the row after mount. No animation;
+ * the row is static so the surface respects vestibular sensitivity
+ * per §19.
+ *
+ * Out of scope (F-096 follow-up slices, deferred):
+ *   - Sprite-based badge icons (slice 1 is text-only labels).
+ *   - Player car livery `paletteRecolour` overlay.
+ *   - Soundtrack-remix rotation in the music runtime.
+ */
+
+import {
+  useEffect,
+  useState,
+  type CSSProperties,
+  type ReactElement,
+} from "react";
+
+import { buildCosmeticBadges, type CosmeticBadge } from "@/game/cosmetics";
+import { loadSave } from "@/persistence/save";
+
+export function CosmeticBadgeRow(): ReactElement {
+  const [badges, setBadges] = useState<readonly CosmeticBadge[] | null>(null);
+
+  useEffect(() => {
+    const outcome = loadSave();
+    const save = outcome.kind === "loaded" ? outcome.save : null;
+    setBadges(buildCosmeticBadges(save?.unlockedCosmetics));
+  }, []);
+
+  if (badges === null) {
+    return (
+      <div
+        data-testid="cosmetic-badge-row"
+        data-state="hydrating"
+        style={hiddenStyle}
+        aria-hidden="true"
+      />
+    );
+  }
+
+  if (badges.length === 0) {
+    return (
+      <div
+        data-testid="cosmetic-badge-row"
+        data-state="empty"
+        style={hiddenStyle}
+        aria-hidden="true"
+      />
+    );
+  }
+
+  return (
+    <ul
+      data-testid="cosmetic-badge-row"
+      data-state="ready"
+      aria-label="Unlocked cosmetics"
+      style={rowStyle}
+    >
+      {badges.map((badge) => (
+        <li
+          key={badge.cosmeticId}
+          data-testid={`cosmetic-badge-${badge.cosmeticId}`}
+          style={badgeStyle}
+        >
+          {badge.label}
+        </li>
+      ))}
+    </ul>
+  );
+}
+
+const hiddenStyle: CSSProperties = {
+  display: "none",
+};
+
+const rowStyle: CSSProperties = {
+  listStyle: "none",
+  padding: 0,
+  margin: "0.75rem 0 0",
+  display: "flex",
+  flexWrap: "wrap",
+  gap: "0.4rem",
+  justifyContent: "center",
+};
+
+const badgeStyle: CSSProperties = {
+  fontSize: "0.78rem",
+  letterSpacing: "0.02em",
+  padding: "0.25rem 0.6rem",
+  border: "1px solid #2a2f3d",
+  borderRadius: "999px",
+  background: "rgba(20, 26, 38, 0.6)",
+  color: "#cfd4e0",
+};

--- a/src/data/schemas.ts
+++ b/src/data/schemas.ts
@@ -1032,5 +1032,15 @@ export const SaveGameSchema = z.object({
       prepCardSeen: z.boolean(),
     })
     .optional(),
+  /**
+   * F-096 slice 1. Cosmetic ids the player has unlocked. Today the
+   * only authored entries are the per-tour liveries minted by
+   * `unlockNextTour` (`livery-${tourId}`); the title screen renders
+   * one text badge per id. Future slices wire the same ids into a
+   * paletteRecolour overlay on the player car sprite and a
+   * soundtrack-remix rotation. Optional so existing v4 saves load
+   * without a schema-version bump.
+   */
+  unlockedCosmetics: z.array(slug).optional(),
 });
 export type SaveGame = z.infer<typeof SaveGameSchema>;

--- a/src/game/__tests__/championship.test.ts
+++ b/src/game/__tests__/championship.test.ts
@@ -618,4 +618,17 @@ describe("unlockNextTour", () => {
     unlockNextTour(save, "first-tour", FIXTURE_CHAMPIONSHIP);
     expect(save).toEqual(before);
   });
+
+  it("mints the F-096 livery cosmetic on first completion", () => {
+    const save = unlockedSave("first-tour");
+    const after = unlockNextTour(save, "first-tour", FIXTURE_CHAMPIONSHIP);
+    expect(after.unlockedCosmetics).toEqual(["livery-first-tour"]);
+  });
+
+  it("does not duplicate the F-096 cosmetic on a second completion", () => {
+    const save = unlockedSave("first-tour");
+    const once = unlockNextTour(save, "first-tour", FIXTURE_CHAMPIONSHIP);
+    const twice = unlockNextTour(once, "first-tour", FIXTURE_CHAMPIONSHIP);
+    expect(twice.unlockedCosmetics).toEqual(["livery-first-tour"]);
+  });
 });

--- a/src/game/__tests__/cosmetics.test.ts
+++ b/src/game/__tests__/cosmetics.test.ts
@@ -1,0 +1,86 @@
+/**
+ * Unit tests for the F-096 slice 1 cosmetic-ledger helpers. Pin the
+ * deterministic id format and the title-screen badge build so a
+ * future slice that adds non-livery cosmetics or renames a tour does
+ * not silently break the ledger contract.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import {
+  appendUnlockedCosmetic,
+  buildCosmeticBadges,
+  cosmeticIdForTour,
+} from "@/game/cosmetics";
+
+describe("cosmeticIdForTour", () => {
+  it("derives the livery id from the tour slug", () => {
+    expect(cosmeticIdForTour("velvet-coast")).toBe("livery-velvet-coast");
+    expect(cosmeticIdForTour("crown-circuit")).toBe("livery-crown-circuit");
+  });
+});
+
+describe("appendUnlockedCosmetic", () => {
+  it("seeds an empty list when the save has no unlockedCosmetics yet", () => {
+    expect(appendUnlockedCosmetic(undefined, "livery-velvet-coast")).toEqual([
+      "livery-velvet-coast",
+    ]);
+  });
+
+  it("appends a new id to an existing list", () => {
+    expect(
+      appendUnlockedCosmetic(["livery-velvet-coast"], "livery-iron-borough"),
+    ).toEqual(["livery-velvet-coast", "livery-iron-borough"]);
+  });
+
+  it("returns a copy without duplicating an already-present id", () => {
+    const list = Object.freeze(["livery-velvet-coast"]);
+    const result = appendUnlockedCosmetic(list, "livery-velvet-coast");
+    expect(result).toEqual(["livery-velvet-coast"]);
+    expect(result).not.toBe(list);
+  });
+});
+
+describe("buildCosmeticBadges", () => {
+  it("returns an empty list for an undefined or empty cosmetics array", () => {
+    expect(buildCosmeticBadges(undefined)).toEqual([]);
+    expect(buildCosmeticBadges([])).toEqual([]);
+  });
+
+  it("converts livery ids to title-cased badge labels", () => {
+    expect(
+      buildCosmeticBadges(["livery-velvet-coast", "livery-crown-circuit"]),
+    ).toEqual([
+      {
+        cosmeticId: "livery-velvet-coast",
+        tourId: "velvet-coast",
+        label: "Velvet Coast livery",
+      },
+      {
+        cosmeticId: "livery-crown-circuit",
+        tourId: "crown-circuit",
+        label: "Crown Circuit livery",
+      },
+    ]);
+  });
+
+  it("skips ids that do not match the livery prefix", () => {
+    expect(
+      buildCosmeticBadges([
+        "livery-velvet-coast",
+        "soundtrack-remix-a",
+        "badge-podium-1",
+      ]),
+    ).toEqual([
+      {
+        cosmeticId: "livery-velvet-coast",
+        tourId: "velvet-coast",
+        label: "Velvet Coast livery",
+      },
+    ]);
+  });
+
+  it("skips a malformed livery id whose suffix is empty", () => {
+    expect(buildCosmeticBadges(["livery-"])).toEqual([]);
+  });
+});

--- a/src/game/championship.ts
+++ b/src/game/championship.ts
@@ -55,6 +55,7 @@
 import type { Championship, ChampionshipTour, SaveGame } from "@/data/schemas";
 
 import { computeStipend, easyModeBonus, recordStipendClaim } from "./catchUp";
+import { appendUnlockedCosmetic, cosmeticIdForTour } from "./cosmetics";
 import { PLACEMENT_POINTS } from "./raceResult";
 import { tourCompletionBonus, type RaceBonus } from "./raceBonuses";
 
@@ -474,6 +475,13 @@ export function unlockNextTour(
     nextTourId === null || alreadyUnlocked
       ? save.progress.unlockedTours
       : [...save.progress.unlockedTours, nextTourId];
+  // F-096 slice 1. Mint the per-tour livery cosmetic on first
+  // completion. Re-completion (already in `completedTours`) never
+  // re-mints because `appendUnlockedCosmetic` collapses duplicates.
+  const unlockedCosmetics = appendUnlockedCosmetic(
+    save.unlockedCosmetics,
+    cosmeticIdForTour(completedTourId),
+  );
 
   return {
     ...save,
@@ -482,5 +490,6 @@ export function unlockNextTour(
       completedTours,
       unlockedTours,
     },
+    unlockedCosmetics,
   };
 }

--- a/src/game/cosmetics.ts
+++ b/src/game/cosmetics.ts
@@ -1,0 +1,77 @@
+/**
+ * F-096 slice 1. Cosmetic-unlock ledger.
+ *
+ * Implements the GDD §8 promise that "challenge medals unlock
+ * cosmetics" by minting one cosmetic id per tour completion. Slice 1
+ * surfaces the unlocked set as a row of text badges on the title
+ * screen. Future slices wire the same ids into a livery
+ * `paletteRecolour` overlay on the player car sprite and a
+ * soundtrack-remix rotation in the music runtime.
+ *
+ * Cosmetic ids are deterministic (`livery-${tourId}`), so the
+ * championship-side caller never needs a separate lookup table and a
+ * future migration that renames a tour can rename the cosmetic by
+ * editing the slug, not by re-mapping a hand-authored mapping file.
+ *
+ * Pure: same input always yields the same output. No globals, no
+ * `Date.now()`, no React.
+ */
+
+const COSMETIC_PREFIX = "livery-" as const;
+
+/** The cosmetic id awarded for completing a given tour. */
+export function cosmeticIdForTour(tourId: string): string {
+  return `${COSMETIC_PREFIX}${tourId}`;
+}
+
+/**
+ * Append `cosmeticId` to `unlockedCosmetics` if absent. Always
+ * returns a fresh mutable array so the result fits the
+ * zod-inferred `string[]` shape on `SaveGame.unlockedCosmetics`.
+ */
+export function appendUnlockedCosmetic(
+  unlockedCosmetics: readonly string[] | undefined,
+  cosmeticId: string,
+): string[] {
+  const current = unlockedCosmetics ?? [];
+  if (current.includes(cosmeticId)) return [...current];
+  return [...current, cosmeticId];
+}
+
+export interface CosmeticBadge {
+  readonly cosmeticId: string;
+  readonly tourId: string;
+  /** Player-facing badge label (e.g., `"Iron Borough livery"`). */
+  readonly label: string;
+}
+
+/**
+ * Build the per-cosmetic display rows for the title-screen badge row.
+ * Cosmetics whose id does not match the `livery-${slug}` shape are
+ * skipped so a future slice that adds non-livery cosmetics can extend
+ * this without breaking the slice-1 surface.
+ */
+export function buildCosmeticBadges(
+  unlockedCosmetics: readonly string[] | undefined,
+): readonly CosmeticBadge[] {
+  if (!unlockedCosmetics || unlockedCosmetics.length === 0) return [];
+  const badges: CosmeticBadge[] = [];
+  for (const cosmeticId of unlockedCosmetics) {
+    if (!cosmeticId.startsWith(COSMETIC_PREFIX)) continue;
+    const tourId = cosmeticId.slice(COSMETIC_PREFIX.length);
+    if (tourId.length === 0) continue;
+    badges.push({
+      cosmeticId,
+      tourId,
+      label: `${titleCaseTourId(tourId)} livery`,
+    });
+  }
+  return badges;
+}
+
+function titleCaseTourId(tourId: string): string {
+  return tourId
+    .split("-")
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+    .join(" ");
+}


### PR DESCRIPTION
## Summary
- Implements the GDD §8 "challenge medals unlock cosmetics" promise. Tour completion now mints a per-tour livery cosmetic and the title screen renders one text badge per unlocked cosmetic below the season glance.
- New pure helpers in \`src/game/cosmetics.ts\`: \`cosmeticIdForTour\` (livery-\`tourId\`), \`appendUnlockedCosmetic\` (idempotent fresh-array), \`buildCosmeticBadges\` (filter + title-case).
- \`SaveGameSchema\` gains optional \`unlockedCosmetics: string[]\`. No schema-version bump; existing v4 saves load unchanged because the slot is optional.
- \`unlockNextTour\` mints the cosmetic on first completion. Re-completion no-ops via the existing early-return guard, so the idempotence test that pins reference equality still holds.
- Title-screen badge row is hydration-safe (SSR placeholder + client-only \`loadSave()\` effect) and static (no animation), so the surface respects §19 reduced-motion.
- Deferred under F-096: sprite-based badge icons, player-car livery \`paletteRecolour\` overlay, soundtrack-remix rotation.

## Test plan
- [x] \`pnpm typecheck\` clean
- [x] \`pnpm lint\` clean
- [x] \`pnpm test\` 2926 / 2926 across 158 suites; 9 new \`cosmetics.test.ts\` cases + 2 new \`championship.test.ts\` cases (cosmetic minted on first completion, no duplicate on re-run)
- [x] \`pnpm content-lint\` clean
- [x] \`pnpm docs:check\` clean
- [ ] Manual playtest: complete a tour, confirm the title-screen badge row shows the new "<Tour> livery" pill on next visit; complete a second tour, confirm the row grows.
- [ ] Fresh save regression: confirm the badge row stays hidden (\`data-state="empty"\`) until the first tour completes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added cosmetic badges to the title screen displaying all unlocked liveries
  * Players now unlock unique livery cosmetics upon tour completion; unlocks are permanent and non-repeatable
  * Unlocked cosmetics are saved to player save data for persistence across sessions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->