### PR TITLE
test(e2e): garage cars locked state (F-097 follow-on)

### DIFF
--- a/docs/FOLLOWUPS.md
+++ b/docs/FOLLOWUPS.md
@@ -198,6 +198,14 @@ display names from championship data, livery-cosmetic unlocks
 (those belong under F-096), and an e2e for the locked-state
 disabled button.
 
+2026-05-09 locked-state e2e slice shipped under
+`test/car-locked-state-e2e`. Adds
+`e2e/garage-cars-locked.spec.ts` with two cases: bastion-lm shows
+a disabled "Locked" Buy button plus a "Win Iron Borough to
+unlock." reason pill when no tours are completed, and the same
+button switches to an enabled price label when `iron-borough` is
+in `progress.completedTours`. Closes the deferred sub-item.
+
 2026-05-08 pretty-tour-names slice shipped under
 `feat/tour-pretty-names`. Adds optional `name` to
 `ChampionshipTourSchema`, authors names on all eight tours in

--- a/docs/PROGRESS_LOG.md
+++ b/docs/PROGRESS_LOG.md
@@ -6,6 +6,57 @@ Correct them by adding a new entry that references the old one.
 
 ---
 
+## 2026-05-09: test(e2e): garage cars locked state (F-097 follow-on)
+
+**GDD sections touched:** [§8](gdd/08-progression-and-economy.md)
+(podium-progression unlock - `requiresTour` gating on the cars
+subroute).
+**Branch / PR:** `test/car-locked-state-e2e`, PR pending.
+**Status:** Closes the F-097 deferred sub-item ("e2e for the
+locked-state disabled button"). Other F-097 deferrals (pretty
+tour display names, livery-cosmetic unlocks under F-096) stay
+under their respective followup IDs.
+
+### Done
+- Added `e2e/garage-cars-locked.spec.ts`. Two cases: with no
+  tours completed, the bastion-lm Buy button is disabled with
+  text "Locked" and the lock-reason pill reads "Win Iron Borough
+  to unlock."; with `iron-borough` in `progress.completedTours`
+  the lock-reason pill is gone and the Buy button is enabled
+  with the price label.
+- Save fixture matches the v4 schema in `garage-flow.spec.ts`;
+  the helper takes a `completedTours` argument so the same
+  builder serves both the locked and unlocked cases.
+
+### Verified
+- `pnpm typecheck` clean.
+- `pnpm playwright test e2e/garage-cars-locked.spec.ts
+  --project=chromium` 2 / 2 passed in 12.9 s on the dev server.
+- `pnpm content-lint` clean.
+- `pnpm docs:check` clean.
+
+### Assumptions
+- The seeded credits balance (200000) is well above
+  `bastion-lm.purchasePrice` so the unlocked-case enable
+  assertion does not race the credit gate. If the price ever
+  exceeds 200000 the test should bump the seed.
+- The lock-reason copy (`Win Iron Borough to unlock.`) is read
+  through the championship-name resolver, so a rename in
+  `world-tour-standard.json` would update the test fixture in
+  lockstep with the production string.
+
+### GDD coverage
+- §8 Progression: pinned the locked-state UX with a live e2e on
+  the cars subroute.
+
+### Followups
+- F-097's pretty-tour-names and tour-gating slices already
+  shipped earlier this week; the locked-state e2e closes the
+  remaining deferred sub-item. Livery / cosmetic unlocks remain
+  open under F-096.
+
+---
+
 ## 2026-05-09: feat(ai): context-aware pass side (F-085 slice 3)
 
 **GDD sections touched:** [§15](gdd/15-cpu-opponents-and-ai.md)

--- a/e2e/garage-cars-locked.spec.ts
+++ b/e2e/garage-cars-locked.spec.ts
@@ -1,0 +1,157 @@
+import { expect, test } from "@playwright/test";
+
+/**
+ * F-097 follow-on. Pins the locked-state UX on the garage cars
+ * subroute so a tour-gated car (bastion-lm requires iron-borough)
+ * surfaces a disabled Buy with a "Win Iron Borough to unlock"
+ * reason copy when the player has not completed the prerequisite
+ * tour. Mirrors the unit test in
+ * `src/components/garage/__tests__/...` but exercises the live
+ * route plus the championship-name resolver.
+ */
+
+const SAVE_KEY = "vibegear2:save:v4";
+
+interface SeededSave {
+  version: number;
+  profileName: string;
+  settings: {
+    displaySpeedUnit: "kph" | "mph";
+    assists: {
+      steeringAssist: boolean;
+      autoNitro: boolean;
+      weatherVisualReduction: boolean;
+    };
+    difficultyPreset: "easy" | "normal" | "hard" | "master";
+    transmissionMode: "auto" | "manual";
+    audio: { master: number; music: number; sfx: number };
+    accessibility: {
+      colorBlindMode: "off" | "protanopia" | "deuteranopia" | "tritanopia";
+      reducedMotion: boolean;
+      largeUiText: boolean;
+      screenShakeScale: number;
+    };
+  };
+  garage: {
+    credits: number;
+    ownedCars: ReadonlyArray<string>;
+    activeCarId: string;
+    installedUpgrades: Record<string, Record<string, number>>;
+    pendingDamage: Record<
+      string,
+      {
+        zones: { engine: number; tires: number; body: number };
+        total: number;
+        offRoadAccumSeconds: number;
+      }
+    >;
+    lastRaceCashEarned: number;
+  };
+  progress: { unlockedTours: string[]; completedTours: string[] };
+  records: Record<string, unknown>;
+  ghosts: Record<string, unknown>;
+  writeCounter: number;
+}
+
+test.describe("garage cars locked state", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto("/");
+    const hasStorage = await page.evaluate(
+      () => typeof window.localStorage !== "undefined",
+    );
+    test.skip(!hasStorage, "localStorage unavailable in this browser context");
+  });
+
+  test("bastion-lm is locked until Iron Borough is completed", async ({
+    page,
+  }) => {
+    // Seed a save with cash to spare but no completed tours; the
+    // tour-gated cars should refuse purchase regardless of credits.
+    await page.evaluate(
+      ({ key, save }) => window.localStorage.setItem(key, JSON.stringify(save)),
+      { key: SAVE_KEY, save: buildLockedSave([]) },
+    );
+
+    await page.goto("/garage/cars");
+    await expect(page.getByTestId("car-card-bastion-lm")).toBeVisible();
+
+    const buyButton = page.getByTestId("buy-bastion-lm");
+    await expect(buyButton).toBeVisible();
+    await expect(buyButton).toBeDisabled();
+    await expect(buyButton).toHaveText("Locked");
+
+    const reason = page.getByTestId("lock-reason-bastion-lm");
+    await expect(reason).toBeVisible();
+    await expect(reason).toHaveText("Win Iron Borough to unlock.");
+  });
+
+  test("bastion-lm Buy unlocks once Iron Borough is in completedTours", async ({
+    page,
+  }) => {
+    await page.evaluate(
+      ({ key, save }) => window.localStorage.setItem(key, JSON.stringify(save)),
+      { key: SAVE_KEY, save: buildLockedSave(["iron-borough"]) },
+    );
+
+    await page.goto("/garage/cars");
+    await expect(page.getByTestId("car-card-bastion-lm")).toBeVisible();
+    await expect(page.getByTestId("lock-reason-bastion-lm")).toHaveCount(0);
+
+    const buyButton = page.getByTestId("buy-bastion-lm");
+    await expect(buyButton).toBeVisible();
+    // Save has 200_000 credits, well above bastion-lm.purchasePrice;
+    // the gate is open and the button is enabled with a price label.
+    await expect(buyButton).toBeEnabled();
+    await expect(buyButton).toContainText("Buy");
+  });
+});
+
+function buildLockedSave(completedTours: ReadonlyArray<string>): SeededSave {
+  return {
+    version: 4,
+    profileName: "LockedStateTester",
+    settings: {
+      displaySpeedUnit: "kph",
+      assists: {
+        steeringAssist: false,
+        autoNitro: false,
+        weatherVisualReduction: false,
+      },
+      difficultyPreset: "normal",
+      transmissionMode: "auto",
+      audio: { master: 1, music: 1, sfx: 1 },
+      accessibility: {
+        colorBlindMode: "off",
+        reducedMotion: false,
+        largeUiText: false,
+        screenShakeScale: 1,
+      },
+    },
+    garage: {
+      credits: 200_000,
+      ownedCars: ["sparrow-gt"],
+      activeCarId: "sparrow-gt",
+      installedUpgrades: {
+        "sparrow-gt": {
+          engine: 0,
+          gearbox: 0,
+          dryTires: 0,
+          wetTires: 0,
+          nitro: 0,
+          armor: 0,
+          cooling: 0,
+          aero: 0,
+        },
+      },
+      pendingDamage: {},
+      lastRaceCashEarned: 0,
+    },
+    progress: {
+      unlockedTours: [],
+      completedTours: completedTours.slice(),
+    },
+    records: {},
+    ghosts: {},
+    writeCounter: 0,
+  };
+}


### PR DESCRIPTION
## Summary
- Adds \`e2e/garage-cars-locked.spec.ts\` pinning the locked-state UX on the cars subroute. Two cases: with no tours completed the bastion-lm Buy button is disabled with text \"Locked\" and the lock-reason pill reads \"Win Iron Borough to unlock.\"; with \`iron-borough\` in \`progress.completedTours\` the lock-reason pill is gone and the Buy button is enabled with the price label
- Closes the F-097 deferred sub-item (\"e2e for the locked-state disabled button\"). Other F-097 deferrals (livery / cosmetic unlocks) stay open under F-096

## Test plan
- [x] \`pnpm typecheck\`
- [x] \`pnpm playwright test e2e/garage-cars-locked.spec.ts --project=chromium\` (2 / 2 passed in 12.9 s on the dev server)
- [x] \`pnpm content-lint\`
- [x] \`pnpm docs:check\`
- [ ] CI: lint, typecheck, unit, e2e

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added test coverage for garage car lock/unlock mechanics, verifying disabled states when prerequisites are incomplete and enabled states once requirements are met.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Randroids-Dojo/VibeGear2/pull/216)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->