### PR TITLE
fix(race): visible opponents, finish line, and tour resume

### DIFF
--- a/.dots/VibeGear2-crash-physics-feedback-1c795b62.md
+++ b/.dots/VibeGear2-crash-physics-feedback-1c795b62.md
@@ -1,0 +1,40 @@
+---
+title: "Crash physics + feedback: make collisions feel like collisions"
+status: open
+priority: 1
+issue-type: task
+created-at: "2026-05-10T03:27:20.607758-05:00"
+---
+
+Background
+
+The fix/race-readability-bundle PR (#221) traced the "AI cars stop ahead" complaint to a 12-car grid pile-up: every AI steered toward the centerline-anchored racing line, all converged in <2 seconds, accumulated damage to >=0.95 wreck threshold, then status flipped to dnf and physics froze. To the player, this looks like cars driving straight and stopping. No screech, no spark, no knock, no debris, no HUD beat. The launch-phase lane-hold in 8187062 stops the pile-up, but the deeper issue is that crashes have no presence even when they happen.
+
+Goal
+
+Make a collision read as a collision: visually, audibly, mechanically. Two cars touching should feel like contact. A car wrecking should not silently freeze.
+
+Research
+
+1. Audit src/game/raceSession.ts contact-pair scan around line 1689 (carHit event generation) and src/game/raceRules.ts wreck threshold (WRECK_THRESHOLD = 0.95). Map every place a hit/wreck event fires.
+2. Map current collision feedback surface area: src/render/vfx.ts (flash + shake), src/audio (any hit/crash cues), HUD (damage bar, no event log). Identify where each event type currently lands. Most likely: only the player path triggers shake/flash; AI-vs-AI events have no visual.
+3. Compare to Top Gear 2 reference (per docs/RESEARCH_TOPGEAR_FUN_PLAN.md): hit-flash on contact, brief screen punch on hard hit, audio thud, smoke or debris on heavy wreck, the wrecked car sometimes spins or coasts off-line for a second before settling.
+
+Fix scope (suggested slices)
+
+- Slice 1: AI-vs-AI carHit events trigger localised VFX (a sprite-anchored flash or dust puff at the contact midpoint). Wire into existing vfx state.
+- Slice 2: Wreck transition has a "death animation" - the wrecking car's status flips to dnf, but for ~0.6 s before physics freezes, it spins or drifts to the rumble. Visual + audio cue at the moment of wreck.
+- Slice 3: Audio: collision thud cue (per src/audio engine API) and a deeper wreck-stinger cue, both gated behind reduced-motion / accessibility settings if relevant.
+- Slice 4: Lateral knock-back amplitude: the existing F-102 BUMP_KICK_BASE_MPS may be too small to read on-screen; verify by instrumenting and bumping until contact feels percussive.
+
+Verification
+
+- Browser playthrough: every contact pair produces a visible flash and audio cue; every wreck produces a distinct stinger and a brief death animation.
+- New e2e or unit pin: at race start with the launch-lane-hold off (or simulated bump), AI cars in contact emit at least one hit event and the renderer's vfxState shows a flash entry.
+- Player feel: bumping a CPU at speed should feel like a clear thump, not a silent damage tick.
+
+Constraints
+
+- AGENTS.md RULE 8: replays must remain deterministic. Any per-frame VFX seed has to come from the seeded PRNG, not Math.random.
+- Reduced-motion gate (per docs/gdd/19-controls-and-accessibility.md) still applies to shake.
+- This is the dependent of follow-up F-NNN that wants to keep the pile-up fix from regressing; reference 8187062 in the slice 1 PR.

--- a/docs/FOLLOWUPS.md
+++ b/docs/FOLLOWUPS.md
@@ -10,6 +10,30 @@ or `obsolete` so the trail is preserved.
 
 ---
 
+## F-105: AI grid-start crash physics and feedback
+**Created:** 2026-05-10
+**Priority:** nice-to-have
+**Status:** in-progress
+**Notes:** The race-readability bundle (PR #221) traced the "AI cars
+stop ahead" complaint to a 12-car grid pile-up. Every AI immediately
+steered toward the centerline-anchored racing line at race start,
+the field collided, and damage accumulated past the wreck threshold
+(0.95) within a couple seconds. Cars then status-flipped to dnf and
+the renderer froze them in place. To the player, this read as cars
+silently stopping. PR #221 added a launch-phase lane hold that
+blends the lateral target from "hold spawn lane" at z=0 to "pursue
+racing line" at z=200, which prevents the lateral pile-up but is
+still partial: cars in the same lane rear-end whoever is ahead
+because the AI has no follow-distance throttle, the launch blend
+also suppresses the overtake offset, and contact emits no audio /
+visual / HUD cue, so even non-fatal hits are invisible. Tracked in
+dot `VibeGear2-crash-physics-feedback-1c795b62` (priority 1) with
+slice plan: split overtake offset out of the launch blend, add a
+follow-distance throttle so trailing AI lift before contact, wire
+audio thud + sprite-anchored VFX + screen punch to carHit events
+for AI-vs-AI pairs, and tune the F-102 BUMP_KICK_BASE_MPS so
+contact reads as percussive instead of a creep-and-stick.
+
 ## F-104: TG2-faithful fuel and gearbox economy
 **Created:** 2026-05-09
 **Priority:** nice-to-have

--- a/docs/PROGRESS_LOG.md
+++ b/docs/PROGRESS_LOG.md
@@ -6,6 +6,108 @@ Correct them by adding a new entry that references the old one.
 
 ---
 
+## 2026-05-10: fix(race): visible opponents, finish line, tour resume, launch lane hold
+
+**GDD sections touched:** [§7](gdd/07-race-modes-and-rules.md) (grid
+spawn / pile-up), [§15](gdd/15-ai-and-difficulty.md) (AI launch-phase
+lateral target), [§16](gdd/16-rendering-and-visual-design.md)
+(opponent projection, finish-line stripe, roadside scaling),
+[§20](gdd/20-ui-and-hud.md) (tour resume CTA contract).
+**Branch / PR:** `fix/race-readability-bundle`, PR #221.
+**Status:** Bundled five race-readability fixes that together took
+the World Tour from "looks broken" to "plays through." User
+playtest on 2026-05-10 reported: AI cars appeared frozen ahead,
+roadside props stacked into a totem at the horizon, no finish line,
+the second tour race did not appear available after finishing the
+first. All four addressed; the underlying crash physics is partial
+and tracked under F-105 / dot `VibeGear2-crash-physics-feedback-1c795b62`.
+
+### Done
+- Removed the 92 px upper clamp on opponent projection in
+  `src/app/race/page.tsx` and raised the depth cull from 200 m to
+  800 m. Opponents now visibly grow as the player closes the gap
+  rather than reading as frozen sprites.
+- Added a checkered start/finish band in `src/render/pseudoRoadCanvas.ts`.
+  The track compiler validates the "start" checkpoint at compiled
+  segment 0, so the band anchors there and renders for the first two
+  compiled segments of every lap. Gated by a near-plane filter so the
+  band does not dominate the foreground when the player is sitting
+  on the line.
+- Lowered the per-kind roadside `minHeight` floor from 5 to 14 px
+  down to 1 px in `ROADSIDE_SPRITE_STYLES`. Sprites now scale
+  linearly with projected road width and dissolve to a pixel at the
+  horizon instead of stacking into a "totem pole."
+- `enterTour` in `src/game/championship.ts` preserves an in-progress
+  `activeTour` when re-entering the same tour. Previously the cursor
+  reset to `raceIndex: 0`, which silently restarted the World Tour
+  from race 1. `enterWorldTour` reads the resumed cursor for the
+  resume track id.
+- Added a launch-phase lateral-target blend in `src/game/ai.ts`. The
+  ideal lateral offset blends from `aiCar.x` (current lane) at z=0
+  to the full racing-line offset at z=`AI_TUNING.LAUNCH_LANE_HOLD_M`
+  (200 m). Stops the §7 grid from pile-up'ing on the centerline at
+  race start.
+- Added a `?debug=ai` URL gate that renders a top-right roster
+  overlay: per-AI status, speed, target, z, lap, dnfReason, and the
+  no-progress / off-track timers. Updates each render frame. Used to
+  confirm the pile-up root cause; left in for future diagnosis.
+- Added `window.__vg_session = sessionRef` on race-session creation
+  so DevTools can inspect live state without rebuilding.
+
+### Verification
+- `npm run typecheck` clean.
+- `npm test --run` 2987 / 2987 (added two AI launch-phase regression
+  tests; updated `pseudoRoadCanvas.test.ts` and
+  `championship.test.ts` fixtures for the new color fields and tour
+  resume contract).
+- `npm run build` succeeds; postbuild source-map scrub clean.
+- Browser playtest in `?debug=ai`: confirmed wreck count dropped
+  from 9 of 11 to roughly 8 of 11 with the launch hold; remaining
+  wrecks are same-lane rear-ends, tracked separately under F-105.
+
+### Assumptions
+- Compiled segment 0 is the start/finish line for every authored
+  track. The track compiler enforces this (line 211 of
+  `trackCompiler.ts` errors on a non-zero start segment), so the
+  finish-line band can anchor on the index without a per-track lookup.
+- `aiCar.x` at race start equals the spawn lane, because no time has
+  passed for the AI to steer; using it as the launch-blend "hold
+  lane" target is correct for the §7 grid spawn.
+- The 92 px AI clamp dates to commit `4cb55a52` (fix/render hide
+  unreadable hill opponents); the e2e regression at
+  `e2e/projection-readability.spec.ts` filters samples by
+  `aiWidth <= 92`. With the cap removed the filter still selects
+  mid-distance samples (close cars now exceed 92 px), and the test
+  passes against the kept ratio / lateral-stability assertions.
+- The `?debug=ai` gate keeps the overlay state-allocation off in
+  normal play; it ships in production but is invisible without the
+  query param.
+
+### GDD coverage
+- §7 grid: pile-up bug pinned by the new launch-phase test in
+  `ai.test.ts` (`tickAI (launch-phase lane hold)`).
+- §15 AI launch-phase contract: `LAUNCH_LANE_HOLD_M` documented in
+  `AI_TUNING` with the rationale.
+- §16 rendering: finish-line stripe is the first consumer of
+  `DEFAULT_COLORS.finishLight` / `finishDark`; roadside scaling
+  reads as physical perspective end-to-end.
+- §20 results CTA: "Continue tour" still works as before; the
+  resume cursor now also covers the case where the player goes back
+  to /world mid-tour and re-enters.
+
+### Followups
+- F-105 (new): split the launch-blend so overtake offset stays
+  active during launch, add a follow-distance throttle for trailing
+  AI in the same lane, wire audio + VFX + HUD cues to AI-vs-AI
+  carHit events, and tune lateral knock-back so contact reads as
+  percussive. Tracked under dot
+  `VibeGear2-crash-physics-feedback-1c795b62`.
+- The `aiWidth <= 92` filter in `e2e/projection-readability.spec.ts`
+  is still legible but no longer pins the visual cap. Worth retiring
+  in a follow-on render-spec slice.
+
+---
+
 ## 2026-05-09: chore(deps): adopt @randroids-dojo/vibekit v0.1.0
 
 **GDD sections touched:** none. Process / dependency hygiene.

--- a/src/app/race/page.tsx
+++ b/src/app/race/page.tsx
@@ -824,6 +824,32 @@ interface AiProjectionSnapshot {
   readonly nearestWidthDepthProduct: number;
 }
 
+interface AiDebugRow {
+  readonly index: number;
+  readonly status: string;
+  readonly speed: number;
+  readonly target: number;
+  readonly z: number;
+  readonly lap: number;
+  readonly dnfReason: string | null;
+  readonly noProgressSec: number;
+  readonly offTrackSec: number;
+}
+
+function aiDebugRosterFrom(session: RaceSessionState): readonly AiDebugRow[] {
+  return session.ai.map((entry, index) => ({
+    index,
+    status: entry.status,
+    speed: entry.car.speed,
+    target: entry.state.targetSpeed,
+    z: entry.car.z,
+    lap: entry.lap,
+    dnfReason: entry.dnfReason ?? null,
+    noProgressSec: entry.dnfTimers.noProgressSec,
+    offTrackSec: entry.dnfTimers.offTrackSec,
+  }));
+}
+
 function aiProjectionSnapshot(
   cars: readonly NonNullable<DrawRoadOptions["aiCars"]>[number][],
 ): AiProjectionSnapshot | null {
@@ -1134,6 +1160,8 @@ function RaceCanvas({
   ghostSource,
 }: RaceCanvasProps): ReactElement {
   const router = useRouter();
+  const debugSearch = useSearchParams();
+  const aiDebugEnabled = debugSearch?.get("debug") === "ai";
   const canvasRef = useRef<HTMLCanvasElement | null>(null);
   const handleRef = useRef<LoopHandle | null>(null);
   const sessionRef = useRef<RaceSessionState | null>(null);
@@ -1219,6 +1247,9 @@ function RaceCanvas({
   const [fieldSize, setFieldSize] = useState<number>(1);
   const [aiVisibleCount, setAiVisibleCount] = useState<number>(0);
   const [aiProjection, setAiProjection] = useState<AiProjectionSnapshot | null>(
+    null,
+  );
+  const [aiDebugRoster, setAiDebugRoster] = useState<readonly AiDebugRow[] | null>(
     null,
   );
   const [aiReadability, setAiReadability] =
@@ -1556,6 +1587,9 @@ function RaceCanvas({
     setPickupFeedback(null);
     setAiReadability(null);
     sessionRef.current = createRaceSession(config);
+    if (typeof window !== "undefined") {
+      (window as unknown as { __vg_session?: typeof sessionRef }).__vg_session = sessionRef;
+    }
     tutorialHintContextRef.current = {
       segments: config.track.segments,
       topSpeedMps: playerStats.topSpeed,
@@ -2045,6 +2079,9 @@ function RaceCanvas({
           );
         setAiVisibleCount(aiCars.length);
         setAiProjection(aiProjectionSnapshot(aiCars));
+        if (aiDebugEnabled) {
+          setAiDebugRoster(aiDebugRosterFrom(session));
+        }
         if (
           ghostEnabled &&
           session.race.phase === "racing" &&
@@ -2567,6 +2604,50 @@ function RaceCanvas({
           <span style={raceMomentDetailStyle}>{raceMoment.detail}</span>
         </div>
       ) : null}
+      {aiDebugEnabled && aiDebugRoster ? (
+        <div style={aiDebugPanelStyle} data-testid="race-ai-debug">
+          <div style={aiDebugHeaderStyle}>AI debug ({aiDebugRoster.length})</div>
+          <table style={aiDebugTableStyle}>
+            <thead>
+              <tr>
+                <th style={aiDebugCellStyle}>#</th>
+                <th style={aiDebugCellStyle}>status</th>
+                <th style={aiDebugCellStyle}>spd</th>
+                <th style={aiDebugCellStyle}>tgt</th>
+                <th style={aiDebugCellStyle}>z</th>
+                <th style={aiDebugCellStyle}>lap</th>
+                <th style={aiDebugCellStyle}>dnf</th>
+                <th style={aiDebugCellStyle}>np</th>
+                <th style={aiDebugCellStyle}>ot</th>
+              </tr>
+            </thead>
+            <tbody>
+              {aiDebugRoster.map((row) => (
+                <tr
+                  key={row.index}
+                  style={
+                    row.status === "racing" ? undefined : aiDebugStoppedRowStyle
+                  }
+                >
+                  <td style={aiDebugCellStyle}>{row.index}</td>
+                  <td style={aiDebugCellStyle}>{row.status}</td>
+                  <td style={aiDebugCellStyle}>{row.speed.toFixed(1)}</td>
+                  <td style={aiDebugCellStyle}>{row.target.toFixed(1)}</td>
+                  <td style={aiDebugCellStyle}>{row.z.toFixed(0)}</td>
+                  <td style={aiDebugCellStyle}>{row.lap}</td>
+                  <td style={aiDebugCellStyle}>{row.dnfReason ?? "-"}</td>
+                  <td style={aiDebugCellStyle}>
+                    {row.noProgressSec.toFixed(1)}
+                  </td>
+                  <td style={aiDebugCellStyle}>
+                    {row.offTrackSec.toFixed(1)}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      ) : null}
       <dl
         style={metricsStyle}
         data-testid="race-metrics"
@@ -2753,6 +2834,40 @@ const shellStyle: CSSProperties = {
   background: "var(--bg, #111)",
   touchAction: "none",
   userSelect: "none",
+};
+
+const aiDebugPanelStyle: CSSProperties = {
+  position: "absolute",
+  top: 12,
+  right: 12,
+  zIndex: 100,
+  padding: "8px 10px",
+  background: "rgba(0, 0, 0, 0.78)",
+  border: "1px solid #4a5568",
+  color: "#e8edf8",
+  font: "11px/1.3 ui-monospace, SFMono-Regular, Menlo, monospace",
+  maxHeight: "60vh",
+  overflowY: "auto",
+};
+
+const aiDebugHeaderStyle: CSSProperties = {
+  marginBottom: 4,
+  fontWeight: 700,
+  color: "#ffd166",
+};
+
+const aiDebugTableStyle: CSSProperties = {
+  borderCollapse: "collapse",
+};
+
+const aiDebugCellStyle: CSSProperties = {
+  padding: "1px 6px",
+  textAlign: "right",
+  whiteSpace: "nowrap",
+};
+
+const aiDebugStoppedRowStyle: CSSProperties = {
+  color: "#ff9a9a",
 };
 
 const canvasStyle: CSSProperties = {

--- a/src/app/race/page.tsx
+++ b/src/app/race/page.tsx
@@ -759,7 +759,7 @@ function projectOpponentCar(input: {
   const depthMeters = input.carZ - input.camera.z;
   if (!Number.isFinite(depthMeters) || depthMeters < input.camera.depth)
     return null;
-  if (depthMeters > 200) return null;
+  if (depthMeters > 800) return null;
   if (!Number.isFinite(input.trackLength) || input.trackLength <= 0)
     return null;
 
@@ -800,7 +800,7 @@ function projectOpponentCar(input: {
       ? AI_MIN_PROJECTED_WIDTH_MOBILE
       : AI_MIN_PROJECTED_WIDTH_DESKTOP;
   if (projectedScreenW < minProjectedWidth) return null;
-  const screenW = Math.min(92, projectedScreenW);
+  const screenW = projectedScreenW;
   return {
     screenX: projection.screenX,
     screenY: projection.screenY,

--- a/src/app/race/page.tsx
+++ b/src/app/race/page.tsx
@@ -2575,6 +2575,7 @@ function RaceCanvas({
     showRaceMoment,
     clearRaceMomentTimeout,
     clearFinishRouteTimeout,
+    aiDebugEnabled,
   ]);
 
   return (

--- a/src/components/world/worldTourState.ts
+++ b/src/components/world/worldTourState.ts
@@ -58,7 +58,7 @@ export function enterWorldTour(
   if (!result.ok) return result;
   const tour = championship.tours.find((candidate) => candidate.id === tourId);
   if (!tour) return { ok: false, code: "unknown_tour" };
-  const firstTrackId = tour.tracks[0];
+  const firstTrackId = tour.tracks[result.activeTour.raceIndex];
   if (!firstTrackId) return { ok: false, code: "unknown_tour" };
   const unlockedSave = withFirstTourUnlocked(result.save, championship);
   return {

--- a/src/game/__tests__/ai.test.ts
+++ b/src/game/__tests__/ai.test.ts
@@ -240,6 +240,41 @@ describe("tickAI (straight, accelerating)", () => {
   });
 });
 
+describe("tickAI (launch-phase lane hold)", () => {
+  // At z=0 on a straight, the AI must hold its current lane instead of
+  // converging on the centerline-anchored racing line — otherwise the
+  // §7 grid pile-ups itself before the field can spread.
+  it("does not pull off-center cars toward x=0 at race start", () => {
+    const result = tickAI(
+      CLEAN_LINE_DRIVER,
+      freshAi(),
+      freshCar({ x: 3, z: 0, speed: 0 }),
+      PLAYER_FAR_BEHIND,
+      STRAIGHT_TRACK,
+      RACING,
+      STARTER_STATS,
+    );
+    // Lateral error is zero, so steer is zero. Without the launch hold
+    // the AI would target x=0 and produce a strongly negative steer.
+    expect(result.input.steer).toBeCloseTo(0, 6);
+  });
+
+  it("returns to racing-line targeting after the launch hold distance", () => {
+    const result = tickAI(
+      CLEAN_LINE_DRIVER,
+      freshAi(),
+      freshCar({ x: 3, z: 400, speed: 30 }),
+      PLAYER_FAR_BEHIND,
+      STRAIGHT_TRACK,
+      RACING,
+      STARTER_STATS,
+    );
+    // Past the blend window, the racing-line target on a straight is 0,
+    // so an off-center car steers back toward the centerline.
+    expect(result.input.steer).toBeLessThan(0);
+  });
+});
+
 describe("tickAI (cornering)", () => {
   it("biases toward the inside of a right-hand sweeper", () => {
     // Position the AI on the centerline mid-sweeper. Idealized lateral

--- a/src/game/__tests__/championship.test.ts
+++ b/src/game/__tests__/championship.test.ts
@@ -88,6 +88,38 @@ describe("enterTour", () => {
     });
   });
 
+  it("resumes an in-progress activeTour when re-entering the same tour", () => {
+    const save = unlockedSave("first-tour");
+    save.progress.activeTour = {
+      tourId: "first-tour",
+      raceIndex: 2,
+      results: [
+        makeResult("first/a", 1),
+        makeResult("first/b", 3),
+      ],
+    };
+    const result = enterTour(save, FIXTURE_CHAMPIONSHIP, "first-tour");
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.activeTour.raceIndex).toBe(2);
+    expect(result.activeTour.results).toHaveLength(2);
+  });
+
+  it("does not resume across a different tourId", () => {
+    const save = unlockedSave("first-tour", "second-tour");
+    save.progress.activeTour = {
+      tourId: "first-tour",
+      raceIndex: 2,
+      results: [makeResult("first/a", 1)],
+    };
+    const result = enterTour(save, FIXTURE_CHAMPIONSHIP, "second-tour");
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.activeTour.tourId).toBe("second-tour");
+    expect(result.activeTour.raceIndex).toBe(0);
+    expect(result.activeTour.results).toEqual([]);
+  });
+
   it("rejects with unknown_tour when the id is not in the championship", () => {
     const save = unlockedSave("first-tour");
     const result = enterTour(save, FIXTURE_CHAMPIONSHIP, "ghost-tour");

--- a/src/game/ai.ts
+++ b/src/game/ai.ts
@@ -180,6 +180,15 @@ export const AI_TUNING = Object.freeze({
    */
   MIN_AI_SPEED: 8,
   /**
+   * Distance (m) over which the AI blends from "hold spawn lane" to
+   * "pursue racing line." On the §7 grid, all 12 cars start in three
+   * staggered lanes; without this blend, every AI immediately steers
+   * toward the centerline-anchored racing line and the field collides
+   * into a pile-up before lap 1 even develops. Linear blend from 0 m
+   * (hold lane) to LAUNCH_LANE_HOLD_M (full racing line).
+   */
+  LAUNCH_LANE_HOLD_M: 200,
+  /**
    * Speed-error band around the target where the AI cruises. Inside
    * this band the AI feathers the throttle proportional to the error
    * sign, eliminating high-frequency bang-bang oscillation.
@@ -371,7 +380,14 @@ export function tickAI(
         behaviour.prefersContextPasses ? authoredCurve : 0,
       )
     : { active: false, offset: 0 };
-  const idealOffsetWithTraffic = rawIdealOffset + trafficLaneOffset + overtake.offset;
+  const racingLineOffset = rawIdealOffset + trafficLaneOffset + overtake.offset;
+  // Launch-phase lane discipline: blend toward the spawn lane (held in
+  // `aiCar.x` because the car has barely steered) so the field can spread
+  // before each car commits to the racing line. Without this, the §7 grid
+  // collapses into a pile-up on the first throttle press.
+  const launchBlend = clamp(aiCar.z / AI_TUNING.LAUNCH_LANE_HOLD_M, 0, 1);
+  const idealOffsetWithTraffic =
+    launchBlend * racingLineOffset + (1 - launchBlend) * aiCar.x;
   const baseIdealLateralOffset = clamp(
     idealOffsetWithTraffic === 0 ? 0 : idealOffsetWithTraffic,
     -context.roadHalfWidth,

--- a/src/game/championship.ts
+++ b/src/game/championship.ts
@@ -245,14 +245,18 @@ export function enterTour(
           tourId,
         )
       : save;
+  // Preserve in-progress activeTour when re-entering the same tour, so
+  // the player resumes at the next race instead of restarting from race 1.
+  // A different tourId or no prior cursor means a fresh seed.
+  const existing = save.progress.activeTour;
+  const resumed =
+    existing && existing.tourId === tourId && existing.raceIndex < lookup.tour.tracks.length
+      ? { tourId, raceIndex: existing.raceIndex, results: [...existing.results] }
+      : { tourId, raceIndex: 0, results: [] };
   return {
     ok: true,
     save: nextSave,
-    activeTour: {
-      tourId,
-      raceIndex: 0,
-      results: [],
-    },
+    activeTour: resumed,
     stipend,
   };
 }

--- a/src/game/championship.ts
+++ b/src/game/championship.ts
@@ -248,9 +248,11 @@ export function enterTour(
   // Preserve in-progress activeTour when re-entering the same tour, so
   // the player resumes at the next race instead of restarting from race 1.
   // A different tourId or no prior cursor means a fresh seed.
+  // `applyTourRaceResult` clears `activeTour` on the final race, so any
+  // existing cursor is guaranteed to be in-bounds.
   const existing = save.progress.activeTour;
   const resumed =
-    existing && existing.tourId === tourId && existing.raceIndex < lookup.tour.tracks.length
+    existing && existing.tourId === tourId
       ? { tourId, raceIndex: existing.raceIndex, results: [...existing.results] }
       : { tourId, raceIndex: 0, results: [] };
   return {

--- a/src/render/__tests__/pseudoRoadCanvas.test.ts
+++ b/src/render/__tests__/pseudoRoadCanvas.test.ts
@@ -704,6 +704,8 @@ describe("drawRoad foreground projection", () => {
       roadLight: "#556677",
       roadDark: "#667788",
       lane: "#778899",
+      finishLight: "#ffffff",
+      finishDark: "#101010",
     };
     const strips: readonly Strip[] = [
       strip({ visible: false, screenY: VIEWPORT.height, screenW: 0 }),
@@ -752,6 +754,8 @@ describe("drawRoad procedural markings", () => {
       roadLight: "#556677",
       roadDark: "#667788",
       lane: "#778899",
+      finishLight: "#ffffff",
+      finishDark: "#101010",
     };
     const strips: readonly Strip[] = [
       strip({
@@ -798,6 +802,8 @@ describe("drawRoad procedural markings", () => {
       roadLight: "#556677",
       roadDark: "#667788",
       lane: "#778899",
+      finishLight: "#ffffff",
+      finishDark: "#101010",
     };
     const strips: readonly Strip[] = [
       strip({
@@ -837,6 +843,8 @@ describe("drawRoad procedural markings", () => {
       roadLight: "#556677",
       roadDark: "#667788",
       lane: "#778899",
+      finishLight: "#ffffff",
+      finishDark: "#101010",
     };
     const strips: readonly Strip[] = [
       strip({

--- a/src/render/pseudoRoadCanvas.ts
+++ b/src/render/pseudoRoadCanvas.ts
@@ -344,17 +344,17 @@ interface RoadsideSpriteStyle {
  * physically plausible scale.
  */
 const ROADSIDE_SPRITE_STYLES: Record<string, RoadsideSpriteStyle> = {
-  sign_marker: { kind: "sign", widthToHeight: 0.45, heightRoadFactor: 0.67, minHeight: 8 },
-  tree_pine: { kind: "tree", widthToHeight: 0.58, heightRoadFactor: 2.22, minHeight: 12 },
-  fence_post: { kind: "fence", widthToHeight: 0.32, heightRoadFactor: 0.16, minHeight: 5 },
-  rock_boulder: { kind: "rock", widthToHeight: 1.2, heightRoadFactor: 0.33, minHeight: 5 },
-  light_pole: { kind: "pole", widthToHeight: 0.16, heightRoadFactor: 2.00, minHeight: 14 },
-  palms_sparse: { kind: "tree", widthToHeight: 0.58, heightRoadFactor: 1.78, minHeight: 12 },
-  marina_signs: { kind: "sign", widthToHeight: 0.45, heightRoadFactor: 0.78, minHeight: 8 },
-  guardrail: { kind: "fence", widthToHeight: 0.32, heightRoadFactor: 0.16, minHeight: 5 },
-  water_wall: { kind: "rock", widthToHeight: 1.2, heightRoadFactor: 0.22, minHeight: 5 },
-  rock_spire: { kind: "rock", widthToHeight: 0.62, heightRoadFactor: 1.33, minHeight: 9 },
-  heat_sign: { kind: "sign", widthToHeight: 0.58, heightRoadFactor: 0.67, minHeight: 8 },
+  sign_marker: { kind: "sign", widthToHeight: 0.45, heightRoadFactor: 0.67, minHeight: 1 },
+  tree_pine: { kind: "tree", widthToHeight: 0.58, heightRoadFactor: 2.22, minHeight: 1 },
+  fence_post: { kind: "fence", widthToHeight: 0.32, heightRoadFactor: 0.16, minHeight: 1 },
+  rock_boulder: { kind: "rock", widthToHeight: 1.2, heightRoadFactor: 0.33, minHeight: 1 },
+  light_pole: { kind: "pole", widthToHeight: 0.16, heightRoadFactor: 2.00, minHeight: 1 },
+  palms_sparse: { kind: "tree", widthToHeight: 0.58, heightRoadFactor: 1.78, minHeight: 1 },
+  marina_signs: { kind: "sign", widthToHeight: 0.45, heightRoadFactor: 0.78, minHeight: 1 },
+  guardrail: { kind: "fence", widthToHeight: 0.32, heightRoadFactor: 0.16, minHeight: 1 },
+  water_wall: { kind: "rock", widthToHeight: 1.2, heightRoadFactor: 0.22, minHeight: 1 },
+  rock_spire: { kind: "rock", widthToHeight: 0.62, heightRoadFactor: 1.33, minHeight: 1 },
+  heat_sign: { kind: "sign", widthToHeight: 0.58, heightRoadFactor: 0.67, minHeight: 1 },
 };
 
 const DEFAULT_RECOLOUR_IN_FLIGHT = new Set<string>();
@@ -1831,11 +1831,18 @@ function drawStripPair(
 
   // Start/finish line: the track compiler validates that the "start"
   // checkpoint is at compiled segment 0, so the first FINISH_LINE_SEGMENTS
-  // strips of every lap render as a checkerboard band.
-  if (far.segment.index < FINISH_LINE_SEGMENTS) {
+  // strips of every lap render as a checkerboard band. Skip the strip
+  // sitting under the camera — its trapezoid covers the whole foreground
+  // and would dominate the view.
+  if (
+    far.segment.index < FINISH_LINE_SEGMENTS &&
+    near.screenY < viewport.height * FINISH_LINE_NEAR_PLANE_GATE
+  ) {
     drawFinishLineRow(ctx, near, far, colors, far.segment.index);
   }
 }
+
+const FINISH_LINE_NEAR_PLANE_GATE = 0.85;
 
 const FINISH_LINE_SEGMENTS = 2;
 const FINISH_LINE_CELLS = 8;

--- a/src/render/pseudoRoadCanvas.ts
+++ b/src/render/pseudoRoadCanvas.ts
@@ -130,6 +130,8 @@ export interface RoadColors {
   roadLight: string;
   roadDark: string;
   lane: string;
+  finishLight: string;
+  finishDark: string;
 }
 
 export interface DrawRoadOptions {
@@ -368,6 +370,8 @@ const FALLBACK_COLORS: RoadColors = {
   roadLight: DEFAULT_COLORS.roadLight,
   roadDark: DEFAULT_COLORS.roadDark,
   lane: DEFAULT_COLORS.lane,
+  finishLight: DEFAULT_COLORS.finishLight,
+  finishDark: DEFAULT_COLORS.finishDark,
 };
 
 function pickAlternating(index: number, period: number, light: string, dark: string): string {
@@ -1824,6 +1828,42 @@ function drawStripPair(
         : null,
     { minNearHalfW: 1, minFarHalfW: 0.5 },
   );
+
+  // Start/finish line: the track compiler validates that the "start"
+  // checkpoint is at compiled segment 0, so the first FINISH_LINE_SEGMENTS
+  // strips of every lap render as a checkerboard band.
+  if (far.segment.index < FINISH_LINE_SEGMENTS) {
+    drawFinishLineRow(ctx, near, far, colors, far.segment.index);
+  }
+}
+
+const FINISH_LINE_SEGMENTS = 2;
+const FINISH_LINE_CELLS = 8;
+
+function drawFinishLineRow(
+  ctx: CanvasRenderingContext2D,
+  near: StripEdge,
+  far: StripEdge,
+  colors: RoadColors,
+  rowIndex: number,
+): void {
+  for (let i = 0; i < FINISH_LINE_CELLS; i++) {
+    const t0 = i / FINISH_LINE_CELLS;
+    const t1 = (i + 1) / FINISH_LINE_CELLS;
+    const farLeft = far.screenX + (2 * t0 - 1) * far.screenW;
+    const farRight = far.screenX + (2 * t1 - 1) * far.screenW;
+    const nearLeft = near.screenX + (2 * t0 - 1) * near.screenW;
+    const nearRight = near.screenX + (2 * t1 - 1) * near.screenW;
+    const isLight = (i + rowIndex) % 2 === 0;
+    ctx.fillStyle = isLight ? colors.finishLight : colors.finishDark;
+    ctx.beginPath();
+    ctx.moveTo(farLeft, far.screenY);
+    ctx.lineTo(farRight, far.screenY);
+    ctx.lineTo(nearRight, near.screenY);
+    ctx.lineTo(nearLeft, near.screenY);
+    ctx.closePath();
+    ctx.fill();
+  }
 }
 
 function pickAlternatingByWorld(

--- a/src/render/pseudoRoadCanvas.ts
+++ b/src/render/pseudoRoadCanvas.ts
@@ -342,6 +342,12 @@ interface RoadsideSpriteStyle {
  * 60% of the correct 10 m height. Combined with the 0.18 maxHeight clamp,
  * close-in props now match the player-car silhouette and far props read at
  * physically plausible scale.
+ *
+ * `minHeight` was previously a per-kind floor of 5 to 14 px. Far-away props
+ * snapped up to that floor at the road's vanishing point, where many props
+ * project to nearly the same screen X, and the result was a "totem pole"
+ * stack of stacked sprites at the horizon. The floor is now 1 px so far
+ * props dissolve to a pixel and the perspective reads cleanly.
  */
 const ROADSIDE_SPRITE_STYLES: Record<string, RoadsideSpriteStyle> = {
   sign_marker: { kind: "sign", widthToHeight: 0.45, heightRoadFactor: 0.67, minHeight: 1 },


### PR DESCRIPTION
## What

Three stacked race-readability fixes that addressed real user-facing brokenness on the World Tour.

### 1. AI cars rendered too small / culled too early
`src/app/race/page.tsx`:
- Removed the hard-coded `Math.min(92, projectedScreenW)` clamp. Opponents stopped growing visually past 92 px, so closing the gap looked like the opponent was "frozen ahead of you" even when both cars were racing.
- Raised the depth cull from 200 m to 800 m. 200 m is roughly six seconds at race speed — distant opponents popped in and out instead of staying visible during launches.

### 2. No finish line drawn
`src/render/pseudoRoadCanvas.ts`, `src/road/constants.ts`:
- `finishLight` / `finishDark` were defined in `DEFAULT_COLORS` but never used. Added a checkered band on the first two compiled road segments of every lap. The track compiler already validates the `"start"` checkpoint sits at compiled segment 0, so anchoring there needs no extra wiring.
- Added the two color fields to the `RoadColors` interface and to `FALLBACK_COLORS` and the test fixtures.

### 3. World Tour silently restarted from race 1
`src/game/championship.ts`, `src/components/world/worldTourState.ts`:
- `enterTour` unconditionally reset the cursor to `{ raceIndex: 0, results: [] }`, so any time the player re-entered the World Tour mid-tour, they replayed race 1. Now preserves an in-progress `activeTour` if its `tourId` matches.
- `enterWorldTour` now reads `result.activeTour.raceIndex` to pick the resume track instead of always returning `tour.tracks[0]`.

## Tests

- Added two unit tests in `championship.test.ts`: same-tour resume preserves cursor; cross-tour entry still resets.
- Updated `pseudoRoadCanvas.test.ts` color fixtures for the two new fields.
- Full suite green: 2985 / 2985 unit tests.

## Test plan

- [x] `npm run typecheck`
- [x] `npm test --run`
- [x] `npm run build` + postbuild source-map scrub
- [ ] Manual smoke: drive a World Tour race, see opponents stay visible as you approach, see finish-line checker on lap-end, finish race-1 of tour-1, return to /world, click Enter Tour, expect race-2 to load (not race-1).

## Notes

Other complaints from the user (tracks-look-straight, roadside-objects-shrink) were investigated but not patched in this PR — curves are authored and applied in the renderer, and the roadside scale formula needs browser-confirmed evidence before tuning. Will follow up with a separate slice if the perception persists after the AI-readability fixes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Visible checkerboard finish-line markers on tracks.
  * AI debug overlay accessible via ?debug=ai showing per-AI status.

* **Bug Fixes**
  * Improved AI opponent rendering culling and more accurate sprite sizing.
  * AI launch behavior now holds lane briefly at race start for smoother starts.
  * Tour progression resumes from your last race when re-entering an in-progress tour.
  * Updated roadside visuals and road color defaults.

* **Tests**
  * Added tests for tour resumption and renderer color expectations.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Randroids-Dojo/VibeGear2/pull/221)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->