### PR TITLE
feat(ai): context-aware pass side (F-085 slice 3)

### DIFF
--- a/docs/FOLLOWUPS.md
+++ b/docs/FOLLOWUPS.md
@@ -530,7 +530,8 @@ schema field does not exist yet.
 ## F-085: Late-race overtake decisions and racing-line overtake awareness
 **Created:** 2026-05-05
 **Priority:** nice-to-have
-**Status:** in-progress
+**Status:** done
+**Resolved:** 2026-05-09
 **Notes:** Slice 1 shipped 2026-05-09 under
 `feat/ai-vs-ai-overtake`: extended `overtakeOffset` to accept any
 threat (player or AI) and added `pickOvertakeTarget` that picks
@@ -543,9 +544,16 @@ shipped 2026-05-09 under `feat/bully-pass-margin`: added
 cautious `1.25`, others `1.0`) and threaded it into
 `overtakeOffset` so the effective lateral pass margin scales by
 archetype. Bully now rubs more on a pass per §15 "Bully defends
-and rubs more often"; cautious leaves more lateral room. Inside-
-pass-under-braking and outside-pass-in-sweepers preferences are
-the remaining open work for F-085. Original entry below.
+and rubs more often"; cautious leaves more lateral room. Slice 3
+shipped 2026-05-09 under `feat/context-pass-side` and closes the
+followup: added `prefersContextPasses` to `AIBehaviour` (bully
+`false`, others `true`) plus
+`OVERTAKE_BRAKING_CURVE_THRESHOLD = 0.4` /
+`OVERTAKE_SWEEPER_CURVE_THRESHOLD = 0.1` tuning, and a
+`pickOvertakePassSide(target, authoredCurve)` helper. Tight curves
+select inside-pass; sweepers select outside-pass; below the
+sweeper threshold and for the bully archetype the routine falls
+through to the easier-pass rule. Original entry below.
 
 Pain point #3 diagnosis (loop iter 3) confirmed all six
 §15 archetypes are wired in `src/game/aiArchetypes.ts` and reach the

--- a/docs/PROGRESS_LOG.md
+++ b/docs/PROGRESS_LOG.md
@@ -6,6 +6,83 @@ Correct them by adding a new entry that references the old one.
 
 ---
 
+## 2026-05-09: feat(ai): context-aware pass side (F-085 slice 3)
+
+**GDD sections touched:** [§15](gdd/15-cpu-opponents-and-ai.md)
+("Passing behavior" - inside-pass-under-braking and outside-pass-
+in-sweepers preferences with a bully override that ignores
+convention).
+**Branch / PR:** `feat/context-pass-side`, PR pending.
+**Status:** Closes F-085. Final slice of the AI overtake-awareness
+trio shipped today (slice 1 AI-vs-AI overtake awareness, slice 2
+bully pass-margin override, slice 3 context-aware pass side).
+
+### Done
+- Added `prefersContextPasses: boolean` to `AIBehaviour` in
+  `src/game/aiArchetypes.ts`. The aggressive (Bully) row reads
+  `false`; every other row reads `true`. Bully ignores §15
+  passing convention per spec.
+- Added two `AI_TUNING` thresholds in `src/game/ai.ts`:
+  `OVERTAKE_BRAKING_CURVE_THRESHOLD = 0.4` (above this magnitude,
+  treat segment as a tight curve / braking zone and prefer the
+  inside line) and `OVERTAKE_SWEEPER_CURVE_THRESHOLD = 0.1` (above
+  this and below the braking threshold, treat as a sweeper and
+  prefer the outside line).
+- Added `pickOvertakePassSide(target, authoredCurve)` helper.
+  Inside-pass picks `sign(curve)` so a right-hander selects the
+  right side (the inside line is shorter); outside-pass picks
+  `-sign(curve)` so the AI swings wide and uses the natural arc.
+  Below the sweeper threshold the helper falls through to the
+  easier-pass rule (`target.x <= 0 ? 1 : -1`).
+- Threaded `behaviour.prefersContextPasses ? authoredCurve : 0`
+  from `tickAI` into `overtakeOffset(..., authoredCurve)` so the
+  bully archetype always passes `0` and falls through to the
+  easier-pass rule, while every other archetype reads the live
+  authored curve under the AI on this tick.
+
+### Verified
+- `pnpm typecheck` clean.
+- `pnpm lint` clean.
+- `pnpm vitest run` 2977 / 2977 across 162 suites; 4 new cases
+  in the new `tickAI (context-aware pass side)` describe block:
+  outside-pass on right sweeper, bully ignores convention on
+  same right sweeper (ordering vs clean line), inside-pass on
+  tight left, easier-pass fallback on a straight.
+- `pnpm content-lint` clean.
+- `pnpm docs:check` clean.
+
+### Assumptions
+- The two thresholds at `0.4` and `0.1` were chosen against the
+  authored cornering values across the 35 track JSONs:
+  `TrackSegmentSchema` keeps `curve` in `[-1, 1]`, real authored
+  curves cluster around `0.2 - 0.5` for sweepers and corners,
+  and `0.4` selects the upper band that drivers reliably brake
+  for.
+- Below the sweeper threshold (effectively straight), the
+  easier-pass rule still fires. This preserves the previous
+  behaviour for the straight-line overtake case shipped in slice
+  1, so the existing four `tickAI (AI-vs-AI overtake awareness)`
+  cases (which use `STRAIGHT_TRACK`) all pass without change.
+- The bully gate is implemented at the call site
+  (`prefersContextPasses ? authoredCurve : 0`) rather than inside
+  `pickOvertakePassSide`. This keeps the helper pure - it reads
+  one input and returns one output without an archetype branch -
+  and centralises the archetype-policy decision next to the
+  other archetype-keyed reads in `tickAI`.
+
+### GDD coverage
+- §15 Passing behavior: covered. Inside-pass-under-braking,
+  outside-pass-in-sweepers, and the bully override all ship with
+  this slice. The remaining racing-line concerns (e.g.,
+  defensive line on the inside when defending vs. attacking) are
+  out of scope for F-085 and would file as future followups if
+  the playtest reveals a gap.
+
+### Followups
+- F-085 closes with this slice.
+
+---
+
 ## 2026-05-09: feat(ai): bully pass-margin override (F-085 slice 2)
 
 **GDD sections touched:** [§15](gdd/15-cpu-opponents-and-ai.md)

--- a/src/game/__tests__/ai.test.ts
+++ b/src/game/__tests__/ai.test.ts
@@ -783,6 +783,97 @@ describe("tickAI (AI-vs-AI overtake awareness)", () => {
   });
 });
 
+describe("tickAI (context-aware pass side)", () => {
+  const SWEEPER_RIGHT: CompiledSegmentBuffer = compileSegments([
+    { len: 1200, curve: 0.2, grade: 0, roadsideLeft: "d", roadsideRight: "d", hazards: [] },
+  ]);
+  const TIGHT_LEFT: CompiledSegmentBuffer = compileSegments([
+    { len: 1200, curve: -0.5, grade: 0, roadsideLeft: "d", roadsideRight: "d", hazards: [] },
+  ]);
+
+  function tickWith(driver: AIDriver, track: CompiledSegmentBuffer) {
+    return tickAI(
+      driver,
+      freshAi(),
+      freshCar({ x: 0, z: 100, speed: 30 }),
+      { car: freshCar({ x: 0, z: -200, speed: 30 }) },
+      track,
+      RACING,
+      STARTER_STATS,
+      DEFAULT_AI_TRACK_CONTEXT,
+      0,
+      IDENTITY_CPU_MODIFIERS,
+      1,
+      1,
+      undefined,
+      null,
+      [{ x: 0, z: 110, speed: 28 }],
+    );
+  }
+
+  it("clean line passes outside on a right-handed sweeper", () => {
+    const result = tickWith(archetypeDriver("clean_line"), SWEEPER_RIGHT);
+    // Outside of a right-handed sweeper is the left side (negative
+    // x). The combined racing-line bias (also pulls left) and the
+    // outside-pass offset both push steer negative; the overtake
+    // intent flips the readability cue and sets the intent.
+    expect(result.nextAiState.intent).toBe("overtake");
+    expect(result.input.steer).toBeLessThan(0);
+  });
+
+  it("bully passes on the easier side regardless of curve direction", () => {
+    const cleanLine = tickWith(archetypeDriver("clean_line"), SWEEPER_RIGHT);
+    const bully = tickWith(
+      archetypeDriver("aggressive", { aggression: 1 }),
+      SWEEPER_RIGHT,
+    );
+    // Both archetypes fire overtake intent against the same target.
+    expect(cleanLine.nextAiState.intent).toBe("overtake");
+    expect(bully.nextAiState.intent).toBe("overtake");
+    // Clean line follows the §15 outside-pass rule (negative steer).
+    // Bully ignores convention and reads the easier-pass rule from
+    // `target.x <= 0 -> +1`, so its overtake-offset contribution
+    // pulls right while clean line pulls left. Expect a strict
+    // ordering: bully's steer is greater (less negative or
+    // positive) than clean line's on the same geometry.
+    expect(bully.input.steer).toBeGreaterThan(cleanLine.input.steer);
+  });
+
+  it("clean line passes inside on a tight left-hander (under-braking line)", () => {
+    const result = tickWith(archetypeDriver("clean_line"), TIGHT_LEFT);
+    // Inside of a tight left curve is the left side. The racing-
+    // line bias also pulls left, so steer should be strongly
+    // negative.
+    expect(result.nextAiState.intent).toBe("overtake");
+    expect(result.input.steer).toBeLessThan(0);
+  });
+
+  it("falls back to the easier-pass rule on a straight track", () => {
+    const playerLeft = { x: -1, z: 110, speed: 28 };
+    const result = tickAI(
+      archetypeDriver("clean_line"),
+      freshAi(),
+      freshCar({ x: 0, z: 100, speed: 30 }),
+      { car: freshCar({ x: 0, z: -200, speed: 30 }) },
+      STRAIGHT_TRACK,
+      RACING,
+      STARTER_STATS,
+      DEFAULT_AI_TRACK_CONTEXT,
+      0,
+      IDENTITY_CPU_MODIFIERS,
+      1,
+      1,
+      undefined,
+      null,
+      [playerLeft],
+    );
+    // Target is to the left of the AI; the easier-pass rule selects
+    // the right side, so steer goes positive.
+    expect(result.nextAiState.intent).toBe("overtake");
+    expect(result.input.steer).toBeGreaterThan(0);
+  });
+});
+
 describe("tickAI (bully pass-margin override)", () => {
   // Place the AI directly behind a target on the centerline so the
   // pass-side branch (target.x <= 0) picks side = +1 and the lateral

--- a/src/game/ai.ts
+++ b/src/game/ai.ts
@@ -226,6 +226,22 @@ export const AI_TUNING = Object.freeze({
    * `MAX_FIELD_COMPRESSION_PACE`.
    */
   FIELD_COMPRESSION_PER_METER: 0.0003,
+  /**
+   * Authored curve magnitude above which the overtake routine treats
+   * the segment as a tight braking zone and prefers the inside line
+   * (curve-direction side). `TrackSegmentSchema` keeps `curve` in
+   * `[-1, 1]`; `0.4` selects the upper-third of cornering values
+   * authored on real tracks.
+   */
+  OVERTAKE_BRAKING_CURVE_THRESHOLD: 0.4,
+  /**
+   * Lower bound on the sweeper window. Authored curves between this
+   * value and `OVERTAKE_BRAKING_CURVE_THRESHOLD` are treated as
+   * "in a sweeper" and pass on the outside line. Below this value
+   * the segment counts as effectively straight and the routine falls
+   * back to the easier-pass rule.
+   */
+  OVERTAKE_SWEEPER_CURVE_THRESHOLD: 0.1,
   /** Lap fraction where rocket starter launch boost stops applying. */
   ROCKET_LAUNCH_FRACTION: 0.18,
   /** Lap fraction where rocket starter late fade starts applying. */
@@ -352,6 +368,7 @@ export function tickAI(
         overtakeTarget,
         context.roadHalfWidth,
         behaviour.passMarginScalar,
+        behaviour.prefersContextPasses ? authoredCurve : 0,
       )
     : { active: false, offset: 0 };
   const idealOffsetWithTraffic = rawIdealOffset + trafficLaneOffset + overtake.offset;
@@ -674,11 +691,56 @@ function pickOvertakeTarget(
   return best;
 }
 
+/**
+ * Pick the lateral side (`+1` for right of the target, `-1` for
+ * left) the AI should pass on. The default rule is "more room" -
+ * whichever side of the target has more clear road - but when an
+ * authored curve is supplied the AI prefers the §15 racing-line
+ * preferences:
+ *
+ *   - Tight curve (|curve| > `OVERTAKE_BRAKING_CURVE_THRESHOLD`):
+ *     inside-pass-under-braking. Pass-side equals the sign of the
+ *     curve so a right-hander selects the right side (the inside
+ *     line is the shorter path).
+ *   - Sweeper (|curve| in `[OVERTAKE_SWEEPER_CURVE_THRESHOLD,
+ *     OVERTAKE_BRAKING_CURVE_THRESHOLD]`): outside-pass-in-sweepers.
+ *     Pass-side is the negative of the sign of the curve so the AI
+ *     swings wide and uses the natural arc.
+ *   - Below the sweeper threshold (effectively straight): falls
+ *     through to the more-room rule.
+ *
+ * The bully archetype passes `0` here at the call site so it
+ * always falls through to the more-room rule.
+ */
+function pickOvertakePassSide(
+  target: OvertakeThreat,
+  authoredCurve: number,
+): 1 | -1 {
+  if (Number.isFinite(authoredCurve)) {
+    const magnitude = Math.abs(authoredCurve);
+    if (magnitude >= AI_TUNING.OVERTAKE_BRAKING_CURVE_THRESHOLD) {
+      return authoredCurve > 0 ? 1 : -1;
+    }
+    if (magnitude >= AI_TUNING.OVERTAKE_SWEEPER_CURVE_THRESHOLD) {
+      return authoredCurve > 0 ? -1 : 1;
+    }
+  }
+  return target.x <= 0 ? 1 : -1;
+}
+
 function overtakeOffset(
   aiCar: Readonly<CarState>,
   target: OvertakeThreat,
   roadHalfWidth: number,
   passMarginScalar: number,
+  /**
+   * Authored curve under the AI on this tick. `0` selects the
+   * easier-pass rule (whichever side has more room). A non-zero
+   * value selects an inside or outside line based on the curve
+   * magnitude. Bully archetypes pass `0` here so they ignore the
+   * preference per §15.
+   */
+  authoredCurve: number,
 ): { active: boolean; offset: number } {
   // Effective pass margin scaled by the archetype's
   // `passMarginScalar`. Bully rubs more (< 1.0); cautious leaves
@@ -687,7 +749,7 @@ function overtakeOffset(
     0,
     AI_TUNING.OVERTAKE_PLAYER_MARGIN_METERS * passMarginScalar,
   );
-  const passSide = target.x <= 0 ? 1 : -1;
+  const passSide = pickOvertakePassSide(target, authoredCurve);
   const desiredTarget = target.x + passSide * effectiveMargin;
   const boundedTarget = clamp(
     desiredTarget,

--- a/src/game/aiArchetypes.ts
+++ b/src/game/aiArchetypes.ts
@@ -27,6 +27,16 @@ export interface AIBehaviour {
    * during a pass.
    */
   readonly passMarginScalar: number;
+  /**
+   * When `true`, the overtake routine reads the authored curve under
+   * the AI and prefers the inside line in a braking zone (tight
+   * curve) and the outside line in a sweeper (gentle curve). When
+   * `false` the archetype falls back to the simple "easier-pass"
+   * rule (whichever side has more room) regardless of context. The
+   * bully archetype reads `false` per §15 "Passing behavior" - the
+   * bully ignores convention.
+   */
+  readonly prefersContextPasses: boolean;
 }
 
 export const AI_ARCHETYPE_BEHAVIOURS: Readonly<Record<AIArchetype, AIBehaviour>> =
@@ -46,6 +56,7 @@ export const AI_ARCHETYPE_BEHAVIOURS: Readonly<Record<AIArchetype, AIBehaviour>>
       brilliantPaceBonus: 0,
       trafficLanePressure: 0.05,
       passMarginScalar: 1,
+      prefersContextPasses: true,
     }),
     clean_line: Object.freeze({
       archetype: "clean_line",
@@ -62,6 +73,7 @@ export const AI_ARCHETYPE_BEHAVIOURS: Readonly<Record<AIArchetype, AIBehaviour>>
       brilliantPaceBonus: 0,
       trafficLanePressure: 0,
       passMarginScalar: 1,
+      prefersContextPasses: true,
     }),
     aggressive: Object.freeze({
       archetype: "aggressive",
@@ -79,6 +91,9 @@ export const AI_ARCHETYPE_BEHAVIOURS: Readonly<Record<AIArchetype, AIBehaviour>>
       trafficLanePressure: 0.45,
       // Bully rubs more on a pass: 60 % of the polite pass margin.
       passMarginScalar: 0.6,
+      // Bully ignores convention - takes the easier pass regardless
+      // of inside / outside line context.
+      prefersContextPasses: false,
     }),
     defender: Object.freeze({
       archetype: "defender",
@@ -96,6 +111,7 @@ export const AI_ARCHETYPE_BEHAVIOURS: Readonly<Record<AIArchetype, AIBehaviour>>
       trafficLanePressure: -0.2,
       // Cautious leaves more lateral room on a pass.
       passMarginScalar: 1.25,
+      prefersContextPasses: true,
     }),
     wet_specialist: Object.freeze({
       archetype: "wet_specialist",
@@ -112,6 +128,10 @@ export const AI_ARCHETYPE_BEHAVIOURS: Readonly<Record<AIArchetype, AIBehaviour>>
       brilliantPaceBonus: 0.06,
       trafficLanePressure: 0.2,
       passMarginScalar: 1,
+      // Chaotic is occasionally brilliant, occasionally wrong - we
+      // let it follow context too so the brilliant moments are read-
+      // able as actual racing decisions rather than coin flips.
+      prefersContextPasses: true,
     }),
     endurance: Object.freeze({
       archetype: "endurance",
@@ -128,6 +148,7 @@ export const AI_ARCHETYPE_BEHAVIOURS: Readonly<Record<AIArchetype, AIBehaviour>>
       brilliantPaceBonus: 0,
       trafficLanePressure: 0,
       passMarginScalar: 1,
+      prefersContextPasses: true,
     }),
   });
 


### PR DESCRIPTION
## Summary
- Adds \`prefersContextPasses\` to every \`AIBehaviour\` row in \`src/game/aiArchetypes.ts\`: aggressive (Bully) \`false\`, every other archetype \`true\`. Bully ignores §15 passing convention per spec.
- Adds two \`AI_TUNING\` thresholds in \`src/game/ai.ts\`: \`OVERTAKE_BRAKING_CURVE_THRESHOLD = 0.4\` and \`OVERTAKE_SWEEPER_CURVE_THRESHOLD = 0.1\`. Tight curves above the braking threshold select the inside line; curves in the sweeper window select the outside line; below the sweeper threshold the routine falls through to the easier-pass rule
- Adds \`pickOvertakePassSide(target, authoredCurve)\`. Inside-pass picks \`sign(curve)\`; outside-pass picks \`-sign(curve)\`. Bully ignores context via the call site passing \`0\` for the curve parameter
- Closes F-085 (the AI-vs-AI overtake-awareness trio shipped today: slice 1 visibility across the field, slice 2 bully pass-margin override, slice 3 context-aware pass side)

## Why
§15 \"Passing behavior\" calls for inside-pass-under-braking + outside-pass-in-sweepers preferences with a bully override that ignores convention. Without this slice, every AI passes by the same \"more room\" rule regardless of track context, so the racing-line read isn't visible from the player's car. With this slice, polite drivers commit to the racing-line conventions while the bully cuts across regardless.

## Test plan
- [x] \`pnpm typecheck\`
- [x] \`pnpm lint\`
- [x] \`pnpm vitest run\` (2977 / 2977 across 162 suites; 4 new cases in \`tickAI (context-aware pass side)\`)
- [x] \`pnpm content-lint\`
- [x] \`pnpm docs:check\`
- [ ] CI: lint, typecheck, unit, e2e

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * AI opponents now intelligently choose passing lines based on track curves and geometry for more realistic overtaking behavior.

* **Tests**
  * Added test suite validating AI passing decisions across various track configurations and driving archetypes.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Randroids-Dojo/VibeGear2/pull/215)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->