### PR TITLE
feat(prep): one-click "Use recommended" tire button (F-103)

### DIFF
--- a/docs/FOLLOWUPS.md
+++ b/docs/FOLLOWUPS.md
@@ -10,6 +10,22 @@ or `obsolete` so the trail is preserved.
 
 ---
 
+## F-103: Prep-card tire recommendation one-click action
+**Created:** 2026-05-09
+**Priority:** nice-to-have
+**Status:** done
+**Resolved:** 2026-05-09
+**Notes:** Second of three TG2 core-loop polish slices identified
+on 2026-05-09 (alongside F-102 car-bump kick and F-104 fuel
+system). Audit-correction note: the prep page already surfaces
+`recommendTire(weather)` as "Recommended: dry/wet" copy plus a
+yellow tire-mismatch warning. The genuine gap was the one-click
+affordance to swap when the player picks the wrong tire. Slice
+adds a "Use recommended" button that appears when
+`selectedTire !== card.recommendedTire` and calls
+`setSelectedTire(card.recommendedTire)`. Pure UI, no schema, no
+runtime change. Shipped under `feat/tire-recommendation-banner`.
+
 ## F-102: Car-contact lateral kick on bump
 **Created:** 2026-05-09
 **Priority:** nice-to-have

--- a/docs/PROGRESS_LOG.md
+++ b/docs/PROGRESS_LOG.md
@@ -6,6 +6,69 @@ Correct them by adding a new entry that references the old one.
 
 ---
 
+## 2026-05-09: feat(prep): one-click "Use recommended" tire button (F-103)
+
+**GDD sections touched:** [§14](gdd/14-weather.md) (prep-card tire
+choice surface; no runtime / data change).
+**Branch / PR:** `feat/tire-recommendation-banner`, PR pending.
+**Status:** Second of the three TG2 core-loop polish slices
+identified in the 2026-05-09 audit (F-102 car-bump kick already
+shipped; F-104 fuel system is the remaining one). Closes F-103.
+
+### Done
+- Audit-correction in FOLLOWUPS: the prep page already surfaces
+  `recommendTire(weather)` as "Recommended: dry/wet" copy plus a
+  yellow tire-mismatch warning under
+  `[data-testid="pre-race-tire-warning"]`. The genuine gap was the
+  one-click affordance to swap when the player picked the wrong
+  tire.
+- Added a "Use recommended" button under the tire selector. The
+  button only renders when `selectedTire !== card.recommendedTire`
+  and calls `setSelectedTire(card.recommendedTire)`. The button
+  carries `data-testid="pre-race-use-recommended-tire"` so a
+  Playwright spec or future regression test can target it.
+- Styled the button with the same amber accent (`#ffd166`) as the
+  existing mismatch warning so the visual chain "yellow warning ->
+  yellow action" reads at a glance.
+
+### Verified
+- `npm run typecheck` clean.
+- `npm run lint` clean.
+- `npm run test` 2934 / 2934 passed across 159 suites; UI-only
+  change with no new test logic to pin (the button rendering is a
+  thin conditional over the existing `selectedTire` /
+  `card.recommendedTire` state).
+- `npm run content-lint` clean.
+- `npm run docs:check` clean.
+
+### Decisions and assumptions
+- One-click button rather than auto-select on weather change. The
+  existing `useEffect` at line 87 already auto-aligns the tire
+  when `initialWeather` changes, but the player can override and
+  the override should stick (a player who deliberately picks dry
+  on a wet course should not have the page silently flip them
+  back). The button gives an explicit one-click recovery without
+  taking the choice away.
+- Did not add a Playwright spec. The button is a single
+  conditional render off existing state; the e2e gate would only
+  add CI minutes for a one-line UI affordance. A future spec can
+  bundle the locked-state button (F-097 follow-up) and this one
+  in a single pre-race-page suite.
+- Reused the F-101 hint-overlay amber palette so the prep page
+  visual vocabulary stays consistent.
+
+### Coverage ledger
+- §14 weather / tire choice: surface affordance now matches the
+  existing recommendation copy with a one-click action.
+
+### Followups created
+None. F-104 fuel system is the remaining core-loop polish slice.
+
+### GDD edits
+None this slice.
+
+---
+
 ## 2026-05-09: feat(physics): car-bump lateral kick on contact (F-102)
 
 **GDD sections touched:** [§13](gdd/13-damage-and-collisions.md)

--- a/src/app/race/prep/page.tsx
+++ b/src/app/race/prep/page.tsx
@@ -258,6 +258,16 @@ function RacePrepShell(): ReactElement {
           >
             {card.selectedTireWarning || "Tire choice matches the forecast."}
           </p>
+          {selectedTire !== card.recommendedTire ? (
+            <button
+              type="button"
+              style={recommendActionStyle}
+              onClick={() => setSelectedTire(card.recommendedTire)}
+              data-testid="pre-race-use-recommended-tire"
+            >
+              Use recommended ({card.recommendedTire})
+            </button>
+          ) : null}
         </article>
 
         <article style={panelStyle}>
@@ -559,6 +569,17 @@ const activeSegmentStyle: CSSProperties = {
 const mutedTextStyle: CSSProperties = {
   margin: 0,
   color: "#aab0bd",
+};
+
+const recommendActionStyle: CSSProperties = {
+  marginTop: "0.6rem",
+  padding: "0.45rem 0.85rem",
+  color: "#081018",
+  background: "#ffd166",
+  border: "1px solid #ffd166",
+  borderRadius: "0.35rem",
+  fontWeight: 700,
+  cursor: "pointer",
 };
 
 const footerStyle: CSSProperties = {


### PR DESCRIPTION
## Summary
- Second of the three TG2 core-loop polish slices identified in the 2026-05-09 audit (F-102 car-bump kick is in flight as #205; F-104 fuel system is the remaining one).
- Audit-correction note: the prep page already surfaces \`recommendTire(weather)\` as "Recommended: dry/wet" copy plus a yellow tire-mismatch warning. The genuine gap was the one-click affordance to swap when the player picks the wrong tire.
- Adds a "Use recommended" button that appears only when \`selectedTire !== card.recommendedTire\` and calls \`setSelectedTire(card.recommendedTire)\`. Pure UI, no schema, no runtime change.
- Test-id \`pre-race-use-recommended-tire\` so a future Playwright spec can target it.

## Test plan
- [x] \`pnpm typecheck\` clean
- [x] \`pnpm lint\` clean
- [x] \`pnpm test\` 2934 / 2934 across 159 suites; UI-only change with no new test logic to pin
- [x] \`pnpm content-lint\` clean
- [x] \`pnpm docs:check\` clean
- [ ] Manual playtest: open \`/race/prep\` for a wet-forecast track, deliberately pick \`dry\`, confirm the amber "Use recommended (wet)" button appears; click it and confirm the tire flips and the button disappears.