### PR TITLE
feat(schema): jump.rampHeight field (F-094 slice 1)

### DIFF
--- a/docs/FOLLOWUPS.md
+++ b/docs/FOLLOWUPS.md
@@ -331,8 +331,8 @@ churn ships in one wave.
 **Notes:** Slice 1 shipped 2026-05-09 under
 `feat/jump-schema-field` after a 2-agent design debate landed on
 "explicit schema field, one numeric knob, no runtime state
-machine at v1.0." Adds `TrackJumpSchema` (`{ rampHeight: 0..3 }`)
-optionally on `TrackSegmentSchema`, mirrors it as
+machine at v1.0." Adds `TrackJumpSchema` (`{ rampHeight }` strictly positive, max
+3 m) optionally on `TrackSegmentSchema`, mirrors it as
 `jumpRampHeight?: number` on `CompiledSegment`, and the compiler
 writes the value onto the first compiled subsegment only so the
 runtime trigger does not multiply when an authored segment

--- a/docs/FOLLOWUPS.md
+++ b/docs/FOLLOWUPS.md
@@ -327,8 +327,22 @@ churn ships in one wave.
 ## F-094: Authored jumps and crests across tours 2-8
 **Created:** 2026-05-07
 **Priority:** nice-to-have
-**Status:** open
-**Notes:** Surfaced by the 2026-05-07 mass-appeal audit (Tier A #5).
+**Status:** in-progress
+**Notes:** Slice 1 shipped 2026-05-09 under
+`feat/jump-schema-field` after a 2-agent design debate landed on
+"explicit schema field, one numeric knob, no runtime state
+machine at v1.0." Adds `TrackJumpSchema` (`{ rampHeight: 0..3 }`)
+optionally on `TrackSegmentSchema`, mirrors it as
+`jumpRampHeight?: number` on `CompiledSegment`, and the compiler
+writes the value onto the first compiled subsegment only so the
+runtime trigger does not multiply when an authored segment
+subdivides. Behaviour-neutral on the 35 existing tracks. Slices
+2-5 still open: renderer lift (parabolic `liftPx` curve keyed on
+`rampHeight`), audio cue + §16 camera shake on the lift curve's
+descent-zero crossing, AI sprite parity, and per-tour authoring
+across tours 2-8. Original entry below.
+
+Surfaced by the 2026-05-07 mass-appeal audit (Tier A #5).
 Zero of the 35 track JSONs declare jumps, ramps, or dramatic positive
 grades for air time. GDD §3 names jumps as a Top Gear 2 staple
 ("pickups, jumps, obstacles"). The schema supports `grade` per segment

--- a/docs/PROGRESS_LOG.md
+++ b/docs/PROGRESS_LOG.md
@@ -17,9 +17,11 @@ parity, and the per-tour authoring slices stay open.
 
 ### Done
 - Added `TrackJumpSchema` in `src/data/schemas.ts` with a single
-  bounded numeric field (`rampHeight: 0..3 meters`). Optional on
-  `TrackSegmentSchema` so the 35 existing track JSONs validate
-  unchanged.
+  bounded numeric field (`rampHeight`: strictly positive, max 3
+  meters). Optional on `TrackSegmentSchema` so the existing track
+  JSONs validate unchanged. Zero rejects so the field's presence
+  always marks a real launch; a zero ramp would be a degenerate
+  authoring.
 - Mirrored the field as `jumpRampHeight?: number` on
   `CompiledSegment` in `src/road/types.ts`. Optional so legacy
   consumers see the same shape they always did.
@@ -35,7 +37,7 @@ parity, and the per-tour authoring slices stay open.
 - `pnpm vitest run` 2983 / 2983 across 162 suites; 2 new cases in
   `trackCompiler.test.ts` covering the schema-accept + first-
   subsegment-only mirror, and the schema-reject path for out-of-
-  range `rampHeight` (negative + above 3).
+  range `rampHeight` (negative, zero, and above 3).
 - `pnpm content-lint` clean.
 - `pnpm docs:check` clean.
 

--- a/docs/PROGRESS_LOG.md
+++ b/docs/PROGRESS_LOG.md
@@ -6,6 +6,69 @@ Correct them by adding a new entry that references the old one.
 
 ---
 
+## 2026-05-09: feat(schema): jump.rampHeight field (F-094 slice 1)
+
+**GDD sections touched:** [§3](gdd/03-design-pillars.md) (Top Gear 2
+"jumps, obstacles" staple) and [§22](gdd/22-data-schemas.md)
+(`TrackSegmentSchema` extension).
+**Branch / PR:** `feat/jump-schema-field`, PR pending.
+**Status:** Slice 1 of F-094. Renderer lift, audio cue, AI sprite
+parity, and the per-tour authoring slices stay open.
+
+### Done
+- Added `TrackJumpSchema` in `src/data/schemas.ts` with a single
+  bounded numeric field (`rampHeight: 0..3 meters`). Optional on
+  `TrackSegmentSchema` so the 35 existing track JSONs validate
+  unchanged.
+- Mirrored the field as `jumpRampHeight?: number` on
+  `CompiledSegment` in `src/road/types.ts`. Optional so legacy
+  consumers see the same shape they always did.
+- Compiler in `src/road/trackCompiler.ts` writes
+  `jumpRampHeight` only on the first compiled subsegment of an
+  authored segment. A jump is one discrete launch event per
+  authored segment; subdividing across compiled subsegments would
+  multiply the runtime trigger.
+
+### Verified
+- `pnpm typecheck` clean.
+- `pnpm lint` clean.
+- `pnpm vitest run` 2983 / 2983 across 162 suites; 2 new cases in
+  `trackCompiler.test.ts` covering the schema-accept + first-
+  subsegment-only mirror, and the schema-reject path for out-of-
+  range `rampHeight` (negative + above 3).
+- `pnpm content-lint` clean.
+- `pnpm docs:check` clean.
+
+### Assumptions
+- **One numeric knob over three.** The 2-agent design debate that
+  produced this slice considered three-field
+  (`rampHeight + landZone + minSpeedMps`) and one-field designs.
+  Both agents converged on one field after Round 3: speed-gating
+  is a runtime feel constant and `landZone` can be derived from
+  the lift curve's descent-zero crossing in slice 3, so encoding
+  them in 35 track JSONs would be premature.
+- **Schema vs. renderer-only detection.** The debate's other axis
+  was "use existing `grade` band edges + a derived crest detector"
+  vs. "explicit schema field." Both agents agreed authorial intent
+  ("this is a jump") is a contract worth encoding rather than
+  reverse-engineering from a numerical coincidence on `grade`.
+- **First subsegment only.** Pickups already follow this pattern
+  in `trackCompiler.ts`. Reusing the convention keeps the runtime
+  trigger semantics consistent across schema decorators.
+
+### GDD coverage
+- §22 Data schemas: `TrackSegmentSchema` extended in a backward-
+  compatible way.
+- §3 Design pillars: this slice does not yet make jumps visible -
+  that lands in slice 2 (renderer lift). It's the schema scaffold
+  for the visible feature.
+
+### Followups
+- F-094 stays in-progress for slices 2-5 (renderer lift, audio +
+  camera shake, AI sprite parity, per-tour authoring).
+
+---
+
 ## 2026-05-09: test(e2e): feedback FAB coverage (F-077)
 
 **GDD sections touched:** Q-012 option (b) - the global feedback

--- a/src/data/schemas.ts
+++ b/src/data/schemas.ts
@@ -179,13 +179,16 @@ export type TrackPickup = z.infer<typeof TrackPickupSchema>;
  * renderer reads `rampHeight` (in meters) to compute a parabolic
  * sprite lift on top of the existing grade-driven projection;
  * `grade` continues to shape the road silhouette, and `rampHeight`
- * adds a decoupled launch on top of it. Future slices may extend
- * this object with audio-cue or landing-zone fields, but the v1.0
- * contract is deliberately one numeric knob so authoring stays
- * legible across the 35 shipped track JSONs.
+ * adds a decoupled launch on top of it. The field's presence
+ * means "this segment is a jump"; a zero or negative ramp would
+ * be a degenerate authoring (no visible launch), so the schema
+ * requires a strictly positive height. Future slices may extend
+ * this object with audio-cue or landing-zone fields; v1.0 is
+ * deliberately one numeric knob so authoring stays legible
+ * across the existing track JSONs.
  */
 export const TrackJumpSchema = z.object({
-  rampHeight: z.number().min(0).max(3),
+  rampHeight: z.number().positive().max(3),
 });
 export type TrackJump = z.infer<typeof TrackJumpSchema>;
 

--- a/src/data/schemas.ts
+++ b/src/data/schemas.ts
@@ -174,6 +174,21 @@ export const TrackPickupSchema = z.object({
 });
 export type TrackPickup = z.infer<typeof TrackPickupSchema>;
 
+/**
+ * Optional decorator marking a segment as an authored jump. The
+ * renderer reads `rampHeight` (in meters) to compute a parabolic
+ * sprite lift on top of the existing grade-driven projection;
+ * `grade` continues to shape the road silhouette, and `rampHeight`
+ * adds a decoupled launch on top of it. Future slices may extend
+ * this object with audio-cue or landing-zone fields, but the v1.0
+ * contract is deliberately one numeric knob so authoring stays
+ * legible across the 35 shipped track JSONs.
+ */
+export const TrackJumpSchema = z.object({
+  rampHeight: z.number().min(0).max(3),
+});
+export type TrackJump = z.infer<typeof TrackJumpSchema>;
+
 export const TrackSegmentSchema = z.object({
   len: positiveNumber,
   curve: z.number().min(-1).max(1),
@@ -184,6 +199,7 @@ export const TrackSegmentSchema = z.object({
   pickups: z.array(TrackPickupSchema).optional(),
   inTunnel: z.boolean().optional(),
   tunnelMaterial: slug.optional(),
+  jump: TrackJumpSchema.optional(),
 });
 export type TrackSegment = z.infer<typeof TrackSegmentSchema>;
 

--- a/src/road/__tests__/trackCompiler.test.ts
+++ b/src/road/__tests__/trackCompiler.test.ts
@@ -251,6 +251,14 @@ describe("compileTrack (full-track entry point)", () => {
       lengthMeters: 60,
     });
     expect(TrackSchema.safeParse(negative).success).toBe(false);
+    // Zero is a degenerate authoring: the field's presence marks
+    // the segment as a jump, but a zero ramp would launch nothing.
+    // Reject so authors do not ship surprise no-ops.
+    const zero = track({
+      segments: [seg({ len: 60, jump: { rampHeight: 0 } })],
+      lengthMeters: 60,
+    });
+    expect(TrackSchema.safeParse(zero).success).toBe(false);
   });
 
   it("compiles a 13 m authored segment to 3 compiled segments (ceil(13/6))", () => {

--- a/src/road/__tests__/trackCompiler.test.ts
+++ b/src/road/__tests__/trackCompiler.test.ts
@@ -217,6 +217,42 @@ describe("compileTrack (full-track entry point)", () => {
     });
   });
 
+  it("accepts authored jump.rampHeight in TrackSchema and mirrors it onto the first compiled subsegment", () => {
+    const t = track({
+      segments: [
+        seg({ len: 13, jump: { rampHeight: 1.8 } }),
+        seg({ len: 60 }),
+        seg({ len: 60 }),
+        seg({ len: 60 }),
+      ],
+      lengthMeters: 193,
+    });
+    const parsed = TrackSchema.safeParse(t);
+    expect(parsed.success).toBe(true);
+    const compiled = compileTrack(t);
+    // 13 m authored at 6 m/segment compiles to 3 subsegments. Only
+    // the first carries jumpRampHeight so the runtime trigger does
+    // not multiply when an authored segment subdivides.
+    expect(compiled.segments[0]!.jumpRampHeight).toBeCloseTo(1.8, 6);
+    expect(compiled.segments[1]!.jumpRampHeight).toBeUndefined();
+    expect(compiled.segments[2]!.jumpRampHeight).toBeUndefined();
+    // Segments without an authored jump stay unchanged.
+    expect(compiled.segments[3]!.jumpRampHeight).toBeUndefined();
+  });
+
+  it("rejects out-of-range jump.rampHeight values via the schema", () => {
+    const tooHigh = track({
+      segments: [seg({ len: 60, jump: { rampHeight: 5 } })],
+      lengthMeters: 60,
+    });
+    expect(TrackSchema.safeParse(tooHigh).success).toBe(false);
+    const negative = track({
+      segments: [seg({ len: 60, jump: { rampHeight: -1 } })],
+      lengthMeters: 60,
+    });
+    expect(TrackSchema.safeParse(negative).success).toBe(false);
+  });
+
   it("compiles a 13 m authored segment to 3 compiled segments (ceil(13/6))", () => {
     const t = track({
       segments: [seg({ len: 13 }), seg({ len: 13 })],

--- a/src/road/trackCompiler.ts
+++ b/src/road/trackCompiler.ts
@@ -169,6 +169,10 @@ export function compileTrack(track: Track): CompiledTrack {
         pickupIds: i === 0 ? pickupIds : EMPTY_IDS,
         inTunnel: seg.inTunnel === true || seg.hazards.includes("tunnel"),
         tunnelMaterialId: seg.tunnelMaterial,
+        // A jump is one discrete launch event per authored segment; only
+        // the first compiled subsegment carries it so the runtime
+        // trigger does not multiply when an authored segment subdivides.
+        jumpRampHeight: i === 0 ? seg.jump?.rampHeight : undefined,
       });
       cumulativeIndex += 1;
     }
@@ -356,6 +360,7 @@ export function compileSegments(authored: readonly TrackSegment[]): CompiledSegm
         pickupIds: i === 0 ? pickupIds : EMPTY_IDS,
         inTunnel: seg.inTunnel === true || seg.hazards.includes("tunnel"),
         tunnelMaterialId: seg.tunnelMaterial,
+        jumpRampHeight: i === 0 ? seg.jump?.rampHeight : undefined,
       });
       cumulativeIndex += 1;
     }

--- a/src/road/types.ts
+++ b/src/road/types.ts
@@ -74,6 +74,14 @@ export interface CompiledSegment {
   pickupIds: readonly string[];
   inTunnel?: boolean;
   tunnelMaterialId?: string;
+  /**
+   * Authored jump decorator mirrored from `TrackSegment.jump`. When
+   * set, the renderer reads `rampHeight` (meters) to lift the player
+   * car sprite along a parabolic curve on top of the existing
+   * grade-driven projection. Optional so the 35 existing tracks
+   * compile unchanged.
+   */
+  jumpRampHeight?: number;
 }
 
 /**


### PR DESCRIPTION
## Summary
- Adds \`TrackJumpSchema\` in \`src/data/schemas.ts\` with a single bounded numeric field (\`rampHeight: 0..3 meters\`). Optional on \`TrackSegmentSchema\` so the 35 existing track JSONs validate unchanged
- Mirrors as \`jumpRampHeight?: number\` on \`CompiledSegment\` in \`src/road/types.ts\`
- Compiler writes \`jumpRampHeight\` only on the first compiled subsegment of an authored segment, reusing the pickup-on-first-subsegment convention so the runtime trigger does not multiply when an authored segment subdivides
- Behaviour-neutral on existing tracks. First slice of F-094

## Why
F-094's mass-appeal audit (Tier A #5) found that none of the 35 track JSONs declare jumps - GDD §3 names jumps as a Top Gear 2 staple. A 2-agent design debate considered three-field (\`rampHeight + landZone + minSpeedMps\`) vs. one-field, and renderer-only-detection vs. explicit-schema designs. Both agents converged on \"explicit schema field, one numeric knob, no runtime state machine at v1.0\":

1. \"This is a jump\" is authorial intent worth encoding rather than reverse-engineering from a numerical coincidence on \`grade\`.
2. Speed-gating is a runtime feel constant; \`landZone\` can be derived from the lift curve's descent-zero crossing in slice 3.

## Slice plan after this PR
- Slice 2: renderer lift - pure \`computeJumpLift\` helper + \`liftPx\` on the player car prop, parabolic curve keyed on \`rampHeight\`.
- Slice 3: audio cue + §16 camera shake on the lift curve's descent-zero crossing (no state machine).
- Slice 4: AI sprite lift parity (renderer-only).
- Slice 5: author 1-3 jumps per track across tours 2-8.

## Test plan
- [x] \`pnpm typecheck\`
- [x] \`pnpm lint\`
- [x] \`pnpm vitest run\` (2983 / 2983 across 162 suites; 2 new cases in trackCompiler.test.ts: schema-accept + first-subsegment-only mirror, and schema-reject for out-of-range \`rampHeight\`)
- [x] \`pnpm content-lint\`
- [x] \`pnpm docs:check\`
- [ ] CI: lint, typecheck, unit, e2e

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Tracks can include optional jump ramps with configurable positive ramp heights (capped).
  * Compiled track segments carry jump ramp metadata only for the first subsegment of an authored segment.
  * Player sprites lift and launch with parabolic motion from jump ramps.

* **Tests**
  * Added validation and compilation tests for jump ramp values and propagation behavior.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Randroids-Dojo/VibeGear2/pull/219)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->