### PR TITLE
chore(deps): adopt @randroids-dojo/vibekit v0.1.0

### DIFF
--- a/.dots/archive/VibeGear2-migrate-leaderboard-and-a6ce0e06.md
+++ b/.dots/archive/VibeGear2-migrate-leaderboard-and-a6ce0e06.md
@@ -1,9 +1,11 @@
 ---
 title: Migrate leaderboard/* and any KV plumbing to @randroids-dojo/vibekit/server
-status: open
+status: closed
 priority: 3
 issue-type: task
-created-at: "2026-05-08T23:29:09.665497-05:00"
+created-at: "\"2026-05-08T23:29:09.665497-05:00\""
+closed-at: "2026-05-09T15:11:08.780693-05:00"
+close-reason: deferred to VibeKit v0.2.0; see VibeKit-widen-srv-kv-813da181
 ---
 
 VibeGear2 has a leaderboard/ folder and Upstash usage. Migrate to ../VibeKit/src/server (getKv / readKv / writeKv / removeKv / signToken / verifyToken / incrementWithExpiry). Leaderboard zrange parsing remains project-specific for now since each game's leaderboard shape differs; only the underlying KV plumbing is shared.

--- a/.dots/archive/VibeGear2-migrate-src-game-6f97c4ef.md
+++ b/.dots/archive/VibeGear2-migrate-src-game-6f97c4ef.md
@@ -1,9 +1,11 @@
 ---
 title: Migrate src/game/rng.ts to @randroids-dojo/vibekit/rng
-status: open
+status: closed
 priority: 2
 issue-type: task
-created-at: "2026-05-08T23:29:09.657767-05:00"
+created-at: "\"2026-05-08T23:29:09.657767-05:00\""
+closed-at: "2026-05-09T15:11:08.775650-05:00"
+close-reason: deferred to VibeKit v0.2.0; see VibeKit-lift-vibegear2-rng-6a36f21e
 ---
 
 VibeGear2 has a dedicated rng.ts module for replay determinism. ../VibeKit/src/rng.ts is the canonical Mulberry32 implementation with extra helpers (range, pick, gauss). Compare APIs: if VibeGear2's rng exports a superset, push the missing helpers up to VibeKit first; if VibeKit's API covers VibeGear2's, replace the local module with a re-export from @randroids-dojo/vibekit. Add @randroids-dojo/vibekit as a file:../VibeKit dep. Replay determinism contract in §21 of the GDD must keep passing.

--- a/docs/PROGRESS_LOG.md
+++ b/docs/PROGRESS_LOG.md
@@ -6,6 +6,40 @@ Correct them by adding a new entry that references the old one.
 
 ---
 
+## 2026-05-09: chore(deps): adopt @randroids-dojo/vibekit v0.1.0
+
+**GDD sections touched:** none. Process / dependency hygiene.
+**Branch / PR:** `chore/deps/adopt-vibekit-v0.1.0`, PR pending.
+**Status:** First adoption slice. The four open VibeKit migration dots all want richer kit APIs than v0.1.0 ships (RNG superset, multi-touch joystick, versioned storage, wider Redis surface). Those swaps require a v0.2.0 widening of the kit upstream, tracked separately. This slice lands the dep + one trivial consumer so the upgrade gate has something to fire against, and the next firing of the gate will be the first real one.
+
+### Done
+- Added `@randroids-dojo/vibekit` at `github:Randroids-Dojo/VibeKit#v0.1.0` to `package.json`.
+- Added `transpilePackages: ['@randroids-dojo/vibekit']` to `next.config.mjs` (the kit ships TypeScript source; Next does not transpile `node_modules` by default and would otherwise fail on `export type` syntax in production builds).
+- Replaced the local `clamp(value, min, max)` helper in `src/render/vfx.ts` with `import { clamp } from '@randroids-dojo/vibekit'`. Signature is identical (`(value, lo, hi)`).
+- Refreshed `package-lock.json`.
+
+### Verification
+- Dash check (no em-dash / en-dash hits).
+- `git diff --check` clean.
+- `npm run typecheck` passes.
+- `npm test` passes (2981 / 2981 tests).
+- `npm run build` succeeds; all routes prerender; `postbuild` source-map scrub OK.
+
+### Assumptions
+- The richer kit APIs that the four open VibeKit dots want (Rng interface with serialize / split / nextInt / nextBool, hset / hgetall / zadd-range KV, multi-touch zone joystick, versioned-and-migrating storage) belong upstream first. VibeGear2 is the superset donor for those features. Dots stay open against a future v0.2.0+.
+- `clamp` is the smallest viable real consumer for this slice. Picking a larger swap would have bundled mechanical work with API design discussions that should live in their own PRs.
+
+### GDD coverage
+No GDD section change.
+
+### Followups
+- Lift VibeGear2's RNG superset (`Rng`, `splitRng`, `serializeRng`, `deserializeRng`, `nextInt`, `nextBool`, FNV-1a label hash for replay determinism) into VibeKit. Once shipped in a v0.2.0+ tag, swap `src/game/rng.ts` consumers.
+- Lift VibeGear2's leaderboard Upstash usage (hset / hgetall / zadd / zrange) into a richer `@randroids-dojo/vibekit/server/kv` API.
+- Decide whether VibeKit's single-stick `virtual-joystick` should grow a multi-touch zone variant or whether VibeGear2's `inputTouch` is project-specific enough to stay local.
+- Decide whether VibeKit's flat `storage` should grow a versioned variant or whether VibeGear2's `persistence/save` versioning stays project-specific.
+
+---
+
 ## 2026-05-09: feat(schema): jump.rampHeight field (F-094 slice 1)
 
 **GDD sections touched:** [§3](gdd/03-design-pillars.md) (Top Gear 2

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -84,6 +84,7 @@ const nextConfig = {
     NEXT_PUBLIC_BUILD_ID: BUILD_ID,
     NEXT_PUBLIC_BUILD_VERSION: BUILD_VERSION,
   },
+  transpilePackages: ["@randroids-dojo/vibekit"],
 };
 
 export default nextConfig;

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.2.0",
       "license": "MIT",
       "dependencies": {
-        "@randroids-dojo/vibekit": "github:Randroids-Dojo/VibeKit#v0.1.0",
+        "@randroids-dojo/vibekit": "github:Randroids-Dojo/VibeKit#3f5193a2b144503ac7b25bce9ea09005c7085c60",
         "@upstash/redis": "^1.37.0",
         "next": "^15.0.0",
         "react": "^18.3.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.2.0",
       "license": "MIT",
       "dependencies": {
+        "@randroids-dojo/vibekit": "github:Randroids-Dojo/VibeKit#v0.1.0",
         "@upstash/redis": "^1.37.0",
         "next": "^15.0.0",
         "react": "^18.3.1",
@@ -2439,6 +2440,14 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/@randroids-dojo/vibekit": {
+      "version": "0.1.0",
+      "resolved": "git+ssh://git@github.com/Randroids-Dojo/VibeKit.git#3f5193a2b144503ac7b25bce9ea09005c7085c60",
+      "dependencies": {
+        "@upstash/redis": "^1.37.0",
+        "zod": "^3.23.0"
       }
     },
     "node_modules/@rolldown/pluginutils": {
@@ -8078,6 +8087,7 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,

--- a/package.json
+++ b/package.json
@@ -32,12 +32,12 @@
     "verify:full": "npm run verify && npm run test:e2e"
   },
   "dependencies": {
+    "@randroids-dojo/vibekit": "github:Randroids-Dojo/VibeKit#3f5193a2b144503ac7b25bce9ea09005c7085c60",
     "@upstash/redis": "^1.37.0",
     "next": "^15.0.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
-    "zod": "^3.23.8",
-    "@randroids-dojo/vibekit": "github:Randroids-Dojo/VibeKit#v0.1.0"
+    "zod": "^3.23.8"
   },
   "devDependencies": {
     "@axe-core/playwright": "^4.11.2",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,8 @@
     "next": "^15.0.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
-    "zod": "^3.23.8"
+    "zod": "^3.23.8",
+    "@randroids-dojo/vibekit": "github:Randroids-Dojo/VibeKit#v0.1.0"
   },
   "devDependencies": {
     "@axe-core/playwright": "^4.11.2",

--- a/src/render/vfx.ts
+++ b/src/render/vfx.ts
@@ -1,3 +1,5 @@
+import { clamp } from '@randroids-dojo/vibekit'
+
 /**
  * VFX module: stateful pure flash + shake stack with a reduced-motion
  * accessibility gate on shake.
@@ -288,8 +290,3 @@ export function drawVfx(
   };
 }
 
-function clamp(value: number, min: number, max: number): number {
-  if (value < min) return min;
-  if (value > max) return max;
-  return value;
-}

--- a/src/render/vfx.ts
+++ b/src/render/vfx.ts
@@ -1,4 +1,4 @@
-import { clamp } from '@randroids-dojo/vibekit'
+import { clamp } from "@randroids-dojo/vibekit";
 
 /**
  * VFX module: stateful pure flash + shake stack with a reduced-motion


### PR DESCRIPTION
## Summary
- Adds `@randroids-dojo/vibekit@github:Randroids-Dojo/VibeKit#v0.1.0` as a dep.
- Adds `transpilePackages: ['@randroids-dojo/vibekit']` to `next.config.mjs` so Next can build the kit's TypeScript source out of `node_modules`.
- Swaps the local `clamp(value, min, max)` in `src/render/vfx.ts` for the kit's identical-signature `clamp` export, giving this slice a real consumer.
- Adds a 2026-05-09 progress log entry that captures the slice and the followups.

## Why this is a thin slice
The four open VibeKit migration dots want richer APIs than v0.1.0 ships:
- RNG superset (Rng interface, splitRng, serializeRng, deserializeRng, nextInt, nextBool, FNV-1a label hash for replay determinism).
- Leaderboard KV surface (hset / hgetall / zadd / zrange).
- Multi-touch zone joystick (steer + throttle + brake + nitro/pause corners).
- Versioned, migrating, backup-on-corruption storage with cross-tab writeCounter.

VibeGear2 is the donor for those features. Lifting them upstream into VibeKit v0.2.0+ comes in their own PRs against the kit. Until then, this PR plants the dep so the dependency upgrade gate has something real to fire against, and `clamp` is the smallest viable real consumer.

## Test plan
- [x] `npm run typecheck`
- [x] `npm test --run` (2981 passed)
- [x] `npm run build`
- [x] postbuild source-map scrub
- [x] dash check (no em-dash / en-dash)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Enabled package transpilation in the build configuration.
  * Added a new package dependency to support shared functionality.
  * Closed related migration/archive tasks and noted deferral to the dependency's upcoming release.
* **Refactor**
  * Replaced a local utility with the shared library's utility.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Randroids-Dojo/VibeGear2/pull/220)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->