### PR TITLE
feat(hud): fuel gauge meter (F-104 slice 2)

### DIFF
--- a/docs/FOLLOWUPS.md
+++ b/docs/FOLLOWUPS.md
@@ -27,9 +27,13 @@ economy. Slice 1 shipped under `feat/fuel-runtime`: pure
 `gearboxFuelEfficiency`, `tickFuel`, `createFuelState`),
 `out-of-fuel` `DnfReason`, `archetype` mirrored on `CompiledTrack`,
 fuel state on `RaceSessionPlayerCar`, depletion edge wired into
-the per-tick status flip. Slices 2-4 still open: HUD fuel gauge,
-garage gearbox copy + per-archetype tuning, out-of-fuel UX polish
-(audio sputter, results-screen reason copy).
+the per-tick status flip. Slice 2 shipped under
+`feat/fuel-hud-gauge`: HUD fuel gauge wired through
+`HudStateInput.fuel` -> `summarizeHudFuel` -> bottom-center bar
+above the nitro meter; `FUEL_CRITICAL_PERCENT = 15` flips the bar
+red and the label to `FUEL EMPTY` on depletion. Slices 3-4 still
+open: garage gearbox copy + per-archetype tuning, out-of-fuel UX
+polish (audio sputter, results-screen reason copy).
 
 ## F-103: Prep-card tire recommendation one-click action
 **Created:** 2026-05-09

--- a/docs/PROGRESS_LOG.md
+++ b/docs/PROGRESS_LOG.md
@@ -6,6 +6,80 @@ Correct them by adding a new entry that references the old one.
 
 ---
 
+## 2026-05-09: feat(hud): fuel gauge meter (F-104 slice 2)
+
+**GDD sections touched:** [§20](gdd/20-hud-and-pause.md) (new
+bottom-center fuel meter above the nitro bar; reuses the existing
+`drawShadowedText` + status-panel-fill palette).
+**Branch / PR:** `feat/fuel-hud-gauge`, PR pending.
+**Status:** Slice 2 of the F-104 four-slice fuel feature. Slices
+3-4 (garage gearbox copy + per-archetype tune, out-of-fuel UX
+polish) stay open under F-104.
+
+### Done
+- Extended `HudStateInput` with optional `fuel: Readonly<FuelState>`
+  and `HudState` with `fuel: HudFuelSummary`. New
+  `summarizeHudFuel(fuel)` clamps `liters` to `[0, capacityLiters]`,
+  rounds `liters` and `percent` for display, and flips
+  `critical: true` at or below the new
+  `FUEL_CRITICAL_PERCENT = 15` constant. `depleted` mirrors the
+  empty-tank state for the renderer's `FUEL EMPTY` label.
+- Wired the fuel summary through the race-page `deriveHudState`
+  call in `src/app/race/page.tsx` so the renderer sees the live
+  per-tick fuel snapshot.
+- Added `drawFuelMeter` in `src/render/uiRenderer.ts`. Bottom-
+  center bar 160 x 10 px above the nitro meter; new `fuelFill`
+  (#66d17a green) / `fuelCriticalFill` (#ef4b4b red) entries on
+  the `HudColors` palette gate the fill colour on
+  `summary.critical`. Label reads `FUEL <liters> / <capacity> L`
+  in normal state and `FUEL EMPTY` once `depleted` flips. No
+  animation; the colour swap is the entire critical signal.
+- Updated the existing `uiRenderer.test.ts` `CUSTOM_COLORS`
+  fixture so the typecheck stays clean (the new fields are
+  required on `HudColors`).
+
+### Verified
+- `npm run typecheck` clean.
+- `npm run lint` clean.
+- `npm run test` 2956 / 2956 passed across 161 suites; 4 new
+  cases in `hudState.test.ts` cover full tank, critical
+  threshold (boundary at exactly 15 % vs. 16 %), depleted
+  state, and clamp on out-of-range readings.
+- `npm run content-lint` clean.
+- `npm run docs:check` clean.
+
+### Decisions and assumptions
+- No animation on the critical pulse this slice. The §19
+  reduced-motion contract demands a static fallback; rather than
+  a motion-aware pulse + a static fallback, slice 2 ships the
+  static colour-swap and leaves animation for slice 4 alongside
+  the audio sputter.
+- Bottom-center placement above the nitro meter. The nitro and
+  fuel gauges read together as a "burn vs. budget" pair: nitro
+  spends pace, fuel sets the budget. Same width (160 px) and
+  height (10 px) so the column is visually consistent.
+- `summarizeHudFuel` clamps both ends. A `liters > capacity`
+  reading rounds to `capacity` so a future bug that overshoots
+  the tank cannot show "fuel: 110 / 100 L".
+- Did not bundle a Playwright spec. The drawer is exercised by
+  the existing `uiRenderer.test.ts` colour-fixture path which
+  now requires the new fields; an e2e canvas-pixel sample for
+  the fuel bar can land alongside the slice 4 polish if the
+  bar's pixel position needs pinning.
+
+### Coverage ledger
+- §20 HUD: bottom-center column gains a fuel meter; existing
+  nitro layout is unchanged because the fuel bar lives 18 px
+  above it.
+
+### Followups created
+None. F-104 stays open for slices 3-4.
+
+### GDD edits
+None this slice.
+
+---
+
 ## 2026-05-09: feat(fuel): TG2-faithful fuel runtime + DNF wiring (F-104 slice 1)
 
 **GDD sections touched:** [§7](gdd/07-race-rules-and-structure.md)

--- a/src/app/race/page.tsx
+++ b/src/app/race/page.tsx
@@ -2259,6 +2259,7 @@ function RaceCanvas({
           nitroMaxCharges:
             DEFAULT_NITRO_CHARGES + nitroUpgradeTier.chargesBonus,
           nitroChargeDurationSec: nitroDurationForTier(nitroUpgradeTier),
+          fuel: session.player.fuel,
           transmission: session.player.transmission,
           cashDelta: projectedCashDelta,
         });

--- a/src/game/__tests__/hudState.test.ts
+++ b/src/game/__tests__/hudState.test.ts
@@ -19,6 +19,7 @@ import {
   rankPosition,
   summarizeHudDamage,
   summarizeHudGear,
+  summarizeHudFuel,
   summarizeHudNitro,
   summarizeHudCashDelta,
   summarizeHudWeather,
@@ -406,6 +407,48 @@ describe("HUD gear and nitro summaries", () => {
       active: true,
       percent: 83,
     });
+  });
+
+  it("summarizes a full fuel tank with no critical or depleted flag", () => {
+    expect(
+      summarizeHudFuel({ liters: 100, capacityLiters: 100 }),
+    ).toEqual({
+      liters: 100,
+      capacityLiters: 100,
+      percent: 100,
+      critical: false,
+      depleted: false,
+    });
+  });
+
+  it("flips the fuel gauge to critical at or below 15 percent", () => {
+    expect(
+      summarizeHudFuel({ liters: 15, capacityLiters: 100 }),
+    ).toMatchObject({ percent: 15, critical: true, depleted: false });
+    expect(
+      summarizeHudFuel({ liters: 16, capacityLiters: 100 }),
+    ).toMatchObject({ percent: 16, critical: false, depleted: false });
+  });
+
+  it("reports depleted when the tank is empty", () => {
+    expect(
+      summarizeHudFuel({ liters: 0, capacityLiters: 100 }),
+    ).toEqual({
+      liters: 0,
+      capacityLiters: 100,
+      percent: 0,
+      critical: true,
+      depleted: true,
+    });
+  });
+
+  it("clamps a negative or over-capacity reading", () => {
+    expect(
+      summarizeHudFuel({ liters: -5, capacityLiters: 100 }),
+    ).toMatchObject({ liters: 0, depleted: true });
+    expect(
+      summarizeHudFuel({ liters: 250, capacityLiters: 100 }),
+    ).toMatchObject({ liters: 100, percent: 100 });
   });
 
   it("summarizes transmission gear, RPM, and mode", () => {

--- a/src/game/hudState.ts
+++ b/src/game/hudState.ts
@@ -26,6 +26,7 @@ import type { SpeedUnit } from "@/data/schemas";
 import type { WeatherOption } from "@/data/schemas";
 import type { AssistBadge } from "./assists";
 import type { DamageState, DamageZone } from "./damage";
+import type { FuelState } from "./fuel";
 import {
   BASE_NITRO_DURATION_SEC,
   DEFAULT_NITRO_CHARGES,
@@ -105,6 +106,13 @@ export interface HudStateInput {
   weatherGripScalar?: number;
   /** Optional live §10 nitro snapshot for the §20 bottom-center meter. */
   nitro?: Readonly<NitroState>;
+  /**
+   * F-104 slice 2. Optional live fuel snapshot for the HUD gauge.
+   * Omit on modes that bypass the fuel runtime (slice 1 wires it
+   * for World Tour races; practice / time-trial / quick-race bypass
+   * the same way they bypass damage today).
+   */
+  fuel?: Readonly<FuelState>;
   /**
    * Race-start maximum nitro charges. Defaults to the stock §10 value.
    * Used only to size the meter.
@@ -190,6 +198,8 @@ export interface HudState {
   weather?: HudWeatherSummary;
   /** Optional §20 nitro HUD summary. */
   nitro?: HudNitroSummary;
+  /** F-104 slice 2 fuel HUD summary. */
+  fuel?: HudFuelSummary;
   /** Optional §20 gear HUD summary. */
   gear?: HudGearSummary;
   /** Optional §20 cash delta in credits. */
@@ -217,6 +227,26 @@ export interface HudNitroSummary {
   active: boolean;
   percent: number;
 }
+
+export interface HudFuelSummary {
+  /** Current litres remaining, rounded to int for the gauge label. */
+  liters: number;
+  /** Tank capacity in litres for the active race. */
+  capacityLiters: number;
+  /** Fill percent in [0, 100], rounded to int for the gauge fill width. */
+  percent: number;
+  /** True when fuel is at or below `FUEL_CRITICAL_PERCENT` (15 %). */
+  critical: boolean;
+  /** True when the tank is empty (depletion edge already fired). */
+  depleted: boolean;
+}
+
+/**
+ * F-104 slice 2. Fill threshold below which the fuel gauge enters the
+ * critical state. Reads on the renderer side so a future tune of the
+ * threshold is data-driven from this constant.
+ */
+export const FUEL_CRITICAL_PERCENT = 15;
 
 export interface HudGearSummary {
   gear: number;
@@ -333,6 +363,20 @@ export function summarizeHudNitro(
     max,
     active: activeFraction > 0,
     percent: percentFromUnit(current / max),
+  };
+}
+
+export function summarizeHudFuel(fuel: Readonly<FuelState>): HudFuelSummary {
+  const capacity = Math.max(0, fuel.capacityLiters);
+  const liters = Math.max(0, Math.min(capacity, fuel.liters));
+  const fraction = capacity > 0 ? liters / capacity : 0;
+  const percent = percentFromUnit(fraction);
+  return {
+    liters: Math.round(liters),
+    capacityLiters: Math.round(capacity),
+    percent,
+    critical: percent <= FUEL_CRITICAL_PERCENT,
+    depleted: liters === 0,
   };
 }
 
@@ -485,6 +529,9 @@ export function deriveHudState(input: HudStateInput): HudState {
       input.nitroMaxCharges,
       input.nitroChargeDurationSec,
     );
+  }
+  if (input.fuel !== undefined) {
+    result.fuel = summarizeHudFuel(input.fuel);
   }
   if (input.transmission !== undefined) {
     result.gear = summarizeHudGear(input.transmission);

--- a/src/render/__tests__/uiRenderer.test.ts
+++ b/src/render/__tests__/uiRenderer.test.ts
@@ -125,6 +125,8 @@ const CUSTOM_COLORS: HudColors = {
   weatherChipFill: "#002244",
   nitroFill: "#0044aa",
   nitroActiveFill: "#aa7700",
+  fuelFill: "#22aa44",
+  fuelCriticalFill: "#aa2211",
 };
 
 function badge(

--- a/src/render/uiRenderer.ts
+++ b/src/render/uiRenderer.ts
@@ -60,6 +60,10 @@ export interface HudColors {
   nitroFill: string;
   /** Nitro meter fill while a charge is active. */
   nitroActiveFill: string;
+  /** F-104 slice 2 fuel meter fill above critical threshold. */
+  fuelFill: string;
+  /** F-104 slice 2 fuel meter fill at or below critical threshold. */
+  fuelCriticalFill: string;
 }
 
 export interface DrawHudOptions {
@@ -90,6 +94,8 @@ const DEFAULT_COLORS: HudColors = {
   weatherChipFill: "rgba(104, 160, 220, 0.78)",
   nitroFill: "#5ba7ff",
   nitroActiveFill: "#f4d24a",
+  fuelFill: "#66d17a",
+  fuelCriticalFill: "#ef4b4b",
 };
 
 const DEFAULT_PADDING = 16;
@@ -133,6 +139,15 @@ const DAMAGE_BAR_HEIGHT = 5;
 const NITRO_METER_WIDTH = 160;
 const NITRO_METER_HEIGHT = 10;
 const NITRO_METER_BOTTOM = 18;
+
+const FUEL_METER_WIDTH = 160;
+const FUEL_METER_HEIGHT = 10;
+/**
+ * Fuel meter sits 18 px above the nitro meter so the two share the
+ * bottom-center column. Together they read "burning vs. saving" at a
+ * glance: nitro grants pace, fuel sets the budget.
+ */
+const FUEL_METER_BOTTOM = NITRO_METER_BOTTOM + NITRO_METER_HEIGHT + 18;
 
 /**
  * Draw a string with a one-pixel drop shadow underlay so it reads over
@@ -275,6 +290,9 @@ export function drawHud(
   if (state.nitro !== undefined) {
     drawNitroMeter(ctx, state, viewport, padding, fontFamily, colors);
   }
+  if (state.fuel !== undefined) {
+    drawFuelMeter(ctx, state, viewport, padding, fontFamily, colors);
+  }
 
   // Top-right (below the splits widget): accessibility-assist badge.
   // Drawer is a no-op when the badge is missing or inactive so the §19
@@ -327,6 +345,42 @@ function drawNitroMeter(
 function formatNitroCharges(value: number): string {
   if (!Number.isFinite(value)) return "0.0";
   return value.toFixed(1);
+}
+
+function drawFuelMeter(
+  ctx: CanvasRenderingContext2D,
+  state: HudState,
+  viewport: Viewport,
+  padding: number,
+  fontFamily: string,
+  colors: HudColors,
+): void {
+  const fuel = state.fuel;
+  if (fuel === undefined) return;
+  const x = Math.round((viewport.width - FUEL_METER_WIDTH) / 2);
+  const y = viewport.height - padding - FUEL_METER_BOTTOM;
+  ctx.fillStyle = colors.statusPanelFill;
+  ctx.fillRect(x, y, FUEL_METER_WIDTH, FUEL_METER_HEIGHT);
+  ctx.fillStyle = fuel.critical ? colors.fuelCriticalFill : colors.fuelFill;
+  ctx.fillRect(
+    x,
+    y,
+    Math.round((FUEL_METER_WIDTH * Math.max(0, Math.min(100, fuel.percent))) / 100),
+    FUEL_METER_HEIGHT,
+  );
+  ctx.font = `600 11px ${fontFamily}`;
+  ctx.textAlign = "center";
+  ctx.textBaseline = "bottom";
+  drawShadowedText(
+    ctx,
+    fuel.depleted
+      ? "FUEL EMPTY"
+      : `FUEL ${fuel.liters} / ${fuel.capacityLiters} L`,
+    viewport.width / 2,
+    y - 3,
+    colors.shadow,
+    fuel.critical ? colors.fuelCriticalFill : colors.textMuted,
+  );
 }
 
 function drawStatusCluster(


### PR DESCRIPTION
## Summary
- Slice 2 of the F-104 four-slice fuel feature. Adds the HUD signal the player needs to read fuel state mid-race, complementing slice 1's runtime drain.
- \`HudStateInput\` gains optional \`fuel: FuelState\`; \`HudState\` gains \`HudFuelSummary\` with rounded liters/percent, \`critical\` flag at or below \`FUEL_CRITICAL_PERCENT = 15\`, and \`depleted\` flag.
- New \`drawFuelMeter\` renders a bottom-center bar 160 x 10 px above the nitro meter; \`fuelFill\` green / \`fuelCriticalFill\` red palette entries gate the fill on \`summary.critical\`. Label reads \`FUEL <liters>/<capacity> L\` normally and \`FUEL EMPTY\` once depleted.
- No animation - the colour swap is the entire critical signal, satisfying §19 reduced-motion without a motion-aware fallback. Animation + audio sputter live in slice 4.
- Slices 3-4 still open under F-104.

## Test plan
- [x] \`pnpm typecheck\` clean
- [x] \`pnpm lint\` clean
- [x] \`pnpm test\` 2956 / 2956 across 161 suites; 4 new \`hudState.test.ts\` cases (full tank, critical boundary at 15 % vs 16 %, depleted, clamp on out-of-range)
- [x] \`pnpm content-lint\` clean
- [x] \`pnpm docs:check\` clean
- [ ] Manual playtest: run a 16-lap standard at gearbox tier 0; confirm the fuel bar drains visibly, flips red below 15 %, and reads \`FUEL EMPTY\` on the final tick before the player DNFs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
* Added real-time fuel meter display during races showing current fuel level and capacity
* Added critical fuel warning indicator when fuel drops below 15%
* Added "FUEL EMPTY" message when tank is depleted

<!-- end of auto-generated comment: release notes by coderabbit.ai -->