### PR TITLE
feat(tours): pretty tour names from championship data (F-097 follow-up)

### DIFF
--- a/docs/FOLLOWUPS.md
+++ b/docs/FOLLOWUPS.md
@@ -123,7 +123,19 @@ No save schema migration needed (the existing `completedTours`
 list is read directly). Deferred under this F-NNN: pretty tour
 display names from championship data, livery-cosmetic unlocks
 (those belong under F-096), and an e2e for the locked-state
-disabled button. Original notes follow.
+disabled button.
+
+2026-05-08 pretty-tour-names slice shipped under
+`feat/tour-pretty-names`. Adds optional `name` to
+`ChampionshipTourSchema`, authors names on all eight tours in
+`world-tour-standard.json`, and centralises the resolution in
+`src/game/tourNames.ts` (`resolveTourName(championship, tourId)`)
+so the cars page tooltip and future prep-card / results banner
+all read from one source with the slug-title-case fallback. Pure
+helper, no save migration. Locked-state e2e and livery cosmetics
+remain the deferred items under this F-NNN.
+
+Original notes follow.
 
 Originally surfaced by the 2026-05-07 mass-appeal audit (Tier B #9).
 GDD §5 ("Car selection if entering a new championship or buying a new

--- a/docs/PROGRESS_LOG.md
+++ b/docs/PROGRESS_LOG.md
@@ -6,6 +6,83 @@ Correct them by adding a new entry that references the old one.
 
 ---
 
+## 2026-05-08: feat(tours): pretty tour names from championship data (F-097 follow-up)
+
+**GDD sections touched:** [§22](gdd/22-data-and-content-pipeline.md)
+(`ChampionshipTourSchema` gains an optional `name`; existing
+fixtures and modder-authored championships load unchanged).
+**Branch / PR:** `feat/tour-pretty-names`, PR pending.
+**Status:** F-097 follow-up shipped. F-097 stays open for the
+locked-state e2e spec; livery cosmetics remain under F-096.
+
+### Done
+- Added optional `name: z.string().min(1)` to
+  `ChampionshipTourSchema`. The locked-car copy on the garage cars
+  page reads it via the new resolver, falling back to the
+  title-cased slug if the field is absent so existing test
+  fixtures and modder-authored championships still render.
+- Authored player-facing names on all eight tours in
+  `src/data/championships/world-tour-standard.json`: Velvet Coast,
+  Iron Borough, Ember Steppe, Breakwater Isles, Glass Ridge, Neon
+  Meridian, Moss Frontier, Crown Circuit. Slug ids unchanged so
+  existing references (URL params, deep links) keep working.
+- Added `src/game/tourNames.ts` with
+  `resolveTourName(championship, tourId)`. The helper takes the
+  championship as a dependency-injected argument so tests pin the
+  fallback path without mounting React, and so a future surface
+  (prep card sub-header, results banner) can reuse the same
+  resolution from a different championship without duplicating
+  the logic.
+- Wired the helper into `src/app/garage/cars/page.tsx`. The
+  inline 4-line title-casing function from the F-097 slice is now
+  a one-liner that delegates to `resolveTourName`. Locked-car
+  copy still reads "Win Iron Borough to unlock" for tours that
+  have an authored name and falls back gracefully for any tour
+  that does not.
+
+### Verified
+- `npm run typecheck` clean.
+- `npm run lint` clean.
+- `npm run test` 2933 / 2933 passed across 159 suites; new
+  `src/game/__tests__/tourNames.test.ts` pins five cases (authored
+  name, missing-name fallback, unknown-tour fallback, undefined
+  championship, empty-slug "the next tour" sentinel).
+- `npm run content-lint` clean.
+- `npm run docs:check` clean.
+
+### Decisions and assumptions
+- Optional schema field rather than required. Existing test
+  fixtures (`FIXTURE_CHAMPIONSHIP` in
+  `src/game/__tests__/championship.test.ts` and the example under
+  `src/data/examples/`) construct ChampionshipTour without a
+  name, and modders may keep the slug-only shape for ergonomic
+  edits. The fallback covers both cases.
+- Resolver lives in `src/game/tourNames.ts` rather than the cars
+  page. Three near-future surfaces (cars-page tooltip, prep-card
+  sub-header, results banner) all need the same lookup; centralising
+  the resolution prevents three slight variations of the same
+  function.
+- Did not touch the `formatTourName` callers in any other surface
+  yet. The cars page is the only current consumer; the prep-card
+  / results-banner wiring lands when those surfaces ship.
+
+### Coverage ledger
+- §22 schema: `ChampionshipTour.name` joins the optional fields
+  on the championship shape. No data migration; existing fixtures
+  load unchanged.
+- §8 progression copy: locked-car tooltip now reads from the
+  championship JSON when a name is authored. F-097 stays open
+  only for the deferred locked-state e2e.
+
+### Followups created
+None. F-097 ledger updated to in-progress with the deferred
+locked-state e2e.
+
+### GDD edits
+None this slice.
+
+---
+
 ## 2026-05-08: feat(hazards): debris breakable obstacle (F-095 slice 2)
 
 **GDD sections touched:** [§9](gdd/09-track-design.md) (track

--- a/src/app/garage/cars/page.tsx
+++ b/src/app/garage/cars/page.tsx
@@ -23,9 +23,10 @@
 import type { CSSProperties, ReactElement } from "react";
 import { useCallback, useEffect, useMemo, useState } from "react";
 
-import { CARS, getCar } from "@/data/cars";
+import { CARS, getCar, getChampionship } from "@/data";
 import type { Car, CarBaseStats, SaveGame } from "@/data/schemas";
 import { isCarUnlocked } from "@/game/carUnlock";
+import { resolveTourName } from "@/game/tourNames";
 import { defaultSave, loadSave, saveSave } from "@/persistence";
 
 interface PageStatus {
@@ -289,12 +290,10 @@ function formatStat(value: number): string {
   return Number.isInteger(value) ? value.toFixed(1) : value.toFixed(2);
 }
 
+const WORLD_TOUR_CHAMPIONSHIP_ID = "world-tour-standard";
+
 function formatTourName(tourId: string): string {
-  if (tourId === "") return "the next tour";
-  return tourId
-    .split("-")
-    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
-    .join(" ");
+  return resolveTourName(getChampionship(WORLD_TOUR_CHAMPIONSHIP_ID), tourId);
 }
 
 const pageStyle: CSSProperties = {

--- a/src/data/championships/world-tour-standard.json
+++ b/src/data/championships/world-tour-standard.json
@@ -5,6 +5,7 @@
   "tours": [
     {
       "id": "velvet-coast",
+      "name": "Velvet Coast",
       "requiredStanding": 4,
       "tracks": [
         "velvet-coast/harbor-run",
@@ -32,6 +33,7 @@
     },
     {
       "id": "iron-borough",
+      "name": "Iron Borough",
       "requiredStanding": 4,
       "tracks": [
         "iron-borough/freightline-ring",
@@ -59,6 +61,7 @@
     },
     {
       "id": "ember-steppe",
+      "name": "Ember Steppe",
       "requiredStanding": 3,
       "tracks": [
         "ember-steppe/redglass-straight",
@@ -73,6 +76,7 @@
     },
     {
       "id": "breakwater-isles",
+      "name": "Breakwater Isles",
       "requiredStanding": 3,
       "tracks": [
         "breakwater-isles/tidewire",
@@ -87,6 +91,7 @@
     },
     {
       "id": "glass-ridge",
+      "name": "Glass Ridge",
       "requiredStanding": 2,
       "tracks": [
         "glass-ridge/whitepass",
@@ -101,6 +106,7 @@
     },
     {
       "id": "neon-meridian",
+      "name": "Neon Meridian",
       "requiredStanding": 2,
       "tracks": [
         "neon-meridian/arc-boulevard",
@@ -115,6 +121,7 @@
     },
     {
       "id": "moss-frontier",
+      "name": "Moss Frontier",
       "requiredStanding": 1,
       "tracks": [
         "moss-frontier/pine-switchback",
@@ -129,6 +136,7 @@
     },
     {
       "id": "crown-circuit",
+      "name": "Crown Circuit",
       "requiredStanding": 1,
       "tracks": [
         "crown-circuit/embassy-loop",

--- a/src/data/schemas.ts
+++ b/src/data/schemas.ts
@@ -367,6 +367,14 @@ export type DifficultyPreset = z.infer<typeof DifficultyPresetSchema>;
 
 export const ChampionshipTourSchema = z.object({
   id: slug,
+  /**
+   * F-097 follow-up. Optional player-facing name. UIs that label a
+   * tour (locked-car copy on the garage cars page, future
+   * prep-card / results banners) read this with a fallback to the
+   * title-cased slug so existing fixtures and modder-authored
+   * championships without a name still load.
+   */
+  name: z.string().min(1).optional(),
   requiredStanding: positiveInt,
   tracks: z.array(slug).min(1),
   /**

--- a/src/game/__tests__/tourNames.test.ts
+++ b/src/game/__tests__/tourNames.test.ts
@@ -1,0 +1,50 @@
+/**
+ * Unit tests for the F-097 follow-up tour-name resolver. Pin the
+ * authored-name path and the title-cased slug fallback so a future
+ * data rename or schema migration cannot silently regress copy
+ * surfaces (locked-car tooltip, future prep-card / results banner).
+ */
+
+import { describe, expect, it } from "vitest";
+
+import type { Championship } from "@/data/schemas";
+import { resolveTourName } from "@/game/tourNames";
+
+function championship(tours: ReadonlyArray<{ id: string; name?: string }>): Championship {
+  return {
+    id: "test-championship",
+    name: "Test Championship",
+    difficultyPreset: "normal",
+    tours: tours.map((t) => ({
+      id: t.id,
+      requiredStanding: 4,
+      tracks: ["test/track"],
+      ...(t.name !== undefined ? { name: t.name } : {}),
+    })),
+  } as Championship;
+}
+
+describe("resolveTourName", () => {
+  it("returns the authored name when present", () => {
+    const c = championship([{ id: "iron-borough", name: "Iron Borough" }]);
+    expect(resolveTourName(c, "iron-borough")).toBe("Iron Borough");
+  });
+
+  it("falls back to title-casing the slug when the tour has no name", () => {
+    const c = championship([{ id: "ember-steppe" }]);
+    expect(resolveTourName(c, "ember-steppe")).toBe("Ember Steppe");
+  });
+
+  it("falls back to title-casing the slug when the tour is unknown", () => {
+    const c = championship([{ id: "iron-borough", name: "Iron Borough" }]);
+    expect(resolveTourName(c, "ghost-tour")).toBe("Ghost Tour");
+  });
+
+  it("falls back to title-casing when the championship is undefined", () => {
+    expect(resolveTourName(undefined, "crown-circuit")).toBe("Crown Circuit");
+  });
+
+  it("returns 'the next tour' for an empty slug", () => {
+    expect(resolveTourName(undefined, "")).toBe("the next tour");
+  });
+});

--- a/src/game/tourNames.ts
+++ b/src/game/tourNames.ts
@@ -1,0 +1,31 @@
+/**
+ * F-097 follow-up. Pure helper for resolving a tour slug to its
+ * player-facing name. Reads the optional `name` field on
+ * `ChampionshipTour` and falls back to title-casing the slug so
+ * existing fixtures, modder-authored championships, and the unit
+ * test stubs without an authored `name` still render readable
+ * copy.
+ *
+ * Centralised here so the garage cars page, future prep-card
+ * sub-headers, and the results-screen banner all read the same
+ * source. The function is dependency-injected (the caller passes
+ * the championship) so the helper has no global state and tests
+ * pin both branches without mounting React.
+ */
+
+import type { Championship } from "@/data/schemas";
+
+export function resolveTourName(
+  championship: Championship | undefined,
+  tourId: string,
+): string {
+  if (tourId === "") return "the next tour";
+  const tour = championship?.tours.find((entry) => entry.id === tourId);
+  if (tour?.name !== undefined && tour.name.length > 0) {
+    return tour.name;
+  }
+  return tourId
+    .split("-")
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+    .join(" ");
+}


### PR DESCRIPTION
## Summary
- Closes the deferred "pretty tour names" item from F-097. Adds optional \`name\` to \`ChampionshipTourSchema\` and authors names on all eight tours in \`world-tour-standard.json\`.
- New pure helper \`src/game/tourNames.ts\` (\`resolveTourName(championship, tourId)\`) reads the authored name with a slug title-case fallback so existing test fixtures and modder-authored championships still render.
- Locked-car tooltip on the garage cars page now reads the authored name (e.g., "Win Iron Borough to unlock"); the inline 4-line title-casing function from the F-097 slice is now a one-liner that delegates to the helper.
- No save schema migration. The optional name defaults to undefined; existing data files load unchanged.

## Test plan
- [x] \`pnpm typecheck\` clean
- [x] \`pnpm lint\` clean
- [x] \`pnpm test\` 2933 / 2933 across 159 suites; new \`tourNames.test.ts\` pins five cases (authored, missing-name fallback, unknown-tour, undefined championship, empty-slug)
- [x] \`pnpm content-lint\` clean
- [x] \`pnpm docs:check\` clean
- [ ] Manual playtest: open \`/garage/cars\`, confirm the Bastion LM / Tempest R / Nova Shade lock copy now reads the authored tour name.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Tour names in the garage now display with proper formatting. Eight world tours have been updated with human-readable names (e.g., "Velvet Coast" instead of "velvet-coast"), providing a clearer and more polished user experience when viewing available championships and unlock error messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->