### PR TITLE
fix(ai): follow-distance throttle + overtake during launch (F-105 slice 1)

### DIFF
--- a/docs/FOLLOWUPS.md
+++ b/docs/FOLLOWUPS.md
@@ -22,17 +22,18 @@ the field collided, and damage accumulated past the wreck threshold
 the renderer froze them in place. To the player, this read as cars
 silently stopping. PR #221 added a launch-phase lane hold that
 blends the lateral target from "hold spawn lane" at z=0 to "pursue
-racing line" at z=200, which prevents the lateral pile-up but is
-still partial: cars in the same lane rear-end whoever is ahead
-because the AI has no follow-distance throttle, the launch blend
-also suppresses the overtake offset, and contact emits no audio /
-visual / HUD cue, so even non-fatal hits are invisible. Tracked in
-dot `VibeGear2-crash-physics-feedback-1c795b62` (priority 1) with
-slice plan: split overtake offset out of the launch blend, add a
-follow-distance throttle so trailing AI lift before contact, wire
-audio thud + sprite-anchored VFX + screen punch to carHit events
-for AI-vs-AI pairs, and tune the F-102 BUMP_KICK_BASE_MPS so
-contact reads as percussive instead of a creep-and-stick.
+racing line" at z=200, which prevents the lateral pile-up. The
+next slice (PR pending, branch `fix/ai-rear-end-wrecks`, 2026-05-11)
+split the overtake offset out of the launch blend so trailing cars
+can step out to pass during launch, and added a follow-distance
+throttle cap so a trailing AI within 14 m of a same-lane leader
+targets the leader's speed minus a 1 m/s buffer. Debug overlay went
+from 3 racing / 8 wrecked at 10 s to 8 racing / 3 wrecked under the
+same fixture. Remaining work tracked in dot
+`VibeGear2-crash-physics-feedback-1c795b62`: AI-vs-AI carHit VFX,
+wreck "death animation" before physics freeze, audio thud + wreck
+stinger, and lateral knock-back tuning so contact reads as
+percussive instead of a creep-and-stick.
 
 ## F-104: TG2-faithful fuel and gearbox economy
 **Created:** 2026-05-09

--- a/docs/PROGRESS_LOG.md
+++ b/docs/PROGRESS_LOG.md
@@ -6,6 +6,80 @@ Correct them by adding a new entry that references the old one.
 
 ---
 
+## 2026-05-11: fix(ai): follow-distance throttle + overtake-during-launch (F-105 slice 1)
+
+**GDD sections touched:** [§15](gdd/15-ai-and-difficulty.md) (AI
+controller).
+**Branch / PR:** `fix/ai-rear-end-wrecks`, PR pending.
+**Status:** First slice of F-105 / dot
+`VibeGear2-crash-physics-feedback-1c795b62`. After PR #221 (lateral
+lane hold) shipped, the user observed that AI cars were still
+DNF'ing in large numbers. Debug overlay confirmed they were
+status-flipped to dnf reason "wrecked" within ~5 seconds of race
+start at z values in the 25 to 80 m range - rear-ends in the same
+lane, since the trailing AI had no follow-distance behavior and the
+launch blend suppressed the overtake offset that would otherwise
+make trailers step out to pass.
+
+### Done
+- Split the overtake offset out of the launch-phase blend in
+  `src/game/ai.ts`. Overtake bias is now always additive over the
+  blended racing-line / lane-hold target, so a trailing AI can step
+  out to pass during launch instead of slamming into a same-lane
+  leader.
+- Added a follow-distance throttle cap (`followDistanceCap` helper):
+  when a peer sits within `FOLLOW_DISTANCE_METERS` (14 m) and
+  `|dx| < FOLLOW_LANE_THRESHOLD_METERS` (2.4 m), the trailing AI
+  caps its target speed at the leader's speed minus
+  `FOLLOW_SPEED_BUFFER_M_PER_S` (1 m/s). The trailer lifts off
+  before contact and the wreck-damage band stays empty.
+- Added four ai.test.ts regression tests: overtake offset stays
+  active during launch, follow-distance cap engages on a close
+  same-lane leader, cap ignores leaders past 14 m, cap ignores
+  laterally adjacent leaders.
+
+### Verification
+- `npm run typecheck` clean.
+- `npm test --run` 2991 / 2991. (Updated the weather-skill test in
+  `raceSession.test.ts` to park the player far ahead so the new
+  follow-distance cap does not dominate the assertion; the
+  fixture's intent was the weather multiplier on target speed, not
+  the follow behavior.)
+- `npm run build` succeeds.
+- Browser playthrough with `?debug=ai`: 8 of 11 AI cars are still
+  racing at 10 s into the race (was 3 of 11 before this slice).
+  The remaining 3 wrecks happen at z values 245 to 303 - well past
+  the launch hold - so they are mid-race contact and not the grid
+  pile-up.
+
+### Assumptions
+- "Same lane" is `|dx| < 2.4 m`, slightly wider than CAR_WIDTH_M
+  (1.8) so the throttle cap engages just before lateral contact
+  rather than at the moment of contact. Wider would let a parallel
+  car wrongly trigger the cap.
+- `FOLLOW_DISTANCE_METERS` 14 m gives the trailer about half a
+  second of separation at race-pace 30 m/s, enough to brake before
+  contact. Tighter would let the wreck accumulate; looser would
+  flatten field compression too aggressively.
+- The follow-distance cap can drop below MIN_AI_SPEED when the
+  leader is essentially stopped (e.g., spawn grid before
+  countdown). The MIN_AI_SPEED floor still applies after the cap,
+  so the trailing AI never targets less than 8 m/s.
+
+### GDD coverage
+- §15 AI: `LAUNCH_LANE_HOLD_M` (pinned in PR #221) and the new
+  `FOLLOW_DISTANCE_METERS` / `FOLLOW_LANE_THRESHOLD_METERS` /
+  `FOLLOW_SPEED_BUFFER_M_PER_S` constants now define the AI's
+  inter-car spacing contract. Documented in `AI_TUNING`.
+
+### Followups
+- F-105 remains in-progress for the next slices: AI-vs-AI carHit
+  VFX (sprite-anchored flash), wreck "death animation" before
+  physics freeze, audio thud + wreck stinger, and lateral
+  knock-back tuning so contact reads as percussive.
+
+---
+
 ## 2026-05-10: fix(race): visible opponents, finish line, tour resume, launch lane hold
 
 **GDD sections touched:** [§7](gdd/07-race-modes-and-rules.md) (grid

--- a/src/game/__tests__/ai.test.ts
+++ b/src/game/__tests__/ai.test.ts
@@ -273,6 +273,91 @@ describe("tickAI (launch-phase lane hold)", () => {
     // so an off-center car steers back toward the centerline.
     expect(result.input.steer).toBeLessThan(0);
   });
+
+  // Overtake offset must stay active during launch so trailing cars can
+  // step out of lane to pass a slower leader. Without this, same-lane
+  // cars rear-end each other in the launch window.
+  it("keeps overtake offset active during the launch hold", () => {
+    // Player sits as a slow leader 10 m ahead, in the same lane as the AI.
+    const playerLeader: PlayerView = {
+      car: freshCar({ x: 0, z: 10, speed: 5 }),
+    };
+    const result = tickAI(
+      CLEAN_LINE_DRIVER,
+      freshAi(),
+      freshCar({ x: 0, z: 0, speed: 20 }),
+      playerLeader,
+      STRAIGHT_TRACK,
+      RACING,
+      STARTER_STATS,
+    );
+    // With overtake active, the steer command should be non-zero
+    // (the AI is biased toward one side to pass).
+    expect(Math.abs(result.input.steer)).toBeGreaterThan(0);
+  });
+});
+
+describe("tickAI (follow-distance throttle)", () => {
+  // A leader 8 m ahead in the same lane should cap the trailer's target
+  // at the leader's speed - buffer, so the trailer lifts off instead of
+  // creeping into the contact band.
+  it("caps target speed when a same-lane car sits close ahead", () => {
+    const leader: PlayerView = {
+      car: freshCar({ x: 0, z: 8, speed: 20 }),
+    };
+    const result = tickAI(
+      CLEAN_LINE_DRIVER,
+      freshAi(),
+      freshCar({ x: 0, z: 0, speed: 30 }),
+      leader,
+      STRAIGHT_TRACK,
+      RACING,
+      STARTER_STATS,
+    );
+    // Capped below the leader's 20 m/s. The exact cap is 20 - buffer.
+    expect(result.nextAiState.targetSpeed).toBeLessThan(20);
+  });
+
+  it("ignores leaders outside the follow window", () => {
+    // Leader 30 m ahead is outside FOLLOW_DISTANCE_METERS (14).
+    const distantLeader: PlayerView = {
+      car: freshCar({ x: 0, z: 30, speed: 10 }),
+    };
+    const result = tickAI(
+      CLEAN_LINE_DRIVER,
+      freshAi(),
+      freshCar({ x: 0, z: 0, speed: 30 }),
+      distantLeader,
+      STRAIGHT_TRACK,
+      RACING,
+      STARTER_STATS,
+    );
+    // No cap applied; the AI targets its own top speed.
+    expect(result.nextAiState.targetSpeed).toBeCloseTo(
+      STARTER_STATS.topSpeed,
+      6,
+    );
+  });
+
+  it("ignores leaders in a different lane", () => {
+    // Leader 8 m ahead but offset laterally by 3 m (well past 2.4 m).
+    const adjacentLeader: PlayerView = {
+      car: freshCar({ x: 3, z: 8, speed: 10 }),
+    };
+    const result = tickAI(
+      CLEAN_LINE_DRIVER,
+      freshAi(),
+      freshCar({ x: 0, z: 0, speed: 30 }),
+      adjacentLeader,
+      STRAIGHT_TRACK,
+      RACING,
+      STARTER_STATS,
+    );
+    expect(result.nextAiState.targetSpeed).toBeCloseTo(
+      STARTER_STATS.topSpeed,
+      6,
+    );
+  });
 });
 
 describe("tickAI (cornering)", () => {

--- a/src/game/__tests__/raceSession.test.ts
+++ b/src/game/__tests__/raceSession.test.ts
@@ -353,16 +353,24 @@ describe("stepRaceSession (racing)", () => {
       ...TEST_DRIVER,
       weatherSkill: { clear: 1, rain: 0.8, fog: 1, snow: 1 },
     };
+    // Park the player far ahead so the AI is not blocked by the
+    // follow-distance throttle cap. The test's intent is the weather
+    // multiplier on target speed; with the default grid the player
+    // sits 5 m ahead of AI[0] in the same lane and the follow cap
+    // would dominate the result.
+    const playerAhead = { stats: STARTER_STATS, initial: { z: 500 } };
     const rainConfig = buildConfig({
       countdownSec: 0,
       weather: "heavy_rain",
       track: trackWithWeather(["clear", "heavy_rain"]),
+      player: playerAhead,
       ai: [{ driver: wetSpecialist, stats: STARTER_STATS }],
     });
     const clearConfig = buildConfig({
       countdownSec: 0,
       weather: "clear",
       track: trackWithWeather(["clear", "heavy_rain"]),
+      player: playerAhead,
       ai: [{ driver: wetSpecialist, stats: STARTER_STATS }],
     });
     const rain = stepRaceSession(

--- a/src/game/ai.ts
+++ b/src/game/ai.ts
@@ -263,6 +263,27 @@ export const AI_TUNING = Object.freeze({
   OVERTAKE_LANE_SHIFT_METERS: 3,
   /** Minimum lateral space from the player target line during a pass. */
   OVERTAKE_PLAYER_MARGIN_METERS: 2,
+  /**
+   * Longitudinal range (m) where a same-lane car ahead triggers the
+   * follow-distance throttle cap. Inside this window the trailing AI
+   * targets the leader's speed instead of its own top, so contact band
+   * (CAR_LENGTH_M = 4 m) stays empty. Tuned to give the trailer about a
+   * second of braking room at race-pace speeds.
+   */
+  FOLLOW_DISTANCE_METERS: 14,
+  /**
+   * Lateral threshold (m) for "same lane" follow-distance detection. A
+   * peer counts as a leader when its |dx| is below this value. Slightly
+   * wider than CAR_WIDTH_M (1.8) so the throttle cap engages just before
+   * lateral contact rather than the moment a car drifts in.
+   */
+  FOLLOW_LANE_THRESHOLD_METERS: 2.4,
+  /**
+   * Margin (m/s) the trailing AI keeps below the leader's speed inside
+   * the follow window. Without it the trailer matches exactly and creeps
+   * up on the leader; with too much, the trailer falls back unnecessarily.
+   */
+  FOLLOW_SPEED_BUFFER_M_PER_S: 1,
 });
 
 /**
@@ -380,14 +401,17 @@ export function tickAI(
         behaviour.prefersContextPasses ? authoredCurve : 0,
       )
     : { active: false, offset: 0 };
-  const racingLineOffset = rawIdealOffset + trafficLaneOffset + overtake.offset;
-  // Launch-phase lane discipline: blend toward the spawn lane (held in
-  // `aiCar.x` because the car has barely steered) so the field can spread
-  // before each car commits to the racing line. Without this, the §7 grid
-  // collapses into a pile-up on the first throttle press.
+  // Launch-phase lane discipline: blend the racing-line target toward the
+  // spawn lane (held in `aiCar.x` because the car has barely steered) so
+  // the §7 grid can spread before each car commits to the centerline. The
+  // overtake offset is held OUT of the blend so AI cars can still pass
+  // each other during launch instead of rear-ending whoever is ahead.
+  const racingLineComponent = rawIdealOffset + trafficLaneOffset;
   const launchBlend = clamp(aiCar.z / AI_TUNING.LAUNCH_LANE_HOLD_M, 0, 1);
   const idealOffsetWithTraffic =
-    launchBlend * racingLineOffset + (1 - launchBlend) * aiCar.x;
+    launchBlend * racingLineComponent +
+    (1 - launchBlend) * aiCar.x +
+    overtake.offset;
   const baseIdealLateralOffset = clamp(
     idealOffsetWithTraffic === 0 ? 0 : idealOffsetWithTraffic,
     -context.roadHalfWidth,
@@ -482,7 +506,16 @@ export function tickAI(
     Math.max(0, curvePenalty) *
     composedPaceScalar *
     (1 + recoveryPaceBonus + fieldCompressionPaceBonus);
-  const targetSpeed = clamp(rawTarget, AI_TUNING.MIN_AI_SPEED, stats.topSpeed);
+  // Follow-distance throttle: if a car is close ahead in roughly the same
+  // lane, cap the target at the leader's speed so the AI lifts off instead
+  // of creeping into rear-end contact. Pairs with the carHit damage scan -
+  // staying out of the contact band keeps cars from accumulating wreck-
+  // threshold damage. Cars wanting to pass already get a non-zero
+  // `overtake.offset` and will steer around the leader; this cap covers
+  // the straight-line case where the trailer has no room to step out yet.
+  const followCap = followDistanceCap(aiCar, [player.car, ...otherAiCars]);
+  const cappedTarget = Math.min(rawTarget, followCap);
+  const targetSpeed = clamp(cappedTarget, AI_TUNING.MIN_AI_SPEED, stats.topSpeed);
 
   // The state we will return regardless of phase. Mirrors the car so
   // other systems can read AI position without poking the physics state.
@@ -678,6 +711,41 @@ interface OvertakeThreat {
   readonly x: number;
   readonly z: number;
   readonly speed: number;
+}
+
+/**
+ * Speed cap for the AI when another car sits close ahead in roughly
+ * the same lane. Returns `+Infinity` when no leader qualifies so the
+ * caller can `Math.min` it against the raw target unconditionally.
+ *
+ * "Same lane" is `|dx| < FOLLOW_LANE_THRESHOLD_METERS`. "Close ahead" is
+ * `0 < dz < FOLLOW_DISTANCE_METERS`. The cap is the leader's speed
+ * minus a small buffer so the trailer holds station rather than
+ * matching exactly and grinding into the contact band.
+ *
+ * Pure: scans the input in order and picks the closest qualifying
+ * leader so the result is deterministic.
+ */
+function followDistanceCap(
+  aiCar: Readonly<CarState>,
+  candidates: ReadonlyArray<OvertakeThreat>,
+): number {
+  let bestGap = Number.POSITIVE_INFINITY;
+  let leaderSpeed = Number.POSITIVE_INFINITY;
+  for (const candidate of candidates) {
+    const gap = candidate.z - aiCar.z;
+    if (gap <= 0 || gap > AI_TUNING.FOLLOW_DISTANCE_METERS) continue;
+    if (
+      Math.abs(candidate.x - aiCar.x) >= AI_TUNING.FOLLOW_LANE_THRESHOLD_METERS
+    )
+      continue;
+    if (gap < bestGap) {
+      bestGap = gap;
+      leaderSpeed = candidate.speed;
+    }
+  }
+  if (!Number.isFinite(leaderSpeed)) return Number.POSITIVE_INFINITY;
+  return Math.max(0, leaderSpeed - AI_TUNING.FOLLOW_SPEED_BUFFER_M_PER_S);
 }
 
 /**


### PR DESCRIPTION
## What

First slice of F-105 / dot `VibeGear2-crash-physics-feedback-1c795b62`. PR #221 stopped the lateral grid pile-up but cars were still DNF'ing on rear-ends. This slice adds same-lane follow distance and unblocks overtake during the launch hold.

## Why

Debug overlay (`?debug=ai`, also from #221) showed 8 of 11 AI cars wrecked within ~5 seconds of race start at z values 25-80m — rear-ends, not lateral pile-up. Two underlying causes:

1. Trailing AI cars had no follow-distance throttle. They targeted their own top speed regardless of a slower car directly ahead and crept into the contact band until damage hit the 0.95 wreck threshold.
2. The launch-phase lane hold from PR #221 blended the overtake offset along with the racing-line bias, so during the first 200m a trailing car couldn't step out to pass — it was stuck behind the leader and rear-ended it.

## Changes

`src/game/ai.ts`:

- **Split overtake out of the launch blend.** Lateral target is now `launchBlend * (rawIdeal + traffic) + (1 - launchBlend) * aiCar.x + overtake.offset`. Overtake is always additive, so trailing cars can pass during launch.
- **`followDistanceCap` helper.** Scans peer cars for the closest one within `FOLLOW_DISTANCE_METERS` (14 m) and `|dx| < FOLLOW_LANE_THRESHOLD_METERS` (2.4 m). Returns the leader's speed minus `FOLLOW_SPEED_BUFFER_M_PER_S` (1 m/s) so the trailer holds station instead of matching exactly.
- Tuning constants land in `AI_TUNING` with docstrings explaining the rationale and tradeoffs.

`src/game/__tests__/ai.test.ts`:
- Overtake offset stays active during launch.
- Follow-distance cap engages on a close same-lane leader.
- Cap ignores leaders past the window.
- Cap ignores laterally-adjacent leaders.

`src/game/__tests__/raceSession.test.ts`:
- Weather-skill test parks the player far ahead so the new follow cap doesn't dominate the assertion. The test's intent was the weather multiplier on target speed.

## Verification

- `npm run typecheck` clean.
- `npm test --run` 2991 / 2991.
- `npm run build` succeeds.
- Browser `?debug=ai` at 10s into a Velvet Coast / Harbor Run race:
  - **Before this slice:** 3 racing, 8 wrecked
  - **After this slice:** 8 racing, 3 wrecked
- Remaining 3 wrecks happen at z=245-303, well past the launch hold. They are mid-race contact and outside the scope of this slice; covered by the remaining F-105 work.

## Followup (still open in F-105 / dot)

- AI-vs-AI `carHit` VFX (sprite-anchored flash)
- Wreck "death animation" before physics freeze
- Audio thud + wreck stinger
- Lateral knock-back tuning so contact reads as percussive

## Test plan

- [x] Unit tests
- [x] Production build
- [ ] Manual smoke: drive a World Tour race, see AI cars stay racing past the launch window; rear-end damage should fall sharply.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced AI collision avoidance: trailing cars now maintain safer distances from vehicles ahead, preventing rear-end contact.
  * Improved launch-phase behavior: AI lateral positioning now better balances racing-line adherence with overtaking intent during race starts.
  * Expanded test coverage for AI decision-making to ensure deterministic, reliable performance.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Randroids-Dojo/VibeGear2/pull/222)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->