### PR TITLE
feat(hazards): debris breakable obstacle (F-095 slice 2)

### DIFF
--- a/docs/FOLLOWUPS.md
+++ b/docs/FOLLOWUPS.md
@@ -171,7 +171,16 @@ back for "I want the gold-podium livery" exactly as Top Gear 2's
 **Created:** 2026-05-07
 **Priority:** nice-to-have
 **Status:** in-progress
-**Notes:** 2026-05-08 oil-slick slice shipped under
+**Notes:** 2026-05-08 debris slice shipped under
+`feat/debris-hazard` (slice 2 of 4). Adds `debris` to
+`HazardKindSchema`, registers it with grip 1 / damage 10
+offRoadObject / 1.5 m width / breakable, and authors three
+placements: Iron Borough Rivet Tunnel start straight, Glass Ridge
+Frostrelay decreasing-radius right, Crown Circuit Victory Causeway
+late-tour right approach. Pure runtime untouched: the existing
+breakable-cone path handled the new entry without code changes.
+
+2026-05-08 oil-slick slice shipped under
 `feat/oil-slick-hazard`. Audit-correction note: the original
 "limited to puddle + gravel_band" framing was wrong on second
 look. The schema already has 7 kinds and 6 are authored (the
@@ -184,11 +193,10 @@ non-breakable, narrower 8 m footprint than a puddle so it sits
 on a single lane), and three authored placements (Foundry Mile
 inside-line uphill apex, Cinder Gate left-curve climb, Grand
 Meridian late tour decreasing-radius left). Deferred under this
-F-NNN: `debris`, `slow_traffic`, `wind_gust`. Each is a clean
-follow-up slice (the pure runtime already handles per-tick grip
-+ optional damage, so debris is a one-line addition; slow_traffic
-needs a per-tick lane-bias term; wind_gust needs a lateral-push
-extension to evaluateHazards). Original notes follow.
+F-NNN: `slow_traffic`, `wind_gust`. Each is a clean follow-up
+slice. `slow_traffic` needs a per-tick lane-bias term;
+`wind_gust` needs a lateral-push extension to `evaluateHazards`.
+Original notes follow.
 
 Surfaced by the 2026-05-07 mass-appeal audit (Tier A #6).
 A grep across all 32 production tracks shows hazards limited to `puddle`

--- a/docs/PROGRESS_LOG.md
+++ b/docs/PROGRESS_LOG.md
@@ -6,6 +6,69 @@ Correct them by adding a new entry that references the old one.
 
 ---
 
+## 2026-05-08: feat(hazards): debris breakable obstacle (F-095 slice 2)
+
+**GDD sections touched:** [§9](gdd/09-track-design.md) (track
+authoring gains a breakable damage hazard), [§22](gdd/22-data-and-content-pipeline.md)
+(`HazardKindSchema` enum extension; existing data files unchanged).
+**Branch / PR:** `feat/debris-hazard`, PR pending.
+**Status:** Slice 2 of 4 in F-095. `slow_traffic` and `wind_gust`
+stay open under F-095.
+
+### Done
+- Added `debris` to `HazardKindSchema`. Schema entry now lists 9
+  kinds (8 after slice 1 + this one).
+- Registered the hazard in `src/data/hazards.json`. Grip 1
+  (damage-only, no lateral grip change), damage 10 offRoadObject
+  (higher than a traffic cone's 6 so the hit reads as a real
+  consequence), 1.5 m width (narrower than a cone's 1.8 m so the
+  player can thread the gap), 4 m length, breakable so the entry
+  joins `brokenHazards` after first contact.
+- Authored the hazard on three production tracks: Iron Borough
+  Rivet Tunnel start straight (segment 0), Glass Ridge Frostrelay
+  late-track decreasing-radius right (segment 7), Crown Circuit
+  Victory Causeway late-tour right approach (segment 6). Each
+  placement targets a sight-line that lets the player react by
+  lap 2 even if they get clipped on lap 1.
+
+### Verified
+- `npm run typecheck` clean.
+- `npm run lint` clean.
+- `npm run test` 2918 / 2918 passed across 157 suites; new
+  `hazards.test.ts` case asserts the Rivet Tunnel authored
+  placement emits an offRoadObject hit with grip 1 and joins
+  `brokenHazards`.
+- `npm run content-lint` clean.
+- `npm run docs:check` clean.
+
+### Decisions and assumptions
+- Pure runtime untouched. `evaluateHazards` already handles the
+  breakable-cone path (write the key into `brokenHazards`, then
+  short-circuit on the next pass), so debris reused that path
+  with damage 10 instead of 6.
+- Width 1.5 m. Cones are 1.8 m and the road is 14 m wide, so a
+  player who picks a clean line can thread debris without
+  bleeding speed. That preserves the tactical-decision goal:
+  debris punishes a sloppy line, not the lap as a whole.
+- Three placements, one per region. A full sweep across all 32
+  tracks belongs in a separate authoring slice once
+  `slow_traffic` / `wind_gust` also land so the tracks pass once
+  in batch, not three times.
+
+### Coverage ledger
+- §9 track-design: hazard variety expanded from 7 authored kinds
+  (after slice 1) to 8 across the 32-track production set.
+- §22 schema: `HazardKindSchema` now lists 9 kinds. Existing
+  hazard JSONs and track files load unchanged.
+
+### Followups created
+None. F-095 stays open for the two remaining hazard kinds.
+
+### GDD edits
+None this slice.
+
+---
+
 ## 2026-05-08: feat(cosmetics): tour-podium livery ledger and title-screen badges (F-096 slice 1)
 
 **GDD sections touched:** [§8](gdd/08-progression-and-rewards.md)

--- a/src/data/hazards.json
+++ b/src/data/hazards.json
@@ -94,5 +94,17 @@
     "damageKind": null,
     "damageMagnitude": null,
     "breakable": false
+  },
+  {
+    "id": "debris",
+    "kind": "debris",
+    "displayName": "Debris",
+    "defaultWidth": 1.5,
+    "defaultLength": 4,
+    "laneOffset": 0,
+    "gripMultiplier": 1,
+    "damageKind": "offRoadObject",
+    "damageMagnitude": 10,
+    "breakable": true
   }
 ]

--- a/src/data/schemas.ts
+++ b/src/data/schemas.ts
@@ -121,6 +121,13 @@ export const HazardKindSchema = z.enum([
   // a drive-by hit. Future slices add `debris`, `slow_traffic`, and
   // `wind_gust` per the F-095 ask.
   "oil_slick",
+  // F-095 slice 2. Debris. A breakable obstacle that lands a
+  // direct off-road-object hit on contact. Higher magnitude than a
+  // traffic cone (10 vs. 6) and narrower (1.5 m vs. 1.8 m) so the
+  // player can thread the gap if they pick a clean line. Once
+  // struck the entry is added to `brokenHazards` for the rest of
+  // the lap, mirroring the existing breakable-cone pattern.
+  "debris",
 ]);
 export type HazardKind = z.infer<typeof HazardKindSchema>;
 

--- a/src/data/tracks/crown-circuit-victory-causeway.json
+++ b/src/data/tracks/crown-circuit-victory-causeway.json
@@ -35,7 +35,7 @@
         { "id": "victory-causeway-apex-nitro", "kind": "nitro", "laneOffset": -0.4, "value": 25 }
       ]
     },
-    { "len": 320, "curve": 0.14, "grade": 0.04, "roadsideLeft": "light_pole", "roadsideRight": "sign_marker", "hazards": [] },
+    { "len": 320, "curve": 0.14, "grade": 0.04, "roadsideLeft": "light_pole", "roadsideRight": "sign_marker", "hazards": ["debris"] },
     { "len": 340, "curve": -0.08, "grade": -0.02, "roadsideLeft": "guardrail", "roadsideRight": "light_pole", "hazards": ["puddle"] },
     {
       "len": 440,

--- a/src/data/tracks/glass-ridge-frostrelay.json
+++ b/src/data/tracks/glass-ridge-frostrelay.json
@@ -36,7 +36,7 @@
     },
     { "len": 280, "curve": 0.06, "grade": -0.04, "roadsideLeft": "rock_boulder", "roadsideRight": "light_pole", "hazards": ["traffic_cone"] },
     { "len": 240, "curve": -0.14, "grade": 0.06, "roadsideLeft": "fence_post", "roadsideRight": "sign_marker", "hazards": ["snow_buildup"] },
-    { "len": 320, "curve": 0.12, "grade": -0.03, "roadsideLeft": "tree_pine", "roadsideRight": "fence_post", "hazards": [] },
+    { "len": 320, "curve": 0.12, "grade": -0.03, "roadsideLeft": "tree_pine", "roadsideRight": "fence_post", "hazards": ["debris"] },
     {
       "len": 380,
       "curve": 0,

--- a/src/data/tracks/iron-borough-rivet-tunnel.json
+++ b/src/data/tracks/iron-borough-rivet-tunnel.json
@@ -11,7 +11,7 @@
   "difficulty": 2,
   "archetype": "short-sprint",
   "segments": [
-    { "len": 240, "curve": 0, "grade": 0, "roadsideLeft": "light_pole", "roadsideRight": "light_pole", "hazards": [] },
+    { "len": 240, "curve": 0, "grade": 0, "roadsideLeft": "light_pole", "roadsideRight": "light_pole", "hazards": ["debris"] },
     {
       "len": 240,
       "curve": -0.1,

--- a/src/game/__tests__/hazards.test.ts
+++ b/src/game/__tests__/hazards.test.ts
@@ -107,4 +107,21 @@ describe("evaluateHazards", () => {
     expect(effect.gripMultiplier).toBeCloseTo(0.5, 6);
     expect(effect.events[0]?.hit).toBeNull();
   });
+
+  it("emits a F-095 debris hit and breaks the entry on first contact", () => {
+    // Rivet Tunnel authored segment 0 (z range 0-240) carries the
+    // F-095 debris entry. Pickup ids and grip stay clean: damage is
+    // direct (offRoadObject, magnitude 10) and the entry is breakable
+    // so a struck debris pile does not re-trigger on the same lap.
+    const track = loadTrack("iron-borough/rivet-tunnel");
+    const effect = evaluateHazards({
+      car: car({ z: 120 }),
+      track,
+      hazardsById: HAZARDS_BY_ID,
+    });
+    expect(effect.events[0]?.hazard.id).toBe("debris");
+    expect(effect.events[0]?.hit?.kind).toBe("offRoadObject");
+    expect(effect.gripMultiplier).toBe(1);
+    expect(effect.brokenHazards.size).toBeGreaterThan(0);
+  });
 });


### PR DESCRIPTION
## Summary
- Second of the four hazard kinds the F-095 audit named. Adds \`debris\` to \`HazardKindSchema\` with grip 1 / damage 10 offRoadObject / 1.5 m width / breakable.
- Authored three placements: Iron Borough Rivet Tunnel start straight, Glass Ridge Frostrelay late-track right, Crown Circuit Victory Causeway late-tour right approach. Each targets a sight-line so a player who gets clipped lap 1 has a clear read by lap 2.
- Pure runtime untouched. \`evaluateHazards\` already handles the breakable-cone path, so debris reused that path with a higher damage magnitude and a narrower footprint that lets a clean line thread the gap.
- Deferred under F-095: \`slow_traffic\` (per-tick lane-bias term), \`wind_gust\` (lateral-push extension to \`evaluateHazards\`).

## Test plan
- [x] \`pnpm typecheck\` clean
- [x] \`pnpm lint\` clean
- [x] \`pnpm test\` 2918 / 2918 across 157 suites; new \`hazards.test.ts\` case asserts the Rivet Tunnel authored placement emits an offRoadObject hit with grip 1 and joins \`brokenHazards\`
- [x] \`pnpm content-lint\` clean
- [x] \`pnpm docs:check\` clean
- [ ] Manual playtest: drive Rivet Tunnel / Frostrelay / Victory Causeway on lap 1, confirm debris hit reads as a real consequence; complete the same lap on lap 2 and confirm the entry stays broken.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added "debris" as a new breakable hazard on select track segments — deals impact damage, can be destroyed on first contact, and influences vehicle grip and race dynamics.

* **Tests**
  * Added unit test coverage validating debris spawn, damage type, grip behavior, and breakage mechanics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->