### PR TITLE
chore(followups): close F-104 and audit-correct F-091

### DIFF
--- a/docs/FOLLOWUPS.md
+++ b/docs/FOLLOWUPS.md
@@ -385,7 +385,18 @@ end-of-tour bonus credit is desired.
 ## F-091: AI fires nitro per archetype on straights and last-lap pushes
 **Created:** 2026-05-07
 **Priority:** nice-to-have
-**Status:** open
+**Status:** done
+**Resolved:** 2026-05-09 (audit-correction; the entry was filed against
+a stale `tickAI` snapshot. The decision module
+`src/game/aiNitroFire.ts` exists - 213 lines, four window types: launch,
+panic, straight, finish-line - and `src/game/ai.ts:480` already calls
+`decideFireNitro({ archetype, nitroUsage, nitro, seed, aiSpeed,
+topSpeed, authoredCurve, lap, totalLaps, lapFraction, playerGapMeters,
+weather })` and forwards the result onto the `Input.nitro` field at
+line 499. The 2026-05-07 audit was filed before the call site was
+wired; the actual implementation landed before the audit was logged.
+Verified by reading `src/game/ai.ts:480-499` and the
+`src/game/__tests__/aiNitroFire.test.ts` coverage.)
 **Notes:** Surfaced by the 2026-05-07 mass-appeal audit (Tier S #1).
 The full nitro plumbing exists for AI cars
 (`src/game/raceSession.ts:1454-1469` ticks `aiNitroResult` and forwards

--- a/docs/FOLLOWUPS.md
+++ b/docs/FOLLOWUPS.md
@@ -13,7 +13,8 @@ or `obsolete` so the trail is preserved.
 ## F-104: TG2-faithful fuel and gearbox economy
 **Created:** 2026-05-09
 **Priority:** nice-to-have
-**Status:** in-progress
+**Status:** done
+**Resolved:** 2026-05-09
 **Notes:** Third of the three TG2 core-loop polish slices identified
 on 2026-05-09 (alongside F-102 car-bump kick and F-103 prep-card
 tire affordance, both shipped). Goal: TG2-faithful fuel runtime so


### PR DESCRIPTION
## Summary
- Marks the F-104 followup entry \`done\` with \`Resolved: 2026-05-09\` now that slice 4 (PR #210) has merged. F-104 is the four-slice TG2-faithful fuel feature (runtime drain, HUD gauge, garage gearbox copy, results-screen DNF reason copy)
- Audit-corrects F-091 (\"AI fires nitro per archetype\") from \`open\` to \`done\`. The 2026-05-07 entry was filed against a stale snapshot; the decision module \`src/game/aiNitroFire.ts\` (213 lines, four window types: launch, panic, straight, finish-line) and the \`tickAI\` call site at \`src/game/ai.ts:480\` already forward the result onto \`Input.nitro\`. Verified against the existing \`aiNitroFire.test.ts\` suite

## Test plan
- [x] \`pnpm docs:check\` clean
- [x] \`pnpm content-lint\` clean
- [ ] CI sanity (no source changes)