### PR TITLE
feat(fuel): TG2-faithful fuel runtime + DNF wiring (F-104 slice 1)

### DIFF
--- a/docs/FOLLOWUPS.md
+++ b/docs/FOLLOWUPS.md
@@ -10,6 +10,27 @@ or `obsolete` so the trail is preserved.
 
 ---
 
+## F-104: TG2-faithful fuel and gearbox economy
+**Created:** 2026-05-09
+**Priority:** nice-to-have
+**Status:** in-progress
+**Notes:** Third of the three TG2 core-loop polish slices identified
+on 2026-05-09 (alongside F-102 car-bump kick and F-103 prep-card
+tire affordance, both shipped). Goal: TG2-faithful fuel runtime so
+the gearbox upgrade actually matters - longer races are
+unsurvivable at gearbox tier 0 unless the player upgrades. 2026-05-09
+research pass confirmed TG2 had per-race fuel that depleted with
+no mid-race refuel (no on-road gas cans, no pit stops); the
+strategic spend driver was the gearbox upgrade improving fuel
+economy. Slice 1 shipped under `feat/fuel-runtime`: pure
+`src/game/fuel.ts` module (`fuelCapacityForArchetype`,
+`gearboxFuelEfficiency`, `tickFuel`, `createFuelState`),
+`out-of-fuel` `DnfReason`, `archetype` mirrored on `CompiledTrack`,
+fuel state on `RaceSessionPlayerCar`, depletion edge wired into
+the per-tick status flip. Slices 2-4 still open: HUD fuel gauge,
+garage gearbox copy + per-archetype tuning, out-of-fuel UX polish
+(audio sputter, results-screen reason copy).
+
 ## F-103: Prep-card tire recommendation one-click action
 **Created:** 2026-05-09
 **Priority:** nice-to-have

--- a/docs/PROGRESS_LOG.md
+++ b/docs/PROGRESS_LOG.md
@@ -6,6 +6,105 @@ Correct them by adding a new entry that references the old one.
 
 ---
 
+## 2026-05-09: feat(fuel): TG2-faithful fuel runtime + DNF wiring (F-104 slice 1)
+
+**GDD sections touched:** [§7](gdd/07-race-rules-and-structure.md)
+(`DnfReason` gains `out-of-fuel`),
+[§11](gdd/11-cars-and-stats.md) (gearbox upgrade tier now also
+scales fuel economy via the F-104 runtime), [§22](gdd/22-data-and-content-pipeline.md)
+(`CompiledTrack` gains `archetype` mirrored from the source
+`Track.archetype`).
+**Branch / PR:** `feat/fuel-runtime`, PR pending.
+**Status:** Slice 1 of the F-104 four-slice fuel feature. Slices
+2-4 (HUD gauge, garage gearbox copy + per-archetype tune,
+out-of-fuel UX polish) stay open under F-104.
+
+### Done
+- Added `src/game/fuel.ts` with four pure helpers:
+  `fuelCapacityForArchetype` (100/400/280/220 L for short-sprint /
+  standard / long-scenic / endurance), `gearboxFuelEfficiency`
+  (linear 10 % per tier, tier 0 = 1.0, tier 5 = 1.5),
+  `tickFuel` (per-tick drain reducer with depletion edge), and
+  `createFuelState` (full tank at session creation).
+  `BASE_CONSUMPTION_LPS_PER_MPS = 0.015` is sized so a stock-gearbox
+  player at 50 m/s avg burns ~98 L over a 130 s short-sprint - tight
+  but survivable at gearbox tier 0 on tour 1.
+- Extended `DnfReason` in `src/game/raceRules.ts` with
+  `"out-of-fuel"`. The depletion edge in `stepRaceSession` flips
+  `nextPlayerStatus` to `"dnf"` and `nextPlayerDnfReason` to
+  `"out-of-fuel"`. The fuel reason wins over the §7 off-track /
+  no-progress windows on the same tick (the car can no longer
+  make progress because the tank is empty); the §13 wreck reason
+  still wins over fuel.
+- Mirrored the source `Track.archetype` onto `CompiledTrack` in
+  `src/road/types.ts` and `src/road/trackCompiler.ts` so the
+  fuel runtime can size the per-race capacity at session creation
+  without re-reading the authored JSON.
+- Extended `RaceSessionPlayerCar` with a `fuel: FuelState` field;
+  initialised in `createRaceSession` from the track archetype and
+  threaded through `clonePlayerCar` so the countdown -> racing
+  promotion preserves it. Wired `tickFuel` into the per-tick
+  player path in `stepRaceSession`. AI cars are not tracked in
+  slice 1 (the grid runs without fuel so a stock-gearbox player
+  does not race against AI that DNFs on lap 6 of a 16-lap
+  standard).
+
+### Verified
+- `npm run typecheck` clean.
+- `npm run lint` clean.
+- `npm run test` 2952 / 2952 passed across 161 suites; new
+  `src/game/__tests__/fuel.test.ts` pins 12 cases covering the
+  per-archetype capacity table, the gearbox-tier scalar (tier
+  0..5 + negative + NaN), the per-tick drain (tier 0 baseline,
+  tier 5 reduction, zero / negative dt no-op, zero / negative
+  speed no-op, depletion edge, no-double-edge), and the long-run
+  130 s short-sprint sanity (player at gearbox 0 finishes with
+  margin). The 158 existing race-session tests stayed green
+  because every fixture builds player state through
+  `createRaceSession`, which now seeds `fuel` automatically.
+- `npm run content-lint` clean.
+- `npm run docs:check` clean.
+
+### Decisions and assumptions
+- Player only in slice 1. AI cars do not have fuel state. The
+  grid race-finish flow already handles AI DNFs cleanly, but the
+  fuel runtime intentionally skips them so the player can race
+  against opponents that always finish. Adding AI fuel later
+  would require a per-AI capacity curve and a tuning pass; that
+  belongs in F-104 slice 3 or beyond.
+- Gearbox tier read once per tick from
+  `config.player.upgrades?.gearbox`. The tier never changes mid-
+  race, so a lookup per tick is safe (no stale-tier hazard).
+- Capacity values are placeholders. The 100/400/280/220 numbers
+  are seeded against rough lap-time math (4-lap short-sprint at
+  50 m/s avg burns ~90 L). Slice 3 tunes against playtest data
+  per archetype; the test that pins the long-run drain is the
+  guard.
+- `tickFuel` always returns a fresh `FuelState` even when the
+  drain rounds to zero. Avoids the reference-equality footgun
+  the F-096 cosmetics slice hit; downstream callers can compare
+  by value.
+
+### Coverage ledger
+- §7 race rules: DNF surface gains a 5th reason. Existing tests
+  pin the 4 prior reasons; the test fixture for the new reason
+  is the depletion-edge case in `fuel.test.ts`.
+- §11 cars and stats: gearbox upgrade tier now also scales fuel
+  economy via the F-104 runtime. The §11 spec already named the
+  gearbox tier; slice 1 wires it to a second consumer.
+- §22 schema: `CompiledTrack.archetype` joins `difficulty` as a
+  source-mirrored field on the compiled output. No data file
+  changes; existing tracks already declare `archetype` (default
+  `"standard"`).
+
+### Followups created
+None. F-104 stays open for slices 2-4.
+
+### GDD edits
+None this slice.
+
+---
+
 ## 2026-05-09: feat(prep): one-click "Use recommended" tire button (F-103)
 
 **GDD sections touched:** [§14](gdd/14-weather.md) (prep-card tire

--- a/src/game/__tests__/fuel.test.ts
+++ b/src/game/__tests__/fuel.test.ts
@@ -1,0 +1,145 @@
+/**
+ * Unit tests for the F-104 slice 1 fuel runtime. Pin the per-archetype
+ * capacity curve, the gearbox-tier scalar, the per-tick drain shape,
+ * and the depletion edge so a future tune of any constant cannot
+ * silently regress the TG2-faithful "no mid-race refuel" loop.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import {
+  BASE_CONSUMPTION_LPS_PER_MPS,
+  createFuelState,
+  fuelCapacityForArchetype,
+  gearboxFuelEfficiency,
+  tickFuel,
+} from "@/game/fuel";
+
+describe("fuelCapacityForArchetype", () => {
+  it("returns the per-archetype capacity in litres", () => {
+    expect(fuelCapacityForArchetype("short-sprint")).toBe(100);
+    expect(fuelCapacityForArchetype("standard")).toBe(400);
+    expect(fuelCapacityForArchetype("long-scenic")).toBe(280);
+    expect(fuelCapacityForArchetype("endurance")).toBe(220);
+  });
+});
+
+describe("gearboxFuelEfficiency", () => {
+  it("returns 1.0 at tier 0 and ramps 10 % per tier up to 1.5 at tier 5", () => {
+    expect(gearboxFuelEfficiency(0)).toBeCloseTo(1.0, 6);
+    expect(gearboxFuelEfficiency(1)).toBeCloseTo(1.1, 6);
+    expect(gearboxFuelEfficiency(2)).toBeCloseTo(1.2, 6);
+    expect(gearboxFuelEfficiency(3)).toBeCloseTo(1.3, 6);
+    expect(gearboxFuelEfficiency(4)).toBeCloseTo(1.4, 6);
+    expect(gearboxFuelEfficiency(5)).toBeCloseTo(1.5, 6);
+  });
+
+  it("clamps a negative or non-finite tier to identity", () => {
+    expect(gearboxFuelEfficiency(-1)).toBe(1);
+    expect(gearboxFuelEfficiency(Number.NaN)).toBe(1);
+  });
+});
+
+describe("createFuelState", () => {
+  it("starts the tank full at the archetype capacity", () => {
+    const state = createFuelState("short-sprint");
+    expect(state.liters).toBe(100);
+    expect(state.capacityLiters).toBe(100);
+  });
+});
+
+describe("tickFuel", () => {
+  it("drains liters at BASE_CONSUMPTION_LPS_PER_MPS * speed * dt at tier 0", () => {
+    const state = createFuelState("standard");
+    const result = tickFuel({
+      state,
+      speedMps: 50,
+      gearboxTier: 0,
+      dt: 1,
+    });
+    expect(result.state.liters).toBeCloseTo(
+      400 - BASE_CONSUMPTION_LPS_PER_MPS * 50,
+      6,
+    );
+    expect(result.state.capacityLiters).toBe(400);
+    expect(result.depleted).toBe(false);
+  });
+
+  it("scales the drain inversely with the gearbox-tier efficiency", () => {
+    const state = createFuelState("standard");
+    const tier0 = tickFuel({ state, speedMps: 50, gearboxTier: 0, dt: 1 });
+    const tier5 = tickFuel({ state, speedMps: 50, gearboxTier: 5, dt: 1 });
+    const burn0 = state.liters - tier0.state.liters;
+    const burn5 = state.liters - tier5.state.liters;
+    // Tier 5 burns 50 % less fuel than tier 0 over the same tick.
+    expect(burn5).toBeCloseTo(burn0 / 1.5, 6);
+  });
+
+  it("clamps to zero on the depletion tick and reports the edge", () => {
+    const state = { liters: 0.1, capacityLiters: 100 };
+    const result = tickFuel({
+      state,
+      speedMps: 50,
+      gearboxTier: 0,
+      dt: 1,
+    });
+    expect(result.state.liters).toBe(0);
+    expect(result.depleted).toBe(true);
+  });
+
+  it("does not re-emit the depletion edge once the tank is already empty", () => {
+    const state = { liters: 0, capacityLiters: 100 };
+    const result = tickFuel({
+      state,
+      speedMps: 50,
+      gearboxTier: 0,
+      dt: 1,
+    });
+    expect(result.state.liters).toBe(0);
+    expect(result.depleted).toBe(false);
+  });
+
+  it("collapses to a no-op for non-positive dt (paused / countdown tick)", () => {
+    const state = createFuelState("short-sprint");
+    expect(tickFuel({ state, speedMps: 50, gearboxTier: 0, dt: 0 }).state).toBe(
+      state,
+    );
+    expect(
+      tickFuel({ state, speedMps: 50, gearboxTier: 0, dt: -1 }).state,
+    ).toBe(state);
+  });
+
+  it("does not drain at zero speed", () => {
+    const state = createFuelState("short-sprint");
+    const result = tickFuel({
+      state,
+      speedMps: 0,
+      gearboxTier: 0,
+      dt: 1,
+    });
+    expect(result.state.liters).toBe(100);
+  });
+
+  it("clamps a negative speed to zero (defensive)", () => {
+    const state = createFuelState("short-sprint");
+    const result = tickFuel({
+      state,
+      speedMps: -10,
+      gearboxTier: 0,
+      dt: 1,
+    });
+    expect(result.state.liters).toBe(100);
+  });
+
+  it("a stock-gearbox player at 50 m/s avg burns ~98 L over a 130 s short-sprint", () => {
+    // Sanity: a 4-lap 1.5 km short-sprint averaging 50 m/s takes 120 s
+    // and burns 90 L. Capacity 100 L leaves a comfortable margin so a
+    // first-tour player does not run out at tier 0.
+    let state = createFuelState("short-sprint");
+    for (let s = 0; s < 130; s += 1) {
+      state = tickFuel({ state, speedMps: 50, gearboxTier: 0, dt: 1 }).state;
+    }
+    expect(state.liters).toBeGreaterThan(0);
+    expect(100 - state.liters).toBeGreaterThan(95);
+  });
+});

--- a/src/game/fuel.ts
+++ b/src/game/fuel.ts
@@ -1,0 +1,133 @@
+/**
+ * F-104 slice 1. TG2-faithful fuel runtime.
+ *
+ * Per the 2026-05-09 research pass on Top Gear 2 (1994, SNES):
+ *   - Cars carry a per-race fuel reserve that depletes as the car drives.
+ *   - There are no mid-race refuels (no pit stops, no on-road gas cans;
+ *     those were the 1992 Top Gear mechanic dropped in the sequel).
+ *   - The strategic spend driver is the gearbox upgrade in the garage:
+ *     a higher tier gives better fuel economy so longer races become
+ *     survivable.
+ *
+ * This module is the pure side of the runtime. Slice 2 wires the HUD
+ * gauge and slice 3 tunes the per-archetype capacities + the gearbox
+ * tier curve against playtest data.
+ *
+ * Pure: same inputs always produce the same output. No globals, no
+ * `Date.now()`, no React. Only the player's fuel is tracked in slice 1
+ * - the AI grid runs without fuel so a stock-gearbox player does not
+ * have to win against AI cars that DNF on lap 6 of a 16-lap standard.
+ *
+ * Capacity curve (litres) by `TrackArchetype`. Sized so a player at
+ * gearbox tier 0 finishes a `short-sprint` with comfortable margin and
+ * needs to upgrade the gearbox to survive `standard` / `long-scenic` /
+ * `endurance` archetypes. The numbers will be re-tuned in F-104 slice 3
+ * once playtest data is in.
+ */
+
+import type { TrackArchetype } from "@/data/schemas";
+
+/**
+ * Base fuel drain (litres / second) per metre / second of speed.
+ * `tickFuel` reads `BASE_CONSUMPTION_LPS_PER_MPS * speed_mps * dt`
+ * for the per-tick burn before the gearbox-tier scalar.
+ */
+export const BASE_CONSUMPTION_LPS_PER_MPS = 0.015;
+
+/**
+ * Per-archetype starting capacity. `createRaceSession` reads
+ * `fuelCapacityForArchetype(track.archetype) / gearboxFuelEfficiency(tier)`
+ * is NOT how it works - the gearbox scalar lives on consumption,
+ * not on capacity, so a tier 0 car runs out before a tier 5 car at the
+ * same archetype.
+ */
+const CAPACITY_BY_ARCHETYPE: Readonly<Record<TrackArchetype, number>> = {
+  "short-sprint": 100,
+  standard: 400,
+  "long-scenic": 280,
+  endurance: 220,
+};
+
+export function fuelCapacityForArchetype(archetype: TrackArchetype): number {
+  return CAPACITY_BY_ARCHETYPE[archetype];
+}
+
+/**
+ * Gearbox-tier fuel-economy multiplier. `tickFuel` divides the base
+ * drain by this scalar so a higher tier burns less fuel per metre.
+ *
+ * Linear ramp at 10 % per tier. Tier 0 = 1.0 (base), tier 5 = 1.5
+ * (50 % more range). Mirrors the §11 `upgradeCaps.gearbox` cap, which
+ * tops out at tier 5 on every car. The curve is intentionally gentle
+ * so gearbox tiers are a strategic compounding spend rather than a
+ * single jump from "DNF" to "safe".
+ */
+export function gearboxFuelEfficiency(tier: number): number {
+  if (!Number.isFinite(tier) || tier < 0) return 1;
+  return 1 + tier * 0.1;
+}
+
+export interface FuelState {
+  /** Current litres remaining. Clamped to `[0, capacityLiters]`. */
+  readonly liters: number;
+  /** Maximum capacity for the active race. Set at session creation. */
+  readonly capacityLiters: number;
+}
+
+export interface TickFuelInput {
+  readonly state: FuelState;
+  /** Forward speed in m/s; reads `car.speed` at the call site. */
+  readonly speedMps: number;
+  /** Gearbox upgrade tier; `save.garage.installedUpgrades[carId].gearbox`. */
+  readonly gearboxTier: number;
+  /** Tick duration in seconds. */
+  readonly dt: number;
+}
+
+export interface TickFuelResult {
+  readonly state: FuelState;
+  /**
+   * True the tick the player crosses from `liters > 0` to `liters === 0`.
+   * The race-session reducer reads this and flips the player's status to
+   * `dnf` with `dnfReason: "out-of-fuel"`.
+   */
+  readonly depleted: boolean;
+}
+
+/**
+ * Advance the fuel state by one tick. Drain = `BASE_CONSUMPTION_LPS_PER_MPS
+ * * speed_mps * dt / gearboxFuelEfficiency(tier)`. A negative or zero
+ * `dt` collapses to a no-op so paused / countdown ticks do not deplete
+ * the tank. Already-empty tanks stay at zero and report `depleted: false`
+ * (the depletion edge already fired on the prior tick).
+ */
+export function tickFuel(input: TickFuelInput): TickFuelResult {
+  if (!Number.isFinite(input.dt) || input.dt <= 0) {
+    return { state: input.state, depleted: false };
+  }
+  if (input.state.liters <= 0) {
+    return {
+      state: { ...input.state, liters: 0 },
+      depleted: false,
+    };
+  }
+  const speed = Math.max(0, input.speedMps);
+  const drainPerSec =
+    (BASE_CONSUMPTION_LPS_PER_MPS * speed) /
+    gearboxFuelEfficiency(input.gearboxTier);
+  const next = Math.max(0, input.state.liters - drainPerSec * input.dt);
+  const depleted = input.state.liters > 0 && next === 0;
+  return {
+    state: { ...input.state, liters: next },
+    depleted,
+  };
+}
+
+/**
+ * Build the initial `FuelState` for a fresh race. Capacity comes from
+ * the track archetype; the tank starts full.
+ */
+export function createFuelState(archetype: TrackArchetype): FuelState {
+  const capacityLiters = fuelCapacityForArchetype(archetype);
+  return { liters: capacityLiters, capacityLiters };
+}

--- a/src/game/raceRules.ts
+++ b/src/game/raceRules.ts
@@ -194,6 +194,7 @@ export type DnfReason =
   | "no-progress"
   | "retired"
   | "wrecked"
+  | "out-of-fuel"
   | null;
 
 export interface DnfTickResult {

--- a/src/game/raceSession.ts
+++ b/src/game/raceSession.ts
@@ -74,6 +74,11 @@ import {
 import { getDamageBand, getDamageScalars } from "./damageBands";
 import type { DamageScalars } from "./damageBands";
 import {
+  createFuelState,
+  tickFuel,
+  type FuelState,
+} from "./fuel";
+import {
   resolvePresetScalars,
   type AssistScalars,
 } from "./difficultyPresets";
@@ -484,6 +489,17 @@ export interface RaceSessionAICar {
 export interface RaceSessionPlayerCar {
   car: CarState;
   nitro: NitroState;
+  /**
+   * F-104 slice 1. Per-race fuel reserve. Drains as the player drives
+   * via `tickFuel`; the gearbox upgrade tier scales economy.
+   * Depletion mid-race flips status to `dnf` with `dnfReason:
+   * "out-of-fuel"`. Capacity comes from
+   * `fuelCapacityForArchetype(track.archetype)` at session creation.
+   * AI cars are not tracked in slice 1 (the grid runs without fuel
+   * so a stock-gearbox player does not race against AI that DNFs on
+   * lap 6 of a 16-lap standard).
+   */
+  fuel: FuelState;
   lastNitroPressed: boolean;
   transmission: TransmissionState;
   /**
@@ -806,6 +822,7 @@ export function createRaceSession(config: RaceSessionConfig): RaceSessionState {
   const player: RaceSessionPlayerCar = {
     car: { ...INITIAL_CAR_STATE, ...(config.player.initial ?? {}) },
     nitro: createNitroForCar(config.player.stats, config.player.upgrades ?? null),
+    fuel: createFuelState(config.track.archetype),
     lastNitroPressed: false,
     transmission: createTransmissionForCar(config.player.stats, {
       mode: config.player.transmissionMode ?? "auto",
@@ -1832,6 +1849,23 @@ export function stepRaceSession(
     }
   }
 
+  // F-104 slice 1. Fuel tick. Drains only while the player is in
+  // `"racing"` status; countdown / pause / DNF ticks do not consume
+  // fuel. The depletion edge flips the player to `dnf` with reason
+  // `"out-of-fuel"` unless the player already wrecked this tick (wreck
+  // wins because the car is out of the race for a different reason).
+  const playerFuelResult = playerIsRacing
+    ? tickFuel({
+        state: state.player.fuel,
+        speedMps: nextPlayerCar.speed,
+        gearboxTier: config.player.upgrades?.gearbox ?? 0,
+        dt,
+      })
+    : { state: state.player.fuel, depleted: false };
+  if (playerFuelResult.depleted && !playerWreckedThisTick) {
+    nextPlayerStatus = "dnf";
+  }
+
   // §7 per-AI lap rollover + finishing. Each AI tracks its own lap
   // counter (the `RaceState.lap` field is player-only) and accumulates
   // a per-lap-times array so the §7 final-state builder can derive the
@@ -1888,6 +1922,11 @@ export function stepRaceSession(
   // so it doesn't even run on the wrecked tick.)
   if (playerWreckedThisTick) {
     nextPlayerDnfReason = "wrecked";
+  } else if (playerFuelResult.depleted) {
+    // F-104 slice 1. Out-of-fuel wins over off-track / no-progress on
+    // the same tick: the car can no longer make progress because the
+    // tank is empty, so the §7 windows are irrelevant.
+    nextPlayerDnfReason = "out-of-fuel";
   } else if (playerDnfResult?.dnf) {
     nextPlayerStatus = "dnf";
     nextPlayerDnfReason = playerDnfResult.reason;
@@ -2045,6 +2084,7 @@ export function stepRaceSession(
     player: {
       car: nextPlayerCar,
       nitro: playerNitroAfterPickups,
+      fuel: playerFuelResult.state,
       // Mirror the post-assist nitro value so the next tick's
       // rising-edge detection in `tickNitro` matches the input the
       // physics step actually consumed. This matters under
@@ -2329,6 +2369,7 @@ function clonePlayerCar(
   return {
     car: { ...player.car },
     nitro: { ...player.nitro },
+    fuel: { ...player.fuel },
     lastNitroPressed: player.lastNitroPressed,
     transmission: { ...player.transmission },
     lastShiftUpPressed: player.lastShiftUpPressed,

--- a/src/road/trackCompiler.ts
+++ b/src/road/trackCompiler.ts
@@ -303,6 +303,7 @@ export function compileTrack(track: Track): CompiledTrack {
     laneCount: track.laneCount,
     weatherOptions: [...track.weatherOptions],
     difficulty: track.difficulty,
+    archetype: track.archetype,
     minimapPoints,
     pickupsById,
     warnings,

--- a/src/road/types.ts
+++ b/src/road/types.ts
@@ -7,7 +7,12 @@
  * without pulling in either the projector or the canvas drawer.
  */
 
-import type { TrackPickup, TrackSpawn, WeatherOption } from "@/data/schemas";
+import type {
+  TrackArchetype,
+  TrackPickup,
+  TrackSpawn,
+  WeatherOption,
+} from "@/data/schemas";
 
 /**
  * Virtual camera that the player car never visibly leaves.
@@ -120,6 +125,13 @@ export interface CompiledTrack {
    * keep the runtime path single-source from the compiled output.
    */
   difficulty: number;
+  /**
+   * §7 lap-count archetype mirrored from the source `Track.archetype`.
+   * The F-104 fuel runtime reads this to size the per-race fuel
+   * capacity at session creation without re-reading the authored
+   * JSON.
+   */
+  archetype: TrackArchetype;
   /**
    * Minimap polyline, one point per compiled segment, normalised into
    * the unit square. Honours `Track.minimapPoints` when supplied;


### PR DESCRIPTION
## Summary
- First slice of the F-104 four-slice fuel feature. 2026-05-09 research pass on TG2 confirmed the mechanic: per-race fuel that depletes with no mid-race refuel; the strategic spend driver is the gearbox upgrade improving fuel economy.
- New pure \`src/game/fuel.ts\`: \`fuelCapacityForArchetype\` (100/400/280/220 L), \`gearboxFuelEfficiency\` (linear 10 % per tier, tier 0 = 1.0, tier 5 = 1.5), \`tickFuel\` reducer with depletion edge, \`createFuelState\`.
- \`DnfReason\` gains \`"out-of-fuel"\`. Depletion edge in \`stepRaceSession\` flips player status to dnf; the fuel reason wins over §7 off-track / no-progress windows on the same tick but §13 wreck still wins.
- \`CompiledTrack\` mirrors \`track.archetype\` so the fuel runtime can size per-race capacity. \`RaceSessionPlayerCar\` gains \`fuel: FuelState\`; threaded through \`clonePlayerCar\`.
- AI cars are not tracked in slice 1 - the grid runs without fuel so a stock-gearbox player does not race opponents that DNF on lap 6 of a 16-lap standard.
- Slices 2-4 still open under F-104: HUD fuel gauge, garage gearbox copy + per-archetype tune, out-of-fuel UX polish.

## Test plan
- [x] \`pnpm typecheck\` clean
- [x] \`pnpm lint\` clean
- [x] \`pnpm test\` 2952 / 2952 across 161 suites; new \`fuel.test.ts\` pins 12 cases (capacity table, gearbox-tier scalar including negative/NaN, drain shape, depletion edge, no-double-edge, long-run sanity)
- [x] \`pnpm content-lint\` clean
- [x] \`pnpm docs:check\` clean
- [ ] Manual playtest: race a 4-lap short-sprint at gearbox 0; confirm finish with margin. Race a 16-lap standard at gearbox 0; confirm DNF with reason "out-of-fuel". Upgrade gearbox to tier 2 and re-run; confirm survivable.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added in-race fuel management with track-dependent tank capacities and speed/gearbox-based consumption.
  * Players can deplete fuel mid-race and receive a new "out-of-fuel" DNF status.

* **Integrations**
  * Per-track archetype metadata included so tracks influence fuel behavior.
  * Race sessions now track player fuel and advance it only during active racing.

* **Tests**
  * Comprehensive unit tests cover fuel capacities, efficiency tiers, ticking behavior and edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->