### PR TITLE
test(e2e): feedback FAB coverage (F-077)

### DIFF
--- a/docs/FOLLOWUPS.md
+++ b/docs/FOLLOWUPS.md
@@ -735,8 +735,18 @@ post-merge; rotation does not require code changes.
 ## F-077: Playwright coverage for the Feedback FAB
 **Created:** 2026-05-05
 **Priority:** polish
-**Status:** open
-**Notes:** The slice ships unit tests for `POST /api/feedback` and a
+**Status:** done
+**Resolved:** 2026-05-09 (shipped under `test/feedback-fab-e2e`).
+Adds `e2e/feedback-fab.spec.ts` with three cases against a stubbed
+`/api/feedback` route: open + type + submit + assert success
+(including request-payload inspection via `page.waitForRequest`),
+Escape closes the panel without POSTing, click outside dismisses
+the panel. The `?errors=1` hide rule mentioned in the original
+note was an inaccurate read of the FAB doc comment - the FAB and
+the dev `?errors=1` panel "can coexist", so no hide-rule applies.
+Original note follows.
+
+The slice ships unit tests for `POST /api/feedback` and a
 server-render smoke test for `FeedbackFab`. A future spec should drive
 the open-panel, type, submit flow in a real browser against a stubbed
 `/api/feedback` route and assert the success state, the Escape and

--- a/docs/PROGRESS_LOG.md
+++ b/docs/PROGRESS_LOG.md
@@ -6,6 +6,48 @@ Correct them by adding a new entry that references the old one.
 
 ---
 
+## 2026-05-09: test(e2e): feedback FAB coverage (F-077)
+
+**GDD sections touched:** Q-012 option (b) - the global feedback
+FAB that POSTs to `/api/feedback`. Coverage was unit + SSR-shape
+only; this slice pins the live in-browser flow against a stubbed
+API route.
+**Branch / PR:** `test/feedback-fab-e2e`, PR pending.
+**Status:** Closes F-077.
+
+### Done
+- Added `e2e/feedback-fab.spec.ts` with three cases: open + type +
+  submit + assert success state (with the POST request payload
+  inspected via `page.waitForRequest`); Escape closes without
+  submitting; click outside closes the panel.
+- Each case stubs `/api/feedback` via `page.route` so the test
+  never reaches GitHub or the production rate-limit token.
+
+### Verified
+- `pnpm typecheck` clean.
+- `pnpm playwright test e2e/feedback-fab.spec.ts --project=chromium`
+  3 / 3 passed in 11.8 s on the dev server.
+- `pnpm content-lint` clean.
+- `pnpm docs:check` clean.
+
+### Assumptions
+- The `?errors=1` hidden-while rule mentioned in the F-077 entry
+  was an inaccurate read of the FAB doc comment. The comment
+  actually says the FAB and the dev `?errors=1` panel "can
+  coexist", so there is no hide-rule to test.
+- Click-outside is asserted against the `game-title` element on
+  `/`, which sits well outside the panel and the toggle button so
+  the click never accidentally hits either.
+
+### GDD coverage
+- Q-012: feedback surface. Live-browser coverage now exists in
+  addition to the unit + SSR-shape tests.
+
+### Followups
+- F-077 closes.
+
+---
+
 ## 2026-05-09: feat(audio): fuel-depleted sputter cue (F-104 follow-on)
 
 **GDD sections touched:** [§18](gdd/18-audio-and-music.md) (race

--- a/e2e/feedback-fab.spec.ts
+++ b/e2e/feedback-fab.spec.ts
@@ -1,0 +1,87 @@
+import { expect, test } from "@playwright/test";
+
+/**
+ * F-077. Playwright coverage for the global Feedback FAB. The FAB
+ * mounts in `app/layout.tsx`, so any route renders it. We drive
+ * the open / type / submit / dismiss flow against a stubbed
+ * `/api/feedback` route so the test does not depend on GitHub
+ * connectivity or the rate-limit token.
+ */
+
+test.describe("feedback FAB", () => {
+  test.beforeEach(async ({ page }) => {
+    // Stub the feedback API so the test never reaches GitHub. Reply
+    // with a minimal 200 payload mirroring the production shape.
+    await page.route("**/api/feedback", async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ ok: true, issueUrl: "https://example.invalid/1" }),
+      });
+    });
+  });
+
+  test("opens the panel, submits a message, and shows the success state", async ({
+    page,
+  }) => {
+    await page.goto("/");
+
+    const toggle = page.getByTestId("feedback-fab-toggle");
+    await expect(toggle).toBeVisible();
+    await toggle.click();
+
+    const panel = page.getByTestId("feedback-fab-panel");
+    await expect(panel).toBeVisible();
+
+    const textarea = page.getByTestId("feedback-fab-textarea");
+    const submit = page.getByTestId("feedback-fab-submit");
+
+    // Submit is disabled until the textarea has at least one
+    // non-whitespace character; an empty form must not POST.
+    await expect(submit).toBeDisabled();
+    await textarea.fill("Brake-flash readability is great in the rain.");
+    await expect(submit).toBeEnabled();
+
+    const requestPromise = page.waitForRequest("**/api/feedback");
+    await submit.click();
+    const request = await requestPromise;
+    expect(request.method()).toBe("POST");
+    const body = JSON.parse(request.postData() ?? "{}") as Record<
+      string,
+      unknown
+    >;
+    expect(typeof body.title).toBe("string");
+    expect(body.body).toBe("Brake-flash readability is great in the rain.");
+
+    // Success block replaces the form once the stubbed 200 lands.
+    await expect(page.getByTestId("feedback-fab-success")).toBeVisible();
+  });
+
+  test("Escape closes the panel without submitting", async ({ page }) => {
+    let postCount = 0;
+    await page.route("**/api/feedback", async (route) => {
+      postCount += 1;
+      await route.fulfill({ status: 200, body: "{}" });
+    });
+
+    await page.goto("/");
+    await page.getByTestId("feedback-fab-toggle").click();
+    await expect(page.getByTestId("feedback-fab-panel")).toBeVisible();
+
+    await page.keyboard.press("Escape");
+    await expect(page.getByTestId("feedback-fab-panel")).toHaveCount(0);
+    expect(postCount).toBe(0);
+  });
+
+  test("click outside the panel dismisses it", async ({ page }) => {
+    await page.goto("/");
+    await page.getByTestId("feedback-fab-toggle").click();
+    await expect(page.getByTestId("feedback-fab-panel")).toBeVisible();
+
+    // Click the page header / title - safely outside the panel and
+    // the toggle button. The Title page renders a `game-title`
+    // testid that sits at the top of the layout.
+    await page.getByTestId("game-title").click();
+    await expect(page.getByTestId("feedback-fab-panel")).toHaveCount(0);
+  });
+});


### PR DESCRIPTION
## Summary
- Adds \`e2e/feedback-fab.spec.ts\`. Three cases against a stubbed \`/api/feedback\` route: open + type + submit + assert success (with the POST payload inspected via \`page.waitForRequest\`); Escape closes the panel without POSTing; click outside dismisses the panel
- Each case stubs the API via \`page.route\` so the test never reaches GitHub or the production rate-limit token
- Closes F-077. The \`?errors=1\` hide rule mentioned in the original followup was an inaccurate read of the FAB doc comment - the FAB and the dev \`?errors=1\` panel \"can coexist\"

## Test plan
- [x] \`pnpm typecheck\`
- [x] \`pnpm playwright test e2e/feedback-fab.spec.ts --project=chromium\` (3 / 3 passed in 11.8 s on the dev server)
- [x] \`pnpm content-lint\`
- [x] \`pnpm docs:check\`
- [ ] CI: lint, typecheck, unit, e2e

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added end-to-end tests for the Feedback feature to improve quality assurance and system reliability.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Randroids-Dojo/VibeGear2/pull/218)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->