### PR TITLE
feat(garage): surface gearbox fuel-range bonus (F-104 slice 3)

### DIFF
--- a/docs/FOLLOWUPS.md
+++ b/docs/FOLLOWUPS.md
@@ -31,9 +31,14 @@ the per-tick status flip. Slice 2 shipped under
 `feat/fuel-hud-gauge`: HUD fuel gauge wired through
 `HudStateInput.fuel` -> `summarizeHudFuel` -> bottom-center bar
 above the nitro meter; `FUEL_CRITICAL_PERCENT = 15` flips the bar
-red and the label to `FUEL EMPTY` on depletion. Slices 3-4 still
-open: garage gearbox copy + per-archetype tuning, out-of-fuel UX
-polish (audio sputter, results-screen reason copy).
+red and the label to `FUEL EMPTY` on depletion. Slice 3 shipped
+under `feat/fuel-garage-copy`: gearbox tier rows on the upgrade
+page now surface the cumulative fuel-range bonus (`+10 % fuel
+range` at tier 1, `+20 %` at tier 2, ...) alongside the existing
+top-speed effect, so the player sees why upgrading the gearbox
+extends how far they get on a tank. Pure UI; runtime drain still
+reads the same `gearboxFuelEfficiency` curve. Slice 4 still open:
+out-of-fuel UX polish (audio sputter, results-screen reason copy).
 
 ## F-103: Prep-card tire recommendation one-click action
 **Created:** 2026-05-09

--- a/docs/PROGRESS_LOG.md
+++ b/docs/PROGRESS_LOG.md
@@ -6,6 +6,59 @@ Correct them by adding a new entry that references the old one.
 
 ---
 
+## 2026-05-09: feat(garage): gearbox fuel-range copy (F-104 slice 3)
+
+**GDD sections touched:** [§12](gdd/12-upgrade-and-economy-system.md)
+(no schema or data change; presentation-only refinement of the
+gearbox tier row on the garage upgrade page so the player sees why
+the gearbox upgrade extends fuel range).
+**Branch / PR:** `feat/fuel-garage-copy`, PR pending.
+**Status:** Slice 3 of the F-104 four-slice fuel feature. Slice 4
+(out-of-fuel UX polish - audio sputter and results-screen reason
+copy) stays open under F-104.
+
+### Done
+- Added `gearboxFuelRangeBonusLabel(tier)` and `formatRowEffects`
+  in `src/components/garage/garageUpgradeState.ts`. Gearbox rows
+  now append `+N% fuel range` (cumulative vs. stock, derived from
+  the existing `gearboxFuelEfficiency` curve) to the existing
+  `formatEffects` output. Non-gearbox rows are unchanged.
+- The label uses `gearboxFuelEfficiency(upgrade.tier)` directly so
+  the per-tier bonus stays in sync with the runtime drain curve in
+  `src/game/fuel.ts`. Linear ramp at 10 % per tier vs. stock
+  matches the §12 cap of tier 5.
+
+### Verified
+- `pnpm typecheck` clean.
+- `pnpm lint` clean.
+- `pnpm vitest run src/components/garage/__tests__/garageUpgradeState.test.ts`
+  7 / 7 passed; two new cases assert the gearbox row contains
+  `+10% fuel range` at tier 1 and `+20% fuel range` at tier 2,
+  plus a regression case asserting non-gearbox rows do not pick up
+  the suffix.
+
+### Assumptions
+- The cumulative-vs-stock framing (`+10 %`, `+20 %`, ...) is
+  clearer than marginal-from-previous-tier (`+10 %`, `+9.1 %`,
+  ...). It mirrors how the existing numeric effect labels
+  surface percentages relative to the base stat (`accel +4 %`,
+  `top speed +3 %`), so the row stays consistent.
+- No tuning change to `BASE_CONSUMPTION_LPS_PER_MPS` or the
+  per-archetype capacity table in this slice. Playtest data
+  drives the next tune pass; in the meantime the slice 1
+  defaults stand.
+
+### GDD coverage
+- §12 Upgrade and economy: presentation-only; no requirement
+  delta. The §12 row already lists gearbox as a category; this
+  slice surfaces the F-104 fuel-range effect on it.
+
+### Followups
+- F-104 slice 4 (out-of-fuel UX polish) still open per the
+  `docs/FOLLOWUPS.md` F-104 entry.
+
+---
+
 ## 2026-05-09: feat(hud): fuel gauge meter (F-104 slice 2)
 
 **GDD sections touched:** [§20](gdd/20-hud-and-pause.md) (new

--- a/src/components/garage/__tests__/garageUpgradeState.test.ts
+++ b/src/components/garage/__tests__/garageUpgradeState.test.ts
@@ -34,6 +34,48 @@ describe("buildGarageUpgradeView", () => {
     expect(engine?.disabledReason).toBe("");
   });
 
+  it("surfaces the cumulative fuel-range bonus on gearbox rows", () => {
+    const save: SaveGame = {
+      ...defaultSave(),
+      garage: {
+        ...defaultSave().garage,
+        credits: 50000,
+      },
+    };
+
+    const view = buildGarageUpgradeView(save);
+    const gearbox = view.rows.find((row) => row.category === "gearbox");
+    expect(gearbox?.nextUpgrade?.tier).toBe(1);
+    expect(gearbox?.effectsLabel).toContain("+10% fuel range");
+
+    const tier2View = buildGarageUpgradeView({
+      ...save,
+      garage: {
+        ...save.garage,
+        installedUpgrades: {
+          ...save.garage.installedUpgrades,
+          "sparrow-gt": {
+            ...save.garage.installedUpgrades["sparrow-gt"]!,
+            gearbox: 1,
+          },
+        },
+      },
+    });
+    const tier2Gearbox = tier2View.rows.find((row) => row.category === "gearbox");
+    expect(tier2Gearbox?.nextUpgrade?.tier).toBe(2);
+    expect(tier2Gearbox?.effectsLabel).toContain("+20% fuel range");
+  });
+
+  it("does not append a fuel-range bonus to non-gearbox rows", () => {
+    const save: SaveGame = {
+      ...defaultSave(),
+      garage: { ...defaultSave().garage, credits: 50000 },
+    };
+    const view = buildGarageUpgradeView(save);
+    const engine = view.rows.find((row) => row.category === "engine");
+    expect(engine?.effectsLabel).not.toContain("fuel range");
+  });
+
   it("disables a next tier when credits are short", () => {
     const save: SaveGame = {
       ...defaultSave(),

--- a/src/components/garage/garageUpgradeState.ts
+++ b/src/components/garage/garageUpgradeState.ts
@@ -177,10 +177,9 @@ function formatRowEffects(
 ): string {
   const base = formatEffects(upgrade.effects);
   if (category !== "gearbox") return base;
-  // F-104 slice 3. Surface the gearbox tier's fuel-range bonus next to the
-  // numeric effects so the player sees why upgrading the gearbox extends
-  // how far they get on a tank. The per-tier range multiplier comes from
-  // `gearboxFuelEfficiency` and is linear (10 % per tier vs stock).
+  // Gearbox tiers extend fuel range via `gearboxFuelEfficiency`; surface
+  // the cumulative-vs-stock bonus alongside the numeric effects so the
+  // upgrade row tells the player why this row matters for endurance.
   const range = gearboxFuelRangeBonusLabel(upgrade.tier);
   return base === "No numeric effect listed" ? range : `${base}, ${range}`;
 }

--- a/src/components/garage/garageUpgradeState.ts
+++ b/src/components/garage/garageUpgradeState.ts
@@ -8,6 +8,7 @@ import type {
 import { UpgradeCategorySchema } from "@/data/schemas";
 import { UPGRADES } from "@/data/upgrades";
 import type { EconomyFailure } from "@/game/economy";
+import { gearboxFuelEfficiency } from "@/game/fuel";
 
 const UPGRADE_CATEGORIES: ReadonlyArray<UpgradeCategory> =
   UpgradeCategorySchema.options;
@@ -65,7 +66,9 @@ export function buildGarageUpgradeView(
         : nextUpgrade
           ? `${tierLabel(nextUpgrade.tier)} (${nextUpgrade.cost} credits)`
           : "No upgrade available",
-      effectsLabel: nextUpgrade ? formatEffects(nextUpgrade.effects) : "No further effect",
+      effectsLabel: nextUpgrade
+        ? formatRowEffects(category, nextUpgrade)
+        : "No further effect",
       canPurchase,
       disabledReason: disabledReason({
         activeCar,
@@ -166,6 +169,25 @@ function tierLabel(tier: number): string {
     default:
       return `Tier ${tier}`;
   }
+}
+
+function formatRowEffects(
+  category: UpgradeCategory,
+  upgrade: Upgrade,
+): string {
+  const base = formatEffects(upgrade.effects);
+  if (category !== "gearbox") return base;
+  // F-104 slice 3. Surface the gearbox tier's fuel-range bonus next to the
+  // numeric effects so the player sees why upgrading the gearbox extends
+  // how far they get on a tank. The per-tier range multiplier comes from
+  // `gearboxFuelEfficiency` and is linear (10 % per tier vs stock).
+  const range = gearboxFuelRangeBonusLabel(upgrade.tier);
+  return base === "No numeric effect listed" ? range : `${base}, ${range}`;
+}
+
+function gearboxFuelRangeBonusLabel(tier: number): string {
+  const bonus = (gearboxFuelEfficiency(tier) - 1) * 100;
+  return `+${Math.round(bonus)}% fuel range`;
 }
 
 function formatEffects(effects: Upgrade["effects"]): string {


### PR DESCRIPTION
## Summary
- Gearbox tier rows on the garage upgrade page now append a cumulative `+N% fuel range` effect derived from `gearboxFuelEfficiency`, alongside the existing numeric effect labels
- Pure UI change: non-gearbox rows are unchanged, and the runtime drain curve in `src/game/fuel.ts` is untouched
- Slice 3 of the F-104 four-slice fuel feature; slice 4 (out-of-fuel UX polish) still open

## Why
Slice 1 added the runtime drain and slice 2 added the HUD gauge. Without copy on the gearbox upgrade row, players see fuel run out but have no in-shop signal that upgrading the gearbox extends range. This slice closes the loop so the strategic spend is legible.

## Test plan
- [x] `pnpm typecheck`
- [x] `pnpm lint`
- [x] `pnpm vitest run src/components/garage/__tests__/garageUpgradeState.test.ts` (7 / 7)
- [x] `pnpm docs:check`
- [x] `pnpm content-lint`
- [ ] CI: lint, typecheck, unit, e2e

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Gearbox upgrades now display a cumulative fuel-range bonus with tier progression details in their effects display.
  * Engine upgrades and other non-gearbox categories correctly exclude the fuel-range bonus from their effects information.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Randroids-Dojo/VibeGear2/pull/209)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->