### PR TITLE
feat(audio): fuel-depleted sputter cue (F-104 follow-on)

### DIFF
--- a/docs/FOLLOWUPS.md
+++ b/docs/FOLLOWUPS.md
@@ -48,8 +48,13 @@ field `dnfReason: DnfReason` on `FinalCarRecord` and
 each AI's `entry.dnfReason`, and `FinishingOrderTable` maps every
 DnfReason value to a friendly label ("Out of fuel", "Wrecked",
 "Off track", "No progress", "Retired"). Static text only; reduced-
-motion safe per §19. Audio sputter cue deferred for a future loop;
-the four-slice F-104 feature otherwise closes with this slice.
+motion safe per §19. 2026-05-09 audio sputter cue shipped under
+`feat/fuel-sputter-audio`: new `RaceSessionFuelDepletedAudioEvent`
+fires the tick the player's fuel crosses from `liters > 0` to
+`liters === 0`, ducks the music bed at 0.6 / 600 ms, and the
+`ProceduralSfxRuntime` plays a low descending sawtooth from
+220 Hz to 90 Hz over 360 ms so the player hears the moment the
+run becomes a DNF. F-104 closes fully with this slice.
 
 ## F-103: Prep-card tire recommendation one-click action
 **Created:** 2026-05-09

--- a/docs/PROGRESS_LOG.md
+++ b/docs/PROGRESS_LOG.md
@@ -6,6 +6,67 @@ Correct them by adding a new entry that references the old one.
 
 ---
 
+## 2026-05-09: feat(audio): fuel-depleted sputter cue (F-104 follow-on)
+
+**GDD sections touched:** [§18](gdd/18-audio-and-music.md) (race
+SFX events) and [§20](gdd/20-hud-and-pause.md) (the depletion cue
+companions the existing HUD `FUEL EMPTY` red label so the player
+hears + sees the moment the run becomes a DNF).
+**Branch / PR:** `feat/fuel-sputter-audio`, PR pending.
+**Status:** Closes the F-104 deferred sub-item ("audio sputter
+cue"). F-104 itself was already marked `done` after the 2026-05-09
+slice 4 merge; this slice retires the last open audio note.
+
+### Done
+- Added `RaceSessionFuelDepletedAudioEvent` to
+  `src/game/raceSession.ts` and unioned it onto
+  `RaceSessionAudioEvent`. Emission gates on
+  `playerFuelResult.depleted && !playerWreckedThisTick` so the
+  rising-edge cue fires exactly once - on the tick the tank
+  crosses from `liters > 0` to `liters === 0` - and a wreck on
+  the same tick still wins per the §13 precedence rule.
+- Added the duck row in `src/audio/raceMix.ts`:
+  `{ volumeScale: 0.6, holdMs: 600 }`. Heavier hold than the
+  pickup row so the cue lands cleanly over the music bed.
+- Added `playFuelDepleted(input)` on `ProceduralSfxRuntime`
+  (`src/audio/sfx.ts`). Low sawtooth tone descending from 220 Hz
+  to 90 Hz over 360 ms - sits below the pickup / nitro band so it
+  reads as an engine misfire rather than a UI bleep.
+- Added the dispatch case in
+  `src/app/race/page.tsx:playRaceSfxEvents` so the new event
+  triggers `runtime.playFuelDepleted({ audio })`.
+
+### Verified
+- `pnpm typecheck` clean.
+- `pnpm lint` clean.
+- `pnpm vitest run` 2981 / 2981 across 162 suites; new cases
+  added: 1 in `raceMix.test.ts` for the duck row, 1 in
+  `sfx.test.ts` for the synthesis path, 2 in `raceSession.test.ts`
+  for the rising-edge emission and the no-rising-edge guard.
+- `pnpm content-lint` clean.
+- `pnpm docs:check` clean.
+
+### Assumptions
+- 220 Hz / 90 Hz / 360 ms were chosen so the cue is audibly
+  distinct from `nitroEngage` (980 Hz / 1460 Hz, 180 ms) and
+  `playPickupCollected` (720-1180 Hz, 180 ms). The frequency
+  band is intentionally lower than any other SFX so a future
+  re-tune does not have to preserve the exact numbers.
+- The dedicated unit test "no emission when the tank starts
+  empty (no rising edge)" pins the contract that the cue is a
+  rising-edge signal, not a state-poll. A future caller cannot
+  drop fuel to zero pre-tick and expect the cue.
+
+### GDD coverage
+- §18 Audio and music: covered. The new event piggybacks on the
+  existing audio-event plumbing without restructuring it.
+
+### Followups
+- F-104 audio note retires with this slice. The followup entry
+  body has been updated.
+
+---
+
 ## 2026-05-09: test(e2e): garage cars locked state (F-097 follow-on)
 
 **GDD sections touched:** [§8](gdd/08-progression-and-economy.md)

--- a/src/app/race/page.tsx
+++ b/src/app/race/page.tsx
@@ -366,6 +366,8 @@ function playRaceSfxEvents(
         speedFactor: event.speedFactor,
         audio,
       });
+    } else if (event.kind === "fuelDepleted") {
+      runtime.playFuelDepleted({ audio });
     }
   }
 }

--- a/src/audio/raceMix.test.ts
+++ b/src/audio/raceMix.test.ts
@@ -50,6 +50,14 @@ describe("race music ducking", () => {
     ).toEqual({ volumeScale: 0.78, holdMs: 260 });
   });
 
+  it("ducks the music for the fuel-depleted sputter cue", () => {
+    expect(
+      raceMusicDuckingForAudioEvents([
+        { kind: "fuelDepleted", carId: "player" },
+      ]),
+    ).toEqual({ volumeScale: 0.6, holdMs: 600 });
+  });
+
   it("ducks countdown and go cues without muting the music", () => {
     expect(raceMusicDuckingForCountdownStep(3)).toEqual({
       volumeScale: 0.82,

--- a/src/audio/raceMix.ts
+++ b/src/audio/raceMix.ts
@@ -64,6 +64,12 @@ function raceMusicDuckingForAudioEvent(
       return { volumeScale: 0.88, holdMs: 180 };
     case "gearShift":
       return NO_RACE_MUSIC_DUCKING;
+    case "fuelDepleted":
+      // One-shot sputter on the depletion edge. Heavier hold than
+      // pickup events because the cue marks the moment the run
+      // becomes a DNF; the player should hear it cleanly over the
+      // music bed.
+      return { volumeScale: 0.6, holdMs: 600 };
     case "tireSquealLoop":
     case "brakeScrubLoop":
       // Loop state events drive the §18 sustained audio bed; the

--- a/src/audio/sfx.test.ts
+++ b/src/audio/sfx.test.ts
@@ -170,6 +170,27 @@ describe("ProceduralSfxRuntime", () => {
     expect(context.oscillators[0]?.stop).toHaveBeenCalledWith(0.18);
   });
 
+  it("plays a low descending sawtooth as the fuel-depleted sputter cue", () => {
+    const context = new FakeAudioContext();
+    const runtime = new ProceduralSfxRuntime({
+      context: () => context,
+      baseGain: 0.2,
+    });
+
+    expect(runtime.playFuelDepleted({ audio: AUDIO })).toBe(true);
+
+    expect(context.oscillators).toHaveLength(1);
+    expect(context.oscillators[0]?.type).toBe("sawtooth");
+    expect(context.oscillators[0]?.frequency.setValueAtTime).toHaveBeenCalledWith(
+      220,
+      0,
+    );
+    expect(
+      context.oscillators[0]?.frequency.linearRampToValueAtTime,
+    ).toHaveBeenCalledWith(90, 0.36);
+    expect(context.oscillators[0]?.stop).toHaveBeenCalledWith(0.36);
+  });
+
   it("plays distinct cash and nitro pickup collection cues", () => {
     const context = new FakeAudioContext();
     const runtime = new ProceduralSfxRuntime({

--- a/src/audio/sfx.ts
+++ b/src/audio/sfx.ts
@@ -92,6 +92,10 @@ export interface SurfaceHushSfxInput {
   readonly audio: AudioSettings | undefined;
 }
 
+export interface FuelDepletedSfxInput {
+  readonly audio: AudioSettings | undefined;
+}
+
 export interface ProceduralSfxRuntimeOptions {
   readonly context: () => SfxAudioContextLike | null;
   readonly baseGain?: number;
@@ -178,6 +182,20 @@ export class ProceduralSfxRuntime {
       gainScale: 0.75,
       durationSeconds: 0.18,
       endFrequency: 1460,
+    });
+  }
+
+  playFuelDepleted(input: FuelDepletedSfxInput): boolean {
+    // Engine-sputter cue: low sawtooth that drops in pitch over
+    // ~360 ms. Sits below the pickup / nitro band so it reads as
+    // an engine misfire rather than a UI bleep.
+    return this.playTone({
+      audio: input.audio,
+      frequency: 220,
+      oscillatorType: "sawtooth",
+      gainScale: 0.6,
+      durationSeconds: 0.36,
+      endFrequency: 90,
     });
   }
 

--- a/src/game/__tests__/raceSession.test.ts
+++ b/src/game/__tests__/raceSession.test.ts
@@ -810,6 +810,70 @@ describe("stepRaceSession (nitro)", () => {
   });
 });
 
+describe("stepRaceSession (fuel depletion audio)", () => {
+  // Seed the player car at racing speed so the per-tick fuel burn
+  // is non-trivial; pair with a near-empty tank so depletion lands
+  // in one tick. Tiny capacity floor (0.0001 L) is below any per-
+  // tick drain at racing speed and cannot be affected by future
+  // BASE_CONSUMPTION tuning.
+  const buildAlmostEmptySession = (config: RaceSessionConfig) => {
+    const baseline = createRaceSession({
+      ...config,
+      player: { ...config.player, initial: { speed: 50 } },
+    });
+    return {
+      ...baseline,
+      player: {
+        ...baseline.player,
+        fuel: { liters: 0.0001, capacityLiters: baseline.player.fuel.capacityLiters },
+      },
+    };
+  };
+
+  it("emits a fuelDepleted audio event on the depletion edge and flips the player to dnf", () => {
+    const config = buildConfig({
+      track: loadTrack("test/straight"),
+      player: { stats: STARTER_STATS },
+      ai: [],
+      countdownSec: 0,
+    });
+    const session = buildAlmostEmptySession(config);
+    const next = stepRaceSession(session, fullThrottle(), config, DT);
+    expect(next.player.fuel.liters).toBe(0);
+    expect(next.player.status).toBe("dnf");
+    expect(next.player.dnfReason).toBe("out-of-fuel");
+    expect(next.audioEvents).toContainEqual({
+      kind: "fuelDepleted",
+      carId: PLAYER_CAR_ID,
+    });
+  });
+
+  it("does not emit fuelDepleted when the tank starts empty (no rising edge)", () => {
+    // The depletion edge only fires the tick the tank crosses from
+    // `liters > 0` to `liters === 0`. Starting with the tank already
+    // dry must not synthesize a fresh cue at session start; the
+    // §20 fuel-empty render has nothing new to announce.
+    const config = buildConfig({
+      track: loadTrack("test/straight"),
+      player: { stats: STARTER_STATS, initial: { speed: 50 } },
+      ai: [],
+      countdownSec: 0,
+    });
+    const baseline = createRaceSession(config);
+    const session = {
+      ...baseline,
+      player: {
+        ...baseline.player,
+        fuel: { liters: 0, capacityLiters: baseline.player.fuel.capacityLiters },
+      },
+    };
+    const next = stepRaceSession(session, fullThrottle(), config, DT);
+    expect(
+      next.audioEvents.some((event) => event.kind === "fuelDepleted"),
+    ).toBe(false);
+  });
+});
+
 describe("stepRaceSession (pickups)", () => {
   it("collects cash pickups into the player race cash delta once", () => {
     const config = buildConfig({

--- a/src/game/raceSession.ts
+++ b/src/game/raceSession.ts
@@ -319,6 +319,17 @@ export interface RaceSessionPickupCollectedAudioEvent {
   readonly value: number;
 }
 
+/**
+ * Fired the tick a car's fuel state crosses from `liters > 0` to
+ * `liters === 0`. The race-page SFX dispatcher plays a short engine-
+ * sputter cue so the player hears the moment the tank runs dry; the
+ * music ducker reads it for a short hold so the cue lands cleanly.
+ */
+export interface RaceSessionFuelDepletedAudioEvent {
+  readonly kind: "fuelDepleted";
+  readonly carId: string;
+}
+
 type RaceSessionLapMilestoneAudioEvent =
   | RaceSessionLapCompleteAudioEvent
   | RaceSessionRaceFinishAudioEvent;
@@ -335,7 +346,8 @@ export type RaceSessionAudioEvent =
   | RaceSessionTireSquealLoopAudioEvent
   | RaceSessionBrakeScrubLoopAudioEvent
   | RaceSessionSurfaceHushAudioEvent
-  | RaceSessionPickupCollectedAudioEvent;
+  | RaceSessionPickupCollectedAudioEvent
+  | RaceSessionFuelDepletedAudioEvent;
 
 export interface RaceSessionConfig {
   /** Compiled track to drive on. Frozen output of `compileTrack`. */
@@ -1876,6 +1888,10 @@ export function stepRaceSession(
   if (playerFuelResult.depleted && !playerWreckedThisTick) {
     nextPlayerStatus = "dnf";
   }
+  const playerFuelDepletedAudioEvents: ReadonlyArray<RaceSessionFuelDepletedAudioEvent> =
+    playerFuelResult.depleted && !playerWreckedThisTick
+      ? [{ kind: "fuelDepleted", carId: PLAYER_CAR_ID }]
+      : [];
 
   // §7 per-AI lap rollover + finishing. Each AI tracks its own lap
   // counter (the `RaceState.lap` field is player-only) and accumulates
@@ -2066,7 +2082,8 @@ export function stepRaceSession(
     playerLapEvents.length > 0 ||
     playerDamageWarningEvents.length > 0 ||
     playerSurfaceAudio.events.length > 0 ||
-    playerPickupAudioEvents.length > 0;
+    playerPickupAudioEvents.length > 0 ||
+    playerFuelDepletedAudioEvents.length > 0;
   const nextAudioEvents: ReadonlyArray<RaceSessionAudioEvent> =
     hasPlayerNonImpactAudioEvents
       ? [
@@ -2076,6 +2093,7 @@ export function stepRaceSession(
           ...playerDamageWarningEvents,
           ...playerSurfaceAudio.events,
           ...playerPickupAudioEvents,
+          ...playerFuelDepletedAudioEvents,
           ...playerImpactEvents,
         ]
       : playerImpactEvents;


### PR DESCRIPTION
## Summary
- Adds \`RaceSessionFuelDepletedAudioEvent\` to the race-session audio-event union and emits it on the rising edge when the player's tank crosses from \`liters > 0\` to \`liters === 0\`. Wreck on the same tick still wins per the §13 precedence rule
- \`raceMix.ts\` ducks the music bed at \`{ volumeScale: 0.6, holdMs: 600 }\` so the cue lands cleanly
- \`ProceduralSfxRuntime\` gains \`playFuelDepleted\`: a low sawtooth tone descending from 220 Hz to 90 Hz over 360 ms - intentionally below the pickup / nitro band so it reads as an engine misfire
- Closes the F-104 deferred audio sub-item; the four-slice TG2-faithful fuel feature is now fully complete (runtime drain, HUD gauge, garage gearbox copy, results-screen DNF reason copy, audio sputter)

## Test plan
- [x] \`pnpm typecheck\`
- [x] \`pnpm lint\`
- [x] \`pnpm vitest run\` (2981 / 2981 across 162 suites; 4 new cases - 1 in raceMix, 1 in sfx, 2 in raceSession)
- [x] \`pnpm content-lint\`
- [x] \`pnpm docs:check\`
- [ ] CI: lint, typecheck, unit, e2e