### PR TITLE
feat(ai): rubber-band lead compression (F-084)

### DIFF
--- a/docs/FOLLOWUPS.md
+++ b/docs/FOLLOWUPS.md
@@ -557,8 +557,20 @@ is tightly bounded; this is the natural follow-on.
 ## F-084: AI rubber-band lead compression for visible mid-pack churn
 **Created:** 2026-05-05
 **Priority:** nice-to-have
-**Status:** open
-**Notes:** §15 "Rubber-banding philosophy" allows "small pace
+**Status:** done
+**Resolved:** 2026-05-09 (shipped under `feat/ai-rubber-band`).
+Added `fieldCompressionBonus` in `src/game/ai.ts` reading the
+`otherAiCars` snapshot already threaded through `tickAI` for
+F-085 slice 1. Constants `MAX_FIELD_COMPRESSION_PACE = 0.05` and
+`FIELD_COMPRESSION_PER_METER = 0.0003` give +/-3 % per 100 m gap
+to nearest peer ahead / behind, capped at +/-5 %, and the term
+rides the existing `cpuModifiers.recoveryScalar *
+behaviour.recoveryScalar` chain so the §23 ladder
+(`easy = 1.0`, `normal = 0.6`, `hard = 0.25`, `master = 0`)
+naturally enforces the "Easy / Normal only" gate. Original entry
+below.
+
+§15 "Rubber-banding philosophy" allows "small pace
 bonuses to keep midfield relevant" and "mild lead compression in
 easy mode". The current recovery term in `tickAI` only fires when
 the AI trails the player and is capped at +5 % pace

--- a/docs/PROGRESS_LOG.md
+++ b/docs/PROGRESS_LOG.md
@@ -6,6 +6,76 @@ Correct them by adding a new entry that references the old one.
 
 ---
 
+## 2026-05-09: feat(ai): rubber-band lead compression (F-084)
+
+**GDD sections touched:** [§15](gdd/15-cpu-opponents-and-ai.md)
+("Rubber-banding philosophy" - "small pace bonuses to keep midfield
+relevant" + "mild lead compression in easy mode"; tier gating via
+the existing `recoveryScalar` row from §23 so Hard / Master keep
+the "minimal / none" rubber-band).
+**Branch / PR:** `feat/ai-rubber-band`, PR pending.
+**Status:** Closes F-084. Pairs with F-085 slice 1 (AI-vs-AI
+overtake awareness, shipped earlier today): the overtake intent
+only matters when the field stays close enough to pass, and this
+slice keeps the field that close.
+
+### Done
+- Added two `AI_TUNING` constants in `src/game/ai.ts`:
+  `MAX_FIELD_COMPRESSION_PACE = 0.05` (cap +/-5 %) and
+  `FIELD_COMPRESSION_PER_METER = 0.0003` (3 % per 100 m).
+- Added `fieldCompressionBonus(aiCar, otherAiCars)`. Returns a
+  signed pace bonus before the §23 `recoveryScalar` row scales it:
+  positive lifts a trailing AI toward the pack, negative pulls a
+  runaway leader back. Both ends are computed independently and
+  summed so a mid-pack AI cancels out and the field stays
+  compressed around the median.
+- Wired `fieldCompressionPaceBonus` into `tickAI` next to the
+  existing `recoveryPaceBonus`. The composed pace target reads
+  `(1 + recoveryPaceBonus + fieldCompressionPaceBonus)`. Both
+  scale by `cpuModifiers.recoveryScalar * behaviour.recoveryScalar`
+  so the §23 difficulty ladder (`easy = 1.0`, `normal = 0.6`,
+  `hard = 0.25`, `master = 0`) gates compression as the followup
+  spec required without a separate hard/easy branch in the AI tick.
+
+### Verified
+- `pnpm typecheck` clean.
+- `pnpm lint` clean.
+- `pnpm vitest run` 2971 / 2971 across 162 suites; 4 new cases in
+  the new `tickAI (field compression)` describe block: identity
+  throttle with no peers, trailing-AI lift toward a peer ahead,
+  leading-AI penalty with peers behind, Master tier (recoveryScalar
+  = 0) collapses the entire term.
+- `pnpm content-lint` clean.
+- `pnpm docs:check` clean.
+
+### Assumptions
+- The compression term reuses `otherAiCars` already threaded
+  through `tickAI` for F-085 slice 1, so this slice does not
+  extend the function signature again. The pre-physics field
+  snapshot in `stepRaceSession` is the correct read for both
+  features.
+- Reusing `recoveryScalar` rather than introducing a new
+  `compressionScalar` keeps the §23 ladder authoritative. The
+  followup spec ("Easy / Normal only; Hard / Master keep the
+  minimal / none rubber-band") matches the `recoveryScalar`
+  values 1.0 / 0.6 / 0.25 / 0 already in `aiDifficulty.ts`.
+- The leader penalty is symmetric with the trailer bonus
+  (signed sum of two clamped legs). A leader with a peer 100 m
+  behind sees a -3 % cap; a trailer with a peer 100 m ahead
+  sees +3 %. A mid-pack AI with peers on both sides cancels.
+
+### GDD coverage
+- §15 Rubber-banding philosophy: covered by this slice. Tier
+  gating via §23 `recoveryScalar` resolves the "easy mode only"
+  qualifier without a separate code path.
+
+### Followups
+- F-084 closes with this slice.
+- F-085 stays in-progress for the bully overrides + inside /
+  outside pass preferences from the original §15 spec.
+
+---
+
 ## 2026-05-09: feat(ai): AI-vs-AI overtake awareness (F-085 slice 1)
 
 **GDD sections touched:** [§15](gdd/15-cpu-opponents-and-ai.md)

--- a/src/game/__tests__/ai.test.ts
+++ b/src/game/__tests__/ai.test.ts
@@ -533,6 +533,149 @@ describe("tickAI (§15 archetype behaviours)", () => {
   });
 });
 
+describe("tickAI (field compression)", () => {
+  // Helper: drive the same AI under two different peer-field setups
+  // and read the requested target speed via the throttle / brake
+  // proxy. The first call has no peers (baseline), the second has
+  // peers ahead so the compression term should lift the pace.
+  function targetSpeedWithPeers(
+    peers: ReadonlyArray<{ x: number; z: number; speed: number }>,
+  ): number {
+    const result = tickAI(
+      CLEAN_LINE_DRIVER,
+      freshAi(),
+      freshCar({ x: 0, z: 100, speed: STARTER_STATS.topSpeed * 0.5 }),
+      { car: freshCar({ x: 0, z: -50, speed: STARTER_STATS.topSpeed }) },
+      STRAIGHT_TRACK,
+      RACING,
+      STARTER_STATS,
+      DEFAULT_AI_TRACK_CONTEXT,
+      0,
+      IDENTITY_CPU_MODIFIERS,
+      1,
+      1,
+      undefined,
+      null,
+      peers,
+    );
+    return result.input.throttle;
+  }
+
+  it("returns identity throttle when no peers are around (no compression)", () => {
+    expect(targetSpeedWithPeers([])).toBeCloseTo(1, 5);
+  });
+
+  it("a trailing AI with a peer ahead targets a higher speed than the same AI alone", () => {
+    const baseline = tickAI(
+      CLEAN_LINE_DRIVER,
+      freshAi(),
+      freshCar({ x: 0, z: 100, speed: STARTER_STATS.topSpeed * 0.99 }),
+      { car: freshCar({ x: 0, z: -50, speed: STARTER_STATS.topSpeed }) },
+      STRAIGHT_TRACK,
+      RACING,
+      STARTER_STATS,
+      DEFAULT_AI_TRACK_CONTEXT,
+    );
+    const compressed = tickAI(
+      CLEAN_LINE_DRIVER,
+      freshAi(),
+      freshCar({ x: 0, z: 100, speed: STARTER_STATS.topSpeed * 0.99 }),
+      { car: freshCar({ x: 0, z: -50, speed: STARTER_STATS.topSpeed }) },
+      STRAIGHT_TRACK,
+      RACING,
+      STARTER_STATS,
+      DEFAULT_AI_TRACK_CONTEXT,
+      0,
+      IDENTITY_CPU_MODIFIERS,
+      1,
+      1,
+      undefined,
+      null,
+      // Peer 200 m ahead: 200 * 0.0003 = 0.06, capped at 0.05.
+      [{ x: 1, z: 300, speed: STARTER_STATS.topSpeed }],
+    );
+    // The trailing AI now targets a higher speed, so throttle stays
+    // pinned where the baseline already reached the hysteresis band.
+    expect(compressed.input.throttle).toBeGreaterThanOrEqual(
+      baseline.input.throttle,
+    );
+    // The behind-only ai state's compression bonus is positive, so
+    // intent / cue stay benign (no overtake target inside window).
+    expect(compressed.nextAiState.intent).not.toBe("overtake");
+  });
+
+  it("a leading AI with peers behind takes a pace penalty", () => {
+    const result = tickAI(
+      CLEAN_LINE_DRIVER,
+      freshAi(),
+      freshCar({ x: 0, z: 1000, speed: STARTER_STATS.topSpeed }),
+      { car: freshCar({ x: 0, z: -50, speed: STARTER_STATS.topSpeed }) },
+      STRAIGHT_TRACK,
+      RACING,
+      STARTER_STATS,
+      DEFAULT_AI_TRACK_CONTEXT,
+      0,
+      IDENTITY_CPU_MODIFIERS,
+      1,
+      1,
+      undefined,
+      null,
+      // Two peers behind, the closest 200 m back. The leader gets a
+      // -5 % cap on the compression term.
+      [
+        { x: 1, z: 800, speed: STARTER_STATS.topSpeed },
+        { x: -1, z: 600, speed: STARTER_STATS.topSpeed },
+      ],
+    );
+    // At top speed with a -5 % target, the AI should not be at full
+    // throttle: hysteresis band kicks in below the target.
+    expect(result.input.throttle).toBeLessThan(1);
+  });
+
+  it("Master tier (recoveryScalar = 0) flattens the compression entirely", () => {
+    const masterModifiers = {
+      paceScalar: 1.09,
+      recoveryScalar: 0,
+      mistakeScalar: 0.45,
+    } as const;
+    const withPeers = tickAI(
+      CLEAN_LINE_DRIVER,
+      freshAi(),
+      freshCar({ x: 0, z: 100, speed: STARTER_STATS.topSpeed * 0.5 }),
+      { car: freshCar({ x: 0, z: -50, speed: STARTER_STATS.topSpeed }) },
+      STRAIGHT_TRACK,
+      RACING,
+      STARTER_STATS,
+      DEFAULT_AI_TRACK_CONTEXT,
+      0,
+      masterModifiers,
+      1,
+      1,
+      undefined,
+      null,
+      [{ x: 1, z: 300, speed: STARTER_STATS.topSpeed }],
+    );
+    const noPeers = tickAI(
+      CLEAN_LINE_DRIVER,
+      freshAi(),
+      freshCar({ x: 0, z: 100, speed: STARTER_STATS.topSpeed * 0.5 }),
+      { car: freshCar({ x: 0, z: -50, speed: STARTER_STATS.topSpeed }) },
+      STRAIGHT_TRACK,
+      RACING,
+      STARTER_STATS,
+      DEFAULT_AI_TRACK_CONTEXT,
+      0,
+      masterModifiers,
+      1,
+      1,
+    );
+    // Master forces recoveryScalar = 0, so the field-compression
+    // bonus collapses to 0 and both calls produce identical outputs.
+    expect(withPeers.input.throttle).toBeCloseTo(noPeers.input.throttle, 5);
+    expect(withPeers.input.brake).toBeCloseTo(noPeers.input.brake, 5);
+  });
+});
+
 describe("tickAI (AI-vs-AI overtake awareness)", () => {
   it("targets a slower AI ahead when no player is in range", () => {
     const playerOffField: PlayerView = {

--- a/src/game/ai.ts
+++ b/src/game/ai.ts
@@ -211,6 +211,21 @@ export const AI_TUNING = Object.freeze({
   MAX_RECOVERY_PACE_BONUS: 0.05,
   /** Player gap, in meters, that reaches the maximum recovery term. */
   RECOVERY_GAP_FOR_MAX_BONUS: 240,
+  /**
+   * Inter-AI rubber-band compression cap before the §23
+   * `recoveryScalar` row is applied. A trailing AI gets up to +5 %
+   * pace toward the nearest peer ahead; a leading AI gets up to -5 %
+   * toward the nearest peer behind. Easy / Normal scale this to keep
+   * the §15 mid-pack churn observable; Hard / Master flatten it via
+   * `recoveryScalar = 0.25 / 0`.
+   */
+  MAX_FIELD_COMPRESSION_PACE: 0.05,
+  /**
+   * Per-meter scale on the inter-AI compression. The followup spec
+   * is `+/-3 % per 100 m`; the term is clamped at
+   * `MAX_FIELD_COMPRESSION_PACE`.
+   */
+  FIELD_COMPRESSION_PER_METER: 0.0003,
   /** Lap fraction where rocket starter launch boost stops applying. */
   ROCKET_LAUNCH_FRACTION: 0.18,
   /** Lap fraction where rocket starter late fade starts applying. */
@@ -382,6 +397,10 @@ export function tickAI(
     AI_TUNING.MAX_RECOVERY_PACE_BONUS *
     cpuModifiers.recoveryScalar *
     behaviour.recoveryScalar;
+  const fieldCompressionPaceBonus =
+    fieldCompressionBonus(aiCar, otherAiCars) *
+    cpuModifiers.recoveryScalar *
+    behaviour.recoveryScalar;
 
   // Target speed per segment. §15 "AI chooses a lane offset target" plus
   // a per-driver `paceScalar` from §22 maps onto a curve-aware target
@@ -424,7 +443,7 @@ export function tickAI(
     stats.topSpeed *
     Math.max(0, curvePenalty) *
     composedPaceScalar *
-    (1 + recoveryPaceBonus);
+    (1 + recoveryPaceBonus + fieldCompressionPaceBonus);
   const targetSpeed = clamp(rawTarget, AI_TUNING.MIN_AI_SPEED, stats.topSpeed);
 
   // The state we will return regardless of phase. Mirrors the car so
@@ -550,6 +569,47 @@ function lapFraction(totalLength: number, z: number): number {
   if (!Number.isFinite(totalLength) || totalLength <= 0) return 0;
   const normalized = ((z % totalLength) + totalLength) % totalLength;
   return clamp(normalized / totalLength, 0, 1);
+}
+
+/**
+ * Inter-AI lead compression. Returns a signed pace bonus before the
+ * §23 `recoveryScalar` row scales it: positive pulls a trailing AI
+ * toward the pack, negative pulls a runaway leader back. The signed
+ * gap to the closest peer ahead and the closest peer behind are
+ * scaled by `FIELD_COMPRESSION_PER_METER` and clamped at
+ * `MAX_FIELD_COMPRESSION_PACE`.
+ *
+ * Both ends are computed independently and summed so a mid-pack AI
+ * with peers on both sides cancels out (the field stays compressed
+ * around the median rather than collapsing to a point).
+ */
+function fieldCompressionBonus(
+  aiCar: Readonly<CarState>,
+  otherAiCars: ReadonlyArray<OvertakeThreat>,
+): number {
+  if (otherAiCars.length === 0) return 0;
+  let nearestAheadGap = Number.POSITIVE_INFINITY;
+  let nearestBehindGap = Number.POSITIVE_INFINITY;
+  for (const peer of otherAiCars) {
+    const gap = peer.z - aiCar.z;
+    if (gap > 0 && gap < nearestAheadGap) nearestAheadGap = gap;
+    else if (gap < 0 && -gap < nearestBehindGap) nearestBehindGap = -gap;
+  }
+  const aheadBonus = Number.isFinite(nearestAheadGap)
+    ? clamp(
+        nearestAheadGap * AI_TUNING.FIELD_COMPRESSION_PER_METER,
+        0,
+        AI_TUNING.MAX_FIELD_COMPRESSION_PACE,
+      )
+    : 0;
+  const leaderPenalty = Number.isFinite(nearestBehindGap)
+    ? clamp(
+        nearestBehindGap * AI_TUNING.FIELD_COMPRESSION_PER_METER,
+        0,
+        AI_TUNING.MAX_FIELD_COMPRESSION_PACE,
+      )
+    : 0;
+  return aheadBonus - leaderPenalty;
 }
 
 function trafficPressureOffset(


### PR DESCRIPTION
## Summary
- Adds \`fieldCompressionBonus\` in \`src/game/ai.ts\`: each AI's pace target gets a signed bonus from its gap to the nearest peer ahead and the nearest peer behind, capped at +/-5 % at 3 % per 100 m
- Reuses the \`otherAiCars\` snapshot already threaded through \`tickAI\` for F-085 slice 1; no signature change
- Term rides \`cpuModifiers.recoveryScalar * behaviour.recoveryScalar\`, so the existing §23 difficulty ladder (\`easy = 1.0\`, \`normal = 0.6\`, \`hard = 0.25\`, \`master = 0\`) gates compression without a separate code path
- Closes F-084. Pairs with F-085 slice 1 (AI-vs-AI overtake awareness): the overtake intent only matters when the field stays close enough to pass

## Why
The §15 \"rubber-banding philosophy\" allows mild lead compression in easy mode so the player can SEE the leader at midpoint of a 3-lap race. Without it, a Hard or Master grid stretches out and the field becomes invisible from the player's car. With this slice, Easy and Normal grids stay compressed enough for mid-pack churn to be visible.

## Implementation notes
- Mid-pack AI with peers on both sides cancels out (signed sum of two clamped legs), so the field compresses around the median rather than collapsing to a point
- Leader penalty is symmetric with the trailer bonus
- Master tier flattens the term entirely via \`recoveryScalar = 0\`; tested directly

## Test plan
- [x] \`pnpm typecheck\`
- [x] \`pnpm lint\`
- [x] \`pnpm vitest run\` (2971 / 2971 across 162 suites; 4 new cases in \`tickAI (field compression)\`)
- [x] \`pnpm content-lint\`
- [x] \`pnpm docs:check\`
- [ ] CI: lint, typecheck, unit, e2e

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * AI cars now dynamically adjust pacing based on proximity to other AI competitors, creating more responsive and competitive racing behavior.

* **Tests**
  * Added comprehensive test coverage for AI pacing adjustments across various competitive racing scenarios.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Randroids-Dojo/VibeGear2/pull/213)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->