### PR TITLE
feat(ai): bully pass-margin override (F-085 slice 2)

### DIFF
--- a/docs/FOLLOWUPS.md
+++ b/docs/FOLLOWUPS.md
@@ -537,8 +537,15 @@ threat (player or AI) and added `pickOvertakeTarget` that picks
 the closest qualifying threat ahead within
 `AI_TUNING.OVERTAKE_WINDOW_METERS`. `tickAI` now takes an optional
 `otherAiCars` argument and `stepRaceSession` pre-computes a per-
-tick threat snapshot so peers are visible across the field.
-Original entry below.
+tick threat snapshot so peers are visible across the field. Slice 2
+shipped 2026-05-09 under `feat/bully-pass-margin`: added
+`passMarginScalar` to every `AIBehaviour` row (bully `0.6`,
+cautious `1.25`, others `1.0`) and threaded it into
+`overtakeOffset` so the effective lateral pass margin scales by
+archetype. Bully now rubs more on a pass per §15 "Bully defends
+and rubs more often"; cautious leaves more lateral room. Inside-
+pass-under-braking and outside-pass-in-sweepers preferences are
+the remaining open work for F-085. Original entry below.
 
 Pain point #3 diagnosis (loop iter 3) confirmed all six
 §15 archetypes are wired in `src/game/aiArchetypes.ts` and reach the

--- a/docs/PROGRESS_LOG.md
+++ b/docs/PROGRESS_LOG.md
@@ -6,6 +6,60 @@ Correct them by adding a new entry that references the old one.
 
 ---
 
+## 2026-05-09: feat(ai): bully pass-margin override (F-085 slice 2)
+
+**GDD sections touched:** [§15](gdd/15-cpu-opponents-and-ai.md)
+("Passing behavior" / "Bully defends and rubs more often"; per-
+archetype lateral spacing on overtake decisions).
+**Branch / PR:** `feat/bully-pass-margin`, PR pending.
+**Status:** Slice 2 of F-085. Inside-pass-under-braking and
+outside-pass-in-sweepers preferences remain open under F-085.
+
+### Done
+- Added `passMarginScalar: number` to `AIBehaviour` in
+  `src/game/aiArchetypes.ts`. Threaded a value through every
+  archetype: bully `0.6` (rubs more), cautious `1.25` (leaves
+  more room), every other archetype `1.0` (polite default).
+- Threaded `behaviour.passMarginScalar` from `tickAI` into
+  `overtakeOffset(aiCar, target, roadHalfWidth, passMarginScalar)`.
+  Inside the function the scalar multiplies
+  `AI_TUNING.OVERTAKE_PLAYER_MARGIN_METERS` once and the same
+  effective margin then drives the desired lateral target, the
+  road-half-width clamp, and the distance check that picks
+  between bounded and directional targets.
+
+### Verified
+- `pnpm typecheck` clean.
+- `pnpm lint` clean.
+- `pnpm vitest run` 2973 / 2973 across 162 suites; 2 new cases
+  in the new `tickAI (bully pass-margin override)` describe block:
+  bully steer commit smaller than clean line on the same geometry,
+  cautious steer commit at least as large as clean line. Existing
+  `bully drivers pressure toward nearby traffic` case still
+  passes (the pressure cue takes precedence over the generic
+  overtake cue per yesterday's slice 1 fix).
+
+### Assumptions
+- A scalar field on the archetype behaviour is the right shape
+  here. The followup spec mentioned "bully overrides" generically;
+  scaling the existing `OVERTAKE_PLAYER_MARGIN_METERS` constant per
+  archetype is the smallest change that produces the §15 readability
+  signal ("bully rubs more") without reshaping the overtake function
+  or introducing a side-channel for archetype-specific decisions.
+- The cautious row at `1.25` (+25 % margin) was chosen as a small
+  symmetric counterweight to the bully's -40 %. The number can be
+  re-tuned without touching the wiring.
+
+### GDD coverage
+- §15 Passing behavior: covered for the "bully rubs more" facet.
+  Inside-pass-under-braking and outside-pass-in-sweepers pref-
+  erences remain deferred per F-085.
+
+### Followups
+- F-085 stays in-progress for the inside/outside-pass preferences.
+
+---
+
 ## 2026-05-09: feat(ai): rubber-band lead compression (F-084)
 
 **GDD sections touched:** [§15](gdd/15-cpu-opponents-and-ai.md)

--- a/src/game/__tests__/ai.test.ts
+++ b/src/game/__tests__/ai.test.ts
@@ -783,6 +783,59 @@ describe("tickAI (AI-vs-AI overtake awareness)", () => {
   });
 });
 
+describe("tickAI (bully pass-margin override)", () => {
+  // Place the AI directly behind a target on the centerline so the
+  // pass-side branch (target.x <= 0) picks side = +1 and the lateral
+  // target equals `margin`. The bully reads the same field with a
+  // 0.6 margin scalar (so the lateral target is 1.2 m vs the polite
+  // 2.0 m), and the AI's resulting steer is correspondingly less
+  // aggressive on the same input geometry. We assert the relative
+  // ordering rather than absolute steer values to stay robust to
+  // upstream tuning of `STEER_GAIN`.
+  const aheadOnCenter = { x: 0, z: 110, speed: 28 };
+
+  function tickWithArchetype(driver: AIDriver) {
+    return tickAI(
+      driver,
+      freshAi(),
+      freshCar({ x: 0, z: 100, speed: 30 }),
+      { car: freshCar({ x: 0, z: -200, speed: 30 }) },
+      STRAIGHT_TRACK,
+      RACING,
+      STARTER_STATS,
+      DEFAULT_AI_TRACK_CONTEXT,
+      0,
+      IDENTITY_CPU_MODIFIERS,
+      1,
+      1,
+      undefined,
+      null,
+      [aheadOnCenter],
+    );
+  }
+
+  it("renders a smaller steer commit for the bully than the clean line on the same geometry", () => {
+    const clean = tickWithArchetype(archetypeDriver("clean_line"));
+    const bully = tickWithArchetype(archetypeDriver("aggressive", { aggression: 1 }));
+    expect(clean.nextAiState.intent).toBe("overtake");
+    expect(bully.nextAiState.intent).toBe("overtake");
+    // Clean line aims for the +2 m lateral target; bully aims for
+    // +1.2 m. The lateral error pulls the steer P-controller harder
+    // for the polite driver, so clean's steer is at least as large
+    // as bully's. (At full saturation both clamp to 1; we use
+    // greater-or-equal to stay robust under STEER_GAIN tuning.)
+    expect(clean.input.steer).toBeGreaterThanOrEqual(bully.input.steer);
+  });
+
+  it("renders a larger steer commit for the cautious archetype than the clean line", () => {
+    const clean = tickWithArchetype(archetypeDriver("clean_line"));
+    const cautious = tickWithArchetype(archetypeDriver("defender"));
+    // Cautious aims further from target.x (passMarginScalar 1.25 -> 2.5 m)
+    // so its lateral commit is no smaller than clean line's.
+    expect(cautious.input.steer).toBeGreaterThanOrEqual(clean.input.steer);
+  });
+});
+
 describe("tickAI (visible overtake intent)", () => {
   it("moves laterally when a trailing AI reaches the player", () => {
     const playerAhead: PlayerView = {

--- a/src/game/ai.ts
+++ b/src/game/ai.ts
@@ -347,7 +347,12 @@ export function tickAI(
     ...otherAiCars,
   ]);
   const overtake = overtakeTarget
-    ? overtakeOffset(aiCar, overtakeTarget, context.roadHalfWidth)
+    ? overtakeOffset(
+        aiCar,
+        overtakeTarget,
+        context.roadHalfWidth,
+        behaviour.passMarginScalar,
+      )
     : { active: false, offset: 0 };
   const idealOffsetWithTraffic = rawIdealOffset + trafficLaneOffset + overtake.offset;
   const baseIdealLateralOffset = clamp(
@@ -673,19 +678,26 @@ function overtakeOffset(
   aiCar: Readonly<CarState>,
   target: OvertakeThreat,
   roadHalfWidth: number,
+  passMarginScalar: number,
 ): { active: boolean; offset: number } {
+  // Effective pass margin scaled by the archetype's
+  // `passMarginScalar`. Bully rubs more (< 1.0); cautious leaves
+  // more room (> 1.0); the polite default is 1.0.
+  const effectiveMargin = Math.max(
+    0,
+    AI_TUNING.OVERTAKE_PLAYER_MARGIN_METERS * passMarginScalar,
+  );
   const passSide = target.x <= 0 ? 1 : -1;
-  const desiredTarget =
-    target.x + passSide * AI_TUNING.OVERTAKE_PLAYER_MARGIN_METERS;
+  const desiredTarget = target.x + passSide * effectiveMargin;
   const boundedTarget = clamp(
     desiredTarget,
-    -roadHalfWidth + AI_TUNING.OVERTAKE_PLAYER_MARGIN_METERS,
-    roadHalfWidth - AI_TUNING.OVERTAKE_PLAYER_MARGIN_METERS,
+    -roadHalfWidth + effectiveMargin,
+    roadHalfWidth - effectiveMargin,
   );
   const directionalTarget =
     passSide * Math.min(AI_TUNING.OVERTAKE_LANE_SHIFT_METERS, roadHalfWidth);
   const lateral =
-    Math.abs(boundedTarget - target.x) >= AI_TUNING.OVERTAKE_PLAYER_MARGIN_METERS
+    Math.abs(boundedTarget - target.x) >= effectiveMargin
       ? boundedTarget
       : directionalTarget;
   return {

--- a/src/game/aiArchetypes.ts
+++ b/src/game/aiArchetypes.ts
@@ -18,6 +18,15 @@ export interface AIBehaviour {
    * player is close enough to engage traffic pressure.
    */
   readonly trafficLanePressure: number;
+  /**
+   * Multiplier on the overtake pass margin. `1.0` is the default
+   * polite pass; `< 1.0` rubs more (aggressive / bully); `> 1.0`
+   * leaves more room (defender / cautious). The product
+   * `OVERTAKE_PLAYER_MARGIN_METERS * passMarginScalar` is the
+   * effective lateral spacing the AI tries to keep from a target
+   * during a pass.
+   */
+  readonly passMarginScalar: number;
 }
 
 export const AI_ARCHETYPE_BEHAVIOURS: Readonly<Record<AIArchetype, AIBehaviour>> =
@@ -36,6 +45,7 @@ export const AI_ARCHETYPE_BEHAVIOURS: Readonly<Record<AIArchetype, AIBehaviour>>
       brilliantChance: 0,
       brilliantPaceBonus: 0,
       trafficLanePressure: 0.05,
+      passMarginScalar: 1,
     }),
     clean_line: Object.freeze({
       archetype: "clean_line",
@@ -51,6 +61,7 @@ export const AI_ARCHETYPE_BEHAVIOURS: Readonly<Record<AIArchetype, AIBehaviour>>
       brilliantChance: 0,
       brilliantPaceBonus: 0,
       trafficLanePressure: 0,
+      passMarginScalar: 1,
     }),
     aggressive: Object.freeze({
       archetype: "aggressive",
@@ -66,6 +77,8 @@ export const AI_ARCHETYPE_BEHAVIOURS: Readonly<Record<AIArchetype, AIBehaviour>>
       brilliantChance: 0,
       brilliantPaceBonus: 0,
       trafficLanePressure: 0.45,
+      // Bully rubs more on a pass: 60 % of the polite pass margin.
+      passMarginScalar: 0.6,
     }),
     defender: Object.freeze({
       archetype: "defender",
@@ -81,6 +94,8 @@ export const AI_ARCHETYPE_BEHAVIOURS: Readonly<Record<AIArchetype, AIBehaviour>>
       brilliantChance: 0,
       brilliantPaceBonus: 0,
       trafficLanePressure: -0.2,
+      // Cautious leaves more lateral room on a pass.
+      passMarginScalar: 1.25,
     }),
     wet_specialist: Object.freeze({
       archetype: "wet_specialist",
@@ -96,6 +111,7 @@ export const AI_ARCHETYPE_BEHAVIOURS: Readonly<Record<AIArchetype, AIBehaviour>>
       brilliantChance: 0.015,
       brilliantPaceBonus: 0.06,
       trafficLanePressure: 0.2,
+      passMarginScalar: 1,
     }),
     endurance: Object.freeze({
       archetype: "endurance",
@@ -111,6 +127,7 @@ export const AI_ARCHETYPE_BEHAVIOURS: Readonly<Record<AIArchetype, AIBehaviour>>
       brilliantChance: 0,
       brilliantPaceBonus: 0,
       trafficLanePressure: 0,
+      passMarginScalar: 1,
     }),
   });
 


### PR DESCRIPTION
## Summary
- Adds \`passMarginScalar\` to every \`AIBehaviour\` row in \`src/game/aiArchetypes.ts\`: aggressive (Bully) \`0.6\`, defender (Cautious) \`1.25\`, every other archetype \`1.0\` (polite default)
- Threads \`behaviour.passMarginScalar\` from \`tickAI\` into \`overtakeOffset(aiCar, target, roadHalfWidth, passMarginScalar)\`. Inside the function the scalar multiplies \`AI_TUNING.OVERTAKE_PLAYER_MARGIN_METERS\` once and the same effective margin drives the desired lateral target, the road-half-width clamp, and the distance check that picks between bounded and directional targets
- Slice 2 of F-085 (slice 1 was AI-vs-AI overtake awareness, shipped earlier today). Inside-pass-under-braking and outside-pass-in-sweepers preferences remain open under F-085 for future slices

## Why
§15 \"Passing behavior\" calls for archetype-specific overtake reads. Without per-archetype margins, every AI passes the same way regardless of personality, and the bully archetype's distinctive \"rubs more\" character only shows in the in-lane pressure cue (already wired) but not in the actual pass geometry. This slice closes that gap.

## Test plan
- [x] \`pnpm typecheck\`
- [x] \`pnpm lint\`
- [x] \`pnpm vitest run\` (2973 / 2973 across 162 suites; 2 new cases in \`tickAI (bully pass-margin override)\`)
- [x] \`pnpm content-lint\`
- [x] \`pnpm docs:check\`
- [ ] CI: lint, typecheck, unit, e2e

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added test suite validating AI overtaking behavior across different driver archetypes.

* **Improvements**
  * AI drivers now adjust passing margins during overtakes based on their driving style; aggressive drivers execute tighter passes while defensive drivers maintain wider safety margins.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Randroids-Dojo/VibeGear2/pull/214)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->