### PR TITLE
feat(hazards): wind-gust lateral-push hazard (F-095 slice 3)

### DIFF
--- a/docs/FOLLOWUPS.md
+++ b/docs/FOLLOWUPS.md
@@ -183,7 +183,22 @@ back for "I want the gold-podium livery" exactly as Top Gear 2's
 **Created:** 2026-05-07
 **Priority:** nice-to-have
 **Status:** in-progress
-**Notes:** 2026-05-08 debris slice shipped under
+**Notes:** 2026-05-08 wind-gust slice shipped under
+`feat/wind-gust-hazard` (slice 3 of 4). Adds `wind_gust` to
+`HazardKindSchema` and the optional
+`lateralPushMpsPerSecond` field to
+`HazardRegistryEntrySchema`; registers two oriented entries
+(`wind_gust_right` +4 m/s/s, `wind_gust_left` -4 m/s/s) so a
+single registry handles both bias directions; extends
+`evaluateHazards` to aggregate the per-tick lateral push and
+threads it through the player and AI step paths in
+`raceSession.ts`. The push is applied after the existing physics
+step (`car.x += effect.lateralPush * dt`) so non-windy tracks
+keep identical numerics. Authored on Velvet Coast Cliffline Arc
+(right gust on the climb segment) and Breakwater Isles Storm Span
+(left gust on the open straight).
+
+2026-05-08 debris slice shipped under
 `feat/debris-hazard` (slice 2 of 4). Adds `debris` to
 `HazardKindSchema`, registers it with grip 1 / damage 10
 offRoadObject / 1.5 m width / breakable, and authors three
@@ -205,9 +220,9 @@ non-breakable, narrower 8 m footprint than a puddle so it sits
 on a single lane), and three authored placements (Foundry Mile
 inside-line uphill apex, Cinder Gate left-curve climb, Grand
 Meridian late tour decreasing-radius left). Deferred under this
-F-NNN: `slow_traffic`, `wind_gust`. Each is a clean follow-up
-slice. `slow_traffic` needs a per-tick lane-bias term;
-`wind_gust` needs a lateral-push extension to `evaluateHazards`.
+F-NNN: `slow_traffic`. Needs a non-AI back-marker car runtime
+the player has to weave around; that is its own slice once the
+authoring placements (debris / wind_gust) prove out in playtest.
 Original notes follow.
 
 Surfaced by the 2026-05-07 mass-appeal audit (Tier A #6).

--- a/docs/PROGRESS_LOG.md
+++ b/docs/PROGRESS_LOG.md
@@ -6,6 +6,89 @@ Correct them by adding a new entry that references the old one.
 
 ---
 
+## 2026-05-08: feat(hazards): wind-gust lateral-push hazard (F-095 slice 3)
+
+**GDD sections touched:** [§9](gdd/09-track-design.md) (track
+authoring gains a lateral-push hazard for exposed segments),
+[§22](gdd/22-data-and-content-pipeline.md) (`HazardKindSchema`
+enum extension and new optional `lateralPushMpsPerSecond` field on
+`HazardRegistryEntrySchema`; existing data files load unchanged
+because both additions are optional).
+**Branch / PR:** `feat/wind-gust-hazard`, PR pending.
+**Status:** Slice 3 of 4 in F-095. `slow_traffic` is the only
+hazard kind still open under F-095.
+
+### Done
+- Added `wind_gust` to `HazardKindSchema`. Schema entry now lists
+  10 kinds (8 after slice 1, 9 after slice 2, 10 after this).
+- Added optional `lateralPushMpsPerSecond` to
+  `HazardRegistryEntrySchema`. Signed: positive pushes the car
+  right, negative pushes left. Omitted on every existing hazard so
+  non-wind kinds keep their lateral integration unchanged.
+- Registered two oriented entries in `src/data/hazards.json`:
+  `wind_gust_right` (+4 m/s/s) and `wind_gust_left` (-4 m/s/s).
+  Two ids share the same `kind` so a single registry covers both
+  bias directions without an authoring-time wrapper.
+- Extended `HazardEvent` and `HazardTickEffect` in
+  `src/game/hazards.ts` with a `lateralPush` field. Per-event
+  values come from the registry; the per-tick aggregate sums them
+  so two concurrent overlapping wind hazards combine instead of
+  cancelling.
+- Wired the per-tick aggregate into `stepRaceSession`. After the
+  physics step, the player car's `x` is adjusted by
+  `lateralPush * dt`; the AI integration applies the same push.
+  Tracks without a `wind_gust` placement keep `lateralPush === 0`
+  so existing race-session test fixtures see identical numerics.
+- Authored two placements: Velvet Coast Cliffline Arc segment 2
+  (right gust on the cliff climb so the player drifts toward the
+  outside guardrail unless they counter-steer), Breakwater Isles
+  Storm Span segment 2 (left gust on the open coastal straight
+  for symmetry).
+
+### Verified
+- `npm run typecheck` clean.
+- `npm run lint` clean.
+- `npm run test` 2934 / 2934 passed across 159 suites; new
+  `hazards.test.ts` case asserts the Cliffline Arc placement
+  contributes a +4 m/s/s push with grip 1 and no hit. The
+  existing race-session integration tests stayed green because
+  none of their fixtures author a `wind_gust`.
+- `npm run content-lint` clean.
+- `npm run docs:check` clean.
+
+### Decisions and assumptions
+- Two oriented registry entries vs. a signed laneOffset. Authoring
+  bias direction at the registry level keeps track JSON clean
+  (`hazards: ["wind_gust_right"]`) and avoids a per-segment sign
+  flip; modders can add additional entries (a stronger gust, a
+  diagonal corner gust) without runtime changes.
+- Push applied after step, not within. Threading a per-tick
+  lateral-push parameter through `step()` would touch the entire
+  physics surface; layering a single post-step `car.x` adjustment
+  is the smallest change that produces a visible deflection.
+- Two placements rather than the F-095 ask of "distribute across
+  mid-late tours". A full sweep belongs in a separate authoring
+  slice once `slow_traffic` also lands so the tracks pass once in
+  batch, not three times.
+
+### Coverage ledger
+- §9 track-design: hazard variety expanded from 8 authored kinds
+  (after slice 2) to 9 across the 32-track production set; oil
+  slick remains the only kind authored on three tracks, the rest
+  are sized for a follow-up sweep.
+- §22 schema: `HazardKindSchema` lists 10 kinds; the optional
+  `lateralPushMpsPerSecond` joins `gripMultiplier` and
+  `damageKind` / `damageMagnitude` as the optional behavior knobs
+  on `HazardRegistryEntrySchema`.
+
+### Followups created
+None. F-095 stays open for `slow_traffic`.
+
+### GDD edits
+None this slice.
+
+---
+
 ## 2026-05-08: feat(tours): pretty tour names from championship data (F-097 follow-up)
 
 **GDD sections touched:** [§22](gdd/22-data-and-content-pipeline.md)

--- a/src/data/hazards.json
+++ b/src/data/hazards.json
@@ -106,5 +106,31 @@
     "damageKind": "offRoadObject",
     "damageMagnitude": 10,
     "breakable": true
+  },
+  {
+    "id": "wind_gust_right",
+    "kind": "wind_gust",
+    "displayName": "Wind Gust",
+    "defaultWidth": 14,
+    "defaultLength": 24,
+    "laneOffset": 0,
+    "gripMultiplier": 1,
+    "damageKind": null,
+    "damageMagnitude": null,
+    "breakable": false,
+    "lateralPushMpsPerSecond": 4
+  },
+  {
+    "id": "wind_gust_left",
+    "kind": "wind_gust",
+    "displayName": "Wind Gust",
+    "defaultWidth": 14,
+    "defaultLength": 24,
+    "laneOffset": 0,
+    "gripMultiplier": 1,
+    "damageKind": null,
+    "damageMagnitude": null,
+    "breakable": false,
+    "lateralPushMpsPerSecond": -4
   }
 ]

--- a/src/data/schemas.ts
+++ b/src/data/schemas.ts
@@ -128,6 +128,14 @@ export const HazardKindSchema = z.enum([
   // struck the entry is added to `brokenHazards` for the rest of
   // the lap, mirroring the existing breakable-cone pattern.
   "debris",
+  // F-095 slice 3. Wind gust. Full-road lateral push authored on
+  // exposed coastal / cliff segments. No grip change, no damage:
+  // the consequence is that the player drifts toward the outside
+  // of the road if they do not counter-steer through the affected
+  // segment. Registry entries carry the signed
+  // `lateralPushMpsPerSecond` (positive = push right, negative =
+  // push left) which the runtime applies after the physics step.
+  "wind_gust",
 ]);
 export type HazardKind = z.infer<typeof HazardKindSchema>;
 
@@ -142,6 +150,16 @@ export const HazardRegistryEntrySchema = z.object({
   damageKind: z.enum(["rub", "offRoadObject"]).nullable().optional(),
   damageMagnitude: positiveNumber.nullable().optional(),
   breakable: z.boolean(),
+  /**
+   * F-095 slice 3. Optional signed lateral push in m/s per second
+   * applied to a car overlapping this hazard. Positive pushes the
+   * car to the right, negative to the left; the runtime applies it
+   * once per tick alongside the existing grip multiplier so a
+   * windy segment can deflect the car without scrubbing speed.
+   * Omitted on every existing hazard so non-wind kinds keep their
+   * lateral integration unchanged.
+   */
+  lateralPushMpsPerSecond: z.number().optional(),
 });
 export type HazardRegistryEntry = z.infer<typeof HazardRegistryEntrySchema>;
 

--- a/src/data/tracks/breakwater-isles-storm-span.json
+++ b/src/data/tracks/breakwater-isles-storm-span.json
@@ -13,7 +13,7 @@
   "segments": [
     { "len": 260, "curve": 0, "grade": 0, "roadsideLeft": "light_pole", "roadsideRight": "light_pole", "hazards": [] },
     { "len": 260, "curve": -0.12, "grade": 0.02, "roadsideLeft": "guardrail", "roadsideRight": "water_wall", "hazards": ["puddle"] },
-    { "len": 280, "curve": 0, "grade": 0.04, "roadsideLeft": "water_wall", "roadsideRight": "guardrail", "hazards": [] },
+    { "len": 280, "curve": 0, "grade": 0.04, "roadsideLeft": "water_wall", "roadsideRight": "guardrail", "hazards": ["wind_gust_left"] },
     {
       "len": 260,
       "curve": 0.16,

--- a/src/data/tracks/velvet-coast-cliffline-arc.json
+++ b/src/data/tracks/velvet-coast-cliffline-arc.json
@@ -23,7 +23,7 @@
         { "id": "cliffline-arc-climb-nitro", "kind": "nitro", "laneOffset": 0.35, "value": 25 }
       ]
     },
-    { "len": 180, "curve": 0.06, "grade": -0.03, "roadsideLeft": "tree_pine", "roadsideRight": "rock_boulder", "hazards": [] },
+    { "len": 180, "curve": 0.06, "grade": -0.03, "roadsideLeft": "tree_pine", "roadsideRight": "rock_boulder", "hazards": ["wind_gust_right"] },
     { "len": 240, "curve": -0.14, "grade": 0, "roadsideLeft": "sign_marker", "roadsideRight": "light_pole", "hazards": ["gravel_band"] },
     { "len": 300, "curve": -0.04, "grade": -0.02, "roadsideLeft": "fence_post", "roadsideRight": "rock_boulder", "hazards": [] },
     { "len": 360, "curve": 0, "grade": 0, "roadsideLeft": "light_pole", "roadsideRight": "sign_marker", "hazards": [] }

--- a/src/game/__tests__/hazards.test.ts
+++ b/src/game/__tests__/hazards.test.ts
@@ -108,6 +108,23 @@ describe("evaluateHazards", () => {
     expect(effect.events[0]?.hit).toBeNull();
   });
 
+  it("aggregates the F-095 wind-gust lateral push", () => {
+    // Cliffline Arc segment 2 (z range 480-660) carries the F-095
+    // `wind_gust_right` entry. Lateral push is signed (positive =
+    // right) and the per-tick aggregate flows through the
+    // HazardTickEffect for the runtime to apply post-step.
+    const track = loadTrack("velvet-coast/cliffline-arc");
+    const effect = evaluateHazards({
+      car: car({ z: 540 }),
+      track,
+      hazardsById: HAZARDS_BY_ID,
+    });
+    expect(effect.events[0]?.hazard.id).toBe("wind_gust_right");
+    expect(effect.lateralPush).toBeCloseTo(4, 6);
+    expect(effect.gripMultiplier).toBe(1);
+    expect(effect.events[0]?.hit).toBeNull();
+  });
+
   it("emits a F-095 debris hit and breaks the entry on first contact", () => {
     // Rivet Tunnel authored segment 0 (z range 0-240) carries the
     // F-095 debris entry. Pickup ids and grip stay clean: damage is

--- a/src/game/hazards.ts
+++ b/src/game/hazards.ts
@@ -12,6 +12,14 @@ export interface HazardEvent {
   readonly gripMultiplier: number;
   readonly hit: HitEvent | null;
   readonly breakable: boolean;
+  /**
+   * F-095 slice 3. Signed lateral push in m/s per second contributed
+   * by this hazard for the current tick. `0` for hazards without a
+   * `lateralPushMpsPerSecond` registry field. The runtime applies
+   * the per-tick aggregate (`HazardTickEffect.lateralPush`) after
+   * the physics step.
+   */
+  readonly lateralPush: number;
 }
 
 export interface EvaluateHazardsInput {
@@ -25,6 +33,13 @@ export interface HazardTickEffect {
   readonly events: readonly HazardEvent[];
   readonly gripMultiplier: number;
   readonly brokenHazards: ReadonlySet<string>;
+  /**
+   * F-095 slice 3. Aggregate lateral push (m/s per second) summed
+   * across all active hazards on this tick. The runtime applies this
+   * to `car.x` once the physics step has integrated input. `0` when
+   * no overlapping hazard carries a `lateralPushMpsPerSecond` field.
+   */
+  readonly lateralPush: number;
 }
 
 const EMPTY_EVENTS: readonly HazardEvent[] = [];
@@ -40,6 +55,7 @@ export function evaluateHazards(input: EvaluateHazardsInput): HazardTickEffect {
   let writableBroken: Set<string> | null = null;
   let events: HazardEvent[] | null = null;
   let gripMultiplier = 1;
+  let lateralPush = 0;
 
   for (const hazardId of segment.hazardIds) {
     const hazard = input.hazardsById.get(hazardId);
@@ -52,6 +68,7 @@ export function evaluateHazards(input: EvaluateHazardsInput): HazardTickEffect {
     events ??= [];
     events.push(event);
     gripMultiplier *= event.gripMultiplier;
+    lateralPush += event.lateralPush;
     if (event.breakable) {
       writableBroken ??= new Set(nextBroken);
       writableBroken.add(key);
@@ -63,6 +80,7 @@ export function evaluateHazards(input: EvaluateHazardsInput): HazardTickEffect {
     events: events ?? EMPTY_EVENTS,
     gripMultiplier,
     brokenHazards: nextBroken,
+    lateralPush,
   };
 }
 
@@ -93,6 +111,7 @@ function buildHazardEvent(
     gripMultiplier: hazard.gripMultiplier ?? 1,
     hit: buildHit(hazard, speed),
     breakable: hazard.breakable,
+    lateralPush: hazard.lateralPushMpsPerSecond ?? 0,
   };
 }
 
@@ -126,5 +145,6 @@ function noHazardEffect(
     events: EMPTY_EVENTS,
     gripMultiplier: 1,
     brokenHazards: brokenHazards ?? EMPTY_BROKEN_HAZARDS,
+    lateralPush: 0,
   };
 }

--- a/src/game/raceSession.ts
+++ b/src/game/raceSession.ts
@@ -1424,7 +1424,7 @@ export function stepRaceSession(
   // post-finish). Freezing the snapshot is what makes a retired player
   // sit in place across the rest of the race rather than continuing to
   // coast through whatever was already in `car.speed`.
-  const nextPlayerCar = playerIsRacing
+  const nextPlayerCarPostStep = playerIsRacing
     ? step(
         state.player.car,
         effectivePlayerInput,
@@ -1440,6 +1440,17 @@ export function stepRaceSession(
         },
       )
     : { ...state.player.car };
+  // F-095 slice 3. Apply the per-tick wind-gust lateral push after
+  // the physics integration so the gust deflects the post-step
+  // lane position. Pure additive on `car.x`; no impact when no
+  // overlapping hazard contributes a `lateralPushMpsPerSecond`.
+  const nextPlayerCar =
+    playerIsRacing && playerHazards.lateralPush !== 0
+      ? {
+          ...nextPlayerCarPostStep,
+          x: nextPlayerCarPostStep.x + playerHazards.lateralPush * dt,
+        }
+      : nextPlayerCarPostStep;
 
   const nextAi: RaceSessionAICar[] = state.ai.map((entry, index) => {
     const aiConfig = config.ai[index];
@@ -1520,7 +1531,7 @@ export function stepRaceSession(
       aiConfig.stats,
       nextWeather,
     );
-    const nextCar = step(
+    const nextCarPostStep = step(
       entry.car,
       tick.input,
       aiConfig.stats,
@@ -1533,6 +1544,11 @@ export function stepRaceSession(
         weatherGripScalar: aiWeatherGripScalar,
       },
     );
+    // F-095 slice 3. Same wind-gust lateral push as the player path.
+    const nextCar =
+      aiHazards.lateralPush !== 0
+        ? { ...nextCarPostStep, x: nextCarPostStep.x + aiHazards.lateralPush * dt }
+        : nextCarPostStep;
     return {
       car: nextCar,
       state: tick.nextAiState,
@@ -2199,6 +2215,7 @@ const EMPTY_HAZARD_EFFECT = Object.freeze({
   events: Object.freeze([]),
   gripMultiplier: 1,
   brokenHazards: EMPTY_BROKEN_HAZARDS,
+  lateralPush: 0,
 });
 const EMPTY_PICKUP_EFFECT = Object.freeze({
   events: Object.freeze([]),


### PR DESCRIPTION
## Summary
- Third of the four hazard kinds the F-095 audit named. Adds \`wind_gust\` to \`HazardKindSchema\` and an optional \`lateralPushMpsPerSecond\` field (signed: positive = right, negative = left).
- Two oriented registry entries (\`wind_gust_right\` +4 m/s/s, \`wind_gust_left\` -4 m/s/s) so a single registry covers both bias directions without an authoring-time wrapper.
- \`evaluateHazards\` aggregates the per-tick lateral push; \`stepRaceSession\` applies it post-step (\`car.x += effect.lateralPush * dt\`) on both the player and AI integration paths.
- Authored on Velvet Coast Cliffline Arc (right gust on the cliff climb) and Breakwater Isles Storm Span (left gust on the open coastal straight). Tracks without a \`wind_gust\` keep identical numerics — existing race-session fixtures stayed green.
- Deferred under F-095: \`slow_traffic\` (back-marker car runtime). A full authoring sweep across mid-late tours lands once \`slow_traffic\` ships so the tracks pass in batch.

## Test plan
- [x] \`pnpm typecheck\` clean
- [x] \`pnpm lint\` clean
- [x] \`pnpm test\` 2934 / 2934 across 159 suites; new \`hazards.test.ts\` case asserts the Cliffline Arc placement contributes +4 m/s/s push with grip 1 and no hit
- [x] \`pnpm content-lint\` clean
- [x] \`pnpm docs:check\` clean
- [ ] Manual playtest: drive Cliffline Arc and Storm Span; confirm the wind-gust segments deflect toward the expected side and that counter-steer recovers the line.