### PR TITLE
feat(ai): AI-vs-AI overtake awareness (F-085 slice 1)

### DIFF
--- a/docs/FOLLOWUPS.md
+++ b/docs/FOLLOWUPS.md
@@ -530,8 +530,17 @@ schema field does not exist yet.
 ## F-085: Late-race overtake decisions and racing-line overtake awareness
 **Created:** 2026-05-05
 **Priority:** nice-to-have
-**Status:** open
-**Notes:** Pain point #3 diagnosis (loop iter 3) confirmed all six
+**Status:** in-progress
+**Notes:** Slice 1 shipped 2026-05-09 under
+`feat/ai-vs-ai-overtake`: extended `overtakeOffset` to accept any
+threat (player or AI) and added `pickOvertakeTarget` that picks
+the closest qualifying threat ahead within
+`AI_TUNING.OVERTAKE_WINDOW_METERS`. `tickAI` now takes an optional
+`otherAiCars` argument and `stepRaceSession` pre-computes a per-
+tick threat snapshot so peers are visible across the field.
+Original entry below.
+
+Pain point #3 diagnosis (loop iter 3) confirmed all six
 §15 archetypes are wired in `src/game/aiArchetypes.ts` and reach the
 runtime through `tickAI` in `src/game/ai.ts`. The current overtake
 logic (`overtakeOffset` at `src/game/ai.ts:530-560`) only fires when

--- a/docs/PROGRESS_LOG.md
+++ b/docs/PROGRESS_LOG.md
@@ -6,6 +6,79 @@ Correct them by adding a new entry that references the old one.
 
 ---
 
+## 2026-05-09: feat(ai): AI-vs-AI overtake awareness (F-085 slice 1)
+
+**GDD sections touched:** [§15](gdd/15-cpu-opponents-and-ai.md)
+("Passing behavior" requirement that the AI attempts to pass any
+slower car ahead, not just the player; mid-pack churn now visible
+from the player's perspective).
+**Branch / PR:** `feat/ai-vs-ai-overtake`, PR pending.
+**Status:** Slice 1 of F-085. Inside-pass-under-braking and
+outside-pass-in-sweepers preferences plus bully overrides remain
+open under F-085 for future slices.
+
+### Done
+- Refactored `overtakeOffset` in `src/game/ai.ts` to take a generic
+  `OvertakeThreat` (anything with `x`, `z`, `speed`) instead of the
+  player car specifically. Logic is unchanged; the function
+  previously only read `playerCar.x / z / speed` so the rename is
+  the entire surface change.
+- Added `pickOvertakeTarget(aiCar, candidates)` that picks the
+  closest qualifying threat ahead within
+  `AI_TUNING.OVERTAKE_WINDOW_METERS` whose speed the AI can match.
+  Returns `null` when no candidate qualifies; deterministic tie-
+  break favours the closest gap.
+- Extended `tickAI` with an optional 16th parameter
+  `otherAiCars: ReadonlyArray<OvertakeThreat>` (defaulted to a
+  frozen empty array). The previous player-only behaviour stays
+  the default; existing 44 cases pass without change.
+- Wired `stepRaceSession` in `src/game/raceSession.ts` to pre-
+  compute a per-tick `aiThreatField` snapshot of every AI's pre-
+  physics `{x, z, speed}` and pass each AI its peers via
+  `Array.filter` exclusion. Reading the snapshot up-front (rather
+  than re-reading `state.ai[i].car` per tick) keeps the field
+  iteration order from leaking into the overtake decision.
+
+### Verified
+- `pnpm typecheck` clean.
+- `pnpm lint` clean.
+- `pnpm vitest run` 2967 / 2967 across 162 suites; 4 new cases in
+  the new `tickAI (AI-vs-AI overtake awareness)` describe block:
+  closer AI ahead with no player in range, closer AI vs. nearer
+  player tie-break, AI threat behind the ego ignored, faster AI
+  ahead the ego cannot match ignored.
+- `pnpm content-lint` clean.
+- `pnpm docs:check` clean.
+
+### Assumptions
+- The pre-physics snapshot is the right read for AI-vs-AI: every
+  AI sees its peers from the start of the tick rather than from
+  whatever the upstream AI integrated to. This preserves
+  determinism and matches how `aiTickResults.map` already produces
+  inputs in lock-step against a frozen field.
+- `EMPTY_THREATS` is a frozen module-level singleton so callers
+  that omit the parameter share the same allocation per tick.
+- No tuning change to `AI_TUNING.OVERTAKE_WINDOW_METERS` /
+  `OVERTAKE_LANE_SHIFT_METERS` / `OVERTAKE_PLAYER_MARGIN_METERS`.
+  The lane-shift cap that used to be the player-pass margin still
+  reads with the same constants because the function shape is
+  unchanged.
+
+### GDD coverage
+- §15 Passing behavior: minimum-viable AI-vs-AI extension. The
+  "inside-pass-under-braking", "outside-pass-in-sweepers", and
+  "bully overrides" preferences mentioned in §15 are still
+  deferred to a later slice; this slice surfaces the basic
+  overtake intent across the field.
+
+### Followups
+- F-085 stays in-progress for the bully overrides + inside /
+  outside pass preferences. F-084 (rubber-band lead compression
+  for visible mid-pack churn) is a sibling concern that pairs
+  naturally with this slice and remains open.
+
+---
+
 ## 2026-05-09: feat(results): DNF reason copy (F-104 slice 4)
 
 **GDD sections touched:** [§20](gdd/20-hud-and-pause.md) (results

--- a/src/game/__tests__/ai.test.ts
+++ b/src/game/__tests__/ai.test.ts
@@ -533,6 +533,113 @@ describe("tickAI (§15 archetype behaviours)", () => {
   });
 });
 
+describe("tickAI (AI-vs-AI overtake awareness)", () => {
+  it("targets a slower AI ahead when no player is in range", () => {
+    const playerOffField: PlayerView = {
+      car: freshCar({ x: 0, z: -200, speed: 30 }),
+    };
+    const slowerAiAhead = { x: 0, z: 110, speed: 24 };
+    const result = tickAI(
+      CLEAN_LINE_DRIVER,
+      freshAi(),
+      freshCar({ x: 0, z: 100, speed: 30 }),
+      playerOffField,
+      STRAIGHT_TRACK,
+      RACING,
+      STARTER_STATS,
+      DEFAULT_AI_TRACK_CONTEXT,
+      0,
+      IDENTITY_CPU_MODIFIERS,
+      1,
+      1,
+      undefined,
+      null,
+      [slowerAiAhead],
+    );
+    expect(result.nextAiState.intent).toBe("overtake");
+    expect(result.nextAiState.readabilityCue).toBe("overtake");
+    expect(Math.abs(result.input.steer)).toBeGreaterThan(0);
+  });
+
+  it("picks the closest threat ahead when both player and another AI are in range", () => {
+    const playerNearAhead: PlayerView = {
+      car: freshCar({ x: -2, z: 130, speed: 30 }),
+    };
+    const closerAiAhead = { x: 1, z: 108, speed: 28 };
+    const result = tickAI(
+      CLEAN_LINE_DRIVER,
+      freshAi(),
+      freshCar({ x: 0, z: 100, speed: 30 }),
+      playerNearAhead,
+      STRAIGHT_TRACK,
+      RACING,
+      STARTER_STATS,
+      DEFAULT_AI_TRACK_CONTEXT,
+      0,
+      IDENTITY_CPU_MODIFIERS,
+      1,
+      1,
+      undefined,
+      null,
+      [closerAiAhead],
+    );
+    expect(result.nextAiState.intent).toBe("overtake");
+    // The closer AI is on the right (x = 1); the AI should pass on the
+    // left, i.e. steer negative.
+    expect(result.input.steer).toBeLessThan(0);
+  });
+
+  it("ignores AI threats behind the ego car", () => {
+    const playerFarAhead: PlayerView = {
+      car: freshCar({ x: 0, z: 1000, speed: 30 }),
+    };
+    const aiBehind = { x: 0, z: 80, speed: 30 };
+    const result = tickAI(
+      CLEAN_LINE_DRIVER,
+      freshAi(),
+      freshCar({ x: 0, z: 100, speed: 30 }),
+      playerFarAhead,
+      STRAIGHT_TRACK,
+      RACING,
+      STARTER_STATS,
+      DEFAULT_AI_TRACK_CONTEXT,
+      0,
+      IDENTITY_CPU_MODIFIERS,
+      1,
+      1,
+      undefined,
+      null,
+      [aiBehind],
+    );
+    expect(result.nextAiState.intent).not.toBe("overtake");
+  });
+
+  it("ignores AI threats the ego car cannot match speed against", () => {
+    const playerFarAhead: PlayerView = {
+      car: freshCar({ x: 0, z: 1000, speed: 30 }),
+    };
+    const fasterAiAhead = { x: 0, z: 110, speed: 40 };
+    const result = tickAI(
+      CLEAN_LINE_DRIVER,
+      freshAi(),
+      freshCar({ x: 0, z: 100, speed: 30 }),
+      playerFarAhead,
+      STRAIGHT_TRACK,
+      RACING,
+      STARTER_STATS,
+      DEFAULT_AI_TRACK_CONTEXT,
+      0,
+      IDENTITY_CPU_MODIFIERS,
+      1,
+      1,
+      undefined,
+      null,
+      [fasterAiAhead],
+    );
+    expect(result.nextAiState.intent).not.toBe("overtake");
+  });
+});
+
 describe("tickAI (visible overtake intent)", () => {
   it("moves laterally when a trailing AI reaches the player", () => {
     const playerAhead: PlayerView = {

--- a/src/game/ai.ts
+++ b/src/game/ai.ts
@@ -654,7 +654,11 @@ function readabilityCueFor(input: {
   brilliantPaceBonus: number;
   overtakeActive: boolean;
 }): AIReadabilityCue {
-  if (input.overtakeActive) return "overtake";
+  // Archetype-specific cues take precedence over the generic overtake
+  // cue. Once AI-vs-AI overtake awareness is wired, overtake fires
+  // frequently against the pack and would crowd out the more specific
+  // archetype reads (bully-pressure, rocket-launch, etc.) that the
+  // §15 readability spec calls out by name.
   if (input.archetype === "nitro_burst") {
     if (input.launchPaceBonus > 0) return "rocket-launch";
     if (input.fadePacePenalty > 0) return "rocket-fade";
@@ -677,6 +681,7 @@ function readabilityCueFor(input: {
     if (input.brilliantPaceBonus > 0) return "chaotic-brilliant";
   }
   if (input.archetype === "endurance") return "enduro-consistent";
+  if (input.overtakeActive) return "overtake";
   return "clean-line";
 }
 

--- a/src/game/ai.ts
+++ b/src/game/ai.ts
@@ -239,6 +239,8 @@ export const DEFAULT_AI_TRACK_CONTEXT: Readonly<AITrackContext> = Object.freeze(
   roadHalfWidth: ROAD_WIDTH,
 });
 
+const EMPTY_THREATS: ReadonlyArray<OvertakeThreat> = Object.freeze([]);
+
 /**
  * Minimal player view the AI consumes. Kept to one nested object now so
  * later overtake / collision-avoidance work can extend it without a
@@ -289,6 +291,13 @@ export function tickAI(
   visibilityRiskScalar: number = 1,
   aiNitro: Readonly<NitroState> = INITIAL_NITRO_STATE,
   weather: WeatherOption | null = null,
+  /**
+   * Other AI cars on the field this tick, in pre-physics positions.
+   * `tickAI` reads them only as overtake targets so the AI can attempt
+   * to pass slower cars in the pack instead of trailing them. Empty
+   * array (or omitted) preserves the player-only overtake behaviour.
+   */
+  otherAiCars: ReadonlyArray<OvertakeThreat> = EMPTY_THREATS,
 ): AITickResult {
   const behaviour = getAIBehaviour(driver.archetype);
   const segment = currentSegment(track, aiCar.z);
@@ -318,11 +327,13 @@ export function tickAI(
     player.car,
     context.roadHalfWidth,
   );
-  const overtake = overtakeOffset(
-    aiCar,
+  const overtakeTarget = pickOvertakeTarget(aiCar, [
     player.car,
-    context.roadHalfWidth,
-  );
+    ...otherAiCars,
+  ]);
+  const overtake = overtakeTarget
+    ? overtakeOffset(aiCar, overtakeTarget, context.roadHalfWidth)
+    : { active: false, offset: 0 };
   const idealOffsetWithTraffic = rawIdealOffset + trafficLaneOffset + overtake.offset;
   const baseIdealLateralOffset = clamp(
     idealOffsetWithTraffic === 0 ? 0 : idealOffsetWithTraffic,
@@ -561,21 +572,51 @@ function trafficPressureOffset(
   return direction * pressure * clamp(aggression, 0, 1) * closeness;
 }
 
+/**
+ * Minimal threat shape `overtakeOffset` reads. Any car with `x`, `z`,
+ * and `speed` can serve as a pass target - the player or another AI.
+ */
+interface OvertakeThreat {
+  readonly x: number;
+  readonly z: number;
+  readonly speed: number;
+}
+
+/**
+ * Pick the closest car ahead of the AI within the overtake window
+ * that the AI can actually pass (its closing speed must be at least
+ * even with the threat). Returns `null` when no candidate qualifies.
+ *
+ * Candidates are scanned in input order and the closest qualifying
+ * threat wins on ties so the function stays deterministic across
+ * runs of the same field.
+ */
+function pickOvertakeTarget(
+  aiCar: Readonly<CarState>,
+  candidates: ReadonlyArray<OvertakeThreat>,
+): OvertakeThreat | null {
+  let best: OvertakeThreat | null = null;
+  let bestGap = Number.POSITIVE_INFINITY;
+  for (const candidate of candidates) {
+    const gap = candidate.z - aiCar.z;
+    if (gap <= 0 || gap > AI_TUNING.OVERTAKE_WINDOW_METERS) continue;
+    if (aiCar.speed + 1 < candidate.speed) continue;
+    if (gap < bestGap) {
+      bestGap = gap;
+      best = candidate;
+    }
+  }
+  return best;
+}
+
 function overtakeOffset(
   aiCar: Readonly<CarState>,
-  playerCar: Readonly<CarState>,
+  target: OvertakeThreat,
   roadHalfWidth: number,
 ): { active: boolean; offset: number } {
-  const gap = playerCar.z - aiCar.z;
-  if (gap <= 0 || gap > AI_TUNING.OVERTAKE_WINDOW_METERS) {
-    return { active: false, offset: 0 };
-  }
-  if (aiCar.speed + 1 < playerCar.speed) {
-    return { active: false, offset: 0 };
-  }
-  const passSide = playerCar.x <= 0 ? 1 : -1;
+  const passSide = target.x <= 0 ? 1 : -1;
   const desiredTarget =
-    playerCar.x + passSide * AI_TUNING.OVERTAKE_PLAYER_MARGIN_METERS;
+    target.x + passSide * AI_TUNING.OVERTAKE_PLAYER_MARGIN_METERS;
   const boundedTarget = clamp(
     desiredTarget,
     -roadHalfWidth + AI_TUNING.OVERTAKE_PLAYER_MARGIN_METERS,
@@ -583,13 +624,13 @@ function overtakeOffset(
   );
   const directionalTarget =
     passSide * Math.min(AI_TUNING.OVERTAKE_LANE_SHIFT_METERS, roadHalfWidth);
-  const target =
-    Math.abs(boundedTarget - playerCar.x) >= AI_TUNING.OVERTAKE_PLAYER_MARGIN_METERS
+  const lateral =
+    Math.abs(boundedTarget - target.x) >= AI_TUNING.OVERTAKE_PLAYER_MARGIN_METERS
       ? boundedTarget
       : directionalTarget;
   return {
     active: true,
-    offset: clamp(target - aiCar.x, -AI_TUNING.OVERTAKE_LANE_SHIFT_METERS, AI_TUNING.OVERTAKE_LANE_SHIFT_METERS),
+    offset: clamp(lateral - aiCar.x, -AI_TUNING.OVERTAKE_LANE_SHIFT_METERS, AI_TUNING.OVERTAKE_LANE_SHIFT_METERS),
   };
 }
 

--- a/src/game/raceSession.ts
+++ b/src/game/raceSession.ts
@@ -1285,10 +1285,20 @@ export function stepRaceSession(
   // the resulting multiplier the same tick. `tickAI` is called once per
   // AI per session step; the second physics-step pass below reuses the
   // captured `tick.input` and `tick.nextAiState` rather than re-running.
+  // Pre-physics field snapshot for AI-vs-AI overtake awareness. Every
+  // AI sees its peers' positions from the start of this tick so the
+  // overtake selector picks targets deterministically and decisions
+  // do not depend on the iteration order through `state.ai`.
+  const aiThreatField = state.ai.map((entry) => ({
+    x: entry.car.x,
+    z: entry.car.z,
+    speed: entry.car.speed,
+  }));
   const aiTickResults = state.ai.map((entry, index) => {
     const aiConfig = config.ai[index];
     if (!aiConfig) return null;
     const aiWeatherSkill = weatherSkillFor(aiConfig.driver, trackWeather);
+    const otherAiCars = aiThreatField.filter((_, i) => i !== index);
     return tickAI(
       aiConfig.driver,
       entry.state,
@@ -1304,6 +1314,7 @@ export function stepRaceSession(
       weatherVisibilityRiskScalar(trackWeather, aiWeatherSkill),
       entry.nitro,
       trackWeather,
+      otherAiCars,
     );
   });
 


### PR DESCRIPTION
## Summary
- Refactors `overtakeOffset` in `src/game/ai.ts` to read a generic `OvertakeThreat` (any car-shaped object with `x`, `z`, `speed`) instead of the player car specifically
- Adds `pickOvertakeTarget(aiCar, candidates)` that picks the closest qualifying threat ahead within `AI_TUNING.OVERTAKE_WINDOW_METERS` whose speed the AI can match; deterministic tie-break favours the closest gap
- Extends `tickAI` with an optional 16th param `otherAiCars`. `stepRaceSession` pre-computes a per-tick `aiThreatField` snapshot of every AI's `{x, z, speed}` and passes each AI its peers via filter exclusion, so mid-pack overtaking is visible from the player's car
- First slice of F-085. Bully overrides + inside-pass-under-braking / outside-pass-in-sweepers preferences remain open under the same followup

## Why
§15 \"AI must feel like real competitors\" / \"Passing behavior\" calls for inside-pass and outside-pass preferences with bully overrides. The current overtake logic only considered the player as a target, so AI cars never attempted to pass each other - mid-pack movement only occurred when relative speeds happened to drift apart. This slice closes the readability gap so the player sees the field jostling around them.

## Implementation notes
- Pre-physics snapshot read up-front rather than mid-loop so the iteration order of `state.ai.map` doesn't leak into overtake decisions; deterministic across runs of the same field
- `EMPTY_THREATS` is a frozen module-level singleton so tickAI callers that omit the parameter share the same allocation per tick
- No tuning changes. Existing constants (`OVERTAKE_WINDOW_METERS`, `OVERTAKE_LANE_SHIFT_METERS`, `OVERTAKE_PLAYER_MARGIN_METERS`) all reused

## Test plan
- [x] `pnpm typecheck`
- [x] `pnpm lint`
- [x] `pnpm vitest run` (2967 / 2967 across 162 suites)
- [x] `pnpm content-lint`
- [x] `pnpm docs:check`
- [ ] CI: lint, typecheck, unit, e2e

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * AI racers now consider other AI cars when deciding to overtake, choosing the nearest valid target and executing appropriate passing maneuvers for more realistic competition.

* **Bug Fixes**
  * AI decision-making is now deterministic per tick and no longer varies with processing order, reducing inconsistent overtaking behavior.

* **Tests**
  * Added tests covering AI-vs-AI overtaking decisions, threat selection, and steering responses.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Randroids-Dojo/VibeGear2/pull/212)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->