### PR TITLE
feat(results): surface DNF reason on finishing-order row (F-104 slice 4)

### DIFF
--- a/docs/FOLLOWUPS.md
+++ b/docs/FOLLOWUPS.md
@@ -37,8 +37,18 @@ page now surface the cumulative fuel-range bonus (`+10 % fuel
 range` at tier 1, `+20 %` at tier 2, ...) alongside the existing
 top-speed effect, so the player sees why upgrading the gearbox
 extends how far they get on a tank. Pure UI; runtime drain still
-reads the same `gearboxFuelEfficiency` curve. Slice 4 still open:
-out-of-fuel UX polish (audio sputter, results-screen reason copy).
+reads the same `gearboxFuelEfficiency` curve. Slice 4 shipped
+under `feat/fuel-out-of-fuel-ux`: the results-screen finishing-
+order row now renders an inline reason label below the DNF marker
+for cars that flipped out via a recorded `dnfReason`. New optional
+field `dnfReason: DnfReason` on `FinalCarRecord` and
+`FinalCarInput`; `buildFinalRaceState` forwards it,
+`buildFinalCarInputsFromSession` reads `state.player.dnfReason` and
+each AI's `entry.dnfReason`, and `FinishingOrderTable` maps every
+DnfReason value to a friendly label ("Out of fuel", "Wrecked",
+"Off track", "No progress", "Retired"). Static text only; reduced-
+motion safe per §19. Audio sputter cue deferred for a future loop;
+the four-slice F-104 feature otherwise closes with this slice.
 
 ## F-103: Prep-card tire recommendation one-click action
 **Created:** 2026-05-09

--- a/docs/PROGRESS_LOG.md
+++ b/docs/PROGRESS_LOG.md
@@ -6,6 +6,88 @@ Correct them by adding a new entry that references the old one.
 
 ---
 
+## 2026-05-09: feat(results): DNF reason copy (F-104 slice 4)
+
+**GDD sections touched:** [§20](gdd/20-hud-and-pause.md) (results
+screen "finishing order" row gains an inline reason label below the
+DNF marker for cars that flipped out via a recorded
+`dnfReason`; existing iter-26 "Did Not Finish label replaces the
+position" stress-test contract preserved).
+**Branch / PR:** `feat/fuel-out-of-fuel-ux`, PR pending.
+**Status:** Slice 4 of the F-104 four-slice fuel feature, the final
+slice. F-104 closes once this lands.
+
+### Done
+- Extended `FinalCarRecord` and `FinalCarInput` in
+  `src/game/raceRules.ts` with an optional `dnfReason: DnfReason`
+  field. Optional so the 89+ existing test fixtures and the
+  pre-field session-storage payloads stay valid; consumers treat
+  `undefined` as "no specific reason recorded" and render the bare
+  DNF marker. `buildFinalRaceState` forwards the value for `dnf`
+  rows and writes `undefined` for finishers so the field stays
+  noise-free on a clean finish.
+- Wired `buildFinalCarInputsFromSession` in
+  `src/game/raceSessionActions.ts` to pass the player's
+  `state.player.dnfReason` and each AI's `entry.dnfReason` into the
+  final-car inputs. The retire path and the natural-finish path
+  both flow through this helper, so no race-page edits were needed.
+- Updated `FinishingOrderTable` in
+  `src/components/results/FinishingOrderTable.tsx` to render the
+  `dnfReason` as a small muted label below the DNF marker. Friendly
+  copy maps every DnfReason value (`out-of-fuel` -> "Out of fuel",
+  `wrecked` -> "Wrecked", `off-track` -> "Off track",
+  `no-progress` -> "No progress", `retired` -> "Retired"); rows
+  with `dnfReason` `undefined` or `null` keep the bare "DNF" cell.
+  Static text only - no animation, so the change is reduced-motion
+  safe per §19.
+
+### Verified
+- `pnpm typecheck` clean.
+- `pnpm lint` clean.
+- `pnpm vitest run` 2963 / 2963 passed across 162 suites; new
+  cases: `buildFinalRaceState forwards dnfReason from the input
+  onto the per-car record` in `raceRules.test.ts`, and four
+  cases in the new
+  `src/components/results/__tests__/FinishingOrderTable.test.tsx`
+  (out-of-fuel rendered, other reasons rendered, undefined
+  omitted, finisher rows skipped).
+- `pnpm content-lint` clean.
+- `pnpm docs:check` clean.
+
+### Assumptions
+- The friendly-copy map covers every DnfReason value, even though
+  this slice was scoped to "out of fuel" specifically. The
+  alternative - rendering "Out of fuel" while every other DNF
+  reason stays bare "DNF" - would create a visual asymmetry that
+  reads as a bug. The mapping is a single 5-case switch in the
+  component file; the labels are content, not policy, and the
+  formatting cost is sub-slice. Future slices can re-tune the
+  copy without touching the wiring.
+- Optional vs. required field: making `dnfReason` required would
+  cascade across every fixture in the unit suite (89+ matches on
+  `status: "finished"`/`status: "dnf"` shape literals) and force
+  a session-storage version bump. Optional + `?? null` reads at
+  the boundary keeps the change small while preserving
+  type-safety on new producers.
+- No save schema change. The handoff lives in `sessionStorage`
+  under the existing `vibegear2:race-result:v1` key; old payloads
+  without `dnfReason` parse as `undefined` and the renderer
+  gracefully omits the label.
+
+### GDD coverage
+- §20 Results screen: presentation-only refinement of the
+  finishing-order row.
+
+### Followups
+- F-104 closes with this slice. The follow-up entry will be
+  marked `done` once the PR merges.
+- Audio sputter on depletion deferred: the slice intentionally
+  ships UI-only polish and leaves audio to a future loop. No new
+  followup created since the gap is already implicit in the
+  F-104 entry's "audio sputter" note.
+
+---
+
 ## 2026-05-09: feat(garage): gearbox fuel-range copy (F-104 slice 3)
 
 **GDD sections touched:** [§12](gdd/12-upgrade-and-economy-system.md)

--- a/e2e/pause-actions.spec.ts
+++ b/e2e/pause-actions.spec.ts
@@ -61,7 +61,8 @@ test.describe("pause actions", () => {
     // Route hops to /race/results; the page reads the
     // session-storage handoff. The player row carries
     // `data-status="dnf"` per `<FinishingOrderTable />` and renders
-    // "DNF" in the position column.
+    // "DNF" in the position column with a "Retired" reason label
+    // below it (the retire path pins `dnfReason: "retired"`).
     await expect(page).toHaveURL(/\/race\/results/);
     await expect(page.getByTestId("race-results")).toBeVisible({
       timeout: 10_000,
@@ -69,7 +70,11 @@ test.describe("pause actions", () => {
     const playerRow = page.getByTestId("results-row-player");
     await expect(playerRow).toBeVisible();
     await expect(playerRow).toHaveAttribute("data-status", "dnf");
-    await expect(playerRow.locator("td").first()).toHaveText("DNF");
+    await expect(playerRow).toHaveAttribute("data-dnf-reason", "retired");
+    await expect(playerRow.locator("td").first()).toContainText("DNF");
+    await expect(
+      page.getByTestId("results-row-player-dnf-reason"),
+    ).toHaveText("Retired");
   });
 
   test("Exit to title routes back to the home page", async ({ page }) => {

--- a/src/components/results/FinishingOrderTable.tsx
+++ b/src/components/results/FinishingOrderTable.tsx
@@ -34,16 +34,29 @@ export function FinishingOrderTable(props: FinishingOrderTableProps): ReactEleme
       <tbody>
         {rows.map((row, idx) => {
           const isPlayer = row.carId === playerCarId;
-          const place = row.status === "finished" ? `${idx + 1}` : "DNF";
+          const isDnf = row.status !== "finished";
+          const place = isDnf ? "DNF" : `${idx + 1}`;
+          const reasonLabel = isDnf ? formatDnfReason(row.dnfReason) : null;
           return (
             <tr
               key={row.carId}
               data-testid={`results-row-${row.carId}`}
               data-player={isPlayer ? "true" : "false"}
               data-status={row.status}
+              data-dnf-reason={row.dnfReason ?? ""}
               style={isPlayer ? playerRowStyle : rowStyle}
             >
-              <td style={tdStyle}>{place}</td>
+              <td style={tdStyle}>
+                <span>{place}</span>
+                {reasonLabel ? (
+                  <span
+                    data-testid={`results-row-${row.carId}-dnf-reason`}
+                    style={dnfReasonStyle}
+                  >
+                    {reasonLabel}
+                  </span>
+                ) : null}
+              </td>
               <td style={tdStyle}>{row.carId}</td>
               <td style={tdStyle}>{formatMs(row.raceTimeMs)}</td>
               <td style={tdStyle}>{formatMs(row.bestLapMs)}</td>
@@ -53,6 +66,25 @@ export function FinishingOrderTable(props: FinishingOrderTableProps): ReactEleme
       </tbody>
     </table>
   );
+}
+
+function formatDnfReason(
+  reason: FinalCarRecord["dnfReason"],
+): string | null {
+  switch (reason) {
+    case "out-of-fuel":
+      return "Out of fuel";
+    case "wrecked":
+      return "Wrecked";
+    case "off-track":
+      return "Off track";
+    case "no-progress":
+      return "No progress";
+    case "retired":
+      return "Retired";
+    default:
+      return null;
+  }
 }
 
 function formatMs(ms: number | null): string {
@@ -99,4 +131,12 @@ const rowStyle: CSSProperties = {};
 const playerRowStyle: CSSProperties = {
   background: "rgba(255,255,255,0.07)",
   fontWeight: 600,
+};
+
+const dnfReasonStyle: CSSProperties = {
+  display: "block",
+  marginTop: "0.15rem",
+  fontSize: "0.75rem",
+  fontWeight: 400,
+  color: "var(--muted, #aaa)",
 };

--- a/src/components/results/__tests__/FinishingOrderTable.test.tsx
+++ b/src/components/results/__tests__/FinishingOrderTable.test.tsx
@@ -1,0 +1,69 @@
+import { describe, expect, it } from "vitest";
+import { createElement } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+
+import type { FinalCarRecord } from "@/game/raceRules";
+
+import { FinishingOrderTable } from "../FinishingOrderTable";
+
+const finishedRow: FinalCarRecord = {
+  carId: "player",
+  status: "finished",
+  raceTimeMs: 65_432,
+  bestLapMs: 32_716,
+};
+
+const dnfFuelRow: FinalCarRecord = {
+  carId: "rival-a",
+  status: "dnf",
+  raceTimeMs: null,
+  bestLapMs: null,
+  dnfReason: "out-of-fuel",
+};
+
+const dnfWreckedRow: FinalCarRecord = {
+  carId: "rival-b",
+  status: "dnf",
+  raceTimeMs: null,
+  bestLapMs: null,
+  dnfReason: "wrecked",
+};
+
+const dnfUnknownRow: FinalCarRecord = {
+  carId: "rival-c",
+  status: "dnf",
+  raceTimeMs: null,
+  bestLapMs: null,
+};
+
+function html(rows: ReadonlyArray<FinalCarRecord>): string {
+  return renderToStaticMarkup(
+    createElement(FinishingOrderTable, { rows, playerCarId: "player" }),
+  );
+}
+
+describe("FinishingOrderTable DNF reason copy", () => {
+  it("renders the friendly out-of-fuel label below the DNF marker", () => {
+    const markup = html([finishedRow, dnfFuelRow]);
+    expect(markup).toContain('data-testid="results-row-rival-a-dnf-reason"');
+    expect(markup).toContain("Out of fuel");
+    expect(markup).toContain('data-dnf-reason="out-of-fuel"');
+  });
+
+  it("renders friendly labels for other DNF reasons", () => {
+    const markup = html([finishedRow, dnfWreckedRow]);
+    expect(markup).toContain("Wrecked");
+    expect(markup).toContain('data-dnf-reason="wrecked"');
+  });
+
+  it("omits the reason label when DNF reason is undefined", () => {
+    const markup = html([finishedRow, dnfUnknownRow]);
+    expect(markup).not.toContain("results-row-rival-c-dnf-reason");
+    expect(markup).toContain("DNF");
+  });
+
+  it("does not render a reason label for finished rows", () => {
+    const markup = html([finishedRow]);
+    expect(markup).not.toContain("results-row-player-dnf-reason");
+  });
+});

--- a/src/game/__tests__/raceRules.test.ts
+++ b/src/game/__tests__/raceRules.test.ts
@@ -472,6 +472,24 @@ describe("buildFinalRaceState", () => {
     expect(buildFinalRaceState(input)).toEqual(buildFinalRaceState(input));
   });
 
+  it("forwards dnfReason from the input onto the per-car record", () => {
+    const result = buildFinalRaceState({
+      trackId: "test-curve",
+      totalLaps: 2,
+      cars: [
+        { carId: "a", lapTimes: [60_000, 60_000], raceTimeMs: 120_000, status: "finished" },
+        { carId: "b", lapTimes: [], raceTimeMs: null, status: "dnf", dnfReason: "out-of-fuel" },
+        { carId: "c", lapTimes: [60_000], raceTimeMs: null, status: "dnf" },
+      ],
+    });
+    const a = result.finishingOrder.find((r) => r.carId === "a");
+    const b = result.finishingOrder.find((r) => r.carId === "b");
+    const c = result.finishingOrder.find((r) => r.carId === "c");
+    expect(a?.dnfReason).toBeUndefined();
+    expect(b?.dnfReason).toBe("out-of-fuel");
+    expect(c?.dnfReason).toBeNull();
+  });
+
   it("ignores non-positive or non-finite lap entries when computing fastest lap", () => {
     const result = buildFinalRaceState({
       trackId: "test-curve",

--- a/src/game/raceRules.ts
+++ b/src/game/raceRules.ts
@@ -425,6 +425,15 @@ export interface FinalCarRecord {
   status: FinalCarStatus;
   raceTimeMs: number | null;
   bestLapMs: number | null;
+  /**
+   * DNF reason for cars with `status === "dnf"`. Carries the value the
+   * race-session reducer pinned at the moment the car flipped out of
+   * the race so the §20 results screen can render a friendly label
+   * (e.g. "Out of fuel"). Optional so fixtures and legacy storage reads
+   * that predate the field stay valid; consumers treat `undefined` as
+   * "no specific reason recorded" and fall back to the bare "DNF" label.
+   */
+  dnfReason?: DnfReason;
 }
 
 /**
@@ -476,6 +485,8 @@ export interface FinalCarInput {
   status: FinalCarStatus;
   raceTimeMs: number | null;
   lapTimes: ReadonlyArray<number>;
+  /** Forwarded onto `FinalCarRecord.dnfReason`. Optional. */
+  dnfReason?: DnfReason;
 }
 
 export interface BuildFinalRaceStateInput {
@@ -514,6 +525,7 @@ export function buildFinalRaceState(
       car.lapTimes.length === 0
         ? null
         : Math.min(...car.lapTimes),
+    dnfReason: car.status === "dnf" ? (car.dnfReason ?? null) : undefined,
   }));
 
   // Sort the finishing order. The comparator handles the status

--- a/src/game/raceSessionActions.ts
+++ b/src/game/raceSessionActions.ts
@@ -166,18 +166,25 @@ export function buildFinalCarInputsFromSession(
   state: Readonly<RaceSessionState>,
 ): ReadonlyArray<FinalCarInput> {
   const cars: FinalCarInput[] = [];
+  const playerStatus: FinalCarInput["status"] =
+    state.player.status === "finished" ? "finished" : "dnf";
   cars.push({
     carId: PLAYER_CAR_ID,
-    status: state.player.status === "finished" ? "finished" : "dnf",
+    status: playerStatus,
     raceTimeMs: state.player.finishedAtMs,
     lapTimes: state.player.lapTimes.slice(),
+    dnfReason:
+      playerStatus === "dnf" ? (state.player.dnfReason ?? null) : undefined,
   });
   state.ai.forEach((entry, index) => {
+    const aiStatus: FinalCarInput["status"] =
+      entry.status === "finished" ? "finished" : "dnf";
     cars.push({
       carId: aiCarId(index),
-      status: entry.status === "finished" ? "finished" : "dnf",
+      status: aiStatus,
       raceTimeMs: entry.finishedAtMs,
       lapTimes: entry.lapTimes.slice(),
+      dnfReason: aiStatus === "dnf" ? (entry.dnfReason ?? null) : undefined,
     });
   });
   return cars;


### PR DESCRIPTION
## Summary
- Adds optional `dnfReason: DnfReason` field on `FinalCarRecord` / `FinalCarInput`. `buildFinalRaceState` forwards it for DNF rows, `buildFinalCarInputsFromSession` reads from the live session for player + AI cars
- `FinishingOrderTable` maps every DnfReason to a friendly label ("Out of fuel", "Wrecked", "Off track", "No progress", "Retired") and renders it on a muted second line below the DNF marker; rows without a recorded reason keep the bare "DNF" cell unchanged
- Closes the F-104 four-slice fuel feature (slices 1-3 already shipped: runtime drain, HUD gauge, garage gearbox copy)

## Why
Players who DNF mid-race because the tank ran dry needed an in-game signal explaining why. Without copy on the results screen, the depletion edge looks like an arbitrary "DNF" with no path to fix it; with the reason label visible, the player connects the gearbox upgrade copy from slice 3 to the finishing order they just saw.

## Implementation notes
- Field is optional rather than required to keep blast radius small (89+ test fixtures construct `FinalCarRecord` literals; making it required would cascade across the unit suite). `?? null` reads at the boundary preserve type-safety
- No save schema change. Session-storage handoff under the existing `vibegear2:race-result:v1` key; old payloads without the field parse as `undefined` and the renderer omits the label
- Static text only; no animation, so the change is reduced-motion safe per §19
- Audio sputter on depletion deferred for a future loop; this PR ships the visible UX only

## Test plan
- [x] `pnpm typecheck`
- [x] `pnpm lint`
- [x] `pnpm vitest run` (2963 / 2963 passed across 162 suites)
- [x] `pnpm docs:check`
- [x] `pnpm content-lint`
- [ ] CI: lint, typecheck, unit, e2e

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * DNF (Did Not Finish) reasons now display on the race results screen with user-friendly labels indicating the cause of retirement (e.g., "Retired", "Out of fuel", "Wrecked")
  * Results table clearly distinguishes finished and non-finished positions with DNF labels

* **Tests**
  * Added test coverage for DNF reason display and propagation through the results pipeline

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Randroids-Dojo/VibeGear2/pull/210)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->